### PR TITLE
style: `//` notes that documented a class member are doc comments, across thirteen small packages

### DIFF
--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -333,12 +333,11 @@ export class SpaceManager {
    * occurs (e.g. outside of the graph), which may happen at any point during
    * execution. Because this can occur from a piece calling
    * `setTimeout(() => throw new Error(""), timeout)`, we cannot determine the
-   * offending piece. Because this should not occur frequently, and currently
-   * happens due to older, misbehaving pieces, this should flush out those
-   * misbehaving pieces.
+   * offending piece. Because this should not occur frequently, this should
+   * flush out misbehaving pieces.
    *
-   * Attempts to recreate the worker environment, which should only occur once
-   * per space-wide disabling.
+   * It attempts to recreate the worker environment, which should only occur
+   * once per space-wide disabling.
    */
   #onTerminalError = (event: Event) => {
     // `addEventListener` types its listener over `Event`; the narrowing

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -97,7 +97,10 @@ export class SpaceManager {
     };
   }
 
-  // Update the list of pieces to watch (removing any pieces that are no longer in the list)
+  /**
+   * Updates the list of pieces to watch, removing any pieces that are no
+   * longer in the list.
+   */
   watch(entries: Cell<BGPieceEntry>[]): Cancel {
     const [cancel, addCancel] = useCancelGroup();
 
@@ -325,16 +328,18 @@ export class SpaceManager {
     }
   }
 
-  // This is fired from `WorkerController` when an terminal error
-  // occurs (e.g. outside of the graph), and may happen at any point
-  // during execution.
-  // Because this can occur from a piece calling `setTimeout(() => throw new Error(""), timeout)`
-  // we cannot determine the offending piece. Because this should not occur frequently,
-  // and happening currently due to older, misbehaving pieces, this should flush out
-  // those misbehaving pieces.
-  //
-  // Attempt to recreate the worker environment, which should only occur once per
-  // space-wide disabling.
+  /**
+   * Handler for the event `WorkerController` fires when a terminal error
+   * occurs (e.g. outside of the graph), which may happen at any point during
+   * execution. Because this can occur from a piece calling
+   * `setTimeout(() => throw new Error(""), timeout)`, we cannot determine the
+   * offending piece. Because this should not occur frequently, and currently
+   * happens due to older, misbehaving pieces, this should flush out those
+   * misbehaving pieces.
+   *
+   * Attempts to recreate the worker environment, which should only occur once
+   * per space-wide disabling.
+   */
   #onTerminalError = (event: Event) => {
     // `addEventListener` types its listener over `Event`; the narrowing
     // recovers the controller's own event type, and anything else here is a

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -1651,12 +1651,14 @@ export class CfHarnessEngine {
     }
   }
 
-  // Fail fast before any sandbox execution under enforcement on a sandbox that
-  // lacks the CFC sidecar transports — capability probes included, since they
-  // run scripts inside the same sandbox (not just builtin tools). Checked at
-  // run start rather than construction so an engine can be built and inspected
-  // (config threading, --describe-capabilities) without a live CFC wiring.
-  // Idempotent so the cost is paid once per run.
+  /**
+   * Fails fast before any sandbox execution under enforcement on a sandbox
+   * that lacks the CFC sidecar transports — capability probes included, since
+   * they run scripts inside the same sandbox (not just builtin tools). Checked
+   * at run start rather than construction so an engine can be built and
+   * inspected (config threading, `--describe-capabilities`) without a live CFC
+   * wiring. Idempotent so the cost is paid once per run.
+   */
   #assertCfcTransportReady(): void {
     if (this.#cfcTransportChecked || this.#ownedRunscConfig === undefined) {
       return;

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -738,20 +738,30 @@ const cfcResultFromRunscSidecar = (
 
 export class DockerRunscSandboxRuntime implements SandboxRuntime {
   #cfcTransportReadiness?: CfcTransportReadiness;
-  // Copied once here and read from here afterwards. `config` is public, its
-  // `readonly` binds the reference rather than the fields, and `readonly` is a
-  // compile-time annotation that no longer exists at runtime — so it cannot
-  // stop a JavaScript caller, a cast, or `any`. The probe memoizes a verdict
-  // about these two directories, and a verdict must not outlive the evidence
-  // that produced it; copying the values is what makes the directories unable
-  // to move out from under it, rather than asking a type to be respected.
+
+  /**
+   * Copy of `config.cfcInvocationContextDir`, taken once here and read from
+   * here afterwards. `config` is public, its `readonly` binds the reference
+   * rather than the fields, and `readonly` is a compile-time annotation that
+   * no longer exists at runtime — so it cannot stop a JavaScript caller, a
+   * cast, or `any`. The probe memoizes a verdict about these two directories,
+   * and a verdict must not outlive the evidence that produced it; copying the
+   * values is what makes the directories unable to move out from under it,
+   * rather than asking a type to be respected.
+   */
   readonly #cfcInvocationContextDir?: string;
+
   readonly #cfcResultDir?: string;
-  // The registration reading is about a named runtime reached through a named
-  // binary, so those identify the verdict as much as the directories do.
-  // Copied for the same reason and used on every path that either probes or
-  // launches, so the runtime a verdict describes is the runtime that runs.
+
+  /**
+   * Copy of `config.runtimeName`. The registration reading is about a named
+   * runtime reached through a named binary, so those identify the verdict as
+   * much as the directories do. Copied for the same reason as
+   * `#cfcInvocationContextDir` and used on every path that either probes or
+   * launches, so the runtime a verdict describes is the runtime that runs.
+   */
   readonly #runtimeName: string;
+
   readonly #dockerBinary: string;
   readonly #extraDockerArgs: readonly string[];
   readonly #runner: ProcessRunner;

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -743,26 +743,30 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
    * Copy of `config.cfcInvocationContextDir`, taken once here and read from
    * here afterwards. `config` is public, its `readonly` binds the reference
    * rather than the fields, and `readonly` is a compile-time annotation that
-   * no longer exists at runtime — so it cannot stop a JavaScript caller, a
-   * cast, or `any`. The probe memoizes a verdict about these two directories,
-   * and a verdict must not outlive the evidence that produced it; copying the
-   * values is what makes the directories unable to move out from under it,
-   * rather than asking a type to be respected.
+   * is erased before runtime — so it cannot stop a JavaScript caller, a cast,
+   * or `any`. The probe memoizes a verdict about this directory and
+   * `#cfcResultDir`, and a verdict must not outlive the evidence that
+   * produced it; copying the values is what makes the directories unable to
+   * move out from under it, rather than asking a type to be respected.
    */
   readonly #cfcInvocationContextDir?: string;
 
+  /** Copy of `config.cfcResultDir`, for the same reason. */
   readonly #cfcResultDir?: string;
 
   /**
-   * Copy of `config.runtimeName`. The registration reading is about a named
-   * runtime reached through a named binary, so those identify the verdict as
-   * much as the directories do. Copied for the same reason as
+   * The effective Docker runtime name: a `--runtime` in `extraDockerArgs`
+   * when present, otherwise `config.runtimeName`. The registration reading is
+   * about a named runtime reached through a named binary, so those identify
+   * the verdict as much as the directories do. Held for the same reason as
    * `#cfcInvocationContextDir` and used on every path that either probes or
    * launches, so the runtime a verdict describes is the runtime that runs.
    */
   readonly #runtimeName: string;
 
+  /** Copy of `config.dockerBinary`, for the same reason as `#runtimeName`. */
   readonly #dockerBinary: string;
+
   readonly #extraDockerArgs: readonly string[];
   readonly #runner: ProcessRunner;
 

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -79,8 +79,12 @@ class UnregisteredInstance extends BaseFabricInstance {
     return "Unregistered@1";
   }
 
-  // The encode-side mandate guard fires before any of these are reached, so
-  // they are throwing stubs.
+  //
+  // Unreached stubs
+  //
+  // The encode-side mandate guard fires before any of these are reached.
+  //
+
   [DEEP_FREEZE](_subFreeze: (value: FabricValue) => FabricValue): FabricValue {
     throw new Error("not implemented");
   }

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -228,8 +228,8 @@ export class WorkerReconciler {
   readonly #resolveRenderConfidentiality?: RenderConfidentialityResolver;
 
   /**
-   * The membership provider (spec §4.9.3) whose `subscribe` lets a gated
-   * `Space(X)`-labeled cell re-render when X's ACL syncs or changes. When
+   * The membership provider (spec §4.9.3) whose `subscribe()` lets a gated
+   * `Space(X)`-labeled cell re-render when `X`'s ACL syncs or changes. When
    * `undefined`, there is no reactive upgrade, and the sync snapshot still
    * gates soundly.
    */

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -203,26 +203,36 @@ export class WorkerReconciler {
   #pendingOps: VDomOp[] = [];
   #flushScheduled = false;
 
-  // Track the actual root child node (not the container)
+  /** The actual root child node (not the container). */
   #rootChildId: number | null = null;
+
   #rootCancel: Cancel | null = null;
 
   readonly #onOps: (ops: VDomOp[]) => number | void;
   readonly #onError?: (error: Error) => void;
   readonly #renderDeclassificationPolicy: RenderDeclassificationPolicy;
 
-  // Root-of-tree render policy: the host's default ceiling when configured
-  // (spec §8.10.6), otherwise the historical unbounded policy. Authored
-  // boundaries can only narrow from here.
+  /**
+   * Root-of-tree render policy: the host's default ceiling when configured
+   * (spec §8.10.6), otherwise the unbounded policy. Authored boundaries can
+   * only narrow from here.
+   */
   readonly #rootRenderPolicy: RenderPolicy;
-  // Runner-side display-boundary resolver (Epic H3b): rewrites a cell's
-  // confidentiality label through the exchange rules before the ceiling fit,
-  // admitting `Space(...)`-via-`HasRole` principal forms. Undefined = H3a
-  // exact-match behavior.
+
+  /**
+   * Runner-side display-boundary resolver, which rewrites a cell's
+   * confidentiality label through the exchange rules before the ceiling fit,
+   * admitting `Space(...)`-via-`HasRole` principal forms. When `undefined`,
+   * the label is fit by exact match.
+   */
   readonly #resolveRenderConfidentiality?: RenderConfidentialityResolver;
-  // §4.9.3 Stage 2: the membership provider whose `subscribe` lets a gated
-  // `Space(X)`-labeled cell re-render when X's ACL syncs/changes. Undefined =
-  // no reactive upgrade (the Stage-1 sync snapshot still gates soundly).
+
+  /**
+   * The membership provider (spec §4.9.3) whose `subscribe` lets a gated
+   * `Space(X)`-labeled cell re-render when X's ACL syncs or changes. When
+   * `undefined`, there is no reactive upgrade, and the sync snapshot still
+   * gates soundly.
+   */
   readonly #membershipProvider?: SpaceMembershipProvider;
 
   constructor(options: WorkerReconcilerOptions) {

--- a/packages/html/test/main-renderer.test.ts
+++ b/packages/html/test/main-renderer.test.ts
@@ -40,8 +40,10 @@ class MockConnection {
     return () => this.#lifetime.signal.removeEventListener("abort", teardown);
   }
 
-  // The renderer obtains VDOM capability only through attachVDom; the session
-  // delegates to the mock's recording methods below.
+  /**
+   * Attaches the VDOM capability, which is the only way the renderer obtains
+   * it; the session delegates to the mock's recording methods below.
+   */
   attachVDom(onDispose: () => void) {
     const unregister = this.onDispose(onDispose);
     return {

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -131,14 +131,18 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       return false;
     }
 
-    // A mock carries no metadata, and the inherited read throws on a
-    // link-less cell.
+    /**
+     * Returns `undefined`: a mock carries no metadata, and the inherited read
+     * throws on a link-less cell.
+     */
     getMetaRaw(): undefined {
       return undefined;
     }
 
-    // A mock names no link, so it resolves to itself; a step that needs
-    // otherwise overrides it on the instance.
+    /**
+     * Resolves to itself, since a mock names no link; a step that needs
+     * otherwise overrides it on the instance.
+     */
     resolveAsCell(): MockCell | Cell<unknown> {
       return this;
     }

--- a/packages/iframe-sandbox/test/utils.ts
+++ b/packages/iframe-sandbox/test/utils.ts
@@ -124,9 +124,11 @@ export class ContextShim {
     }
   }
 
-  // Watch writes to `key`. Observers are held apart from `subscribe`'s
-  // callbacks so that a test watching a key does not consume a receipt id,
-  // which would change the ids the guest's own subscriptions are given.
+  /**
+   * Watches writes to `key`. Observers are held apart from `subscribe`'s
+   * callbacks so that a test watching a key does not consume a receipt id,
+   * which would change the ids the guest's own subscriptions are given.
+   */
   observe(key: string, callback: Callback): () => void {
     const entry: [string, Callback] = [key, callback];
     this.observers.push(entry);

--- a/packages/iframe-sandbox/test/utils.ts
+++ b/packages/iframe-sandbox/test/utils.ts
@@ -125,7 +125,7 @@ export class ContextShim {
   }
 
   /**
-   * Watches writes to `key`. Observers are held apart from `subscribe`'s
+   * Watches writes to `key`. Observers are held apart from `subscribe()`'s
    * callbacks so that a test watching a key does not consume a receipt id,
    * which would change the ids the guest's own subscriptions are given.
    */

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -154,9 +154,12 @@ export class FileSystemProgramResolver implements ProgramResolver {
     });
   }
 
-  // Async so that a refusal — an escaping name, bytes that are not text —
-  // arrives as a rejection. A method that returns a promise and also throws
-  // where it is called cannot be handled one way.
+  /**
+   * Reads the data file `name` from the file system. Async so that a refusal
+   * — an escaping name, bytes that are not text — arrives as a rejection. A
+   * method that returns a promise and also throws where it is called cannot be
+   * handled one way.
+   */
   async resolveDataFile(name: string): Promise<Source | undefined> {
     requireDeno("FileSystemProgramResolver");
     let realPath: string | undefined;

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -404,7 +404,7 @@ export class SourceMapParser {
    * Deferred registrations: the boot path registers a _provider_ instead of
    * composing eagerly; the first lookup that needs the filename materializes
    * it. One-shot — the provider is dropped as soon as it runs, so its captured
-   * inputs are released after first use. LRU-bounded like `sourceMaps`: a
+   * inputs are released after first use. LRU-bounded like `#sourceMaps`: a
    * provider whose filename is _never_ looked up (its eval never errored)
    * would otherwise be retained until dispose — one per eval, an unbounded
    * leak on long-lived runners — so this caps it and evicts the oldest.

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -399,15 +399,18 @@ export class SourceMapParser {
     capacity: MAX_SOURCE_MAP_CACHE_SIZE,
   });
   #consumers = new WeakMap<SourceMap, SourceMapConsumer>();
-  // Deferred registrations (CT-1819): the boot path registers a PROVIDER
-  // instead of composing eagerly; the first lookup that needs the filename
-  // materializes it. One-shot — the provider is dropped as soon as it runs,
-  // so its captured inputs are released after first use. LRU-bounded like
-  // `sourceMaps`: a provider whose filename is NEVER looked up (its eval never
-  // errored) would otherwise be retained until dispose — one per eval, an
-  // unbounded leak on long-lived runners — so cap it and evict the oldest.
-  // Evicting an unused provider only means a later error in that (old) eval
-  // goes unmapped, exactly as when the composed-map LRU evicts a stale entry.
+
+  /**
+   * Deferred registrations: the boot path registers a _provider_ instead of
+   * composing eagerly; the first lookup that needs the filename materializes
+   * it. One-shot — the provider is dropped as soon as it runs, so its captured
+   * inputs are released after first use. LRU-bounded like `sourceMaps`: a
+   * provider whose filename is _never_ looked up (its eval never errored)
+   * would otherwise be retained until dispose — one per eval, an unbounded
+   * leak on long-lived runners — so this caps it and evicts the oldest.
+   * Evicting an unused provider only means a later error in that (old) eval
+   * goes unmapped, exactly as when the composed-map LRU evicts a stale entry.
+   */
   #pendingProviders = new LRUCache<
     string,
     () => SourceMap | undefined
@@ -452,9 +455,11 @@ export class SourceMapParser {
     this.#pendingProviders.clear();
   }
 
-  // Fixes stack traces to use source map from eval. Strangely, both Deno and
-  // Chrome at least only observe `sourceURL` but not the source map, so we can
-  // use the former to find the right source map and then apply this.
+  /**
+   * Fixes stack traces to use source map from eval. Strangely, both Deno and
+   * Chrome at least only observe `sourceURL` but not the source map, so we can
+   * use the former to find the right source map and then apply this.
+   */
   parse(stack: string): string {
     return stack.split("\n").map((line) => {
       const match = line.match(stackTracePattern);
@@ -522,8 +527,10 @@ export class SourceMapParser {
     return `    at ${name} (${originalPosition.source}:${originalPosition.line}:${originalPosition.column})`;
   }
 
-  // Map a single position to its original source location.
-  // More efficient than parse() when you only need one position.
+  /**
+   * Maps a single position to its original source location. More efficient
+   * than `parse()` when only one position is needed.
+   */
   mapPosition(
     filename: string,
     line: number,

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -459,7 +459,7 @@ export class RuntimeInternals extends EventTarget {
   // TODO(runtime-worker-refactor)
   #telemetryMarkers: RuntimeTelemetryMarkerResult[] = [];
 
-  /** Optional OTel sink (browser telemetry enabled). Inert when undefined. */
+  /** Optional OTel sink (browser telemetry enabled). Inert when `undefined`. */
   #telemetrySink?: RuntimeTelemetrySink;
 
   constructor(

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -458,7 +458,8 @@ export class RuntimeInternals extends EventTarget {
   > = new Map();
   // TODO(runtime-worker-refactor)
   #telemetryMarkers: RuntimeTelemetryMarkerResult[] = [];
-  // Optional OTel sink (browser telemetry enabled). Inert when undefined.
+
+  /** Optional OTel sink (browser telemetry enabled). Inert when undefined. */
   #telemetrySink?: RuntimeTelemetrySink;
 
   constructor(

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -777,11 +777,14 @@ export class PiecesController<T = unknown> {
     await timePiecePhase("add.synced", () => this.synced());
   }
 
-  // `pieceListSchema` gives its items no shape — they are `unknown` — so
-  // neither the value the caller receives nor the query behind it has anywhere
-  // to descend inside a piece, and no field a piece labels is ever selected.
-  // `asCell` alone would not be enough for that: it bounds the runtime's own
-  // walk, while the memory query walks through it.
+  /**
+   * Syncs the piece list held in `cell`. `pieceListSchema` gives its items no
+   * shape — they are `unknown` — so neither the value the caller receives nor
+   * the query behind it has anywhere to descend inside a piece, and no field a
+   * piece labels is ever selected. `asCell` alone would not be enough for
+   * that: it bounds the runtime's own walk, while the memory query walks
+   * through it.
+   */
   syncPieces(cell: Cell<Cell<unknown>[]>) {
     return cell.asSchema(pieceListSchema).pull();
   }
@@ -1255,7 +1258,9 @@ export class PiecesController<T = unknown> {
     return cell;
   }
 
-  // Return Cell with argument content, loading the pattern if needed.
+  /**
+   * Returns the `Cell` with argument content, loading the pattern if needed.
+   */
   getArgument<T = unknown>(
     piece: Cell<unknown | T>,
   ): Cell<T> {
@@ -1385,16 +1390,18 @@ export class PiecesController<T = unknown> {
     return piece;
   }
 
-  // Consistently return the `Cell<Piece>` of piece with
-  // id `pieceId`, applies the provided `pattern` (which may be
-  // its current pattern -- useful when we are only updating inputs),
-  // and optionally applies `inputs` if provided.
-  //
-  // Reports a failure as itself, whether it happened before or after the
-  // setup transaction committed. `runPatternUpdate` below runs the same
-  // post-commit work and differs precisely here: it issues a receipt, so it
-  // reports a post-commit failure as a `PatternSetupPostCommitError` carrying
-  // that receipt. Callers classifying failures by message want this one.
+  /**
+   * Consistently returns the `Cell<Piece>` of the piece with id `pieceId`,
+   * applying the provided `pattern` (which may be its current pattern -- useful
+   * when we are only updating inputs), and optionally applying `inputs` if
+   * provided.
+   *
+   * Reports a failure as itself, whether it happened before or after the setup
+   * transaction committed. `runPatternUpdate` below runs the same post-commit
+   * work and differs precisely here: it issues a receipt, so it reports a
+   * post-commit failure as a `PatternSetupPostCommitError` carrying that
+   * receipt. Callers classifying failures by message want this one.
+   */
   async runWithPattern(
     pattern: Pattern | Module,
     pieceId: string,
@@ -1698,8 +1705,10 @@ export class PiecesController<T = unknown> {
     await entity.sync();
   }
 
-  // Returns the piece from our active piece list if it is present,
-  // or undefined if it is not
+  /**
+   * Returns the piece from our active piece list if it is present, or
+   * `undefined` if it is not.
+   */
   async getActivePiece(pieceCell: Cell<unknown>) {
     const piecesCell = await this.getPieceRegistry();
     const resolved = pieceCell.resolveAsCell();

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -1392,12 +1392,12 @@ export class PiecesController<T = unknown> {
 
   /**
    * Consistently returns the `Cell<Piece>` of the piece with id `pieceId`,
-   * applying the provided `pattern` (which may be its current pattern -- useful
+   * applying the provided `pattern` (which may be its current pattern — useful
    * when we are only updating inputs), and optionally applying `inputs` if
    * provided.
    *
    * Reports a failure as itself, whether it happened before or after the setup
-   * transaction committed. `runPatternUpdate` below runs the same post-commit
+   * transaction committed. `runPatternUpdate()` below runs the same post-commit
    * work and differs precisely here: it issues a receipt, so it reports a
    * post-commit failure as a `PatternSetupPostCommitError` carrying that
    * receipt. Callers classifying failures by message want this one.

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -853,10 +853,12 @@ export class CommonFabricFormatter implements TypeFormatter {
       : undefined;
   }
 
-  // Detects the "opaque" cell brand, carried by OpaqueCell<T>. Named for the
-  // brand it matches, not the `Reactive` annotation spelling: that is an
-  // identity alias for T (no runtime wrapper, no brand), so it cannot be
-  // detected structurally here — only OpaqueCell can.
+  /**
+   * Detects the opaque cell brand, carried by `OpaqueCell<T>`. Named for the
+   * brand it matches, not the `Reactive` annotation spelling: that is an
+   * identity alias for `T` (no runtime wrapper, no brand), so it cannot be
+   * detected structurally here — only `OpaqueCell` can.
+   */
   #isOpaqueCellType(type: ts.Type, checker: ts.TypeChecker): boolean {
     return isCellBrand(type, checker, "opaque");
   }

--- a/packages/schema-generator/src/formatters/native-type-formatter.ts
+++ b/packages/schema-generator/src/formatters/native-type-formatter.ts
@@ -215,10 +215,7 @@ export class NativeTypeFormatter implements TypeFormatter {
     }) ?? false;
   }
 
-  /**
-   * Returns whether `typeName` names a native type. Exposed so that
-   * `type-utils` can skip generating `$defs` for these.
-   */
+  /** Returns whether `typeName` names a native type, which gets no `$defs`. */
   public static isNativeType(typeName: string | undefined): boolean {
     return typeName !== undefined && NATIVE_TYPE_NAMES.has(typeName);
   }

--- a/packages/schema-generator/src/formatters/native-type-formatter.ts
+++ b/packages/schema-generator/src/formatters/native-type-formatter.ts
@@ -215,7 +215,10 @@ export class NativeTypeFormatter implements TypeFormatter {
     }) ?? false;
   }
 
-  // We expose this so type-utils can skip generating $defs for these
+  /**
+   * Returns whether `typeName` names a native type. Exposed so that
+   * `type-utils` can skip generating `$defs` for these.
+   */
   public static isNativeType(typeName: string | undefined): boolean {
     return typeName !== undefined && NATIVE_TYPE_NAMES.has(typeName);
   }

--- a/packages/test-support/src/compile-byte-cache.ts
+++ b/packages/test-support/src/compile-byte-cache.ts
@@ -73,12 +73,16 @@ const cacheFiles = new WeakMap<ProcessModuleByteCache, string>();
  * instances. A byte cap bounds the total retained JS and evicts oldest-first.
  */
 export class ProcessModuleByteCache implements ModuleByteCache {
-  // Keyed by `${runtimeVersion}\0${identity}`. Map insertion order gives FIFO
-  // eviction (recency-refreshed on read, so eviction is ~LRU).
+  /**
+   * The cached artifacts, keyed by `${runtimeVersion}\0${identity}`. Map
+   * insertion order gives FIFO eviction (recency-refreshed on read, so
+   * eviction is ~LRU).
+   */
   readonly #entries = new Map<
     string,
     { artifact: CompiledModuleArtifact; size: number }
   >();
+
   #totalBytes = 0;
   readonly #maxBytes: number;
 

--- a/packages/ts-transformers/src/core/cf-helpers.ts
+++ b/packages/ts-transformers/src/core/cf-helpers.ts
@@ -109,8 +109,10 @@ export class CFHelpers {
     );
   }
 
-  // Returns an QualifiedName of the requested
-  // helper name e.g. `__cfHelpers.JSONSchema`.
+  /**
+   * Returns a `QualifiedName` for the requested helper name, e.g.
+   * `__cfHelpers.JSONSchema`.
+   */
   getHelperQualified(
     name: string,
   ): ts.QualifiedName {

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -241,9 +241,10 @@ export abstract class Transformer {
 
   abstract transform(context: TransformationContext): ts.SourceFile;
 
-  // Receives a TransformationContext, returning a boolean indicating
-  // whether a transformation should run for this source file.
-  // If not provided, always returns true.
+  /**
+   * Returns whether the transformation should run for `context`'s source
+   * file. This base implementation always returns `true`.
+   */
   filter(_context: TransformationContext): boolean {
     return true;
   }

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -109,7 +109,7 @@ export class BoundedKeyMap<K, V> implements ReadonlyMap<K, V> {
   // Traversals
   //
   // Every traversal runs oldest first, which is the order entries are dropped
-  // in. Together with `size`, `has()`, and `get()` above, these are the
+  // in. Together with `.size`, `has()`, and `get()` above, these are the
   // standard `ReadonlyMap` surface, so a consumer that only reads takes
   // `ReadonlyMap` and accepts either this or a plain `Map`.
   //

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -105,10 +105,14 @@ export class BoundedKeyMap<K, V> implements ReadonlyMap<K, V> {
     this.#entries.clear();
   }
 
-  // The read side is the standard `ReadonlyMap` surface, so a consumer that
-  // only reads takes `ReadonlyMap` and accepts either this or a plain `Map`.
+  //
+  // Traversals
+  //
   // Every traversal runs oldest first, which is the order entries are dropped
-  // in.
+  // in. Together with `size`, `has()`, and `get()` above, these are the
+  // standard `ReadonlyMap` surface, so a consumer that only reads takes
+  // `ReadonlyMap` and accepts either this or a plain `Map`.
+  //
 
   /** @inheritDoc */
   entries(): MapIterator<[K, V]> {

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -69,9 +69,11 @@ export class BuildConfig {
     return path.join(this.root, ...args);
   }
 
-  // A fresh, mutable copy of the workspace manifest, parsed from its original
-  // bytes. The build mutates this copy; the original bytes stay untouched so
-  // the revert can restore the file exactly.
+  /**
+   * Returns a fresh, mutable copy of the workspace manifest, parsed from its
+   * original bytes. The build mutates this copy; the original bytes stay
+   * untouched so the revert can restore the file exactly.
+   */
   manifest(): Record<string, any> {
     return parseJsonc(this.#manifestOriginal) as Record<string, any>;
   }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A `//` block sitting directly above a class member and describing that member is a doc comment in the wrong punctuation: it says what the member is or does, which is what `docs/development/code-comment-style.md` § Doc comments has JSDoc form for. This converts the ones in the packages with the fewest of them, one PR of a series that covers the tree outside `packages/patterns`.

Packages touched: `background-piece-service`, `cf-harness`, `html`, `iframe-sandbox`, `js-compiler`, `lib-shell`, `piece`, `schema-generator`, `test-support`, `ts-transformers`, and `tasks/` (28 sites), plus two group notes in `utils` and a `data-model` test that become section markers, since each titled a run of members rather than describing one.

Each converted member takes the blank line above its doc comment and the blank line below the member that the guide asks for. Where a member sat in an unbroken run of undocumented fields, that means a blank line now separates it from its neighbors.

## What changed inside the comments

The text is carried over as written, with the edits the doc-comment form calls for:

* A method's comment opens with a third-person verb phrase (`Updates the list`, not `Update the list`), and a field's with a noun phrase.
* Identifiers and code-like things take backticks; `--describe-capabilities`, `OpaqueCell<T>`, `$defs`, and `parse()` among them.
* Emphasis by capitals becomes underscores (`_provider_`, `_never_`).
* Two rollout-stage labels and one tracker identifier that the guide keeps out of comments are gone: `(Epic H3b)`, `Stage 2` / `Stage-1`, and `(CT-1819)`. The sentence each sat in says the same thing without it.
* Two fields in `docker-runsc.ts` whose notes opened with "Copied once here" now say what they are copies of.

Left as `//`: the note on `LRUCache.#weigh` in `utils`, which explains how the declaration is written (`| undefined` rather than optional) and is mechanics, not a description of the field.

## How the sites were found

A TypeScript-AST census over every tracked `.ts`/`.tsx` outside `patterns`, vendored types, and generated declarations: for each class member, the `//` blocks in its leading trivia, minus tool directives, section-marker frames, and `TODO`s. A control fixture of nine planted sites and four decoys (a body comment, a template literal, an object-literal member, a static block) reported exactly the nine. Over the tree the census finds 508 sites in 109 files; this PR's packages are the tail of that distribution.

## Verification

* Comment-only, by construction and by proof: each changed file transpiles to byte-identical JavaScript with comments stripped, before and after (19 files, 0 differ).
* The census re-run over the changed files reports zero remaining sites; the blank-line-below detector reports only sites it also reports on `main`.
* `deno fmt --check`, `deno lint`, and `deno task check` repo-wide, all green.
* `deno task test` in every touched package (twelve suites, plus `tasks/build-binaries.test.ts`), all green.

## Review

A `cf-review` pass (report only) found one sentence this PR had introduced that was false against the code, fixed: `#runtimeName` is the effective Docker runtime name, which a `--runtime` in `extraDockerArgs` overrides, not a plain copy of `config.runtimeName`. Also taken: `#cfcResultDir` and `#dockerBinary`, whose neighbors' notes had covered them, get one-line doc comments; `isNativeType()` states its contract without naming its caller; the terminal-error handler's doc no longer describes the deployed world; and code spans, callables, and one field name are marked up as the guide asks.

## Coverage

The Coverage Check counts the `tasks` group one line over its baseline (1807 against 1806), on two runs of this branch against four consecutive `main` runs at 1806. Merging every coverage profile of this branch's run and of the baseline `main` run (`e9b4dd53e`) and diffing `tasks/build-binaries.ts` line by line, with this diff's two-line shift applied, names the line: the closing brace of the file's `if (import.meta.main)` block, whose body no test runs by design (the tests import the module). The brace's line reads as covered or not according to where V8's block range for that `if` ends relative to a line boundary, and this diff moved that boundary by adding two comment lines above it. No executable line changed, and no line that was run before is unrun now.

ACCEPT_COVERAGE_DEBT: tasks +1 lines
