### PR TITLE
style(memory, identity, integration, runtime-client): `//` notes that documented a class member are doc comments

### DIFF
--- a/packages/identity/src/ed25519/index.ts
+++ b/packages/identity/src/ed25519/index.ts
@@ -72,9 +72,12 @@ export class Ed25519Signer<ID extends DIDKey> implements Signer<ID> {
     );
   }
 
-  // The raw 32-byte ed25519 seed. Like toPkcs8, only "noble" implementations
-  // expose the private material; WebCrypto (native) hides it, so this throws.
-  // The array is freshly allocated, so the caller owns it outright.
+  /**
+   * Returns the raw 32-byte ed25519 seed. Like `toPkcs8()`, only noble
+   * implementations expose the private material; WebCrypto (native) hides it,
+   * so this throws. The array is freshly allocated, so the caller owns it
+   * outright.
+   */
   toRaw(): Uint8Array {
     if (this.#impl instanceof NobleEd25519Signer) {
       return this.#impl.privateKey().slice();

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -131,8 +131,8 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
    * entropy directly as the seed with no KDF between — so a caller can do
    * `entropyToMnemonic(identity.toRaw())` to re-encode an existing key as a
    * phrase without re-keying. But the BIP39 vocabulary belongs at that call
-   * site: if a KDF is ever introduced, `toRaw` stays true (it still returns
-   * the seed) while a hypothetical `toEntropy` would silently start lying.
+   * site: if a KDF is ever introduced, `toRaw()` stays true (it still returns
+   * the seed) while a hypothetical `toEntropy()` would silently start lying.
    *
    * Like `toPkcs8()`, only noble implementations can do this — WebCrypto hides
    * the private key material — and it throws otherwise.

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -36,7 +36,7 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
     return this.#verifier;
   }
 
-  // Sign `data` with this identity.
+  /** Signs `payload` with this identity. */
   sign<T>(payload: AsBytes<T>) {
     return this.#keypair.sign(payload);
   }
@@ -46,7 +46,7 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
     return this.#keypair.keyPair;
   }
 
-  // Derive a new `Identity` given a seed string.
+  /** Derives a new `Identity` given a seed string. */
   async derive<ID extends DIDKey>(
     name: string,
     config: IdentityCreateConfig = {},
@@ -60,14 +60,16 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
     return await Identity.fromRaw(new Uint8Array(signedHash), config);
   }
 
-  // Derive PKCS8/PEM bytes from this identity.
-  // Implementations other than "noble" throw as private key
-  // material is needed to create the PKCS8/PEM bytes.
+  /**
+   * Derives PKCS8/PEM bytes from this identity. Implementations other than
+   * noble throw, as private key material is needed to create the PKCS8/PEM
+   * bytes.
+   */
   toPkcs8(): Uint8Array {
     return this.#keypair.toPkcs8();
   }
 
-  // Generate a new identity from raw ed25519 key material.
+  /** Generates a new identity from raw ed25519 key material. */
   static async fromRaw<ID extends DIDKey>(
     rawPrivateKey: Uint8Array,
     config: IdentityCreateConfig = {},
@@ -75,7 +77,7 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
     return new Identity(await Ed25519Signer.fromRaw<ID>(rawPrivateKey, config));
   }
 
-  // Generate a new identity.
+  /** Generates a new identity. */
   static async generate<ID extends DIDKey>(
     config: IdentityCreateConfig = {},
   ): Promise<Identity<ID>> {
@@ -91,18 +93,19 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
     return [new Identity(signer), mnemonic];
   }
 
-  // Generate a new keypair in PKCS8, PEM encoded form.
-  //
-  // Due to hiding access to private key material
-  // in the JS environment (via WebCrypto), we cannot
-  // simply "export" existing keys. If a key should
-  // be stored as PKCS8, generate it with this method.
+  /**
+   * Generates a new keypair in PKCS8, PEM encoded form.
+   *
+   * Due to hiding access to private key material in the JS environment (via
+   * WebCrypto), we cannot simply export existing keys. If a key should be
+   * stored as PKCS8, generate it with this method.
+   */
   static async generatePkcs8(): Promise<Uint8Array> {
     // Not a promise, but force it for consistent interface
     return await Ed25519Signer.generatePkcs8();
   }
 
-  // Read a PKCS8/PEM key.
+  /** Reads a PKCS8/PEM key. */
   static async fromPkcs8<ID extends DIDKey>(
     pkcs8: Uint8Array,
     config: IdentityCreateConfig = {},
@@ -119,19 +122,21 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
     return new Identity(signer);
   }
 
-  // Recover the raw 32-byte ed25519 seed for this identity — the exact inverse
-  // of `fromRaw`, mirroring the `fromPkcs8`/`toPkcs8` pair.
-  //
-  // Named `toRaw`, NOT `toEntropy`, on purpose: it returns a SEED. Those bytes
-  // are *also* valid BIP39 entropy only because `fromMnemonic` uses the
-  // entropy directly as the seed with no KDF between — so a caller can do
-  // `entropyToMnemonic(identity.toRaw())` to re-encode an existing key as a
-  // phrase without re-keying. But the BIP39 vocabulary belongs at that call
-  // site: if a KDF is ever introduced, `toRaw` stays true (it still returns the
-  // seed) while a hypothetical `toEntropy` would silently start lying.
-  //
-  // Like `toPkcs8`, only "noble" implementations can do this — WebCrypto hides
-  // the private key material — and it throws otherwise.
+  /**
+   * Recovers the raw 32-byte ed25519 seed for this identity — the exact
+   * inverse of `fromRaw()`, mirroring the `fromPkcs8()`/`toPkcs8()` pair.
+   *
+   * Named `toRaw`, _not_ `toEntropy`, on purpose: it returns a _seed_. Those
+   * bytes are _also_ valid BIP39 entropy only because `fromMnemonic()` uses the
+   * entropy directly as the seed with no KDF between — so a caller can do
+   * `entropyToMnemonic(identity.toRaw())` to re-encode an existing key as a
+   * phrase without re-keying. But the BIP39 vocabulary belongs at that call
+   * site: if a KDF is ever introduced, `toRaw` stays true (it still returns
+   * the seed) while a hypothetical `toEntropy` would silently start lying.
+   *
+   * Like `toPkcs8()`, only noble implementations can do this — WebCrypto hides
+   * the private key material — and it throws otherwise.
+   */
   toRaw(): Uint8Array {
     return this.#keypair.toRaw();
   }

--- a/packages/identity/src/key-store.ts
+++ b/packages/identity/src/key-store.ts
@@ -27,7 +27,7 @@ export class KeyStore {
     this.#db = db;
   }
 
-  // Get the `name` keypair.
+  /** Gets the `name` keypair. */
   async get(name: string): Promise<Identity | void> {
     const result = await this.#db.get(name);
     if (result) {
@@ -36,12 +36,12 @@ export class KeyStore {
     return result;
   }
 
-  // Set the `name` keypair with `value`.
+  /** Sets the `name` keypair to `value`. */
   async set(name: string, value: Identity): Promise<undefined> {
     await this.#db.set(name, storedFromKeyPair(value.keyPair));
   }
 
-  // Clear the key store's table.
+  /** Clears the key store's table. */
   clear(): Promise<void> {
     return this.#db.clear();
   }
@@ -51,8 +51,10 @@ export class KeyStore {
     return DEFAULT_DB_NAME;
   }
 
-  // Opens a new instance of `KeyStore`.
-  // If no `name` provided, `KeyStore.DEFAULT_DB_NAME` is used.
+  /**
+   * Opens a new instance of `KeyStore`. If no `name` is provided,
+   * `KeyStore.DEFAULT_DB_NAME` is used.
+   */
   static async open(name = KeyStore.DEFAULT_DB_NAME): Promise<KeyStore> {
     const db = await DB.open(name, DB_VERSION, (event: Event) => {
       const e = event as IDBVersionChangeEvent;

--- a/packages/identity/src/pass-key.ts
+++ b/packages/identity/src/pass-key.ts
@@ -36,10 +36,12 @@ export class PassKey {
     return this.#credentials.id;
   }
 
-  // Generate a root key from a `PassKey`.
-  // A root key identity is deterministically derived from a `PassKey`'s
-  // PRF output, a 32-byte hash, which is used as ed25519 key material.
-  // Note: Root keys can only be created from PassKeys obtained via PassKey.get()
+  /**
+   * Generates a root key from this `PassKey`. A root key identity is
+   * deterministically derived from a `PassKey`'s PRF output, a 32-byte hash,
+   * which is used as ed25519 key material. Root keys can only be created from
+   * a `PassKey` obtained via `PassKey.get()`.
+   */
   async createRootKey(): Promise<Identity> {
     const seed = this.#prf();
     if (!seed) {
@@ -51,7 +53,7 @@ export class PassKey {
     return await Identity.fromRaw(seed);
   }
 
-  // Return the secret 32-bytes derived from the passkey's PRF data.
+  /** Returns the secret 32 bytes derived from the passkey's PRF data. */
   #prf(): Uint8Array | null {
     // PRF results are only available when calling `get()`,
     // not during key creation.
@@ -64,16 +66,18 @@ export class PassKey {
     }
   }
 
-  // Register a new Passkey with a WebAuthn Authenticator.
-  // In browsers, must be called via a user gesture.
-  //
-  // A passkey may still be created with an authenticator even if the procedure
-  // fails, e.g. the authenticator or browser is missing some needed features that
-  // can only be determined after key creation.
-  //
-  // Different data is available within `PublicKeyCredentials` depending
-  // on whether it was created or retrieved. We need the PRF assertion
-  // only available on "get" requests, so we don't return a `PassKey` here.
+  /**
+   * Registers a new passkey with a WebAuthn authenticator. In browsers, this
+   * must be called via a user gesture.
+   *
+   * A passkey may still be created with an authenticator even if the procedure
+   * fails, e.g. the authenticator or browser is missing some needed features
+   * that can only be determined after key creation.
+   *
+   * Different data is available within `PublicKeyCredentials` depending on
+   * whether it was created or retrieved. We need the PRF assertion only
+   * available on `get` requests, so we don't return a `PassKey` here.
+   */
   static async create(name: string, displayName: string): Promise<PassKey> {
     const challenge = random(32);
     const userId = random(32);
@@ -119,8 +123,10 @@ export class PassKey {
     return new PassKey(result);
   }
 
-  // Retrieve a `PassKey` from a Web Authn authenticator.
-  // In browsers, must be called via a user gesture.
+  /**
+   * Retrieves a `PassKey` from a WebAuthn authenticator. In browsers, this
+   * must be called via a user gesture.
+   */
   static async get({
     userVerification,
     mediation,

--- a/packages/integration/browser.ts
+++ b/packages/integration/browser.ts
@@ -40,8 +40,10 @@ export class Browser {
     this.#timeout = options.timeout;
   }
 
-  // Passthru of `@astral/astral`'s `Browser#newPage`, applying
-  // the browser timeout.
+  /**
+   * Passes through to `@astral/astral`'s `Browser#newPage`, applying the
+   * browser timeout.
+   */
   async newPage(
     url?: string,
     options?: WaitForOptions & SandboxOptions & UserAgentOptions,
@@ -57,25 +59,29 @@ export class Browser {
     return page;
   }
 
-  // The browser-level CDP websocket endpoint. Chrome supports multiple
-  // concurrent CDP clients, so a second connection (e.g. for CPU profiling
-  // via `cdp-profiler.ts`) can attach alongside Astral's.
+  /**
+   * Returns the browser-level CDP websocket endpoint. Chrome supports multiple
+   * concurrent CDP clients, so a second connection (e.g. for CPU profiling via
+   * `cdp-profiler.ts`) can attach alongside Astral's.
+   */
   wsEndpoint(): string {
     this.#checkIsOk();
     return this.#process!.wsEndpoint();
   }
 
-  // Closes the browser and removes its profile directory.
-  //
-  // The removal follows the close rather than running beside it. Chrome
-  // recreates the directory `--user-data-dir` names, every missing parent
-  // included, whenever it writes into it, so a removal that overlapped one of
-  // the processes the browser started would put the directory back.
-  //
-  // The browser is given up before the wait rather than after it, so that a
-  // page opened while this is running is refused rather than opened on a
-  // browser that is going away. A close that fails hands it back, so a caller
-  // whose browser stopped but whose directory stayed can close again.
+  /**
+   * Closes the browser and removes its profile directory.
+   *
+   * The removal follows the close rather than running beside it. Chrome
+   * recreates the directory `--user-data-dir` names, every missing parent
+   * included, whenever it writes into it, so a removal that overlapped one of
+   * the processes the browser started would put the directory back.
+   *
+   * The browser is given up before the wait rather than after it, so that a
+   * page opened while this is running is refused rather than opened on a
+   * browser that is going away. A close that fails hands it back, so a caller
+   * whose browser stopped but whose directory stayed can close again.
+   */
   async close(): Promise<void> {
     this.#checkIsOk();
     const process = this.#process!;

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -123,7 +123,7 @@ export class Page extends EventTarget {
   /**
    * Rewrites the contents' `console.*` methods to stringify objects. The
    * Astral console handler only provides a concatenated string of all console
-   * arguments, with objects represented as `undefined`. Calling this method
+   * arguments, with objects represented as `"undefined"`. Calling this method
    * after navigating to a fresh document will properly stringify objects in
    * `ConsoleEvent#detail.text`.
    *
@@ -260,7 +260,7 @@ export class Page extends EventTarget {
   }
 
   /**
-   * Astral's keyboard, with `type` patched to apply the configured default
+   * Astral's keyboard, with `type()` patched to apply the configured default
    * delay when a call omits one.
    */
   get keyboard(): Keyboard {
@@ -656,7 +656,7 @@ export class Page extends EventTarget {
   /**
    * Exposes a CDP binding named `name` on the page's global object. Calling
    * `globalThis[name](payload)` in the page produces a `Runtime.bindingCalled`
-   * notification that `onBindingCalled` delivers to the test process. This is
+   * notification that `onBindingCalled()` delivers to the test process. This is
    * how an in-page notifier signals the moment a condition holds without the
    * test polling the DOM.
    */

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -120,17 +120,19 @@ export class Page extends EventTarget {
     return this.#page!.dispatchEvent(event);
   }
 
-  // Extended method: Rewrites the contents' `console.*` methods to stringify
-  // objects. The astral console handler only provides a concatenated
-  // string of all console arguments, with objects represented as `"undefined"`.
-  // Calling this method after navigating to a fresh document will properly
-  // stringify objects in `ConsoleEvent#detail.text`.
-  //
-  // It also retains a bounded in-page tail of every formatted console message
-  // on `globalThis.__cfConsoleTail` ({ t, method, text } entries, oldest
-  // dropped). A failure probe evaluated in the page can include that tail, so
-  // a timeout error reports what the page logged around the stall without the
-  // test having to pipe the whole console stream.
+  /**
+   * Rewrites the contents' `console.*` methods to stringify objects. The
+   * Astral console handler only provides a concatenated string of all console
+   * arguments, with objects represented as `undefined`. Calling this method
+   * after navigating to a fresh document will properly stringify objects in
+   * `ConsoleEvent#detail.text`.
+   *
+   * It also retains a bounded in-page tail of every formatted console message
+   * on `globalThis.__cfConsoleTail` (`{ t, method, text }` entries, oldest
+   * dropped). A failure probe evaluated in the page can include that tail, so
+   * a timeout error reports what the page logged around the stall without the
+   * test having to pipe the whole console stream.
+   */
   async applyConsoleFormatter() {
     this.#checkIsOk();
 
@@ -190,7 +192,7 @@ export class Page extends EventTarget {
     }, { args: [trueConsoleKey, methods] });
   }
 
-  // Extended method: Takes a screenshot, storing the result at `filename`.
+  /** Takes a screenshot, storing the result at `filename`. */
   async screenshot(
     filename: string,
     options?: ScreenshotOptions,
@@ -200,8 +202,10 @@ export class Page extends EventTarget {
     return Deno.writeFile(filename, screenshot);
   }
 
-  // Extended method: Takes a screenshot and HTML capture, storing
-  // the timestamped artifacts in the provided `snapshotDir`.
+  /**
+   * Takes a screenshot and HTML capture, storing the timestamped artifacts in
+   * the provided `snapshotDir`.
+   */
   async snapshot(snapshotName: string, snapshotDir: string): Promise<void> {
     this.#checkIsOk();
     ensureDirSync(snapshotDir);
@@ -222,8 +226,10 @@ export class Page extends EventTarget {
     console.log(`→ Snapshot saved: ${filePrefix}`);
   }
 
-  // Extended method: Waits for `selector` to contain matching `text`.
-  // Times out after page `timeout` settings.
+  /**
+   * Waits for `selector` to contain matching `text`. Times out after the
+   * page's `timeout` settings.
+   */
   async waitForSelectorWithText(
     selector: string,
     text: string,
@@ -244,15 +250,19 @@ export class Page extends EventTarget {
     }
   }
 
-  // The Astral page this wraps. Everything this class does goes through it, so
-  // a caller that replaces something on it changes what this page does.
+  /**
+   * The Astral page this wraps. Everything this class does goes through it, so
+   * a caller that replaces something on it changes what this page does.
+   */
   get astralPage(): AstralPage {
     this.#checkIsOk();
     return this.#page!;
   }
 
-  // Returns Astral's keyboard with `type` patched to apply the configured
-  // default delay when a call omits one.
+  /**
+   * Astral's keyboard, with `type` patched to apply the configured default
+   * delay when a call omits one.
+   */
   get keyboard(): Keyboard {
     this.#checkIsOk();
     const keyboard = this.#page!.keyboard;
@@ -285,11 +295,13 @@ export class Page extends EventTarget {
     this.#defaultTypeDelay = delay;
   }
 
-  // Registers `hook` to run before this page's current document goes away:
-  // a navigation, a reload, or the page closing. Hooks run in the order they
-  // were added, and the returned function removes this one. Anything held in
-  // the document's realm — the runtime worker and what it has accumulated —
-  // is still reachable from a hook and gone once it returns.
+  /**
+   * Registers `hook` to run before this page's current document goes away: a
+   * navigation, a reload, or the page closing. Hooks run in the order they were
+   * added, and the returned function removes this one. Anything held in the
+   * document's realm — the runtime worker and what it has accumulated — is
+   * still reachable from a hook and gone once it returns.
+   */
   addBeforeUnloadHook(hook: () => Promise<void> | void): () => void {
     this.#beforeUnload.push(hook);
     return () => {
@@ -308,11 +320,13 @@ export class Page extends EventTarget {
     }
   }
 
-  // Registers `hook` to run after every navigation this page performs, once
-  // the navigation itself has settled. Hooks run in the order they were added,
-  // and the returned function removes this one. A page carries several at a
-  // time: the shell driver waits here for the shell to finish booting, and a
-  // presentation run starts its recorder here.
+  /**
+   * Registers `hook` to run after every navigation this page performs, once the
+   * navigation itself has settled. Hooks run in the order they were added, and
+   * the returned function removes this one. A page carries several at a time:
+   * the shell driver waits here for the shell to finish booting, and a
+   * presentation run starts its recorder here.
+   */
   addAfterNavigationHook(hook: () => Promise<void> | void): () => void {
     this.#afterNavigation.push(hook);
     return () => {
@@ -375,7 +389,7 @@ export class Page extends EventTarget {
     return () => celestial.removeEventListener("Page.screencastFrame", handler);
   }
 
-  // Passthru of `@astral/astral`'s `Page#evaluate`
+  /** Passes through to `@astral/astral`'s `Page#evaluate`. */
   async evaluate<T, R extends readonly unknown[]>(
     evaluate: EvaluateFunction<T, R>,
     evaluateOptions?: EvaluateOptions<R>,
@@ -384,8 +398,10 @@ export class Page extends EventTarget {
     return await this.#page!.evaluate(evaluate, evaluateOptions);
   }
 
-  // Navigates through the browser protocol and waits for the requested
-  // lifecycle event.
+  /**
+   * Navigates through the browser protocol and waits for the requested
+   * lifecycle event.
+   */
   async goto(url: string, options?: NavigationOptions): Promise<void> {
     this.#checkIsOk();
     await this.#runNavigation(() => this.#navigate(url, options));
@@ -589,7 +605,7 @@ export class Page extends EventTarget {
     await this.#runAfterNavigationHooks();
   }
 
-  // Passthru of `@astral/astral`'s `Page#reload`
+  /** Passes through to `@astral/astral`'s `Page#reload`. */
   async reload(options?: WaitForOptions): Promise<void> {
     this.#checkIsOk();
     await this.#runNavigation(async () => {
@@ -598,11 +614,13 @@ export class Page extends EventTarget {
     });
   }
 
-  // Passthru of `@astral/astral`'s `Page#waitForSelector`.
-  //
-  // With `strategy: "pierce"` the wait is driven by page events and takes no
-  // timeout, and it resolves against the same elements `$` with that strategy
-  // returns: light-DOM elements and elements inside open shadow roots alike.
+  /**
+   * Passes through to `@astral/astral`'s `Page#waitForSelector`.
+   *
+   * With `strategy: "pierce"` the wait is driven by page events and takes no
+   * timeout, and it resolves against the same elements `$` with that strategy
+   * returns: light-DOM elements and elements inside open shadow roots alike.
+   */
   async waitForSelector(
     selector: string,
     options?: WaitForSelectorOptions & SelectorOptions,
@@ -626,7 +644,7 @@ export class Page extends EventTarget {
     );
   }
 
-  // Passthru of `@astral/astral`'s `Page#waitForFunction`
+  /** Passes through to `@astral/astral`'s `Page#waitForFunction`. */
   async waitForFunction<T, R extends readonly unknown[]>(
     func: EvaluateFunction<T, R>,
     evaluateOptions?: EvaluateOptions<R>,
@@ -635,11 +653,13 @@ export class Page extends EventTarget {
     await this.#page!.waitForFunction(func, evaluateOptions);
   }
 
-  // Expose a CDP binding named `name` on the page's global object. Calling
-  // `globalThis[name](payload)` in the page produces a `Runtime.bindingCalled`
-  // notification that `onBindingCalled` delivers to the test process. This is
-  // how an in-page notifier signals the moment a condition holds without the
-  // test polling the DOM.
+  /**
+   * Exposes a CDP binding named `name` on the page's global object. Calling
+   * `globalThis[name](payload)` in the page produces a `Runtime.bindingCalled`
+   * notification that `onBindingCalled` delivers to the test process. This is
+   * how an in-page notifier signals the moment a condition holds without the
+   * test polling the DOM.
+   */
   async addBinding(name: string): Promise<void> {
     this.#checkIsOk();
     await this.#page!.unsafelyGetCelestialBindings().Runtime.addBinding({
@@ -647,9 +667,11 @@ export class Page extends EventTarget {
     });
   }
 
-  // Unsubscribe the current connection from a binding's notifications. The
-  // bound function may remain on the page's global object; the unique per-wait
-  // name keeps that harmless.
+  /**
+   * Unsubscribes the current connection from a binding's notifications. The
+   * bound function may remain on the page's global object; the unique per-wait
+   * name keeps that harmless.
+   */
   async removeBinding(name: string): Promise<void> {
     this.#checkIsOk();
     await this.#page!.unsafelyGetCelestialBindings().Runtime.removeBinding({
@@ -657,8 +679,11 @@ export class Page extends EventTarget {
     });
   }
 
-  // Subscribe to every `Runtime.bindingCalled` notification, invoking `listener`
-  // with the binding name and its payload. Returns an unsubscribe function.
+  /**
+   * Subscribes to every `Runtime.bindingCalled` notification, invoking
+   * `listener` with the binding name and its payload. Returns an unsubscribe
+   * function.
+   */
   onBindingCalled(
     listener: (name: string, payload: string) => void,
   ): () => void {
@@ -674,7 +699,7 @@ export class Page extends EventTarget {
       celestial.removeEventListener("Runtime.bindingCalled", handler);
   }
 
-  // Passthru of `@astral/astral`'s `Page#$`
+  /** Passes through to `@astral/astral`'s `Page#$`. */
   async $(
     selector: string,
     opts?: SelectorOptions,
@@ -686,7 +711,7 @@ export class Page extends EventTarget {
     return this.#decorateElement(element);
   }
 
-  // Passthru of `@astral/astral`'s `Page#$$`
+  /** Passes through to `@astral/astral`'s `Page#$$`. */
   async $$(selector: string, opts?: SelectorOptions): Promise<ElementHandle[]> {
     this.#checkIsOk();
     const elements = opts?.strategy === "pierce"
@@ -695,15 +720,17 @@ export class Page extends EventTarget {
     return elements.map((element) => this.#decorateElement(element));
   }
 
-  // Extended method: Dispatch one trusted click at a viewport point.
-  //
-  // For a caller that has already worked out where to click — a wait that
-  // measured its target at the instant the target was ready, say — this is the
-  // dispatch on its own. A caller whose target can move may provide a function
-  // that refreshes the point after the interaction observer has finished.
-  // The interaction observer sees this dispatch as it sees an element's, with
-  // no element to name, so a presentation recording still moves and pulses its
-  // cursor over a click aimed by coordinates.
+  /**
+   * Dispatches one trusted click at a viewport point.
+   *
+   * For a caller that has already worked out where to click — a wait that
+   * measured its target at the instant the target was ready, say — this is the
+   * dispatch on its own. A caller whose target can move may provide a function
+   * that refreshes the point after the interaction observer has finished. The
+   * interaction observer sees this dispatch as it sees an element's, with no
+   * element to name, so a presentation recording still moves and pulses its
+   * cursor over a click aimed by coordinates.
+   */
   async clickPoint(
     point: { x: number; y: number },
     options?: { refreshPoint?: () => Promise<{ x: number; y: number }> },
@@ -717,7 +744,7 @@ export class Page extends EventTarget {
     );
   }
 
-  // Passthru of `@astral/astral`'s `Page#close`
+  /** Passes through to `@astral/astral`'s `Page#close`. */
   async close() {
     this.#checkIsOk();
     await this.#runBeforeUnloadHooks();
@@ -823,10 +850,12 @@ export class Page extends EventTarget {
     );
   }
 
-  // Dispatch one trusted click at `point`, with the interaction observer told
-  // before and after. The point can be refreshed after the observer has
-  // finished. The observer's failure is reported only when the click itself
-  // succeeded, so a recording problem never masks a click problem.
+  /**
+   * Dispatches one trusted click at `point`, with the interaction observer told
+   * before and after. The point can be refreshed after the observer has
+   * finished. The observer's failure is reported only when the click itself
+   * succeeded, so a recording problem never masks a click problem.
+   */
   async #dispatchObservedClick(
     element: ElementHandle | undefined,
     point: { x: number; y: number },

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -280,8 +280,10 @@ export class ShellIntegration {
     return this.#page!;
   }
 
-  // Browser-level CDP websocket endpoint, for attaching a second CDP client
-  // (e.g. `CdpWorkerProfiler`).
+  /**
+   * Returns the browser-level CDP websocket endpoint, for attaching a second
+   * CDP client (e.g. `CdpWorkerProfiler`).
+   */
   wsEndpoint(): string {
     this.#checkIsOk();
     return this.#browser!.wsEndpoint();
@@ -307,7 +309,7 @@ export class ShellIntegration {
     });
   }
 
-  // Login to the initialized app with provided identity.
+  /** Logs in to the initialized app with the provided `identity`. */
   async login(identity: Identity): Promise<void> {
     await login(this.page(), identity);
   }
@@ -316,12 +318,14 @@ export class ShellIntegration {
     await this.#disposePageRuntime();
   }
 
-  // Wait for the shell's app state to hold this view, and this identity where
-  // one is given. Throws if the wait runs out.
-  //
-  // The view is matched whole, field for field: a state matches when its view
-  // holds the same fields this one holds. A view naming only a space is
-  // matched by the state of a space with no piece open.
+  /**
+   * Waits for the shell's app state to hold this view, and this identity
+   * where one is given. Throws if the wait runs out.
+   *
+   * The view is matched whole, field for field: a state matches when its view
+   * holds the same fields this one holds. A view naming only a space is matched
+   * by the state of a space with no piece open.
+   */
   async waitForState(
     params: {
       view: AppView;
@@ -374,17 +378,17 @@ export class ShellIntegration {
     return state;
   }
 
-  // Navigates to the URL represented by `frontendUrl`,
-  // `spaceName`, and `pieceId`. Waits for state to settle
-  // reflecting these properties.
-  //
-  // `urlPath` sends a different spelling of the same address: the rooted path
-  // to navigate to, where the caller is checking a form the shell reads but
-  // does not write. `view` remains the state this waits for, so such a caller
-  // states what it sends and what that has to reach as two separate things.
-  //
-  // If `identity` provided, logs in with the identity
-  // after navigation.
+  /**
+   * Navigates to the URL represented by `frontendUrl`, `spaceName`, and
+   * `pieceId`. Waits for state to settle reflecting these properties.
+   *
+   * `urlPath` sends a different spelling of the same address: the rooted path
+   * to navigate to, where the caller is checking a form the shell reads but
+   * does not write. `view` remains the state this waits for, so such a caller
+   * states what it sends and what that has to reach as two separate things.
+   *
+   * If `identity` is provided, logs in with the identity after navigation.
+   */
   async goto(
     { frontendUrl, view, urlPath, identity }: {
       frontendUrl: string;

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -379,8 +379,8 @@ export class ShellIntegration {
   }
 
   /**
-   * Navigates to the URL represented by `frontendUrl`, `spaceName`, and
-   * `pieceId`. Waits for state to settle reflecting these properties.
+   * Navigates to the URL that `frontendUrl` and `view` represent, and waits
+   * for state to settle reflecting `view`.
    *
    * `urlPath` sends a different spelling of the same address: the rooted path
    * to navigate to, where the caller is checking a form the shell reads but

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -759,16 +759,18 @@ export class SpaceSession {
   #background = new Set<Promise<void>>();
 
   /**
-   * Watch-mutation ordering: serializes the _application_ of watch responses
-   * (the `#watchSpecs` / `#watchView` mutations) in call order. `#watchIssue`
-   * serializes request _issue_ in call order and, in concurrent mode, advances
-   * as soon as a request has been _sent_ (not answered), so multiple watch
-   * round trips overlap on the wire while application stays ordered. In
-   * single-flight mode `#watchIssue` is unused and each mutation's request and
-   * apply run together on `#watchApply`.
+   * Serializes the _application_ of watch responses (the `#watchSpecs` /
+   * `#watchView` mutations) in call order, so application stays ordered even
+   * when round trips overlap on the wire.
    */
   #watchApply: Promise<void> = Promise.resolve();
 
+  /**
+   * Serializes request _issue_ in call order; in concurrent mode it advances
+   * as soon as a request has been _sent_ (not answered), so multiple watch
+   * round trips overlap on the wire. In single-flight mode it is unused and
+   * each mutation's request and apply run together on `#watchApply`.
+   */
   #watchIssue: Promise<void> = Promise.resolve();
 
   /**

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -196,12 +196,16 @@ export class Client {
   #cancelReconnectDelay: (() => void) | null = null;
   #connected = false;
   #closed = false;
-  // Set when a reconnect handshake fails for a reason retrying cannot change (a
-  // protocol-flag mismatch — the transport is fundamentally incompatible). The
-  // client stops reconnecting and fails every further request with it, instead
-  // of looping forever. A per-session authorization denial does NOT land here:
-  // it terminates only that session (see SpaceSession.restore), leaving sessions
-  // for other spaces on this client alive.
+
+  /**
+   * The error that ended reconnection, set when a reconnect handshake fails
+   * for a reason retrying cannot change (a protocol-flag mismatch — the
+   * transport is fundamentally incompatible). The client stops reconnecting
+   * and fails every further request with it, instead of looping forever. A
+   * per-session authorization denial does _not_ land here: it terminates only
+   * that session (see `SpaceSession.restore()`), leaving sessions for other
+   * spaces on this client alive.
+   */
   #fatalError: Error | null = null;
 
   /**
@@ -691,11 +695,13 @@ export class Client {
     }
   }
 
-  // The reconnect attempt is event-driven: `hello()` awaits the transport's
-  // real open/error/close. The pause between a failed attempt and the next
-  // runs on a timer, since a returning server raises no event to await. The
-  // delay bounds the retry rate, and `close()` ends it through the stored
-  // canceller.
+  /**
+   * Waits `delayMs` between a failed reconnect attempt and the next. The
+   * reconnect attempt itself is event-driven: `hello()` awaits the transport's
+   * real open/error/close. The pause runs on a timer, since a returning server
+   * raises no event to await. The delay bounds the retry rate, and `close()`
+   * ends it through the stored canceller.
+   */
   #waitForReconnectDelay(delayMs: number): Promise<void> {
     if (this.#closed) {
       return Promise.resolve();
@@ -751,20 +757,28 @@ export class SpaceSession {
   #ackScheduled = false;
   #ackFlushing = false;
   #background = new Set<Promise<void>>();
-  // Watch-mutation ordering. `#watchApply` serializes the APPLICATION of watch
-  // responses (the `#watchSpecs` / `#watchView` mutations) in call order.
-  // `#watchIssue` serializes REQUEST ISSUE in call order and, in concurrent
-  // mode, advances as soon as a request has been *sent* (not answered), so
-  // multiple watch round trips overlap on the wire while application stays
-  // ordered. In single-flight mode `#watchIssue` is unused and each mutation's
-  // request+apply run together on `#watchApply` (byte-identical to the pre-
-  // concurrency behavior).
+
+  /**
+   * Watch-mutation ordering: serializes the _application_ of watch responses
+   * (the `#watchSpecs` / `#watchView` mutations) in call order. `#watchIssue`
+   * serializes request _issue_ in call order and, in concurrent mode, advances
+   * as soon as a request has been _sent_ (not answered), so multiple watch
+   * round trips overlap on the wire while application stays ordered. In
+   * single-flight mode `#watchIssue` is unused and each mutation's request and
+   * apply run together on `#watchApply`.
+   */
   #watchApply: Promise<void> = Promise.resolve();
+
   #watchIssue: Promise<void> = Promise.resolve();
-  // Per-session (default off): allow watch-refresh round trips to overlap.
-  // Set by the runner from the `experimentalConcurrentWatchRefresh` storage
-  // setting; see docs/development/EXPERIMENTAL_OPTIONS.md. NOT a process global.
+
+  /**
+   * Whether watch-refresh round trips may overlap (default off). Per-session,
+   * _not_ a process global. Set by the runner from the
+   * `experimentalConcurrentWatchRefresh` storage setting; see
+   * `docs/development/EXPERIMENTAL_OPTIONS.md`.
+   */
   #concurrentWatchRefresh = false;
+
   #closed = false;
   #closeError: Error | null = null;
   #readyOnConnection = true;
@@ -788,12 +802,16 @@ export class SpaceSession {
    * session at restore rather than silently degrading (see `restore`). */
   holdingsProvider: (() => SessionHolding[] | undefined) | undefined;
 
-  // Highest caughtUpLocalSeq already pushed into the WatchView (via a real sync
-  // or a synthetic forward). Subscribers such as runner storage only advance
-  // their own caught-up seq from emitted syncs, so a resume that promotes
-  // caughtUpLocalSeq via the top-level SessionOpenResult field (no sync) must
-  // be forwarded explicitly or their conflict-retry waiters strand.
+  /**
+   * Highest `caughtUpLocalSeq` already pushed into the `WatchView` (via a real
+   * sync or a synthetic forward). Subscribers such as runner storage only
+   * advance their own caught-up seq from emitted syncs, so a resume that
+   * promotes `caughtUpLocalSeq` via the top-level `SessionOpenResult` field
+   * (no sync) must be forwarded explicitly or their conflict-retry waiters
+   * strand.
+   */
   #forwardedCaughtUpLocalSeq = 0;
+
   #caughtUpLocalSeqWaiters: {
     localSeq: number;
     pending: PromiseWithResolvers<void>;
@@ -1570,11 +1588,13 @@ export class SpaceSession {
     }
   }
 
-  // Forward a caught-up marker to WatchView subscribers when it was delivered
-  // out-of-band (top-level SessionOpenResult.caughtUpLocalSeq on resume) rather
-  // than via a sync they already observed. Emits an empty caught-up sync so
-  // downstream waiters (notably runner storage's read-repair gate) resolve
-  // instead of stranding after a reconnect.
+  /**
+   * Forwards a caught-up marker to `WatchView` subscribers when it was
+   * delivered out-of-band (the top-level `SessionOpenResult.caughtUpLocalSeq`
+   * on resume) rather than via a sync they already observed. Emits an empty
+   * caught-up sync so downstream waiters (notably runner storage's read-repair
+   * gate) resolve instead of stranding after a reconnect.
+   */
   #forwardCaughtUpLocalSeqToWatchers(
     localSeq: number | undefined,
   ): void {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1390,31 +1390,42 @@ export class Server {
   #queryEvaluationCaches = new Map<string, QueryEvaluationCache>();
 
   #engines = new Map<string, Promise<Engine.Engine>>();
-  // The resolved-engine index for the SYNC cross-engine lease lookup
-  // (server-execution v2 Phase 5; see openEngine / #liveCoHostedLeaseSpaceFor).
+
+  /**
+   * The resolved-engine index for the synchronous cross-engine lease lookup;
+   * see `openEngine()`.
+   */
   #resolvedEngines = new Map<string, Engine.Engine>();
 
   /** Holds `documentCacheTotalBudgetBytes` across this server's engines and
    * keeps their recency; every engine this server opens reports to it. */
   #documentCacheCoordinator: Engine.DocumentCacheCoordinator;
-  // Synthesized session state for direct out-of-band document writes, such as blob uploads.
+
+  /**
+   * Synthesized session state for direct out-of-band document writes, such as
+   * blob uploads.
+   */
   #directSessionId = `server:${crypto.randomUUID()}`;
+
   #directLocalSeq = 0;
   #dirtySpaces = new Set<string>();
   #dirtyDocsBySpace = new Map<string, Set<string>>();
   #dirtyOriginsBySpace = new Map<string, Map<string, DirtyOrigin>>();
-  // Push priority (Phase 6, protocol.md §3): the subset of each space's
-  // dirty keys whose LATEST novelty came from a `derived` commit — a
-  // PARALLEL annotation, deliberately not a `DirtyOrigin` field: the
-  // origin record is load-bearing for own-echo suppression and is
-  // DELETED on mixed provenance (CT-1927), which must not erase the
-  // priority class. Populated only by `noteExecutorCommit` (the wave
-  // commits), consumed and cleared with the dirty batch, re-merged by
-  // the requeue arm on fan-out failure. A key later re-dirtied by an
-  // authored commit stays in the set — the doc still carries derived
-  // novelty the subscriber has not seen, and priority is best-effort
-  // ordering, never a correctness gate.
+
+  /**
+   * Push priority (`protocol.md` §3): the subset of each space's dirty keys
+   * whose _latest_ novelty came from a `derived` commit — a _parallel_
+   * annotation, deliberately not a `DirtyOrigin` field: the origin record is
+   * load-bearing for own-echo suppression and is _deleted_ on mixed
+   * provenance, which must not erase the priority class. Populated only by
+   * `noteExecutorCommit()` (the wave commits), consumed and cleared with the
+   * dirty batch, re-merged by the requeue arm on fan-out failure. A key later
+   * re-dirtied by an authored commit stays in the set — the doc still carries
+   * derived novelty the subscriber has not seen, and priority is best-effort
+   * ordering, never a correctness gate.
+   */
   #derivedDirtyBySpace = new Map<string, Set<string>>();
+
   #pushPriorityStats: PushPriorityStats = {
     prioritizedSessions: 0,
     followerSessions: 0,
@@ -1422,44 +1433,66 @@ export class Server {
   };
   #refreshTurn: ArmedTurn | null = null;
   #refreshing: Promise<void> | null = null;
-  // Transactions and fan-out share one publication turn per space. A verdict
-  // is sent while its transaction owns the turn, so a sync frame cannot expose
-  // the decision first. Different spaces retain independent turns.
+
+  /**
+   * The publication turn per space, which transactions and fan-out share. A
+   * verdict is sent while its transaction owns the turn, so a sync frame
+   * cannot expose the decision first. Different spaces retain independent
+   * turns.
+   */
   #publicationBySpace = new Map<string, Promise<void>>();
+
   #lastRefreshDurationMs = 0;
-  // The ExecutorHost's in-process observer (serving-loop.md §1 planes
-  // (b)/(d)); undefined until a host attaches. One observer: there is one
-  // host per process.
+
+  /**
+   * The `ExecutorHost`'s in-process observer (`serving-loop.md` §1, planes (b)
+   * and (d)); `undefined` until a host attaches. One observer: there is one
+   * host per process.
+   */
   #serverExecutionObserver: ServerExecutionObserver | undefined;
-  // Per-frame delivery record: the wire strips instance keys (frames
-  // carry scope NAMES), so a delivery rollback cannot recover WHICH
-  // instances a frame carried from the frame alone — a lease holder's
-  // explicit foreign instances would mis-resolve to its own. Keyed by
-  // the frame object (in-process only, never serialized), populated at
-  // frame build, consumed by rollbackUndeliveredSync; a WeakMap so
-  // delivered frames cost nothing.
+
+  /**
+   * Per-frame delivery record: the wire strips instance keys (frames carry
+   * scope _names_), so a delivery rollback cannot recover _which_ instances a
+   * frame carried from the frame alone — a lease holder's explicit foreign
+   * instances would mis-resolve to its own. Keyed by the frame object
+   * (in-process only, never serialized), populated at frame build, consumed by
+   * `rollbackUndeliveredSync()`; a `WeakMap` so delivered frames cost nothing.
+   */
   #deliveredFrameEntries = new WeakMap<SessionEffectMessage, {
     upserts: SessionCacheEntry[];
     removes: SessionCacheEntry[];
   }>();
+
   #store?: URL;
   #operationCodecs: OperationCodecRegistry;
-  // Injected on-disk SQLite sources (Phase 7), keyed by handle cell id. A
-  // registered id is attached read-only from its descriptor path instead of the
-  // cell-derived per-(space,id) file. v1 in-memory; persistence is deferred (see
-  // docs/specs/sqlite-builtin/plans/on-disk-source.md).
+
+  /**
+   * Injected on-disk SQLite sources, keyed by handle cell id. A registered id
+   * is attached read-only from its descriptor path instead of the cell-derived
+   * per-(space, id) file. In-memory only; persistence is deferred (see
+   * `docs/specs/sqlite-builtin/plans/on-disk-source.md`).
+   */
   #diskSources = new DiskSourceRegistry();
-  // Pooled read-only connections (keyed by canonical file path) for SQLite
-  // reads — injected on-disk sources and cell-derived dbs alike run here,
-  // unattached, instead of attach/detach-per-op on the engine connection.
+
+  /**
+   * Pooled read-only connections (keyed by canonical file path) for SQLite
+   * reads — injected on-disk sources and cell-derived dbs alike run here,
+   * unattached, instead of attach/detach-per-op on the engine connection.
+   */
   #readPool = new ReadConnectionPool();
-  // Schemas already created on the write path, keyed by `(space, id, schema)`.
-  // `ensureTables` (additive `CREATE TABLE IF NOT EXISTS` per declared table)
-  // runs only the first time a given schema is seen for a cell-db, not on every
-  // write. Bounded LRU; a miss (eviction / restart) just re-runs ensureTables,
-  // which is idempotent. Keyed by the full schema JSON so a changed declaration
-  // re-ensures (additive migration) with no hash-collision risk.
+
+  /**
+   * Schemas already created on the write path, keyed by `(space, id, schema)`.
+   * `ensureTables()` (additive `CREATE TABLE IF NOT EXISTS` per declared
+   * table) runs only the first time a given schema is seen for a cell-db, not
+   * on every write. Bounded LRU; a miss (eviction or restart) just re-runs
+   * `ensureTables()`, which is idempotent. Keyed by the full schema JSON so a
+   * changed declaration re-ensures (additive migration) with no hash-collision
+   * risk.
+   */
   #ensuredSchemas = new Map<string, true>();
+
   #ensuredSchemasMax = 4096;
 
   #recordSchemaEnsured(key: string): void {
@@ -1996,8 +2029,10 @@ export class Server {
     return null;
   }
 
-  // Writer sessions that de-authorized themselves in a commit: their
-  // session/revoked is held until after the transact verdict goes out.
+  /**
+   * Writer sessions that de-authorized themselves in a commit: their
+   * `session/revoked` is held until after the transact verdict goes out.
+   */
   #deferredSelfRevocations = new Map<string, string | null>();
 
   deliverDeferredSelfRevocation(space: string, sessionId: string): void {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1392,8 +1392,8 @@ export class Server {
   #engines = new Map<string, Promise<Engine.Engine>>();
 
   /**
-   * The resolved-engine index for the synchronous cross-engine lease lookup;
-   * see `openEngine()`.
+   * The resolved-engine index for the synchronous cross-engine lease lookup
+   * in `#liveCoHostedLeaseSpaceFor()`; `openEngine()` populates it.
    */
   #resolvedEngines = new Map<string, Engine.Engine>();
 
@@ -1402,12 +1402,14 @@ export class Server {
   #documentCacheCoordinator: Engine.DocumentCacheCoordinator;
 
   /**
-   * Synthesized session state for direct out-of-band document writes, such as
+   * Synthesized session id for direct out-of-band document writes, such as
    * blob uploads.
    */
   #directSessionId = `server:${crypto.randomUUID()}`;
 
+  /** Local sequence counter for the synthesized direct-write session. */
   #directLocalSeq = 0;
+
   #dirtySpaces = new Set<string>();
   #dirtyDocsBySpace = new Map<string, Set<string>>();
   #dirtyOriginsBySpace = new Map<string, Map<string, DirtyOrigin>>();
@@ -1470,8 +1472,8 @@ export class Server {
   /**
    * Injected on-disk SQLite sources, keyed by handle cell id. A registered id
    * is attached read-only from its descriptor path instead of the cell-derived
-   * per-(space, id) file. In-memory only; persistence is deferred (see
-   * `docs/specs/sqlite-builtin/plans/on-disk-source.md`).
+   * per-(space, id) file. In-memory only: a registration does not survive a
+   * restart.
    */
   #diskSources = new DiskSourceRegistry();
 

--- a/packages/memory/v2/sqlite/disk-source.ts
+++ b/packages/memory/v2/sqlite/disk-source.ts
@@ -27,18 +27,25 @@ export type DiskSourceDescriptor = {
  *  or hijacking the reads of — a handle id resolved in another space. */
 export class DiskSourceRegistry {
   #byKey = new Map<string, DiskSourceDescriptor>();
-  // Cap total entries so a client looping `sqlite.register-disk-source` with
-  // distinct ids cannot grow server memory without bound. Re-registering an
-  // existing `(space, id)` is always allowed (idempotent); only NEW keys past
-  // the cap are rejected — a clear error rather than silent eviction (which
-  // would drop a legitimate source and silently fall back to the cell-db).
+
+  /**
+   * Cap on total entries, so a client looping `sqlite.register-disk-source`
+   * with distinct ids cannot grow server memory without bound. Re-registering
+   * an existing `(space, id)` is always allowed (idempotent); only _new_ keys
+   * past the cap are rejected — a clear error rather than silent eviction
+   * (which would drop a legitimate source and silently fall back to the
+   * cell-db).
+   */
   readonly #maxEntries: number;
 
   constructor(maxEntries = 4096) {
     this.#maxEntries = maxEntries;
   }
 
-  // NUL-separated composite key (`\0` cannot appear in a DID or entity id).
+  /**
+   * Returns the NUL-separated composite key for `space` and `id` (`\0` cannot
+   * appear in a DID or entity id).
+   */
   #key(space: string, id: string): string {
     return `${space}\x00${id}`;
   }

--- a/packages/memory/v2/sqlite/read-pool.ts
+++ b/packages/memory/v2/sqlite/read-pool.ts
@@ -45,9 +45,10 @@ export class ReadConnectionPool {
   }
 
   /**
-   * Returns the pooled connection for `path` in the given mode. Keyed by mode
-   * as well as path: the two modes return different JS values for the same
-   * stored row, so one connection cannot serve both.
+   * Returns the pooled connection for `path` in the given mode, opening one
+   * on a miss and evicting the oldest past `#max`. Keyed by mode as well as
+   * path: the two modes return different JS values for the same stored row,
+   * so one connection cannot serve both.
    */
   #connection(path: string, int64: boolean): Database {
     const key = int64 ? `int64\n${path}` : `plain\n${path}`;

--- a/packages/memory/v2/sqlite/read-pool.ts
+++ b/packages/memory/v2/sqlite/read-pool.ts
@@ -44,8 +44,11 @@ export class ReadConnectionPool {
     this.#max = max;
   }
 
-  // Keyed by mode as well as path: the two modes return different JS values
-  // for the same stored row, so one connection cannot serve both.
+  /**
+   * Returns the pooled connection for `path` in the given mode. Keyed by mode
+   * as well as path: the two modes return different JS values for the same
+   * stored row, so one connection cannot serve both.
+   */
   #connection(path: string, int64: boolean): Database {
     const key = int64 ? `int64\n${path}` : `plain\n${path}`;
     const existing = this.#byPath.get(key);

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -715,10 +715,14 @@ export class RuntimeProcessor {
   #identity: Identity;
   #isDisposed = false;
   #disposingPromise: Promise<void> | undefined;
-  // Cell subscriptions, by the subscribing client's scoped cell key. Two
-  // clients watching one cell are two subscriptions, so that one client's
-  // unsubscribe stops its own feed and no one else's.
+
+  /**
+   * Cell subscriptions, by the subscribing client's scoped cell key. Two
+   * clients watching one cell are two subscriptions, so that one client's
+   * unsubscribe stops its own feed and no one else's.
+   */
   #subscriptions = new Map<string, Cancel>();
+
   #operationSubscriptions = new Map<
     string,
     {
@@ -734,36 +738,55 @@ export class RuntimeProcessor {
     { token: string; prepared: PreparedPieceSourceChange }
   >();
   #telemetry: RuntimeTelemetry;
-  // Whom this runtime acts as and under which enforcement configuration,
-  // fixed by the client that initialized it. A runtime carries exactly one,
-  // and every client attached to it is checked against this one.
+
+  /**
+   * Whom this runtime acts as and under which enforcement configuration, fixed
+   * by the client that initialized it. A runtime carries exactly one, and every
+   * client attached to it is checked against this one.
+   */
   readonly #securityContext: RuntimeSecurityContext;
+
   #telemetryEnabled = false;
   #intentOutcomeCancel: Cancel | undefined;
 
-  // VDOM mounts, by the mounting client's scoped mount id. A mount id comes
-  // from a counter that starts at 1 in each client's own document, so the id
-  // alone names a mount only while there is one client.
+  /**
+   * VDOM mounts, by the mounting client's scoped mount id. A mount id comes
+   * from a counter that starts at 1 in each client's own document, so the id
+   * alone names a mount only while there is one client.
+   */
   #vdomMounts = new Map<
     string,
     { reconciler: WorkerReconciler; cancel: Cancel; client: WorkerClient }
   >();
+
   #vdomBatchIdCounter = 0;
-  // Render-boundary declassification policy applied to every mount's
-  // reconciler, from the initialization data; `allow` when it names none.
+
+  /**
+   * Render-boundary declassification policy applied to every mount's
+   * reconciler, from the initialization data; `allow` when it names none.
+   */
   #renderDeclassificationPolicy: RenderDeclassificationPolicy = "allow";
-  // Host-supplied default render ceiling applied to every mount's
-  // reconciler; undefined when the host set none.
+
+  /**
+   * Host-supplied default render ceiling applied to every mount's reconciler;
+   * `undefined` when the host set none.
+   */
   #renderConfidentialityCeiling?: RenderConfidentialityCeiling;
-  // Runner-side display-boundary resolver, built once from the runtime's
-  // trust config and acting principal when a ceiling is in force. Rewrites a
-  // cell's label through the exchange rules so `Space(...)`-via-`HasRole`
-  // principal forms resolve before the reconciler's ceiling fit.
+
+  /**
+   * Runner-side display-boundary resolver, built once from the runtime's trust
+   * config and acting principal when a ceiling is in force. Rewrites a cell's
+   * label through the exchange rules so `Space(...)`-via-`HasRole` principal
+   * forms resolve before the reconciler's ceiling fit.
+   */
   #renderConfidentialityResolver?: RenderConfidentialityResolver;
-  // The membership provider shared with the resolver above and handed to
-  // every mount's reconciler, so a `Space(X)`-labeled cell blocked before X's
-  // ACL synced re-renders once the ACL grants READ (§4.9.3). Undefined when
-  // no ceiling is in force.
+
+  /**
+   * The membership provider shared with the resolver above and handed to every
+   * mount's reconciler, so a `Space(X)`-labeled cell blocked before X's ACL
+   * synced re-renders once the ACL grants READ (§4.9.3). `undefined` when no
+   * ceiling is in force.
+   */
   #renderMembershipProvider?: SpaceMembershipProvider;
 
   private constructor(
@@ -1273,10 +1296,12 @@ export class RuntimeProcessor {
     return { value: result.ok };
   }
 
-  // A `CellHandle.set` is a blind leaf overwrite (last-write-wins);
-  // `CellHandle.push` sends only appended members and uses Cell.push's native
-  // mergeable operation. The decision is made by METHOD, never by inspecting
-  // the value's shape.
+  /**
+   * Handles a `CellSetRequest`. A `CellHandle.set()` is a blind leaf overwrite
+   * (last-write-wins); `CellHandle.push()` sends only appended members and
+   * uses `Cell.push()`'s native mergeable operation. The decision is made by
+   * _method_, never by inspecting the value's shape.
+   */
   handleCellSet(request: CellSetRequest): void | Promise<void> {
     const commit = this.applyCellSet(request);
     if (request.awaitCommit) return this.#requireCellCommit(commit);
@@ -1556,10 +1581,13 @@ export class RuntimeProcessor {
     };
   }
 
-  // A CellSet is the blind, last-write-wins arm. Runtime.commitUiCellWrite owns
-  // its structural precondition, retry policy, and per-address supersede lane.
-  // Ordinary UI writes remain fire-and-forget, while strict capability writes
-  // can await the same outcome through handleCellSet.
+  /**
+   * Applies a `CellSetRequest`, the blind, last-write-wins arm.
+   * `Runtime.commitUiCellWrite()` owns its structural precondition, retry
+   * policy, and per-address supersede lane. Ordinary UI writes remain
+   * fire-and-forget, while strict capability writes can await the same outcome
+   * through `handleCellSet()`.
+   */
   applyCellSet(request: CellSetRequest) {
     const cell = getCell(this.#runtime, request.cell);
     const value = mapCellRefsToSigilLinks(request.value);
@@ -2003,9 +2031,11 @@ export class RuntimeProcessor {
     return { resolution: result.resolution };
   }
 
-  // Persistence durability, distinct from handleIdle's reactive quiescence:
-  // awaits in-flight compile-cache write-backs so a subsequent load reads the
-  // freshly-written entry instead of recompiling.
+  /**
+   * Awaits in-flight compile-cache write-backs, so a subsequent load reads the
+   * freshly-written entry instead of recompiling. This is persistence
+   * durability, distinct from `handleIdle()`'s reactive quiescence.
+   */
   async handleFlushCompileCacheWrites(): Promise<void> {
     await this.#runtime.patternManager.flushCompileCacheWrites();
   }
@@ -2090,17 +2120,19 @@ export class RuntimeProcessor {
     };
   }
 
-  // Resolves a redirect here rather than through the runner's slug
-  // resolution, which `handleSlugResolve` uses. Do not copy the bare
-  // `parseLink` below into a new caller: a slug cell can be written by a
-  // foreign client over the memory protocol, and `parseSlugRedirect` in
-  // `packages/runner/src/slug-resolution.ts` exists to fold the TypeError a
-  // sigil-shaped payload with broken internals throws into a typed refusal.
-  // These are one walk with two implementations, and this is the copy to
-  // retire.
-  //
-  // TODO(danfuzz): Refuse a cell that is not a piece cell in the surviving
-  // walk, once `parseSlugRedirect` is the one copy.
+  /**
+   * Handles a `PieceGetRequest`. Resolves a redirect here rather than through
+   * the runner's slug resolution, which `handleSlugResolve()` uses. Do not copy
+   * the bare `parseLink()` below into a new caller: a slug cell can be written
+   * by a foreign client over the memory protocol, and `parseSlugRedirect()` in
+   * `packages/runner/src/slug-resolution.ts` exists to fold the `TypeError` a
+   * sigil-shaped payload with broken internals throws into a typed refusal.
+   * These are one walk with two implementations, and this is the copy to
+   * retire.
+   *
+   * TODO(danfuzz): Refuse a cell that is not a piece cell in the surviving
+   * walk, once `parseSlugRedirect` is the one copy.
+   */
   async handlePieceGet(
     request: PieceGetRequest,
   ): Promise<PieceResponse> {

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -2129,13 +2129,12 @@ export class RuntimeProcessor {
    * sigil-shaped payload with broken internals throws into a typed refusal.
    * These are one walk with two implementations, and this is the copy to
    * retire.
-   *
-   * TODO(danfuzz): Refuse a cell that is not a piece cell in the surviving
-   * walk, once `parseSlugRedirect` is the one copy.
    */
   async handlePieceGet(
     request: PieceGetRequest,
   ): Promise<PieceResponse> {
+    // TODO(danfuzz): Refuse a cell that is not a piece cell in the surviving
+    // walk, once `parseSlugRedirect()` is the one copy.
     const cc = this.#getSpaceCtx(request.space);
     // Probed in the scope the request names, because the id alone names a
     // different document in every other scope: reading the default one would

--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -991,10 +991,10 @@ export class CellHandle<T = unknown> {
   }
 
   /**
-   * Serializes `value` into sigil form, which is the same canonical traversal
-   * with hydratable links. It snapshots local values through `applyValue()`
-   * without confusing an ordinary record that happens to resemble a `CellRef`
-   * or replacing a live `CellHandle`.
+   * Serializes `value` for the wire, converting each `CellHandle` to a link
+   * in `linkFormat`: a `CellRef` (`ref`) or a hydratable sigil link (`sigil`).
+   * An ordinary record that happens to resemble a `CellRef` is walked as data,
+   * and a live `CellHandle` is never replaced in place.
    */
   static #serialize(
     value: ClientCellValue,

--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -92,9 +92,13 @@ export class CellHandle<T = unknown> {
   #ref: CellRef;
   #value: T | undefined;
   #cfcLabel: CfcLabelView | undefined;
-  // Whether any subscriber asked for the CFC label. Sticky: once a label-aware
-  // subscription exists on this handle, label changes also fire its callbacks.
+
+  /**
+   * Whether any subscriber asked for the CFC label. Sticky: once a label-aware
+   * subscription exists on this handle, label changes also fire its callbacks.
+   */
   #wantsCfcLabel = false;
+
   #callbacks = new Map<
     number,
     (value: Readonly<T>, cfcLabel: CfcLabelView | undefined) => void
@@ -102,9 +106,12 @@ export class CellHandle<T = unknown> {
   #nextCallbackId = 0;
   #schemaWarned = false;
   #updateGeneration = 0;
-  // Monotonic invocation order for local value mutations on this handle.
-  // Async read and strict-write responses use it to avoid replacing a later
-  // optimistic value while their remote operations remain FIFO-serialized.
+
+  /**
+   * Monotonic invocation order for local value mutations on this handle. Async
+   * read and strict-write responses use it to avoid replacing a later
+   * optimistic value while their remote operations remain FIFO-serialized.
+   */
   #writeGeneration = 0;
 
   constructor(worker: RuntimeClient, cellRef: CellRef, value?: T) {
@@ -421,9 +428,12 @@ export class CellHandle<T = unknown> {
     return child;
   }
 
-  // A push publishes an invocation-time local snapshot, but sends only the
-  // appended members. The runtime owns the authoritative mergeable append, so
-  // an equivalent handle's stale private cache cannot replace committed data.
+  /**
+   * Appends `values` to the array this handle holds. A push publishes an
+   * invocation-time local snapshot, but sends only the appended members. The
+   * runtime owns the authoritative mergeable append, so an equivalent handle's
+   * stale private cache cannot replace committed data.
+   */
   push<U>(
     this: CellHandle<U[]>,
     ...values: T extends (infer U)[] ? U[] : never
@@ -822,8 +832,10 @@ export class CellHandle<T = unknown> {
     });
   }
 
-  // Called when cell has been updated from the backend with
-  // a raw value that may contain CellRefs.
+  /**
+   * Handles an update of the cell from the backend, whose raw value may
+   * contain `CellRef`s.
+   */
   [$onCellUpdate](
     value: unknown,
     labelUpdate?: { cfcLabel: CfcLabelView | undefined },
@@ -978,9 +990,12 @@ export class CellHandle<T = unknown> {
     return CellHandle.#serialize(value, "ref") as FabricValue;
   }
 
-  // The sigil form is the same canonical traversal with hydratable links. It
-  // snapshots local values through applyValue() without confusing an ordinary
-  // record that happens to resemble a CellRef or replacing a live CellHandle.
+  /**
+   * Serializes `value` into sigil form, which is the same canonical traversal
+   * with hydratable links. It snapshots local values through `applyValue()`
+   * without confusing an ordinary record that happens to resemble a `CellRef`
+   * or replacing a live `CellHandle`.
+   */
   static #serialize(
     value: ClientCellValue,
     linkFormat: "ref" | "sigil" = "ref",

--- a/packages/runtime-client/src/client/connection.ts
+++ b/packages/runtime-client/src/client/connection.ts
@@ -169,11 +169,15 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
   #nextMsgId = 0;
   #timeoutMs = DEFAULT_TIMEOUT_MS;
   #initialized = false;
-  // The connection's lifetime. dispose() aborts it; every consumer registers
-  // its teardown against this signal and every in-flight request settles
-  // through it, so there is no disposed state to special-case beyond
-  // `signal.aborted`.
+
+  /**
+   * The connection's lifetime. `dispose()` aborts it; every consumer registers
+   * its teardown against this signal and every in-flight request settles
+   * through it, so there is no disposed state to special-case beyond
+   * `signal.aborted`.
+   */
   #lifetime = new AbortController();
+
   #transport: RuntimeTransport;
   #subscribed = new Map<string, Set<CellHandle>>();
   #subscriptionDiagnostics = new Map<string, SubscriptionCounterTotals>();
@@ -385,8 +389,11 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
     return deferred.promise;
   }
 
-  // Remove a pending request's bookkeeping: clear its timeout and detach its
-  // abort listener. Returns the entry so the caller can settle its deferred.
+  /**
+   * Removes a pending request's bookkeeping: clears its timeout and detaches
+   * its abort listener. Returns the entry so the caller can settle its
+   * deferred.
+   */
   #settle(msgId: number): PendingRequest | undefined {
     const pending = this.#pendingRequests.get(msgId);
     if (!pending) return undefined;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A `//` block sitting directly above a class member and describing that member is a doc comment in the wrong punctuation: it says what the member is or does, which is what `docs/development/code-comment-style.md` § Doc comments has JSDoc form for. This converts the ones in `memory` (19 sites), `identity` (17), `integration` (28), and `runtime-client` (18), one PR of a series that covers the tree outside `packages/patterns`.

Each converted member takes the blank line above its doc comment and the blank line below the member that the guide asks for. Where a member sat in an unbroken run of undocumented fields, as most of `Server`'s and `RuntimeProcessor`'s did, a blank line now separates it from its neighbors.

## What changed inside the comments

The text is carried over as written, with the edits the doc-comment form calls for:

* A method's comment opens with a third-person verb phrase (`Signs`, `Derives`, `Registers`), and a field's or getter's with a noun phrase. Where a method's note opened with rationale and never said what the method does, a sentence saying so now opens it: `Waits \`delayMs\` between a failed reconnect attempt and the next`, `Handles a \`PieceGetRequest\``, `Appends \`values\` to the array this handle holds`.
* `Passthru of ...` on the eight `integration` wrappers reads `Passes through to ...`, and the `Extended method:` label on the five that are not wrappers is gone, since a method that names no Astral counterpart is the extension.
* Identifiers and code-like things take backticks; `SpaceSession.restore()`, `caughtUpLocalSeq`, `WatchView`, `session/revoked`, `{ t, method, text }` among them.
* Emphasis by capitals becomes underscores (`_seed_`, `_latest_`, `_which_`).
* Labels the guide keeps out of comments are gone, the sentence each sat in saying the same thing without it: `Phase 5`, `Phase 6`, `Phase 7`, `(CT-1927)`, `v1`, and `(byte-identical to the pre-concurrency behavior)`, which compared the code to its own past.
* `Server.#resolvedEngines` now names both ends: the lookup that scans it, `#liveCoHostedLeaseSpaceFor()`, and `openEngine()`, which populates it.
* `Identity.sign()`'s comment named its parameter `data`; the parameter is `payload`.

Not touched: the `//` note above `RuntimeClient.getSpaceRootPattern()` in `runtime-client.ts`, which sits a blank line above the doc comment and describes piece operations as a group rather than that method. A section marker there would need to head the first piece operation, which sits earlier in the class, and `resolveSpaceName()` sits inside the region it would title. It is listed with the other residuals in the series' audit.

## How the sites were found

A TypeScript-AST census over every tracked `.ts`/`.tsx` outside `patterns`, vendored types, and generated declarations: for each class member, the `//` blocks in its leading trivia, minus tool directives, section-marker frames, and `TODO`s. A control fixture of nine planted sites and four decoys reported exactly the nine.

## Verification

* Comment-only, by construction and by proof: each changed file transpiles to byte-identical JavaScript with comments stripped, before and after (14 files, 0 differ).
* The census re-run over the changed files reports zero remaining sites; the blank-line-below detector reports two sites in `server.ts`, both of which it also reports on `main` (it reported three there; one of those is fixed here).
* `deno fmt --check`, `deno lint`, and `deno task check` repo-wide, all green.
* `deno task test` in all four packages, all green.

## Review

A `cf-review` pass (report only) found two sentences this PR had introduced that were false against the code, both fixed: `#resolvedEngines` had been repointed from the lookup that scans it to the writer that fills it, on the mistaken belief that the lookup no longer existed; and `CellHandle.#serialize()`'s new opening described only its `sigil` arm and credited it with a call `#pushValues()` makes. Also taken: `#diskSources` states the present fact instead of pointing at a plan document that does not exist; `goto()` names `view` rather than two fields of it; the `TODO` on `handlePieceGet()` sits in the body; `#directLocalSeq` and `#watchIssue` carry the text that was about them; callables take parentheses; and `read-pool.ts`'s `#connection()` says what a miss does.
