### PR TITLE
style(shell): `//` notes that documented a class member are doc comments

### DIFF
--- a/packages/shell/src/lib/global-shortcuts-controller.ts
+++ b/packages/shell/src/lib/global-shortcuts-controller.ts
@@ -20,9 +20,11 @@ type ReactiveAppHost = ReactiveControllerHost & BaseView & { app: AppState };
 export class GlobalShortcutsController implements ReactiveController {
   #host: ReactiveAppHost;
 
-  // Whether the platform's primary shortcut modifier is Command rather than
-  // Control. Read when the host connects, since it depends on `navigator`.
-  // No current binding branches on it; a Cmd/Ctrl shortcut is what does.
+  /**
+   * Whether the platform's primary shortcut modifier is Command rather than
+   * Control. Read when the host connects, since it depends on `navigator`. No
+   * current binding branches on it; a Cmd/Ctrl shortcut is what does.
+   */
   #usesCommandKey = false;
 
   constructor(host: ReactiveAppHost) {

--- a/packages/shell/src/lib/navigation.ts
+++ b/packages/shell/src/lib/navigation.ts
@@ -48,9 +48,8 @@ export class Navigation {
   }
 
   /**
-   * Stops listening. The shell's own `Navigation` lives as long as the page,
-   * so nothing in the application calls this; a caller that builds one around
-   * a fixture needs the four global listeners back.
+   * Stops listening, removing the four global listeners the constructor
+   * added.
    */
   dispose() {
     globalThis.removeEventListener(NAVIGATE_EVENT, this.#onNavigate);

--- a/packages/shell/src/lib/navigation.ts
+++ b/packages/shell/src/lib/navigation.ts
@@ -47,9 +47,11 @@ export class Navigation {
     this.#apply(init);
   }
 
-  // Stop listening. The shell's own `Navigation` lives as long as the page, so
-  // nothing in the application calls this; a caller that builds one around a
-  // fixture needs the four global listeners back.
+  /**
+   * Stops listening. The shell's own `Navigation` lives as long as the page,
+   * so nothing in the application calls this; a caller that builds one around
+   * a fixture needs the four global listeners back.
+   */
   dispose() {
     globalThis.removeEventListener(NAVIGATE_EVENT, this.#onNavigate);
     globalThis.removeEventListener(
@@ -115,13 +117,13 @@ export class Navigation {
     this.#apply(command);
   };
 
-  // Push a new command state to the browser's history.
+  /** Pushes a new command state to the browser's history. */
   #push(command: NavigationCommand) {
     logger.log("Push", command);
     globalThis.history.pushState(command, "", appViewToUrlPath(command));
   }
 
-  // Updates the current browser history state and page with a new title.
+  /** Updates the current browser history state and page with a new title. */
   #replace(command: NavigationCommand, title?: string) {
     logger.log("Replace", command, title);
     globalThis.history.replaceState(
@@ -131,7 +133,7 @@ export class Navigation {
     );
   }
 
-  // Propagates the command state into the App.
+  /** Propagates the command state into the app. */
   #apply(command: NavigationCommand) {
     logger.log("Apply", command);
     this.#app.setView(command);

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -346,8 +346,10 @@ export class XAppView extends BaseView {
     args: () => [this.app, this.rt, this.space],
   });
 
-  // One-shot ?path= deep-link delivery (set after the first send so slug
-  // re-resolutions and task reruns never re-fire it).
+  /**
+   * Whether the one-shot `?path=` deep link has been delivered; set after the
+   * first send so slug re-resolutions and task reruns never re-fire it.
+   */
   #openPathDelivered = false;
 
   /** Deliver a `?path=` deep link into the loaded piece, once.
@@ -483,8 +485,10 @@ export class XAppView extends BaseView {
     args: () => [this.app, this.rt, this.space, this._slugRevision],
   });
 
-  // Derive the active pattern from completed task values so child views never
-  // receive an in-flight or stale selection.
+  /**
+   * Task deriving the active pattern from completed task values, so child
+   * views never receive an in-flight or stale selection.
+   */
   _patterns = new Task(this, {
     task: function (
       [
@@ -902,8 +906,11 @@ export class XAppView extends BaseView {
     }
   }
 
-  // Always defer to the loaded active pattern for the ID,
-  // but until that loads, use an ID in the view if available.
+  /**
+   * Returns the active pattern's id. Always defers to the loaded active
+   * pattern for the id, but until that loads, uses an id in the view if
+   * available.
+   */
   #getActivePatternId(): string | undefined {
     const activePattern = this._patterns.value?.activePattern;
     if (activePattern) return activePattern.id();

--- a/packages/shell/src/views/DeviceLinkView.ts
+++ b/packages/shell/src/views/DeviceLinkView.ts
@@ -163,10 +163,8 @@ export class XDeviceLinkView extends LitElement {
 
   #answered = false;
 
-  /**
-   * Timer guarding the link attempt. `setTimeout` is typed as Node's
-   * `Timeout` under this config, not `number`.
-   */
+  /** Timer which releases the tap-through guard on the accept button. */
+  // `setTimeout` is typed as Node's `Timeout` under this config, not `number`.
   #guardTimer: ReturnType<typeof setTimeout> | undefined;
 
   /** The answer step of this dialog, which a test drives directly. */

--- a/packages/shell/src/views/DeviceLinkView.ts
+++ b/packages/shell/src/views/DeviceLinkView.ts
@@ -162,7 +162,11 @@ export class XDeviceLinkView extends LitElement {
   private accessor guarded = true;
 
   #answered = false;
-  // `setTimeout` is typed as Node's `Timeout` under this config, not `number`.
+
+  /**
+   * Timer guarding the link attempt. `setTimeout` is typed as Node's
+   * `Timeout` under this config, not `number`.
+   */
   #guardTimer: ReturnType<typeof setTimeout> | undefined;
 
   /** The answer step of this dialog, which a test drives directly. */

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -225,10 +225,10 @@ export class XRootView extends BaseView implements ShellApp {
   /**
    * The runtime task, which runs when `AppState` changes and determines if a
    * new `RuntimeInternals` must be created — only when identity or host
-   * (`apiUrl`) change; one runtime serves every space. This is manually run in
-   * `updated()` because we want to compare to previous values, leaving this
-   * task responsible for cleaning up previous runtimes, and creating a new
-   * one.
+   * (`apiUrl`) change; one runtime serves every space. This is run manually,
+   * from `updated()` and after a worker replacement, because we want to
+   * compare to previous values, leaving this task responsible for cleaning up
+   * previous runtimes, and creating a new one.
    */
   #rt = new Task<[AppState | undefined], RuntimeInternals | undefined>(
     this,
@@ -463,9 +463,9 @@ export class XRootView extends BaseView implements ShellApp {
   #spaceResolution: Promise<void> | undefined;
 
   /**
-   * Resolves once the space the current view addresses is known. A view that
-   * names its space resolves that name asynchronously, and addresses no space
-   * until the name lands.
+   * Returns a promise which resolves once the space the current view
+   * addresses is known. A view that names its space resolves that name
+   * asynchronously, and addresses no space until the name lands.
    */
   spaceResolved(): Promise<void> {
     return this.#spaceResolution ?? Promise.resolve();

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -160,10 +160,14 @@ export class XRootView extends BaseView implements ShellApp {
   >();
   #eventAttentionRefreshOwners = new Map<DID, symbol>();
 
-  // Invalidates callbacks from replaced workers. A coded compiler-load error
-  // can arrive through either a request reply or an asynchronous runtime error;
-  // only the currently-owned worker may trigger one replacement.
+  /**
+   * Generation counter which invalidates callbacks from replaced workers. A
+   * coded compiler-load error can arrive through either a request reply or an
+   * asynchronous runtime error; only the currently-owned worker may trigger
+   * one replacement.
+   */
   #runtimeGeneration = 0;
+
   #preserveRuntimeErrorsForNextViewChange = false;
 
   readonly preserveRuntimeErrorsForNextViewChange = (): void => {
@@ -218,11 +222,14 @@ export class XRootView extends BaseView implements ShellApp {
   @state()
   private accessor presenceUrl: string | undefined = PRESENCE_URL?.href;
 
-  // The runtime task runs when AppState changes, and determines if a new
-  // RuntimeInternals must be created — only when identity or host (apiUrl)
-  // change; one runtime serves every space. This is manually run in `updated()`
-  // because we want to compare to previous values, leaving this function
-  // responsible for cleaning up previous runtimes, and creating a new one.
+  /**
+   * The runtime task, which runs when `AppState` changes and determines if a
+   * new `RuntimeInternals` must be created — only when identity or host
+   * (`apiUrl`) change; one runtime serves every space. This is manually run in
+   * `updated()` because we want to compare to previous values, leaving this
+   * task responsible for cleaning up previous runtimes, and creating a new
+   * one.
+   */
   #rt = new Task<[AppState | undefined], RuntimeInternals | undefined>(
     this,
     {
@@ -381,23 +388,28 @@ export class XRootView extends BaseView implements ShellApp {
     super.disconnectedCallback();
   }
 
-  // A page teardown (reload, tab close, external navigation) terminates the
-  // runtime worker, dropping any commit the server has not yet confirmed. The
-  // worker mirrors its pending-commit state to `RuntimeClient.hasPendingWrites`
-  // on every transition, so this synchronous check is current; while writes are
-  // unconfirmed, ask the browser to confirm leaving instead of silently losing
-  // them. Commits confirm quickly (typically well under a second), so the
-  // prompt only appears in the narrow window a reload would actually lose data.
+  /**
+   * Handler for `beforeunload`. A page teardown (reload, tab close, external
+   * navigation) terminates the runtime worker, dropping any commit the server
+   * has not yet confirmed. The worker mirrors its pending-commit state to
+   * `RuntimeClient.hasPendingWrites` on every transition, so this synchronous
+   * check is current; while writes are unconfirmed, this asks the browser to
+   * confirm leaving instead of silently losing them. Commits confirm quickly
+   * (typically well under a second), so the prompt only appears in the narrow
+   * window a reload would actually lose data.
+   */
   #onBeforeUnload = (event: BeforeUnloadEvent): void => {
     if (this.runtime?.hasPendingWrites()) {
       event.preventDefault();
     }
   };
 
-  // Point `space` at the space the new view addresses. This runs before
-  // render, not in updated(), so no render ever pairs a view with the space
-  // of the view it replaced. AppView reads the view and the space together
-  // and treats a space name that disagrees with a space DID as an error.
+  /**
+   * Points `space` at the space the new view addresses. This runs before
+   * render, not in `updated()`, so no render ever pairs a view with the space
+   * of the view it replaced. `XAppView` reads the view and the space together
+   * and treats a space name that disagrees with a space DID as an error.
+   */
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("app")) {
       const previousView = changedProperties.get("app")?.view;
@@ -430,29 +442,40 @@ export class XRootView extends BaseView implements ShellApp {
     }
   }
 
-  // The active browser telemetry sink (undefined when telemetry is disabled
-  // or no runtime); kept only so space.did attribution can track navigation.
+  /**
+   * The active browser telemetry sink (`undefined` when telemetry is disabled
+   * or there is no runtime); kept only so `space.did` attribution can track
+   * navigation.
+   */
   #telemetry: BrowserTelemetry | undefined;
 
-  // The name the current lookup was started for, while the view addresses its
-  // space by name. Navigating within that name keeps the space already
-  // resolved, and keeps a lookup still in flight running. A lookup that fails
-  // clears this, so a later navigation to the same name tries again.
+  /**
+   * The name the current lookup was started for, while the view addresses its
+   * space by name. Navigating within that name keeps the space already
+   * resolved, and keeps a lookup still in flight running. A lookup that fails
+   * clears this, so a later navigation to the same name tries again.
+   */
   #resolvedSpaceName: string | undefined;
-  // Invalidates a resolution that a newer navigation has superseded.
+
+  /** Token which invalidates a resolution a newer navigation has superseded. */
   #resolveSpaceToken = 0;
+
   #spaceResolution: Promise<void> | undefined;
 
-  // Resolves once the space the current view addresses is known. A view that
-  // names its space resolves that name asynchronously, and addresses no space
-  // until the name lands.
+  /**
+   * Resolves once the space the current view addresses is known. A view that
+   * names its space resolves that name asynchronously, and addresses no space
+   * until the name lands.
+   */
   spaceResolved(): Promise<void> {
     return this.#spaceResolution ?? Promise.resolve();
   }
 
-  // Derive the view's space DID — view state, independent of the runtime's
-  // lifecycle. Every path assigns synchronously except a space named by the
-  // view, which has to be looked up.
+  /**
+   * Derives the view's space DID — view state, independent of the runtime's
+   * lifecycle. Every path assigns synchronously except a space named by the
+   * view, which has to be looked up.
+   */
   #syncViewSpace(app: AppState | undefined): void {
     const identity = app?.identity;
     const view = app?.view;
@@ -624,8 +647,11 @@ export class XRootView extends BaseView implements ShellApp {
     this._themePreference = (e as CustomEvent).detail;
   };
 
-  // An event handler cannot await, so a command that fails after its first
-  // suspension point reports as an unhandled rejection.
+  /**
+   * Handler for command events. An event handler cannot await, so a command
+   * that fails after its first suspension point reports as an unhandled
+   * rejection.
+   */
   onCommand = (e: Event) => {
     void this.#runCommand((e as CustomEvent<Command>).detail);
   };
@@ -650,8 +676,10 @@ export class XRootView extends BaseView implements ShellApp {
     return clone(this.app);
   }
 
-  // The application state in the JSON-shaped form that survives the page
-  // boundary the integration harness reads across.
+  /**
+   * Returns the application state in the JSON-shaped form that survives the
+   * page boundary the integration harness reads across.
+   */
   serialize(): AppStateSerialized {
     return serialize(this.state());
   }
@@ -686,8 +714,10 @@ export class XRootView extends BaseView implements ShellApp {
     return this.#commit(next, `set-config ${key}=${value}`);
   }
 
-  // Adopts the next application state and resolves once the render it triggers
-  // has landed.
+  /**
+   * Adopts the next application state and resolves once the render it triggers
+   * has landed.
+   */
   #commit(next: AppState, description: string): Promise<void> {
     this.app = next;
     if (ENVIRONMENT !== "production") {

--- a/packages/shell/src/views/SchedulerGraphView.ts
+++ b/packages/shell/src/views/SchedulerGraphView.ts
@@ -1126,7 +1126,7 @@ export class XSchedulerGraph extends LitElement {
   @state()
   private accessor tableExpandedParents = new Set<string>();
 
-  // When true, sort table by delta values instead of lifetime totals
+  /** Whether to sort the table by delta values instead of lifetime totals. */
   @state()
   private accessor sortByDelta = false;
 
@@ -1150,7 +1150,7 @@ export class XSchedulerGraph extends LitElement {
     );
   }
 
-  // Minimum effective node size before we boost triggered nodes
+  /** Minimum effective node size before we boost triggered nodes. */
   static readonly #READABLE_THRESHOLD = 50;
 
   /** The two action-id label helpers, which a test drives directly. */

--- a/packages/shell/test/error-ipc.test.ts
+++ b/packages/shell/test/error-ipc.test.ts
@@ -30,7 +30,7 @@ class MockTransport extends EventEmitter<TransportEvents>
     return Promise.resolve();
   }
 
-  // Simulate receiving a message from the worker
+  /** Simulates receiving a message from the worker. */
   simulateMessage(msg: IPCRemoteMessage): void {
     this.emit("message", msg);
   }

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -29,8 +29,10 @@ function installBrowserGlobals(): () => void {
     });
   }
   class TestHTMLElement extends EventTarget {
-    // Minimal render root so Lit's connectedCallback (createRenderRoot ->
-    // attachShadow -> adoptStyles) runs without a real DOM.
+    /**
+     * Minimal render root, so Lit's `connectedCallback` (`createRenderRoot`,
+     * then `attachShadow`, then `adoptStyles`) runs without a real DOM.
+     */
     attachShadow() {
       return {
         adoptedStyleSheets: [],

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -30,8 +30,9 @@ function installBrowserGlobals(): () => void {
   }
   class TestHTMLElement extends EventTarget {
     /**
-     * Minimal render root, so Lit's `connectedCallback` (`createRenderRoot`,
-     * then `attachShadow`, then `adoptStyles`) runs without a real DOM.
+     * Returns a minimal render root, so Lit's `connectedCallback`
+     * (`createRenderRoot`, then `attachShadow`, then `adoptStyles`) runs
+     * without a real DOM.
      */
     attachShadow() {
       return {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A `//` block sitting directly above a class member and describing that member is a doc comment in the wrong punctuation: it says what the member is or does, which is what `docs/development/code-comment-style.md` § Doc comments has JSDoc form for. This converts the 25 in `shell`, one PR of a series that covers the tree outside `packages/patterns`.

Each converted member takes the blank line above its doc comment and the blank line below the member that the guide asks for.

## What changed inside the comments

The text is carried over as written, with the edits the doc-comment form calls for:

* A method's comment opens with a third-person verb phrase (`Stops listening`, `Pushes`, `Simulates`), and a field's with a noun phrase. Where a note opened with rationale and never said what the member is, a phrase saying so now opens it: `Generation counter which invalidates ...`, `Handler for \`beforeunload\``, `Timer guarding the link attempt`, `Task deriving the active pattern ...`.
* Identifiers and code-like things take backticks; `?path=`, `updated()`, `AppState`, `space.did` among them.
* `AppView` in a `RootView` comment is named as the class is named, `XAppView`.

Left as `//`: the six group labels over `DebuggerController`'s runs of private fields (`Scheduler graph tracking with historical edges`, `Diagnosis state ...`, and so on). Each heads two to four fields rather than describing one, so a doc comment is the wrong form, and a section marker for each would leave the last marker's region running over the constructor and every method, with nothing in § Classes' marker vocabulary to close it. They are listed with the other residuals in the series' audit.

## How the sites were found

A TypeScript-AST census over every tracked `.ts`/`.tsx` outside `patterns`, vendored types, and generated declarations: for each class member, the `//` blocks in its leading trivia, minus tool directives, section-marker frames, and `TODO`s. A control fixture of nine planted sites and four decoys reported exactly the nine.

## Verification

* Comment-only, by construction and by proof: each changed file transpiles to byte-identical JavaScript with comments stripped, before and after (8 files, 0 differ).
* The census re-run over the changed files reports zero remaining sites; the blank-line-below detector reports none.
* `deno fmt --check`, `deno lint`, and `deno task check` repo-wide, all green.
* `deno task test` in `shell`: 62 passed, 0 failed.

## Review

A `cf-review` pass (report only) found no false statement. Taken: `attachShadow()` opens with a verb phrase; `#guardTimer`'s doc says what the timer does (it releases the tap-through guard) and its typing note sits below the doc comment as mechanics, per "Where one goes"; `dispose()` states its contract without surveying callers; `#rt`'s doc names both places it is run from; `spaceResolved()` says it returns a promise.
