### PR TITLE
style(dashboard, deno-web-test): `//` notes that documented a class member are doc comments

### DIFF
--- a/packages/dashboard/ci-gantt-detail.ts
+++ b/packages/dashboard/ci-gantt-detail.ts
@@ -101,9 +101,13 @@ function parseDetailName(name: string): ParsedName | null {
 }
 
 export class CiGanttDetailStore {
-  // A function defers reading the dashboard cache directory until the first
-  // request, the way the run index defers reading its own file name.
+  /**
+   * The dashboard cache directory, or a function returning it. A function
+   * defers reading the directory until the first request, the way the run
+   * index defers reading its own file name.
+   */
   #directory: string | (() => string) | undefined;
+
   #temporaries = new Set<string>();
 
   constructor(directory?: string | (() => string)) {
@@ -182,10 +186,12 @@ export class CiGanttDetailStore {
     }
   }
 
-  // Drops the attempts of one repository and workflow that `keep` does not
-  // name, and removes temporary files a crashed write left behind. Attempts of
-  // other repositories are left alone, so pruning one source can never take
-  // another's detail. A temporary this process is still writing is left alone.
+  /**
+   * Drops the attempts of one repository and workflow that `keep` does not
+   * name, and removes temporary files a crashed write left behind. Attempts of
+   * other repositories are left alone, so pruning one source can never take
+   * another's detail. A temporary this process is still writing is left alone.
+   */
   async prune(
     source: CiGanttDetailSource,
     keep: Iterable<CachedCiRunReference>,

--- a/packages/dashboard/ci-gantt-detail.ts
+++ b/packages/dashboard/ci-gantt-detail.ts
@@ -102,9 +102,9 @@ function parseDetailName(name: string): ParsedName | null {
 
 export class CiGanttDetailStore {
   /**
-   * The dashboard cache directory, or a function returning it. A function
-   * defers reading the directory until the first request, the way the run
-   * index defers reading its own file name.
+   * The dashboard cache directory, a function returning it, or `undefined`
+   * for the default. A function defers reading the directory until the first
+   * request, the way the run index defers reading its own file name.
    */
   #directory: string | (() => string) | undefined;
 

--- a/packages/dashboard/ci-job-cache.ts
+++ b/packages/dashboard/ci-job-cache.ts
@@ -810,9 +810,12 @@ export class CiJobHistoryStore {
     return this.latest(run.repo, run.workflow, run.runId) ?? run;
   }
 
-  // Every retained attempt of one source, newest first by the time its run
-  // started. Unlike `list`, a run that was attempted more than once contributes
-  // each of its attempts, because each attempt has its own Gantt detail.
+  /**
+   * Returns every retained attempt of one source, newest first by the time
+   * its run started. Unlike `list()`, a run that was attempted more than once
+   * contributes each of its attempts, because each attempt has its own Gantt
+   * detail.
+   */
   attempts(
     repo: string,
     workflow: string,

--- a/packages/dashboard/ci-job-history.ts
+++ b/packages/dashboard/ci-job-history.ts
@@ -2038,9 +2038,9 @@ export class CiJobHistoryCollector {
   /**
    * Returns the subset of `entries` whose step detail reads back, without
    * keeping any of it. An attempt counts as drawable only when its detail
-   * parses, so one
-   * that cannot be read — a format this version does not recognize, a damaged
-   * file — is collected from GitHub again like one that was never stored.
+   * parses, so one that cannot be read — a format this version does not
+   * recognize, a damaged file — is collected from GitHub again like one that
+   * was never stored.
    */
   async #drawableGanttRuns(
     source: CiHistorySource,

--- a/packages/dashboard/ci-job-history.ts
+++ b/packages/dashboard/ci-job-history.ts
@@ -1508,17 +1508,19 @@ export class CiJobHistoryCollector {
     return pending;
   }
 
-  // An attempt keeps its detail for exactly as long as the run index keeps the
-  // attempt. Compression makes an attempt's detail small enough that the whole
-  // retention window fits, so nothing GitHub would have to serve again is
-  // discarded early.
-  //
-  // Passing every attempt the index holds, with no cap of its own, is what
-  // makes pruning safe to run against a chart being assembled: a chart draws
-  // the runs the index names, so the set kept here always covers it. A cap
-  // here would break that, and no amount of coordinating the two would repair
-  // it — a chart would simply be reading files this had already decided to
-  // drop.
+  /**
+   * Drops the Gantt detail of the attempts the run index no longer keeps. An
+   * attempt keeps its detail for exactly as long as the run index keeps the
+   * attempt. Compression makes an attempt's detail small enough that the whole
+   * retention window fits, so nothing GitHub would have to serve again is
+   * discarded early.
+   *
+   * Passing every attempt the index holds, with no cap of its own, is what
+   * makes pruning safe to run against a chart being assembled: a chart draws
+   * the runs the index names, so the set kept here always covers it. A cap here
+   * would break that, and no amount of coordinating the two would repair it — a
+   * chart would simply be reading files this had already decided to drop.
+   */
   async #pruneGanttDetail(source: CiHistorySource): Promise<void> {
     await this.#detail.prune(
       source,
@@ -1998,14 +2000,16 @@ export class CiJobHistoryCollector {
     };
   }
 
-  // Hands each run a chart draws to `visit`, reading one attempt's step detail
-  // at a time and letting go of it before reading the next, so the memory a
-  // chart costs does not grow with its size. The 150 attempts the range slider
-  // allows are around 17 MB of timings between them.
-  //
-  // A run the detail store cannot return is left out, except under an exact
-  // selection, where the caller asked for particular runs and a chart missing
-  // one of them would misrepresent the commit.
+  /**
+   * Hands each run a chart draws to `visit`, reading one attempt's step detail
+   * at a time and letting go of it before reading the next, so the memory a
+   * chart costs does not grow with its size. The 150 attempts the range slider
+   * allows are around 17 MB of timings between them.
+   *
+   * A run the detail store cannot return is left out, except under an exact
+   * selection, where the caller asked for particular runs and a chart missing
+   * one of them would misrepresent the commit.
+   */
   async #eachGanttRun(
     source: CiHistorySource,
     entries: CachedCiRun[],
@@ -2031,10 +2035,13 @@ export class CiJobHistoryCollector {
     return drawn;
   }
 
-  // The subset of `entries` whose step detail reads back, without keeping any
-  // of it. An attempt counts as drawable only when its detail parses, so one
-  // that cannot be read — a format this version does not recognize, a damaged
-  // file — is collected from GitHub again like one that was never stored.
+  /**
+   * Returns the subset of `entries` whose step detail reads back, without
+   * keeping any of it. An attempt counts as drawable only when its detail
+   * parses, so one
+   * that cannot be read — a format this version does not recognize, a damaged
+   * file — is collected from GitHub again like one that was never stored.
+   */
   async #drawableGanttRuns(
     source: CiHistorySource,
     entries: CachedCiRun[],
@@ -2058,8 +2065,11 @@ export class CiJobHistoryCollector {
     ) !== null;
   }
 
-  // The index entries a chart would draw from the cache alone, newest first.
-  // Reading their detail is left to the caller, which often does not need it.
+  /**
+   * Returns the index entries a chart would draw from the cache alone, newest
+   * first. Reading their detail is left to the caller, which often does not
+   * need it.
+   */
   #cachedGanttRuns(
     source: CiHistorySource,
     options: CiGanttOptions,
@@ -2093,9 +2103,11 @@ export class CiJobHistoryCollector {
       .slice(0, options.limit);
   }
 
-  // Collects a chart and returns every run of it at once. Convenient to assert
-  // against, and bounded only by the range slider, so the dashboard itself uses
-  // writeGanttInput instead.
+  /**
+   * Collects a chart and returns every run of it at once. Convenient to assert
+   * against, and bounded only by the range slider, so the dashboard itself
+   * uses `writeGanttInput()` instead.
+   */
   async gantt(
     token: string | undefined,
     source: CiHistorySource,
@@ -2115,8 +2127,11 @@ export class CiJobHistoryCollector {
     );
   }
 
-  // Every run of an already collected chart, held together. Bounded only by the
-  // range slider, so the dashboard uses writeGanttInput instead.
+  /**
+   * Returns every run of an already collected chart, held together. Bounded
+   * only by the range slider, so the dashboard uses `writeGanttInput()`
+   * instead.
+   */
   async ganttRuns(
     source: CiHistorySource,
     selection: GanttSelection,
@@ -2128,9 +2143,11 @@ export class CiJobHistoryCollector {
     return { runs };
   }
 
-  // Collects a chart and writes it straight to `destination` as the JSON the
-  // Gantt renderer reads, one run at a time. Nothing holds the whole chart, so
-  // the dashboard's memory does not grow with the size of the chart it serves.
+  /**
+   * Collects a chart and writes it straight to `destination` as the JSON the
+   * Gantt renderer reads, one run at a time. Nothing holds the whole chart, so
+   * the dashboard's memory does not grow with the size of the chart it serves.
+   */
   async writeGanttInput(
     source: CiHistorySource,
     selection: GanttSelection,
@@ -2157,7 +2174,7 @@ export class CiJobHistoryCollector {
     return written;
   }
 
-  // Hands over the runs of an already collected chart.
+  /** Hands over the runs of an already collected chart. */
   async #emitGantt(
     source: CiHistorySource,
     selection: GanttSelection,

--- a/packages/dashboard/tiles/discord-online.test.ts
+++ b/packages/dashboard/tiles/discord-online.test.ts
@@ -76,17 +76,21 @@ class FakeSocket {
     this.closed = true;
   }
 
-  // Deliver a gateway frame the way the real socket would: JSON in a string.
+  /**
+   * Delivers a gateway frame the way the real socket would: JSON in a string.
+   */
   deliver(frame: unknown) {
     this.onmessage!({ data: JSON.stringify(frame) });
   }
 
-  // Deliver whatever is given, untouched, for the frames that are not JSON.
+  /**
+   * Delivers whatever is given, untouched, for the frames that are not JSON.
+   */
   raw(data: unknown) {
     this.onmessage!({ data });
   }
 
-  // The parsed frames the tile sent back up the socket.
+  /** Returns the parsed frames the tile sent back up the socket. */
   frames(): { op: number; d?: unknown }[] {
     return this.sent.map((s) => JSON.parse(s));
   }

--- a/packages/deno-web-test/manifest.ts
+++ b/packages/deno-web-test/manifest.ts
@@ -26,41 +26,44 @@ export class Manifest {
     this.#config = config;
   }
 
-  // The root directory path of the project being tested.
+  /** The root directory path of the project being tested. */
   get projectDir(): string {
     return this.#projectDir;
   }
 
-  // An array of relative paths to tests
-  // from `projectDir`.
+  /** An array of relative paths to tests from `projectDir`. */
   get tests(): string[] {
     return this.#tests;
   }
 
-  // The root directory path of the static server.
+  /** The root directory path of the static server. */
   get serverDir(): string {
     return path.join(this.#runDir, "server");
   }
 
-  // The directory the browser keeps its profile in.
+  /** The directory the browser keeps its profile in. */
   get profileDir(): string {
     return path.join(this.#runDir, "profile");
   }
 
-  // The requested port the static server is being served on.
-  // If `0` (the default), the actual listening port will be different.
+  /**
+   * The requested port the static server is being served on. If `0` (the
+   * default), the actual listening port will be different.
+   */
   get requestedPort(): number {
     return 0;
   }
 
-  // Configuration defined via `deno-web-test.config.ts`
+  /** Configuration defined via `deno-web-test.config.ts`. */
   get config(): Config {
     return this.#config;
   }
 
-  // Removes everything the run wrote, both directories above included. The
-  // browser has to be closed and the static server stopped first, so that
-  // nothing the run started is writing to either directory as it goes.
+  /**
+   * Removes everything the run wrote, both directories above included. The
+   * browser has to be closed and the static server stopped first, so that
+   * nothing the run started is writing to either directory as it goes.
+   */
   async remove(): Promise<void> {
     await removeDirectory(this.#runDir);
   }

--- a/packages/deno-web-test/runner.ts
+++ b/packages/deno-web-test/runner.ts
@@ -48,8 +48,9 @@ export class Runner {
     );
   }
 
-  // Runs all tests in the browser. Return value
-  // indicates whether all tests have passed successfully or not.
+  /**
+   * Runs all tests in the browser, returning whether all of them passed.
+   */
   async run(): Promise<boolean> {
     this.reporter.onRunStart();
 

--- a/packages/deno-web-test/runner.ts
+++ b/packages/deno-web-test/runner.ts
@@ -48,9 +48,7 @@ export class Runner {
     );
   }
 
-  /**
-   * Runs all tests in the browser, returning whether all of them passed.
-   */
+  /** Runs all tests in the browser, returning whether all of them passed. */
   async run(): Promise<boolean> {
     this.reporter.onRunStart();
 

--- a/packages/deno-web-test/server.ts
+++ b/packages/deno-web-test/server.ts
@@ -7,7 +7,7 @@ export class TestServer {
 
   /**
    * Constructs an instance which serves the static content under
-   * `manifest.serverDir`, for the package rooted at `manifest.projectDir`.
+   * `manifest.serverDir`.
    */
   constructor(manifest: Manifest) {
     this.#server = null;

--- a/packages/deno-web-test/server.ts
+++ b/packages/deno-web-test/server.ts
@@ -5,9 +5,10 @@ export class TestServer {
   #server: Deno.HttpServer<Deno.NetAddr> | null;
   #manifest: Manifest;
 
-  // Takes the root dir of the current package `projectDir`,
-  // and a directory to use as the root of the static
-  // content server `serverDir`.
+  /**
+   * Constructs an instance which serves the static content under
+   * `manifest.serverDir`, for the package rooted at `manifest.projectDir`.
+   */
   constructor(manifest: Manifest) {
     this.#server = null;
     this.#manifest = manifest;
@@ -30,7 +31,7 @@ export class TestServer {
     this.#server.unref();
   }
 
-  // Returns the listening port, if server running.
+  /** Returns the listening port, if the server is running. */
   port(): number | undefined {
     return this.#server?.addr?.port;
   }

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -149,9 +149,11 @@ export class HarnessRun {
     this.stderrText = decode(output.stderr);
   }
 
-  // Fails with `message` followed by the whole transcript. An assertion here
-  // reads one line of what the run printed, and the rest of that output is
-  // what says why the line is not the one it should be.
+  /**
+   * Fails with `message` followed by the whole transcript. An assertion here
+   * reads one line of what the run printed, and the rest of that output is what
+   * says why the line is not the one it should be.
+   */
   assert(condition: boolean, message: string): void {
     if (condition) {
       return;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A `//` block sitting directly above a class member and describing that member is a doc comment in the wrong punctuation: it says what the member is or does, which is what `docs/development/code-comment-style.md` § Doc comments has JSDoc form for. This converts the 14 in `dashboard` and the 11 in `deno-web-test`, one PR of a series that covers the tree outside `packages/patterns`.

Each converted member takes the blank line above its doc comment and the blank line below the member that the guide asks for.

## What changed inside the comments

The text is carried over as written, with the edits the doc-comment form calls for:

* A method's comment opens with a third-person verb phrase, and a field's or getter's with a noun phrase. Where a method's note opened with a noun phrase, `Returns` now opens it (`Returns every retained attempt of one source`); `#pruneGanttDetail()`'s note opened with an invariant and never said what the method does, so `Drops the Gantt detail of the attempts the run index no longer keeps` now opens it.
* `TestServer`'s constructor comment reads `Constructs an instance which ...`, per § "How one starts", and names what it takes as the `manifest` fields it reads rather than as two parameters it does not have.
* Identifiers take backticks: `list()`, `writeGanttInput()`.

## How the sites were found

A TypeScript-AST census over every tracked `.ts`/`.tsx` outside `patterns`, vendored types, and generated declarations: for each class member, the `//` blocks in its leading trivia, minus tool directives, section-marker frames, and `TODO`s. A control fixture of nine planted sites and four decoys reported exactly the nine.

## Verification

* Comment-only, by construction and by proof: each changed file transpiles to byte-identical JavaScript with comments stripped, before and after (8 files, 0 differ).
* The census re-run over the changed files reports zero remaining sites; the blank-line-below detector reports none.
* `deno fmt --check`, `deno lint`, and `deno task check` repo-wide, all green.
* `deno task test` in both packages: `dashboard` 709 + 4 + 8 passed, `deno-web-test` 38 passed, 0 failed.

## Review

A `cf-review` pass (report only) found one clause this PR had introduced that was false against the code, fixed: `TestServer` never reads `manifest.projectDir`, so its constructor's doc no longer names it. Also taken: `run()`'s comment fits on one line and is written on one; a ragged wrap in `#drawableGanttRuns()`'s doc is reflowed; `#directory`'s doc admits the `undefined` state its type has.
