### PR TITLE
style(ui): `//` notes that documented a class member are doc comments, `cf-autocomplete` through `cf-input`

### DIFF
--- a/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
+++ b/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
@@ -544,7 +544,7 @@ export class CFAutocomplete extends BaseElement {
 
   /**
    * Recomputes the memoized filter results, only when the inputs actually
-   * change.
+   * change or the cache is empty.
    */
   private _updateFilteredItemsCache() {
     const currentSelectedValues = this._getSelectedValuesSet();
@@ -706,7 +706,7 @@ export class CFAutocomplete extends BaseElement {
 
   /**
    * Returns whether a processed item matches the search query. Uses
-   * pre-indexed words with `startsWith` for O(words) instead of
+   * pre-indexed words with `startsWith()` for O(words) instead of
    * O(chars*aliases).
    */
   private _processedItemMatchesQuery(

--- a/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
+++ b/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
@@ -378,8 +378,10 @@ export class CFAutocomplete extends BaseElement {
   declare multiple: boolean;
   declare disabled: boolean;
 
-  // Cell controller for value binding
-  // Note: Don't call requestUpdate() in onChange - cell controller already does it
+  /**
+   * Cell controller for value binding. `requestUpdate()` is not called in
+   * `onChange`, since the cell controller already does it.
+   */
   private _cellController = createCellController<string | string[]>(this, {
     timing: { strategy: "debounce", delay: 50 },
     onChange: (newValue, oldValue) => {
@@ -387,7 +389,10 @@ export class CFAutocomplete extends BaseElement {
     },
   });
 
-  // Cell controller for items binding - allows reactive items from lift()
+  /**
+   * Cell controller for items binding, which allows reactive items from
+   * `lift()`.
+   */
   private _itemsCellController = createCellController<AutocompleteItem[]>(
     this,
     {
@@ -416,13 +421,16 @@ export class CFAutocomplete extends BaseElement {
   private _input: HTMLInputElement | null = null;
   private _dropdown: HTMLElement | null = null;
 
-  // Pre-processed search index for fast filtering
+  /** Pre-processed search index for fast filtering. */
   private _processedItems: ProcessedItem[] = [];
 
-  // Throttle flag for scroll/resize position updates
+  /** Throttle flag for scroll/resize position updates. */
   private _positionUpdateScheduled = false;
 
-  // Debounce timer - setTimeout(0) defers to next task, letting input render first
+  /**
+   * Debounce timer. `setTimeout(0)` defers to the next task, letting the input
+   * render first.
+   */
   private _debounceTimer: number | null = null;
 
   constructor() {
@@ -436,7 +444,7 @@ export class CFAutocomplete extends BaseElement {
     this.disabled = false;
   }
 
-  // Theme consumption
+  /** The theme, consumed from the provider. */
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   accessor theme: CFTheme = defaultTheme;
@@ -473,7 +481,10 @@ export class CFAutocomplete extends BaseElement {
     }
   }
 
-  // Throttle scroll/resize updates to RAF to prevent layout thrashing
+  /**
+   * Handler which throttles scroll/resize updates to `requestAnimationFrame`,
+   * to prevent layout thrashing.
+   */
   private _handleScrollOrResize = () => {
     if (this._isOpen && !this._positionUpdateScheduled) {
       this._positionUpdateScheduled = true;
@@ -531,7 +542,10 @@ export class CFAutocomplete extends BaseElement {
     this._updateFilteredItemsCache();
   }
 
-  // Memoized filter computation - only runs when inputs actually change
+  /**
+   * Recomputes the memoized filter results, only when the inputs actually
+   * change.
+   */
   private _updateFilteredItemsCache() {
     const currentSelectedValues = this._getSelectedValuesSet();
     const queryChanged = this._query !== this._lastQuery;
@@ -652,23 +666,23 @@ export class CFAutocomplete extends BaseElement {
     }
   }
 
-  // Helper to get current value from cell controller
+  /** Returns the current value from the cell controller. */
   private _getCurrentValue(): string | readonly string[] | undefined {
     return this._cellController.getValue();
   }
 
-  // Helper to get resolved items (either from Cell or direct array)
+  /** The resolved items, either from the cell or the direct array. */
   private get _resolvedItems(): readonly AutocompleteItem[] {
     return this._itemsCellController.getValue() || [];
   }
 
-  // Helper to get display label for a value
+  /** Returns the display label for `value`. */
   private _getLabelForValue(value: string): string {
     const item = this._resolvedItems.find((i) => i.value === value);
     return item?.label || value;
   }
 
-  // Get the display value for the input in single-select mode
+  /** The display value for the input in single-select mode. */
   private get _displayValue(): string {
     // If in multi-select mode, always show the query (user is always searching)
     if (this.multiple) {
@@ -690,8 +704,11 @@ export class CFAutocomplete extends BaseElement {
     return "";
   }
 
-  // Helper to check if a processed item matches the search query
-  // Uses pre-indexed words with startsWith for O(words) instead of O(chars*aliases)
+  /**
+   * Returns whether a processed item matches the search query. Uses
+   * pre-indexed words with `startsWith` for O(words) instead of
+   * O(chars*aliases).
+   */
   private _processedItemMatchesQuery(
     processed: ProcessedItem,
     queryWords: string[],
@@ -715,7 +732,7 @@ export class CFAutocomplete extends BaseElement {
     return this._cachedShowCustomOption;
   }
 
-  // Computed: total selectable items (limited to what's actually rendered)
+  /** Total selectable items, limited to what is actually rendered. */
   private get _totalSelectableItems(): number {
     const maxRender = this.maxVisible + 4;
     const filteredCount = Math.min(this._filteredItems.length, maxRender);
@@ -1074,7 +1091,7 @@ export class CFAutocomplete extends BaseElement {
     }
   }
 
-  // Remove an item from the selected values (multi-select only)
+  /** Removes an item from the selected values (multi-select only). */
   private _removeItem(item: AutocompleteItem) {
     if (!this.multiple) return;
 
@@ -1131,7 +1148,7 @@ export class CFAutocomplete extends BaseElement {
     this.emit("cf-close", {});
   }
 
-  // Dropdown positioning
+  /** Updates the dropdown's position. */
   private _updateDropdownPosition() {
     if (!this._input) return;
 

--- a/packages/ui/src/v2/components/cf-autolayout/cf-autolayout.ts
+++ b/packages/ui/src/v2/components/cf-autolayout/cf-autolayout.ts
@@ -443,8 +443,10 @@ export class CFAutoLayout extends BaseElement {
     globalThis.removeEventListener("keydown", this._onKeydown);
   }
 
-  // Keep attributes/props as the single source of truth and
-  // enforce mobile exclusivity even when set programmatically.
+  /**
+   * Keeps attributes/props as the single source of truth and enforces mobile
+   * exclusivity even when set programmatically.
+   */
   override updated(changed: Map<string, unknown>) {
     if (changed.has("leftOpen") || changed.has("rightOpen")) {
       // Enforce exclusivity on mobile when both become true.

--- a/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
@@ -792,11 +792,13 @@ export class CFCFCAuthorship extends BaseElement {
     }
   }
 
-  // Re-read the label(s) while a resolved cell's doc is still loading. The
-  // resolved cell is queried one-shot inside `readLabelView` and is not
-  // subscribed to, so without this poll a cold linked/bound-prop author would
-  // stay unverified until an unrelated `value`/`author` change happened to
-  // re-run the read. Bounded by MAX_LABEL_RETRY_COUNT.
+  /**
+   * Re-reads the label(s) while a resolved cell's doc is still loading. The
+   * resolved cell is queried one-shot inside `readLabelView()` and is not
+   * subscribed to, so without this poll a cold linked/bound-prop author would
+   * stay unverified until an unrelated `value`/`author` change happened to
+   * re-run the read. Bounded by `MAX_LABEL_RETRY_COUNT`.
+   */
   private reconcileLabelRetry(): void {
     if (this._valueResolutionPending || this._authorResolutionPending) {
       this.scheduleLabelRetry();

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
@@ -295,8 +295,11 @@ export class CFCFCLabel extends BaseElement {
     this.requestUpdate("cfcLabel", previous);
   }
 
-  // Fallback for a value that exposes getCfcLabel but not subscribe (no live
-  // channel). Subscribable values get their label reactively via observeValue.
+  /**
+   * Refreshes the label, as the fallback for a value that exposes
+   * `getCfcLabel` but not `subscribe` (no live channel). Subscribable values
+   * get their label reactively via `observeValue()`.
+   */
   async refreshLabel(): Promise<void> {
     const requestId = ++this._labelRequestId;
     if (hasLabelSubscription(this.value) || !hasLabelQuery(this.value)) {

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
@@ -297,8 +297,8 @@ export class CFCFCLabel extends BaseElement {
 
   /**
    * Refreshes the label, as the fallback for a value that exposes
-   * `getCfcLabel` but not `subscribe` (no live channel). Subscribable values
-   * get their label reactively via `observeValue()`.
+   * `getCfcLabel()` but not `subscribe()` (no live channel). Subscribable
+   * values get their label reactively via `observeValue()`.
    */
   async refreshLabel(): Promise<void> {
     const requestId = ++this._labelRequestId;

--- a/packages/ui/src/v2/components/cf-chart/cf-chart.ts
+++ b/packages/ui/src/v2/components/cf-chart/cf-chart.ts
@@ -98,7 +98,7 @@ export class CFChart extends BaseElement {
   private _crosshairX: number | null = null;
   private _tooltipInfo: NearestResult | null = null;
 
-  // CellController for $marks prop
+  /** Cell controller for the `$marks` prop. */
   private _marksController = createCellController<MarkConfig[]>(this, {
     timing: { strategy: "immediate" },
   });

--- a/packages/ui/src/v2/components/cf-chat/cf-chat.ts
+++ b/packages/ui/src/v2/components/cf-chat/cf-chat.ts
@@ -202,8 +202,8 @@ export class CFChat extends BaseElement {
   accessor theme: any = {}; // Accept any theme object (partial or full)
 
   /**
-   * The theme consumed from the provider (preferred). This is used when there
-   * is no direct `theme` prop.
+   * The theme consumed from the provider. This is used when there is no
+   * direct `theme` prop.
    */
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })

--- a/packages/ui/src/v2/components/cf-chat/cf-chat.ts
+++ b/packages/ui/src/v2/components/cf-chat/cf-chat.ts
@@ -201,12 +201,15 @@ export class CFChat extends BaseElement {
   @property({ type: Object })
   accessor theme: any = {}; // Accept any theme object (partial or full)
 
-  // Consume theme from provider (preferred). If no direct theme prop, use this.
+  /**
+   * The theme consumed from the provider (preferred). This is used when there
+   * is no direct `theme` prop.
+   */
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   accessor parentTheme: CFTheme = defaultTheme;
 
-  // Internal computed theme for applying CSS variables locally
+  /** Internal computed theme, for applying CSS variables locally. */
   @property({ type: Object, attribute: false })
   accessor _computedTheme: CFTheme = defaultTheme;
 

--- a/packages/ui/src/v2/components/cf-checkbox/cf-checkbox.ts
+++ b/packages/ui/src/v2/components/cf-checkbox/cf-checkbox.ts
@@ -194,7 +194,10 @@ export class CFCheckbox extends BaseElement {
       },
     });
 
-    // Form field controller handles buffering when in cf-form context
+    /**
+     * Form field controller, which handles buffering when in a `cf-form`
+     * context.
+     */
     private _formField = createFormFieldController<boolean>(this, {
       cellController: this._checkedCellController,
       validate: () => {

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -426,61 +426,103 @@ export class CFCodeEditor extends BaseElement {
   private _autofocusFrame: number | null = null;
   private _autofocusIntersectionObserver: IntersectionObserver | null = null;
   private _autofocusResizeObserver: ResizeObserver | null = null;
-  // Track previous backlink names to detect changes for syncing to piece NAME
+
+  /**
+   * Previous backlink names, kept to detect changes for syncing to the piece
+   * `NAME`.
+   */
   private _previousBacklinkNames = new Map<string, string>();
-  // Track subscriptions to piece NAME cells for bidirectional sync
+
+  /** Subscriptions to piece `NAME` cells, for bidirectional sync. */
   private _pieceNameSubscriptions = new Map<string, () => void>();
-  // Cache of resolved piece cell IDs: index in mentionable array → stable piece cell ID.
-  // Populated asynchronously when mentionable changes via resolveAsCell().
+
+  /**
+   * Cache of resolved piece cell ids: index in the mentionable array → stable
+   * piece cell id. Populated asynchronously when the mentionable changes, via
+   * `resolveAsCell()`.
+   */
   private _resolvedPieceIds = new Map<number, string>();
-  // The resolved cell behind each mentionable entry, which a reference stores
-  // directly rather than by id. Populated by the same pass.
+
+  /**
+   * The resolved cell behind each mentionable entry, which a reference stores
+   * directly rather than by id. Populated by the same pass.
+   */
   private _resolvedPieceCells = new Map<number, CellHandle<Mentionable>>();
-  // Which resolution pass may publish its maps. The mentionable HANDLE stays
-  // identical when its contents change, so identity alone cannot stop an
-  // older pass finishing late and overwriting a newer pass's ordering.
+
+  /**
+   * Which resolution pass may publish its maps. The mentionable _handle_ stays
+   * identical when its contents change, so identity alone cannot stop an older
+   * pass finishing late and overwriting a newer pass's ordering.
+   */
   private _resolveGeneration = 0;
-  // `$mentioned` cannot be reconciled while an index row has no piece id.
-  // Calls made during that window leave the latest content for the current
-  // resolution pass to reconcile when it publishes.
+
+  /**
+   * `$mentioned` cannot be reconciled while an index row has no piece id. Calls
+   * made during that window leave the latest content for the current resolution
+   * pass to reconcile when it publishes.
+   */
   private _mentionResolutionPending = false;
+
   private _deferredMentionedContent: string | null = null;
-  // A completion source that withheld a matching index row asks the current
-  // resolution pass to query it again once the row has a usable identity.
+
+  /**
+   * A completion source that withheld a matching index row asks the current
+   * resolution pass to query it again once the row has a usable identity.
+   */
   private _completionAwaitingResolution = false;
+
   private _referencesUnsub: (() => void) | null = null;
-  // Label text last seen for each reference key, to detect a user's edit.
+
+  /** Label text last seen for each reference key, to detect a user's edit. */
   private _previousRefLabels = new Map<string, string>();
-  // Subscriptions to each referenced destination, carrying the identity they
-  // were opened against so a key repointed at a different piece resubscribes
-  // rather than keeping the old one alive.
+
+  /**
+   * Subscriptions to each referenced destination, carrying the identity they
+   * were opened against so a key repointed at a different piece resubscribes
+   * rather than keeping the old one alive.
+   */
   private _refDestinationSubscriptions = new Map<
     string,
     { id: string; unsub: () => void }
   >();
-  // Each referenced destination's name, as its subscription last delivered it.
+
+  /**
+   * Each referenced destination's name, as its subscription last delivered it.
+   */
   private _refNames = new Map<string, string>();
-  // Each referenced destination's own short name, from the same subscription.
-  // A key is absent while its destination publishes none, which is what a
-  // pill with no number beside its label means.
+
+  /**
+   * Each referenced destination's own short name, from the same subscription. A
+   * key is absent while its destination publishes none, which is what a pill
+   * with no number beside its label means.
+   */
   private _refShortNames = new Map<string, string>();
-  // Whether a publication of those names is already waiting to run.
+
+  /** Whether a publication of those names is already waiting to run. */
   private _refShortNamesPublishPending = false;
-  // Keys the document held when it loaded, plus those this editor minted.
-  // Collection only removes entries from this set, so a key another client
-  // added while this one was open is never swept away. Null until the
-  // document has loaded, which is what keeps an empty editor from collecting
-  // the whole map.
+
+  /**
+   * Keys the document held when it loaded, plus those this editor minted.
+   * Collection only removes entries from this set, so a key another client
+   * added while this one was open is never swept away. `null` until the
+   * document has loaded, which is what keeps an empty editor from collecting
+   * the whole map.
+   */
   private _refKeysAtLoad: Set<string> | null = null;
-  // Signature of the last `$mentioned` write in reference mode; null forces
-  // the next attempt, which is how an unresolved key gets retried.
+
+  /**
+   * Signature of the last `$mentioned` write in reference mode; `null` forces
+   * the next attempt, which is how an unresolved key gets retried.
+   */
   private _lastMentionedSignature: string | null = null;
 
-  // Transaction annotation to mark Cell-originated updates.
-  // This is the idiomatic CodeMirror 6 way to distinguish programmatic
-  // changes from user input. The updateListener checks this annotation
-  // and skips setValue for Cell-originated changes, preventing the
-  // feedback loop: Cell → Editor → updateListener → setValue → Cell...
+  /**
+   * Transaction annotation marking cell-originated updates. This is the
+   * idiomatic CodeMirror 6 way to distinguish programmatic changes from user
+   * input. The update listener checks this annotation and skips `setValue()`
+   * for cell-originated changes, preventing the feedback loop: cell → editor
+   * → update listener → `setValue()` → cell...
+   */
   private static _cellSyncAnnotation = Annotation.define<boolean>();
 
   private _cellController = createStringCellController(this, {

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -457,17 +457,19 @@ export class CFCodeEditor extends BaseElement {
   private _resolveGeneration = 0;
 
   /**
-   * `$mentioned` cannot be reconciled while an index row has no piece id. Calls
-   * made during that window leave the latest content for the current resolution
-   * pass to reconcile when it publishes.
+   * Whether `$mentioned` reconciliation is deferred. It cannot be reconciled
+   * while an index row has no piece id; calls made during that window leave
+   * the latest content for the current resolution pass to reconcile when it
+   * publishes.
    */
   private _mentionResolutionPending = false;
 
   private _deferredMentionedContent: string | null = null;
 
   /**
-   * A completion source that withheld a matching index row asks the current
-   * resolution pass to query it again once the row has a usable identity.
+   * Whether a completion source withheld a matching index row and asks the
+   * current resolution pass to query it again once the row has a usable
+   * identity.
    */
   private _completionAwaitingResolution = false;
 

--- a/packages/ui/src/v2/components/cf-fab/cf-fab.ts
+++ b/packages/ui/src/v2/components/cf-fab/cf-fab.ts
@@ -438,7 +438,7 @@ export class CFFab extends BaseElement {
   @property({ type: Object, attribute: false })
   accessor previewMessage: CellHandle<string> | string | undefined = undefined;
 
-  // The resolved value from `previewMessage`
+  /** The resolved value from `previewMessage`. */
   @state()
   accessor _resolvedPreviewMessage: string | undefined = undefined;
 

--- a/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
+++ b/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
@@ -235,7 +235,7 @@ export class CFFileInput extends BaseElement {
   @state()
   protected accessor storedFiles: StoredFile[] = [];
 
-  // Theme consumption
+  /** The theme, consumed from the provider. */
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   accessor theme: CFTheme = defaultTheme;

--- a/packages/ui/src/v2/components/cf-fragment/cf-fragment.ts
+++ b/packages/ui/src/v2/components/cf-fragment/cf-fragment.ts
@@ -23,7 +23,7 @@ export class CFFragment extends HTMLElement {
       .appendChild(document.createElement("slot"));
   }
 
-  // Tell engine to ignore this element for layout purposes
+  /** Tells the engine to ignore this element for layout purposes. */
   connectedCallback() {
     this.style.display = "contents";
   }

--- a/packages/ui/src/v2/components/cf-image-input/cf-image-input.ts
+++ b/packages/ui/src/v2/components/cf-image-input/cf-image-input.ts
@@ -115,7 +115,10 @@ export class CFImageInput extends CFFileInput {
     return !!(this.maxSizeBytes && file.size > this.maxSizeBytes);
   }
 
-  /** Compresses `file` with the image compression utility. */
+  /**
+   * Compresses `file` with the image compression utility when `maxSizeBytes`
+   * is set, and returns it as is otherwise.
+   */
   protected override async compressFile(file: File): Promise<Blob> {
     if (!this.maxSizeBytes) return file;
 
@@ -143,7 +146,9 @@ export class CFImageInput extends CFFileInput {
     return result.blob;
   }
 
-  /** Processes `file`, extracting image dimensions and EXIF. */
+  /**
+   * Processes `file`, reading its image dimensions and storing it with them.
+   */
   protected override async processFile(file: File): Promise<ImageData> {
     const dimensions = await readImageDimensions(file);
     return await this.storeFile(file, dimensions) as ImageData;
@@ -172,7 +177,10 @@ export class CFImageInput extends CFFileInput {
     `;
   }
 
-  /** Renders the element, keeping the `Processing images...` text. */
+  /**
+   * Like the inherited `render()`, except the loading text reads
+   * `Processing images...`.
+   */
   override render() {
     return html`
       <div class="container">

--- a/packages/ui/src/v2/components/cf-image-input/cf-image-input.ts
+++ b/packages/ui/src/v2/components/cf-image-input/cf-image-input.ts
@@ -98,20 +98,24 @@ export class CFImageInput extends CFFileInput {
   @property({ type: Boolean })
   accessor extractExif = false;
 
-  // Alias maxImages to maxFiles for backward compatibility
+  /** Alias of `maxFiles`, for backward compatibility. */
   get maxImages(): number | undefined {
     return this.maxFiles;
   }
+
   set maxImages(value: number | undefined) {
     this.maxFiles = value;
   }
 
-  // Override: Images should be compressed if maxSizeBytes is set and exceeded
+  /**
+   * Returns whether `file` should be compressed: an image is, when
+   * `maxSizeBytes` is set and exceeded.
+   */
   protected override shouldCompressFile(file: File): boolean {
     return !!(this.maxSizeBytes && file.size > this.maxSizeBytes);
   }
 
-  // Override: Use image compression utility
+  /** Compresses `file` with the image compression utility. */
   protected override async compressFile(file: File): Promise<Blob> {
     if (!this.maxSizeBytes) return file;
 
@@ -139,20 +143,20 @@ export class CFImageInput extends CFFileInput {
     return result.blob;
   }
 
-  // Override: Extract image dimensions and EXIF
+  /** Processes `file`, extracting image dimensions and EXIF. */
   protected override async processFile(file: File): Promise<ImageData> {
     const dimensions = await readImageDimensions(file);
     return await this.storeFile(file, dimensions) as ImageData;
   }
 
-  // Override: Always use <img> for images (we know they're images)
+  /** Renders the preview, always with `<img>`, these being images. */
   protected override renderPreview(file: ImageData): TemplateResult {
     return html`
       <img src="${file.url}" alt="${file.name}" />
     `;
   }
 
-  // Override: Add capture attribute to file input
+  /** Renders the file input, adding the `capture` attribute. */
   protected override renderFileInput(): TemplateResult {
     const captureAttr = this.capture !== false ? this.capture : undefined;
 
@@ -168,7 +172,7 @@ export class CFImageInput extends CFFileInput {
     `;
   }
 
-  // Override render to keep "Processing images..." text
+  /** Renders the element, keeping the `Processing images...` text. */
   override render() {
     return html`
       <div class="container">
@@ -181,13 +185,13 @@ export class CFImageInput extends CFFileInput {
     `;
   }
 
-  // Internal handler that calls parent's protected handler
+  /** Internal handler which calls the parent's protected handler. */
   private _handleFileChangeInternal = (event: Event) => {
     // Call parent's protected _handleFileChange method
     super._handleFileChange(event);
   };
 
-  // Override emit to add image-specific event details
+  /** Emits an event, adding image-specific event details. */
   protected override emit<T = any>(
     eventName: string,
     detail?: T,

--- a/packages/ui/src/v2/components/cf-input/cf-input.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.ts
@@ -441,7 +441,10 @@ export class CFInput extends BaseElement {
     },
   });
 
-  // Form field controller handles buffering when in cf-form context
+  /**
+   * Form field controller, which handles buffering when in a `cf-form`
+   * context.
+   */
   private _formField = createFormFieldController<string>(this, {
     cellController: this._cellController,
     validate: () => ({
@@ -483,7 +486,7 @@ export class CFInput extends BaseElement {
     this.addEventListener("focus", this._forwardFocusToInput);
   }
 
-  // Theme consumption
+  /** The theme, consumed from the provider. */
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A `//` block sitting directly above a class member and describing that member is a doc comment in the wrong punctuation: it says what the member is or does, which is what `docs/development/code-comment-style.md` § Doc comments has JSDoc form for. This converts the ones in the first half of `ui`'s components, `cf-autocomplete` through `cf-input` alphabetically (52 sites in 13 files), one PR of a series that covers the tree outside `packages/patterns`. The other half of `ui` is its own PR.

Each converted member takes the blank line above its doc comment and the blank line below the member that the guide asks for. In `cf-code-editor.ts`, where fourteen documented fields sat in one unbroken run, that means a blank line now separates each from the next.

## What changed inside the comments

The text is carried over as written, with the edits the doc-comment form calls for:

* A method's comment opens with a third-person verb phrase (`Removes an item`, `Returns whether a processed item matches`), and a field's or getter's with a noun phrase (`The theme, consumed from the provider`, `The display value for the input`). The eight `Override: ...` labels in `cf-image-input.ts` become sentences saying what each override does.
* Two notes whose second line began a new sentence with no period on the first (`_cellController`, `_processedItemMatchesQuery`) are punctuated as two sentences.
* Identifiers and code-like things take backticks: `requestUpdate()`, `lift()`, `setTimeout(0)`, `$marks`, `cf-form`, `NAME`.
* Emphasis by capitals becomes underscores (`_handle_`).
* One accessor pair keeps its doc comment on the getter and, per "The blank line below", a blank line before the setter.

Left as `//`: the eleven labels that head a run of members rather than describing one, such as `Public properties`, `Internal state`, `Element references`, `Memoized getters`, and `Event handlers` in `cf-autocomplete.ts`, `Image-specific properties` in `cf-image-input.ts`, and `Autosave state` in `cf-file-download.ts`. A doc comment is the wrong form for a label over several members, and a section marker for each would leave regions with no marker to close them, since the labels do not partition the class; they are listed with the other residuals in the series' audit.

## How the sites were found

A TypeScript-AST census over every tracked `.ts`/`.tsx` outside `patterns`, vendored types, and generated declarations: for each class member, the `//` blocks in its leading trivia, minus tool directives, section-marker frames, and `TODO`s. A control fixture of nine planted sites and four decoys reported exactly the nine.

## Verification

* Comment-only, by construction and by proof: each changed file transpiles to byte-identical JavaScript with comments stripped, before and after (13 files, 0 differ).
* The census re-run over the changed files reports only the labels above; the blank-line-below detector reports none.
* `deno fmt --check`, `deno lint`, and `deno task check` repo-wide, all green.
* `deno task test` in `ui`: 171 passed and 70 browser tests passed, 0 failed.

## Review

A `cf-review` pass (report only) found two doc comments this PR had written as contracts the code does not meet, both fixed: `processFile()` reads image dimensions and stores the file but extracts no EXIF, and `compressFile()` returns the file untouched when `maxSizeBytes` is unset. Also taken: `render()` is stated against the inherited `render()`; `_mentionResolutionPending` and `_completionAwaitingResolution` open with `Whether`; `parentTheme` no longer calls the provider preferred, since a non-empty `theme` prop wins; the filter-cache recompute names its empty-cache case; callables take parentheses. The site count above is corrected to what the diff holds.
