### PR TITLE
style(ui): `//` notes that documented a class member are doc comments, `cf-keybind` through `core`

### DIFF
--- a/packages/ui/src/v2/components/cf-keybind/cf-keybind.ts
+++ b/packages/ui/src/v2/components/cf-keybind/cf-keybind.ts
@@ -61,9 +61,10 @@ export class CFKeybind extends BaseElement {
   #metaDown = false;
   #shiftDown = false;
 
-  // Optional router provided by host app
+  /** Optional router, provided by the host app. */
   @consume({ context: keyboardRouterContext, subscribe: false })
   private accessor _router!: KeyboardRouter;
+
   #dispose?: () => void;
 
   constructor() {

--- a/packages/ui/src/v2/components/cf-location/cf-location.ts
+++ b/packages/ui/src/v2/components/cf-location/cf-location.ts
@@ -248,12 +248,12 @@ export class CFLocation extends BaseElement {
     `,
   ];
 
-  // Theme context
+  /** The theme, consumed from the provider. */
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   accessor theme: CFTheme = defaultTheme;
 
-  // Cell binding for location data
+  /** The location data, or a cell binding for it. */
   @property({ attribute: false })
   accessor location: CellHandle<LocationData | null> | LocationData | null =
     null;

--- a/packages/ui/src/v2/components/cf-map/cf-map.ts
+++ b/packages/ui/src/v2/components/cf-map/cf-map.ts
@@ -174,7 +174,7 @@ export class CFMap extends BaseElement {
   declare fitToBounds: boolean;
   declare interactive: boolean;
 
-  // Leaflet map instance
+  /** The Leaflet map instance. */
   private _map: L.Map | null = null;
 
   // Layer groups for organized management
@@ -182,28 +182,31 @@ export class CFMap extends BaseElement {
   private _circleLayer: L.LayerGroup | null = null;
   private _polylineLayer: L.LayerGroup | null = null;
 
-  // Track markers for drag events
+  /** The markers, tracked for drag events. */
   private _leafletMarkers: L.Marker[] = [];
 
-  // Track circles for click events
+  /** The circles, tracked for click events. */
   private _leafletCircles: L.Circle[] = [];
 
-  // Track polylines for cleanup
+  /** The polylines, tracked for cleanup. */
   private _leafletPolylines: L.Polyline[] = [];
 
-  // RAF ID for map initialization (prevent race condition on disconnect)
+  /**
+   * `requestAnimationFrame` id for map initialization, which prevents a race
+   * condition on disconnect.
+   */
   private _rafId: number | null = null;
 
-  // ResizeObserver for automatic map resize when container changes
+  /** `ResizeObserver` for automatic map resize when the container changes. */
   private _resizeObserver: ResizeObserver | null = null;
 
-  // Timeout ID for debounced resize handling
+  /** Timeout id for debounced resize handling. */
   private _resizeTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
-  // Flag to prevent echo loops during programmatic updates
+  /** Whether a programmatic update is in progress; this prevents echo loops. */
   private _isUpdatingFromCell = false;
 
-  // Flag to track pending click events deferred during animations
+  /** A pending click event deferred during an animation, if any. */
   private _pendingClickEvent: L.LeafletMouseEvent | null = null;
 
   // Pending updates deferred during animations
@@ -251,7 +254,7 @@ export class CFMap extends BaseElement {
     },
   });
 
-  // Bound event handler for cleanup
+  /** Bound keydown handler, held so it can be removed on cleanup. */
   private _boundHandleKeydown = this._handleKeydown.bind(this);
 
   constructor() {

--- a/packages/ui/src/v2/components/cf-markdown/heading-id.ts
+++ b/packages/ui/src/v2/components/cf-markdown/heading-id.ts
@@ -100,8 +100,10 @@ class SlugTextRenderer extends TextRenderer {
     return this.#inline(tokens);
   }
 
-  // marked 4 slugged an image's alt text as its lexer left it, without
-  // walking into it.
+  /**
+   * Renders an image's alt text as its lexer left it, without walking into it,
+   * as marked 4 did when slugging.
+   */
   override image({ text }: Tokens.Image): string {
     return escapeNoEncode(text);
   }

--- a/packages/ui/src/v2/components/cf-markdown/heading-id.ts
+++ b/packages/ui/src/v2/components/cf-markdown/heading-id.ts
@@ -101,8 +101,8 @@ class SlugTextRenderer extends TextRenderer {
   }
 
   /**
-   * Renders an image's alt text as its lexer left it, without walking into it,
-   * as marked 4 did when slugging.
+   * Renders an image's alt text as marked 4's lexer left it, without walking
+   * into it, which is how marked 4 slugged one.
    */
   override image({ text }: Tokens.Image): string {
     return escapeNoEncode(text);

--- a/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
+++ b/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
@@ -239,7 +239,7 @@ class MarkdownTemplate {
   }
 
   /**
-   * Renders a link. This template and the ones below sit inline in a run of
+   * Renders a link. This template and `#image()` below sit inline in a run of
    * text, so each one stays on a single line: a line break inside it would put
    * a space beside the element.
    */

--- a/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
+++ b/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
@@ -238,8 +238,11 @@ class MarkdownTemplate {
       : html`<td align=${align}>${content}</td>`;
   }
 
-  // The templates below sit inline in a run of text, so each one stays on a
-  // single line: a line break inside it would put a space beside the element.
+  /**
+   * Renders a link. This template and the ones below sit inline in a run of
+   * text, so each one stays on a single line: a line break inside it would put
+   * a space beside the element.
+   */
   #link(token: Tokens.Link): unknown {
     const label = decodeEntities(token.text);
     const link = token.href;

--- a/packages/ui/src/v2/components/cf-picker/cf-picker.ts
+++ b/packages/ui/src/v2/components/cf-picker/cf-picker.ts
@@ -230,7 +230,10 @@ export class CFPicker extends BaseElement {
     },
   });
 
-  // Cell controller for items - handles subscription to load cell values
+  /**
+   * Cell controller for the items, which handles the subscription that loads
+   * cell values.
+   */
   private _itemsCellController = createArrayCellController<any>(this, {
     timing: { strategy: "immediate" },
   });

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -524,11 +524,12 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
   private _resolvedCell: CellHandle | undefined = undefined;
 
   /**
-   * Whether a click navigates, which is so only when the resolved cell is a
-   * root cell (a real profile piece). A badge bound to a real profile
-   * (rosters/lists) navigates to that profile's page on click; one bound to a
-   * derived/sub-path cell (e.g. a self-view `{name, avatar}` cell on the
-   * profile page itself) is non-navigable and the click is a no-op.
+   * Whether a click navigates, which is so only when `noNavigate` is unset and
+   * the resolved cell is a root cell (a real profile piece). A badge bound to
+   * a real profile (rosters/lists) navigates to that profile's page on click;
+   * one bound to a derived/sub-path cell (e.g. a self-view `{name, avatar}`
+   * cell on the profile page itself) is non-navigable and the click is a
+   * no-op.
    */
   @state()
   private accessor _navigable = false;

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -505,10 +505,11 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
   @state()
   private accessor _avatar: string | undefined = undefined;
 
-  // CT-1648: extra details surfaced in the hover/focus tooltip.
+  /** The bio, an extra detail surfaced in the hover/focus tooltip. */
   @state()
   private accessor _bio: string | undefined = undefined;
 
+  /** The pinned count, an extra detail surfaced in the hover/focus tooltip. */
   @state()
   private accessor _pinnedCount = 0;
 
@@ -519,23 +520,32 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
   @state()
   private accessor _seal: IdentitySeal | undefined = undefined;
 
-  // CT-1750: navigation. `_resolvedCell` is the resolved profile cell;
-  // `_navigable` is true only when it's a root cell (a real profile piece). A
-  // badge bound to a real profile (rosters/lists) navigates to that profile's
-  // page on click; one bound to a derived/sub-path cell (e.g. a self-view
-  // `{name, avatar}` cell on the profile page itself) is non-navigable and the
-  // click is a no-op.
+  /** The resolved profile cell. */
   private _resolvedCell: CellHandle | undefined = undefined;
+
+  /**
+   * Whether a click navigates, which is so only when the resolved cell is a
+   * root cell (a real profile piece). A badge bound to a real profile
+   * (rosters/lists) navigates to that profile's page on click; one bound to a
+   * derived/sub-path cell (e.g. a self-view `{name, avatar}` cell on the
+   * profile page itself) is non-navigable and the click is a no-op.
+   */
   @state()
   private accessor _navigable = false;
 
   private _unsubscribe?: () => void;
   private _resolveGeneration = 0;
 
-  // Liveness: whether this seal is currently registered with the shared cursor
-  // controller, and the last sheen alpha written (so far-from-cursor frames can
-  // skip redundant style writes).
+  /**
+   * Whether this seal is currently registered with the shared cursor
+   * controller.
+   */
   private _livenessRegistered = false;
+
+  /**
+   * The last sheen alpha written, so far-from-cursor frames can skip redundant
+   * style writes.
+   */
   private _lastSheenA = -1;
 
   override connectedCallback(): void {

--- a/packages/ui/src/v2/components/cf-prompt-input/cf-prompt-input.ts
+++ b/packages/ui/src/v2/components/cf-prompt-input/cf-prompt-input.ts
@@ -365,16 +365,23 @@ export class CFPromptInput extends BaseElement {
   declare modelItems: Array<ModelItem | undefined>;
   declare model: CellHandle<string> | string | null;
   declare voice: boolean;
-  // Opt-in: upload File/Blob attachments to the blob store on add (default off,
-  // so existing consumers keep the raw-File pass-through behavior).
+
+  /**
+   * Whether to upload `File`/`Blob` attachments to the blob store on add.
+   * Default off, so a consumer that does not opt in keeps the raw-`File`
+   * pass-through behavior.
+   */
   declare uploadAttachments: boolean;
 
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   accessor theme: CFTheme = defaultTheme;
 
-  // Runtime + space context, consumed the same way cf-file-input does, so the
-  // component can upload attachment bytes itself when uploadAttachments is set.
+  /**
+   * Runtime and space context, consumed the same way `cf-file-input` does, so
+   * the component can upload attachment bytes itself when `uploadAttachments`
+   * is set.
+   */
   @consume({ context: runtimeContext, subscribe: true })
   @property({ attribute: false })
   accessor runtime: RuntimeClient | undefined = undefined;
@@ -386,15 +393,22 @@ export class CFPromptInput extends BaseElement {
   private _textareaElement?: HTMLElement;
   private _modelSelectElement?: HTMLSelectElement;
 
-  // Attachment management
+  /** The attachments, keyed by attachment id. */
   private attachments: Map<string, PromptAttachment> = new Map();
-  // In-flight upload promises, keyed by attachment id, so a submit can wait for
-  // them before emitting (see _handleSend).
+
+  /**
+   * In-flight upload promises, keyed by attachment id, so a submit can wait
+   * for them before emitting (see `_handleSend()`).
+   */
   private _uploadPromises: Map<string, Promise<void>> = new Map();
-  // True while a submit is awaiting in-flight uploads (disables the send btn).
+
+  /**
+   * Whether a submit is awaiting in-flight uploads, which disables the send
+   * button.
+   */
   private _sending = false;
 
-  // Mention controller
+  /** The mention controller. */
   private mentionController = new MentionController(this, {
     onInsert: (markdown, mentionCell) =>
       this._insertMentionAtCursor(markdown, mentionCell),
@@ -402,7 +416,7 @@ export class CFPromptInput extends BaseElement {
     getContent: () => this.value,
   });
 
-  // Model cell controller for binding
+  /** Cell controller for the model binding. */
   private _modelController = createCellController<string>(this, {
     timing: { strategy: "immediate" },
   });

--- a/packages/ui/src/v2/components/cf-prompt-input/cf-prompt-input.ts
+++ b/packages/ui/src/v2/components/cf-prompt-input/cf-prompt-input.ts
@@ -378,14 +378,14 @@ export class CFPromptInput extends BaseElement {
   accessor theme: CFTheme = defaultTheme;
 
   /**
-   * Runtime and space context, consumed the same way `cf-file-input` does, so
-   * the component can upload attachment bytes itself when `uploadAttachments`
-   * is set.
+   * The runtime, consumed so the component can upload attachment bytes itself
+   * when `uploadAttachments` is set.
    */
   @consume({ context: runtimeContext, subscribe: true })
   @property({ attribute: false })
   accessor runtime: RuntimeClient | undefined = undefined;
 
+  /** The space the runtime uploads into, consumed alongside `runtime`. */
   @consume({ context: spaceContext, subscribe: true })
   @property({ attribute: false })
   accessor space: DID | undefined = undefined;

--- a/packages/ui/src/v2/components/cf-radio-group/cf-radio-group.ts
+++ b/packages/ui/src/v2/components/cf-radio-group/cf-radio-group.ts
@@ -164,7 +164,7 @@ export class CFRadioGroup extends BaseElement {
     this.removeEventListener("keydown", this.handleKeydown);
   }
 
-  // Theme consumption
+  /** The theme, consumed from the provider. */
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   accessor theme: CFTheme = defaultTheme;

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -288,7 +288,9 @@ export class CFRender extends BaseElement {
   declare cell: CellHandle | undefined;
   declare variant: UIVariant | undefined;
 
-  // Use Lit ref directive for stable container reference across re-renders
+  /**
+   * Lit ref to the container, which stays stable across re-renders.
+   */
   private _containerRef: Ref<HTMLDivElement> = createRef();
 
   private _cleanup?: () => void;
@@ -297,11 +299,17 @@ export class CFRender extends BaseElement {
   private _linkTargetSetup?: Promise<CellHandle | undefined>;
   private _linkTargetToken?: object;
   private _linkTargetUnsubscribe?: () => void;
-  // Each render captures a generation so older asynchronous work cannot
-  // install a result after the cell or variant changes.
+
+  /**
+   * Render generation. Each render captures one, so older asynchronous work
+   * cannot install a result after the cell or variant changes.
+   */
   private _renderGeneration = 0;
-  // The root piece cell after resolving the (possibly link) `cell`. Reset
-  // whenever `cell` changes.
+
+  /**
+   * The root piece cell after resolving the (possibly link) `cell`. Reset
+   * whenever `cell` changes.
+   */
   private _resolvedCell?: CellHandle;
 
   @state()

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -288,9 +288,7 @@ export class CFRender extends BaseElement {
   declare cell: CellHandle | undefined;
   declare variant: UIVariant | undefined;
 
-  /**
-   * Lit ref to the container, which stays stable across re-renders.
-   */
+  /** Lit ref to the container, which stays stable across re-renders. */
   private _containerRef: Ref<HTMLDivElement> = createRef();
 
   private _cleanup?: () => void;

--- a/packages/ui/src/v2/components/cf-select/cf-select.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.ts
@@ -327,7 +327,7 @@ export class CFSelect extends BaseElement {
     }
   }
 
-  // Theme consumption
+  /** The theme, consumed from the provider. */
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   accessor theme: CFTheme = defaultTheme;

--- a/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.ts
+++ b/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.ts
@@ -97,11 +97,17 @@ export class CFSubmitInput extends BaseElement {
   declare buttonText: string;
   declare inputId: string;
   declare disabled: boolean;
-  // Optional one-time seed for the field text, copied into `value` on first
-  // render. The field is uncontrolled after that.
+
+  /**
+   * Optional one-time seed for the field text, copied into `value` on first
+   * render. The field is uncontrolled after that.
+   */
   declare initialValue: string;
-  // Mirrors the field text. Read on the host as event.target.value when the
-  // submit button is clicked.
+
+  /**
+   * Mirrors the field text. Read on the host as `event.target.value` when the
+   * submit button is clicked.
+   */
   declare value: string;
 
   constructor() {
@@ -116,18 +122,22 @@ export class CFSubmitInput extends BaseElement {
 
   private _seeded = false;
 
-  // Set while a submit is in flight, between the click and the deferred
-  // field-clear. A second submit that arrives in that window — whether a button
-  // click or an Enter keypress — is a duplicate (the field still holds the
-  // submitted text), so its propagation to the host is stopped to suppress a
-  // second create. The flag is reset when the clear runs, including the case
-  // where the clear is skipped because the value changed, so a later submit is
-  // never blocked.
+  /**
+   * Whether a submit is in flight, between the click and the deferred
+   * field-clear. A second submit that arrives in that window — whether a button
+   * click or an Enter keypress — is a duplicate (the field still holds the
+   * submitted text), so its propagation to the host is stopped to suppress a
+   * second create. The flag is reset when the clear runs, including the case
+   * where the clear is skipped because the value changed, so a later submit is
+   * never blocked.
+   */
   private _submitting = false;
 
-  // Copy `initialValue` into the editable `value` once, the first time it is
-  // present. Later `initialValue` changes and the user's own typing are left
-  // alone, so the field stays uncontrolled.
+  /**
+   * Copies `initialValue` into the editable `value` once, the first time it is
+   * present. Later `initialValue` changes and the user's own typing are left
+   * alone, so the field stays uncontrolled.
+   */
   override willUpdate(changed: PropertyValues) {
     super.willUpdate(changed);
     if (!this._seeded && this.initialValue) {
@@ -144,10 +154,12 @@ export class CFSubmitInput extends BaseElement {
     this.value = (event.target as HTMLInputElement).value;
   }
 
-  // True when a click's composed path runs through a control that means "submit"
-  // — the visible cf-button, or the hidden native submit button the browser
-  // clicks for implicit form submission on Enter. Clicks on the field (to
-  // focus/edit) or the surrounding gap are not submits.
+  /**
+   * Returns whether a click's composed path runs through a control that means
+   * submit — the visible `cf-button`, or the hidden native submit button the
+   * browser clicks for implicit form submission on Enter. Clicks on the field
+   * (to focus/edit) or the surrounding gap are not submits.
+   */
   private _isSubmitGesture(event: Event): boolean {
     return event.composedPath().some((node) => {
       const element = node as Element & { type?: string };
@@ -156,10 +168,12 @@ export class CFSubmitInput extends BaseElement {
     });
   }
 
-  // Single click handler for the form. The visible button's click and the
-  // Enter-driven implicit-submission click both bubble through here on their way
-  // to the host, so it is the one place the create gesture is gated and the
-  // in-flight guard is enforced — Enter and a click cannot each fire a create.
+  /**
+   * Handles every click on the form. The visible button's click and the
+   * Enter-driven implicit-submission click both bubble through here on their
+   * way to the host, so it is the one place the create gesture is gated and the
+   * in-flight guard is enforced — Enter and a click cannot each fire a create.
+   */
   private _onClick(event: Event) {
     // Only a submit gesture should reach the host's onClick (the create). Stop
     // field/gap clicks at the shadow boundary so they fire no spurious create.
@@ -202,9 +216,12 @@ export class CFSubmitInput extends BaseElement {
     }, 0);
   }
 
-  // Enter in the field triggers implicit form submission. The trusted click on
-  // the hidden submit button is what carries the create to the host; the form's
-  // own navigation is cancelled so the page does not reload.
+  /**
+   * Handles the form's submit event, which Enter in the field triggers as
+   * implicit form submission. The trusted click on the hidden submit button is
+   * what carries the create to the host; the form's own navigation is
+   * cancelled so the page does not reload.
+   */
   private _onFormSubmit(event: Event) {
     event.preventDefault();
   }

--- a/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.ts
+++ b/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.ts
@@ -105,8 +105,8 @@ export class CFSubmitInput extends BaseElement {
   declare initialValue: string;
 
   /**
-   * Mirrors the field text. Read on the host as `event.target.value` when the
-   * submit button is clicked.
+   * The field text, mirrored; read on the host as `event.target.value` when
+   * the submit button is clicked.
    */
   declare value: string;
 

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -79,13 +79,16 @@ class FakeTab {
 
   /**
    * The tag name a real `<cf-tab>` has as a custom element; `handleKeydown()`
-   * gates on it and calls `focus()`/`click()` on the next tab. `click()` must
-   * dispatch the bubbling `tab-click` the real element emits, which is wired
-   * per-instance in `makeTabs()`.
+   * gates on it and calls `focus()`/`click()` on the next tab.
    */
   tagName = "CF-TAB";
 
+  /**
+   * What `click()` dispatches: it must dispatch the bubbling `tab-click` the
+   * real element emits, which `makeTabs()` wires per instance.
+   */
   onClickDispatch: (() => void) | null = null;
+
   attributes = new Map<string, string>();
   constructor(value: string) {
     this.value = value;
@@ -112,8 +115,8 @@ class FakeTabPanel {
   value: string;
 
   /**
-   * Mirrors the real `CFTabPanel` constructor default (`hidden = true`).
-   * `cf-tab-panel` starts hidden and is revealed only when
+   * Whether the panel is hidden, defaulting to `true` as the real `CFTabPanel`
+   * constructor does. `cf-tab-panel` starts hidden and is revealed only when
    * `updateTabSelection()` matches it; a `false` default would make panels
    * look visible before any sync runs.
    */

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -76,10 +76,15 @@ class FakeTab {
   value: string;
   disabled = false;
   selected = false;
-  // A real <cf-tab> is a custom element; handleKeydown gates on tagName and
-  // calls focus()/click() on the next tab. click() must dispatch the bubbling
-  // `tab-click` the real element emits — wired per-instance in makeTabs.
+
+  /**
+   * The tag name a real `<cf-tab>` has as a custom element; `handleKeydown()`
+   * gates on it and calls `focus()`/`click()` on the next tab. `click()` must
+   * dispatch the bubbling `tab-click` the real element emits, which is wired
+   * per-instance in `makeTabs()`.
+   */
   tagName = "CF-TAB";
+
   onClickDispatch: (() => void) | null = null;
   attributes = new Map<string, string>();
   constructor(value: string) {
@@ -105,10 +110,15 @@ class FakeTab {
 
 class FakeTabPanel {
   value: string;
-  // Mirror the real CFTabPanel constructor default (hidden = true). cf-tab-panel
-  // starts hidden and is revealed only when updateTabSelection() matches it; a
-  // `false` default would make panels look visible before any sync runs.
+
+  /**
+   * Mirrors the real `CFTabPanel` constructor default (`hidden = true`).
+   * `cf-tab-panel` starts hidden and is revealed only when
+   * `updateTabSelection()` matches it; a `false` default would make panels
+   * look visible before any sync runs.
+   */
   hidden = true;
+
   attributes = new Map<string, string>();
   constructor(value: string) {
     this.value = value;

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
@@ -104,7 +104,7 @@ export class CFTabs extends BaseElement {
   declare value: CellHandle<string> | string;
   declare orientation: "horizontal" | "vertical";
 
-  // Track last known value to detect external cell changes
+  /** The last known value, kept to detect external cell changes. */
   private _lastKnownValue: string = "";
 
   /** Cell controller for value binding */
@@ -227,11 +227,14 @@ export class CFTabs extends BaseElement {
 
   private _pendingRetry: number | null = null;
 
-  // `valueOverride` carries an authoritative just-delivered value (a user
-  // click or a cell delivery via the controller's onChange). It matters for
-  // PLAIN string bindings, where a click's setValue has no backing store to
-  // write — a getValue() re-read here would return the stale bound literal
-  // and silently no-op the sync.
+  /**
+   * Syncs the tabs and panels to the selected value. `valueOverride` carries
+   * an authoritative just-delivered value (a user click or a cell delivery via
+   * the controller's `onChange`). It matters for _plain_ string bindings,
+   * where a click's `setValue()` has no backing store to write — a
+   * `getValue()` re-read here would return the stale bound literal and
+   * silently no-op the sync.
+   */
   private updateTabSelection(valueOverride?: string): void {
     // Every sync pass supersedes any pending deferred retry. The retry
     // captures its call's valueOverride, so a retry left armed across a NEWER
@@ -337,12 +340,13 @@ export class CFTabs extends BaseElement {
     this.updateTabSelection();
   };
 
-  // The cf-tab-list element whose internal slot currently carries our
-  // slotchange listener. Tracked by ELEMENT (not a one-shot boolean): a VDOM
-  // consumer that re-renders its tab list re-CREATES the cf-tab-list element,
-  // and a listener left on the discarded element observes nothing — cf-tabs
-  // then never hears about the replacement tabs (part of the plain-value
-  // "one-behind" highlight bug).
+  /**
+   * The `cf-tab-list` element whose internal slot currently carries our
+   * `slotchange` listener. Tracked by _element_ (not a one-shot boolean): a
+   * VDOM consumer that re-renders its tab list _re-creates_ the `cf-tab-list`
+   * element, and a listener left on the discarded element observes nothing —
+   * `cf-tabs` then never hears about the replacement tabs.
+   */
   private _tabListWithSlotListener: Element | null = null;
 
   /**

--- a/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
+++ b/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
@@ -325,7 +325,7 @@ export class CFTextarea extends BaseElement {
     }
   `;
 
-  // Theme consumption
+  /** The theme, consumed from the provider. */
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   accessor theme: CFTheme = defaultTheme;
@@ -345,7 +345,10 @@ export class CFTextarea extends BaseElement {
     },
   });
 
-  // Form field controller handles buffering when in cf-form context
+  /**
+   * Form field controller, which handles buffering when in a `cf-form`
+   * context.
+   */
   private _formField = createFormFieldController<string>(this, {
     cellController: this._cellController,
     validate: () => ({

--- a/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
+++ b/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
@@ -313,15 +313,20 @@ export class CFToolsChip extends BaseElement {
   /** Delay in ms before closing on hover-out. */
   declare closeDelay: number;
 
-  // Track pointer-in to support hover open/close reliably.
+  /** Whether the pointer is in, tracked so hover open/close works reliably. */
   @state()
   private accessor _hovering = false;
-  // Track user toggle state to keep panel open until clicked again.
+
+  /**
+   * Whether the user toggled the panel open, which keeps it open until clicked
+   * again.
+   */
   @state()
   private accessor _toggledOpen = false;
+
   #closeTimer?: ReturnType<typeof setTimeout>;
 
-  // Consume theme and keep overlay/popover state
+  /** The theme, consumed from the provider. */
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   accessor theme: CFTheme = defaultTheme;
@@ -475,13 +480,15 @@ export class CFToolsChip extends BaseElement {
     }
   }
 
-  // Normalize incoming tools (array or native record) to display-friendly
-  // objects with name/description/schema.
-  // Get the resolved tools value (handles both CellHandle and plain values)
+  /** The resolved tools value, from either a `CellHandle` or a plain value. */
   private get _toolsValue(): Readonly<ToolsInput> | undefined {
     return this._cellController.getValue() ?? undefined;
   }
 
+  /**
+   * Normalizes the incoming tools (an array or a native record) to
+   * display-friendly objects with name, description, and schema.
+   */
   private _normalizedTools(): ToolsChipTool[] {
     const t = this._toolsValue;
     if (!t) return [];

--- a/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
+++ b/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
@@ -331,6 +331,7 @@ export class CFToolsChip extends BaseElement {
   @property({ attribute: false })
   accessor theme: CFTheme = defaultTheme;
 
+  // Overlay/popover state
   #overlay: HTMLDivElement | null = null;
   #resizeObs?: ResizeObserver;
   #raf?: number;

--- a/packages/ui/src/v2/core/form-field-controller.test.ts
+++ b/packages/ui/src/v2/core/form-field-controller.test.ts
@@ -41,7 +41,7 @@ class MockHost {
     this.updateCount++;
   }
 
-  // Simulate being an HTMLElement for the host type
+  /** Tag name, simulating an `HTMLElement` for the host type. */
   tagName = "MOCK-HOST";
 }
 
@@ -78,7 +78,7 @@ class MockCellController<T> implements CellControllerLike<T> {
     return this._cell;
   }
 
-  // For testing - directly set value without tracking
+  /** Sets the value directly, without tracking, for a test's use. */
   _setValueDirect(value: T): void {
     this._value = value;
   }

--- a/packages/ui/src/v2/core/form-field-controller.ts
+++ b/packages/ui/src/v2/core/form-field-controller.ts
@@ -94,20 +94,28 @@ export class FormFieldController<T> implements ReactiveController {
   private _cellController: CellControllerLike<T>;
   private _validate: () => ValidationResult;
 
-  // Form context consumer - automatically subscribes to context
+  /** Form context consumer, which automatically subscribes to the context. */
   private _formContextConsumer: ContextConsumer<
     typeof formContext,
     ReactiveControllerHost & HTMLElement
   >;
 
-  // Buffer state (only used when in form context)
+  /** The buffered value, only used when in a form context. */
   private _buffer: T | undefined;
-  // Flag to track if buffer has been set (allows undefined as a valid buffered value)
+
+  /**
+   * Whether the buffer has been set, which allows `undefined` as a valid
+   * buffered value.
+   */
   private _hasBuffer = false;
-  // Original value captured when form field is registered - used for reset
+
+  /**
+   * Original value, captured when the form field is registered and used for
+   * reset.
+   */
   private _originalValue: T | undefined;
 
-  // Form registration cleanup function
+  /** Cleanup function for the form registration. */
   private _formUnregister?: () => void;
 
   constructor(

--- a/packages/ui/src/v2/core/mention-controller.ts
+++ b/packages/ui/src/v2/core/mention-controller.ts
@@ -82,7 +82,7 @@ export class MentionController implements ReactiveController {
   private host: ReactiveControllerHost;
   private config: Required<MentionControllerConfig>;
 
-  // Mention state
+  /** The mention state. */
   private _state: MentionState = {
     showing: false,
     query: "",


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A `//` block sitting directly above a class member and describing that member is a doc comment in the wrong punctuation: it says what the member is or does, which is what `docs/development/code-comment-style.md` § Doc comments has JSDoc form for. This converts the ones in the second half of `ui`, `cf-keybind` through `core` alphabetically (57 sites in 19 files), one PR of a series that covers the tree outside `packages/patterns`. The first half of `ui` is #7026.

Each converted member takes the blank line above its doc comment and the blank line below the member that the guide asks for.

## What changed inside the comments

The text is carried over as written, with the edits the doc-comment form calls for:

* A method's comment opens with a third-person verb phrase (`Copies \`initialValue\``, `Handles every click on the form`), and a field's or getter's with a noun phrase (`The markers, tracked for drag events`, `Whether a submit is in flight`). Where a note opened with rationale and never said what the member is, a phrase saying so now opens it: `Syncs the tabs and panels to the selected value` on `updateTabSelection()`, `Render generation` on `_renderGeneration`, `The tag name a real \`<cf-tab>\` has` on the fake tab's `tagName`.
* Three notes that described two members each are split into one doc comment per member: `cf-profile-badge.ts`'s `_bio`/`_pinnedCount` (the tooltip details), `_resolvedCell`/`_navigable`, and `_livenessRegistered`/`_lastSheenA`.
* The two notes stacked above `_toolsValue` in `cf-tools-chip.ts` described two different members; the second sentence was about `_normalizedTools()` below it, which now carries it.
* Identifiers and code-like things take backticks; `requestAnimationFrame`, `ResizeObserver`, `event.target.value`, `cf-button`, `_handleSend()` among them.
* Emphasis by capitals becomes underscores (`_plain_`, `_element_`, `_re-creates_`).
* Two tracker identifiers the guide keeps out of comments are gone (`CT-1648`, `CT-1750`), as is a parenthetical naming a fixed bug in `_tabListWithSlotListener`'s note.

Left as `//`: the eight labels that head a run of members rather than describing one (`Configuration` and `Internal state` in `cf-location.ts`, `Layer groups for organized management` and `Cell controllers for reactive data binding` in `cf-map.ts`, and so on). A doc comment is the wrong form for a label over several members, and a section marker for each would leave regions with no marker to close them; they are listed with the other residuals in the series' audit.

## How the sites were found

A TypeScript-AST census over every tracked `.ts`/`.tsx` outside `patterns`, vendored types, and generated declarations: for each class member, the `//` blocks in its leading trivia, minus tool directives, section-marker frames, and `TODO`s. A control fixture of nine planted sites and four decoys reported exactly the nine.

## Verification

* Comment-only, by construction and by proof: each changed file transpiles to byte-identical JavaScript with comments stripped, before and after (19 files, 0 differ).
* The census re-run over the changed files reports only the eight labels above; the blank-line-below detector reports none.
* `deno fmt --check`, `deno lint`, and `deno task check` repo-wide, all green.
* `deno task test` in `ui`: 171 passed and 70 browser tests passed, 0 failed.

## Review

A `cf-review` pass (report only) found no false statement, and six places a reader of the guide would ask about, all taken: `runtime` and `space` in `cf-prompt-input.ts` each get their own doc comment, without the claim about how `cf-file-input` consumes them; the fake tab's `onClickDispatch` carries the sentence that was about it rather than `tagName`; `value` in `cf-submit-input.ts` and the fake panel's `hidden` open with a noun phrase; `#link()` names `#image()` rather than "the ones below"; the tools chip's three overlay fields keep a group label, as the other group labels do; `_containerRef`'s comment fits on one line and is written on one. From the nits: `_navigable` names the `noNavigate` gate, and the `heading-id.ts` sentence has its antecedent before its pronoun.
