### PR TITLE
fix: a pattern names `SqliteDb` in its default export, and a database handle input arrives as a handle

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -85,6 +85,7 @@ on the Common Fabric runtime.
 
 - [capabilities/llm.md](capabilities/llm.md) — `generateText` / `generateObject`; reactive results, no `await`
 - [capabilities/fetch.md](capabilities/fetch.md) — `fetchJson` / `fetchText` / `fetchJsonUnchecked` / `fetchBinary`; reactive results, no `await`
+- [capabilities/sqlite.md](capabilities/sqlite.md) — reading a `SqliteDb` a pattern was given as an input: `db.query`, one statement per database, session-scoped results under a read ceiling
 
 ### workflows/ — CLI and testing mechanics
 

--- a/docs/common/capabilities/sqlite.md
+++ b/docs/common/capabilities/sqlite.md
@@ -1,0 +1,123 @@
+# Reading a SQLite Database
+
+A pattern can be handed a SQLite database the way it is handed any other input:
+by reference. The input is typed `SqliteDb`, and the pattern reads it with
+`db.query`. It never opens a file, never names a path, and never picks a source
+— whoever wired the input chose those.
+
+The handle's readable value is a small descriptor, not the data. Reading it as
+a value tells a pattern nothing it can compute over; the rows come back only
+from a query.
+
+## Declaring the input
+
+Type the input `SqliteDb`, imported from `commonfabric`:
+
+```tsx
+// Shown at module scope.
+import { pattern, type SqliteDb } from "commonfabric";
+
+interface Input {
+  orders: SqliteDb;
+}
+
+export default pattern<Input>(({ orders }) => ({
+  count: orders.query<{ n: number }>("SELECT count(*) AS n FROM orders"),
+}));
+```
+
+`SqliteDb` is the whole declaration. A pattern that widens it — to `any`, or to
+a hand-written object type with a `query` method on it — compiles and then
+receives the handle's descriptor value rather than the handle, so `query` is
+missing at run time. What makes the input arrive as a handle is the declared
+type: `SqliteDb` is what the compiler lowers to the cell-shaped input the
+runtime binds a database to.
+
+## db.query
+
+`db.query<Row>(sql, options?)` is a reactive read, not a promise. Never `await`
+it. Call it in the pattern body and read `pending` / `error` / `result`
+reactively; it re-runs when its inputs change, and results are memoized per
+request.
+
+```tsx
+// Shown at module scope.
+export default pattern<{ orders: SqliteDb }>(({ orders }) => {
+  const pending = orders.query<{ id: number; glaze: string; boxes: number }>(
+    "SELECT id, glaze, boxes FROM orders WHERE shipped = 0 ORDER BY id",
+  );
+
+  return lift((rows?: Array<{ glaze: string; boxes: number }>) =>
+    (rows ?? []).map((row) => `${row.boxes} × ${row.glaze}`).join(", ")
+  )(pending.result);
+});
+```
+
+The `<Row>` type argument names the columns the statement projects, and is what
+turns a result into something typed. Without it the rows come back as
+`Record<string, unknown>`, and a `_cf_link` column comes back as a raw link
+string rather than a live cell.
+
+The tables are declared on the database rather than on the pattern, so a
+pattern reading an input database does not restate them. What it needs to know
+is which tables and columns are there — the shape of the contract it is
+querying against — and that is a property of the handle it was given.
+
+Where a pattern also writes to the database, pass `{ reactOn: db }` so the read
+re-runs after a committed write. An input a pattern only reads has nothing to
+react to.
+
+## One statement, one database
+
+A query is a single read-only `SELECT` (a read-only CTE counts). Multiple
+statements, DML, DDL, `PRAGMA`, `ATTACH` and `DETACH` are refused, and so is a
+schema-qualified table name. The consequence worth planning around: one
+statement reads the tables of the one database it was issued on, and no
+statement can join across two handles. Two databases means two queries and a
+join expressed in the pattern.
+
+## Session-scoped results
+
+Where the runtime carries a read ceiling — a lens on what this particular run
+may observe — the result of every query it issues has to be **session-scoped**,
+and a query whose result is broader is refused before anything is written. A
+space- or user-shared result is one cell that every runtime on the space
+resolves, so one runtime cannot narrow it for itself; a session-scoped result
+is the run's own.
+
+Declare the scope on the query:
+
+```tsx
+// Shown at module scope.
+export const recentOrders = (orders: SqliteDb) =>
+  orders.query<{ id: number; glaze: string }>(
+    "SELECT id, glaze FROM orders ORDER BY id DESC LIMIT 20",
+    { scope: "session" },
+  );
+```
+
+`PerSession<>` on the result field and `.asScope("session")` on the query do
+the same thing, and a session-scoped database makes its queries session-scoped
+without a declaration. A run under a ceiling that gets a refusal instead of
+rows is usually a query that declared no scope.
+
+## Labeled columns
+
+A column may declare an `ifc` label on the database's table schema, and that
+label rides into the result: a row read out of a labeled column carries what
+the column requires, and code downstream of the read is held to it. Two
+options bound a read against such a column — `maxConfidentiality` for a ceiling
+the result may not exceed, and `onExceed` to choose between failing the query
+and dropping the rows that exceed it.
+
+## The rest of the API
+
+[`docs/specs/sqlite-builtin/`](../../specs/sqlite-builtin/README.md) is the full
+specification: the handle type and the method surface in
+[01](../../specs/sqlite-builtin/01-api.md), links in columns in
+[02](../../specs/sqlite-builtin/02-cf-link-encoding.md), where a database comes
+from in [03](../../specs/sqlite-builtin/03-database-sources.md), the statement
+guard and transactions in
+[04](../../specs/sqlite-builtin/04-server-execution-and-transactions.md),
+reactivity in [05](../../specs/sqlite-builtin/05-reactivity.md), and the label
+rules in [06](../../specs/sqlite-builtin/06-cfc.md).

--- a/docs/specs/sqlite-builtin/01-api.md
+++ b/docs/specs/sqlite-builtin/01-api.md
@@ -57,11 +57,11 @@ empty object:
 
 ```ts
 // Shown at module scope.
-declare const __sqliteDb: unique symbol;
+export declare const SQLITE_DB_BRAND: unique symbol;
 /** Opaque database handle value (the SqliteDb cell's readable value). Patterns
  *  forward the SqliteDb cell to db.query / db.exec / reactOn; they do not read
  *  the handle fields directly. */
-export type SqliteDatabase = { readonly [__sqliteDb]: true };
+export type SqliteDatabase = { readonly [SQLITE_DB_BRAND]: true };
 
 /** Imperative write: records a SQLite write onto the current transaction. */
 export interface ISqliteExecutable {
@@ -104,6 +104,12 @@ export interface SqliteDb<T = SqliteDatabase>
   extends BrandedCell<T, "sqlite">, IAnyCell<T>, IReadable<T>,
     ISqliteExecutable, ISqliteQueryable {}
 ```
+
+The brand symbol is exported. Nothing reads it — it exists to keep
+`SqliteDatabase` nominal — but a pattern that names `SqliteDb` in an exported
+signature emits a declaration that refers to it, and a symbol the pattern's
+module cannot name is one the compiler refuses to emit past. Every brand in the
+pattern API is exported for that reason.
 
 Why a cell variant rather than `Cell<SqliteDatabase>` or an opaque empty value:
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2712,14 +2712,14 @@ export type DataFileFunction = (path: string) => string;
 // SQLite builtins (docs/specs/sqlite-builtin)
 //
 
-declare const __sqliteDb: unique symbol;
+export declare const SQLITE_DB_BRAND: unique symbol;
 
 /**
  * Database handle. Empty to pattern code; a cell reference to the runtime
  * via the `toCell` back-pointer. Patterns only ever *forward* it (to sqliteQuery
  * / sqliteExecute / reactOn), never read it.
  */
-export type SqliteDatabase = { readonly [__sqliteDb]: true };
+export type SqliteDatabase = { readonly [SQLITE_DB_BRAND]: true };
 
 /** Imperative write on a SqliteDb handle: records a SQLite write onto the
  *  current transaction so it commits atomically with surrounding cell writes

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2712,6 +2712,13 @@ export type DataFileFunction = (path: string) => string;
 // SQLite builtins (docs/specs/sqlite-builtin)
 //
 
+/**
+ * Brand symbol keying {@link SqliteDatabase}, so a handle value is nominal
+ * rather than an empty object any value satisfies. Exported because a pattern
+ * naming `SqliteDb` in an exported signature emits a declaration that refers
+ * to it, and declaration emit cannot name a symbol the pattern's module has
+ * no route to.
+ */
 export declare const SQLITE_DB_BRAND: unique symbol;
 
 /**

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -1324,11 +1324,14 @@ export const runPatternTool: HarnessToolDefinition<
       if (propertySchema === undefined || !isObjectNotArray(propertySchema)) {
         return propertySchema;
       }
-      // A position the argument declares `asCell` — `Cell<T>`, `Stream<T>`,
-      // `SqliteDb` — reads back as the handle rather than as the value, and a
-      // handle is not what the rest of the schema describes. This read is for
-      // the value the input holds, so it drops the handle declaration and
-      // keeps the description of the contents.
+      // A position the argument declares `asCell` — `Cell<T>` and `SqliteDb`,
+      // which is a cell variant — reads back as the handle rather than as the
+      // value, and a handle is not what the rest of the schema describes. This
+      // read is for the value the input holds, so it drops the handle
+      // declaration and keeps the description of the contents. `asStream` is
+      // the other half of that vocabulary and is left alone: no input reaches
+      // this pre-flight declaring one, so what dropping it would read back is
+      // unmeasured.
       const { asCell: _asCell, ...valueSchema } = propertySchema;
       const defs = selectReferencedCfcSchemaDefs(valueSchema, argumentDefs);
       return defs === undefined ? valueSchema : { ...valueSchema, $defs: defs };

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -1324,11 +1324,14 @@ export const runPatternTool: HarnessToolDefinition<
       if (propertySchema === undefined || !isObjectNotArray(propertySchema)) {
         return propertySchema;
       }
-      const defs = selectReferencedCfcSchemaDefs(propertySchema, argumentDefs);
-      return defs === undefined ? propertySchema : {
-        ...propertySchema,
-        $defs: defs,
-      };
+      // A position the argument declares `asCell` — `Cell<T>`, `Stream<T>`,
+      // `SqliteDb` — reads back as the handle rather than as the value, and a
+      // handle is not what the rest of the schema describes. This read is for
+      // the value the input holds, so it drops the handle declaration and
+      // keeps the description of the contents.
+      const { asCell: _asCell, ...valueSchema } = propertySchema;
+      const defs = selectReferencedCfcSchemaDefs(valueSchema, argumentDefs);
+      return defs === undefined ? valueSchema : { ...valueSchema, $defs: defs };
     };
     for (const { key, cell } of liveCellInputs) {
       const readSchema = readSchemaForKey(key);

--- a/packages/cf-harness/test/run-pattern-sqlite-input.test.ts
+++ b/packages/cf-harness/test/run-pattern-sqlite-input.test.ts
@@ -1,0 +1,174 @@
+/**
+ * `run_pattern` over a pattern whose input is a SQLite database handle — the
+ * shape a model writes when the harness hands it an injected store.
+ *
+ * Two separate things carry that run. The source compiles with `SqliteDb`
+ * naming an input, which the js-compiler's brand filter settles at declaration
+ * emit; and the handle cell named as that input reaches the pattern as a
+ * handle, which turns on how `run_pattern` measures a live-cell input against
+ * the argument schema before any piece exists.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { table } from "@commonfabric/memory/sqlite/schema";
+import type { SqliteDbRef } from "@commonfabric/memory/v2";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { Runtime } from "@commonfabric/runner";
+import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { CfHarnessEngine } from "../src/engine.ts";
+import type { RunPatternToolSuccessOutput } from "../src/tools/run-pattern.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+
+const signer = await Identity.fromPassphrase("cf-harness sqlite input");
+
+/**
+ * A pattern typed the way a model types one against an injected store: the
+ * input is a `SqliteDb`, and the rows come from `query` on it.
+ */
+const MAIL_PATTERN_SOURCE = [
+  "import { computed, pattern, type SqliteDb } from 'commonfabric';",
+  "interface BillRow { id: number; subject: string; }",
+  "type Input = { mail: SqliteDb };",
+  "type Output = { subjects: string[]; pending: boolean };",
+  "export default pattern<Input, Output>(({ mail }) => {",
+  "  const bills = mail.query<BillRow>('SELECT id, subject FROM messages', {});",
+  "  return {",
+  "    subjects: computed(() => (bills.result ?? []).map((row) => row.subject)),",
+  "    pending: computed(() => bills.pending === true),",
+  "  };",
+  "});",
+  "",
+].join("\n");
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
+  resolvePath(path: string): string {
+    return path;
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path.startsWith("/workspace");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(_request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+}
+
+describe("run_pattern over a database handle input", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `sqlite-input-${crypto.randomUUID()}`,
+      }),
+      runtime,
+    );
+    await pieces.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /**
+   * Seed a database holding one `messages` row and return the LLM-friendly
+   * link naming its handle cell — the address a model is handed for an
+   * injected store, and passes straight back as an input.
+   */
+  async function seedDatabaseHandle(subject: string): Promise<string> {
+    const space = pieces.getSpace();
+    const dbRef: SqliteDbRef = {
+      id: `sqlite-input-${crypto.randomUUID()}`,
+      tables: {
+        messages: table({ id: "integer primary key", subject: "text" }),
+      },
+    };
+    const tx = runtime.edit();
+    const handle = runtime.getCell<SqliteDbRef>(
+      space,
+      "sqlite-input-handle",
+      undefined,
+      tx,
+    );
+    handle.set(dbRef);
+    tx.recordSqliteWrite!(space, {
+      op: "sqlite",
+      db: dbRef,
+      sql: "INSERT INTO messages (id, subject) VALUES (?, ?)",
+      params: [1, subject],
+    });
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+    return createLLMFriendlyLink(handle.getAsNormalizedFullLink(), space);
+  }
+
+  function createEngine(): CfHarnessEngine {
+    return new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: `sqlite-input-${crypto.randomUUID()}`,
+      cfcEnforcementMode: "disabled",
+      fabricSessionFactory: () => Promise.resolve({ pieces }),
+    });
+  }
+
+  it("runs a pattern whose input is typed `SqliteDb` and queries the database the input names", async () => {
+    const mail = await seedDatabaseHandle("rent");
+    const result = await createEngine().invokeBuiltinTool("run_pattern", {
+      sourceText: MAIL_PATTERN_SOURCE,
+      inputs: { mail },
+    });
+
+    const output = result.output as RunPatternToolSuccessOutput;
+    expect(output.status).toBe("ok");
+
+    // The query is a server round-trip, so the run returns while it is still
+    // in flight; the piece's own result is where it lands.
+    const piece = await pieces.get(output.pieceId);
+    await runtime.idle();
+    await pieces.synced();
+    await runtime.idle();
+    expect(await piece.result.get()).toEqual({
+      pending: false,
+      subjects: ["rent"],
+    });
+  });
+});

--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -118,6 +118,20 @@ types["commonfabric.d.ts"] = await staticCache.getText(
   "types/commonfabric.d.ts",
 );
 
+/**
+ * The modules a pattern's `commonfabric` import resolves to, as the compiler
+ * takes them: one program file per module name, since the resolver maps a
+ * runtime module to a `.d.ts` of the same name among the program's files.
+ */
+const FABRIC_RUNTIME_MODULES = ["commonfabric", "commonfabric/schema"];
+const fabricTypeModules: Record<string, string> = {
+  "commonfabric.d.ts": types["commonfabric.d.ts"],
+  "commonfabric/schema.d.ts": await staticCache.getText(
+    "types/commonfabric-schema.d.ts",
+  ),
+  "cfc.ts": await staticCache.getText("types/cfc.ts"),
+};
+
 /** Resolve via the compiler's resolver, then emit per-module CommonJS. */
 async function resolveAndCompileToModules(
   compiler: TypeScriptCompiler,
@@ -570,6 +584,35 @@ export type PerUser<T> = T & { readonly [SCOPE_BRAND]?: "user" };
     await resolveAndCompileToModules(compiler, program, {
       runtimeModules: ["commonfabric"],
     });
+  });
+
+  it("compiles a pattern whose default export is typed by a branded runtime handle", async () => {
+    // The pattern API's branded handle types key on `unique symbol`s the
+    // sandbox module declares, and TypeScript's declaration emit cannot name
+    // one from the pattern's own emitted declaration. Only the compiler's
+    // filter over those brands (`KNOWN_EXPORTED_SYMBOLS`) keeps this
+    // compiling, and only when the brand is on it — so the real type module
+    // is what this compiles against, not a stand-in.
+
+    const program = new InMemoryProgram("/main.tsx", {
+      "/main.tsx": `
+import { pattern, type SqliteDb } from "commonfabric";
+
+interface BillRow { id: number; subject: string; }
+type Input = { mail: SqliteDb };
+type Output = { bills: unknown };
+
+export default pattern<Input, Output>(({ mail }) => ({
+  bills: mail.query<BillRow>("SELECT id, subject FROM messages", {}),
+}));
+`,
+      ...fabricTypeModules,
+    });
+    const compiler = new TypeScriptCompiler(types);
+    const modules = await resolveAndCompileToModules(compiler, program, {
+      runtimeModules: FABRIC_RUNTIME_MODULES,
+    });
+    expect(modules.get("/main.tsx")).toBeDefined();
   });
 
   it("Inlines errors", async () => {

--- a/packages/js-compiler/typescript/diagnostics/checker.ts
+++ b/packages/js-compiler/typescript/diagnostics/checker.ts
@@ -27,6 +27,7 @@ const KNOWN_EXPORTED_SYMBOLS = [
   "CELL_INNER_TYPE",
   "DEFAULT_MARKER",
   "SCOPE_BRAND",
+  "SQLITE_DB_BRAND",
 ];
 
 // TS2578 "Unused '@ts-expect-error' directive." must not fail STORED-source

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -443,6 +443,7 @@ type IntentionallyUnrequired =
   | "DEFAULT_MARKER"
   | "FRAMEWORK_PROVIDED_MARKER"
   | "SCOPE_BRAND"
+  | "SQLITE_DB_BRAND"
   // The CFC authoring vocabulary. `packages/api/index.ts` re-exports the types
   // out of `cfc.ts` with `export type *`, and TypeScript carries the value
   // meaning of those names into the module's type even though nothing is

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -3242,6 +3242,13 @@ export type DataFileFunction = (path: string) => string;
 // SQLite builtins (docs/specs/sqlite-builtin)
 //
 
+/**
+ * Brand symbol keying {@link SqliteDatabase}, so a handle value is nominal
+ * rather than an empty object any value satisfies. Exported because a pattern
+ * naming `SqliteDb` in an exported signature emits a declaration that refers
+ * to it, and declaration emit cannot name a symbol the pattern's module has
+ * no route to.
+ */
 export declare const SQLITE_DB_BRAND: unique symbol;
 
 /**

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -3242,14 +3242,14 @@ export type DataFileFunction = (path: string) => string;
 // SQLite builtins (docs/specs/sqlite-builtin)
 //
 
-declare const __sqliteDb: unique symbol;
+export declare const SQLITE_DB_BRAND: unique symbol;
 
 /**
  * Database handle. Empty to pattern code; a cell reference to the runtime
  * via the `toCell` back-pointer. Patterns only ever *forward* it (to sqliteQuery
  * / sqliteExecute / reactOn), never read it.
  */
-export type SqliteDatabase = { readonly [__sqliteDb]: true };
+export type SqliteDatabase = { readonly [SQLITE_DB_BRAND]: true };
 
 /** Imperative write on a SqliteDb handle: records a SQLite write onto the
  *  current transaction so it commits atomically with surrounding cell writes


### PR DESCRIPTION
## What

A pattern can now name `SqliteDb` in its default export, and a database handle input arrives at `run_pattern` as a handle.

`SqliteDatabase`'s brand was the one `unique symbol` in the pattern API that `packages/api/index.ts` did not export, and the only one missing from the js-compiler's `KNOWN_EXPORTED_SYMBOLS`. A pattern whose default export is the `pattern(...)` call itself emits a declaration referring to that symbol, and the declaration check refused it: "Default export of the module has or is using private name '__sqliteDb'". Assigning to a `const` first hid it, which is why the checked-in patterns and Loom's own panel compiled.

The brand is now exported as `SQLITE_DB_BRAND`, listed in the checker's brand filter beside `CELL_BRAND` and `SCOPE_BRAND`, and recorded in the builder's `IntentionallyUnrequired` as a brand with no runtime value — the three places every other brand in the API already appears.

Getting past the compile exposed a second refusal on `run_pattern`'s own path. Its pre-flight check reads a live-cell input through the argument schema for that key; where the key is declared `asCell`, that read returns the handle, which the same schema then rejects because it describes the contents. The read now drops the handle declaration, so a `SqliteDb` input is measured by the descriptor it holds. (`Stream<T>` is declared by `asStream`, a separate keyword this leaves in place.)

## Why

CT-2189 probe A run 2: a pattern-author child wrote the correct typed program (`mail: SqliteDb`, session-scoped `mail.query`) on its first attempt and the compiler refused it four times. Root cause of both the compile refusals and the fallback typing that followed.

## Tests

`packages/cf-harness/test/run-pattern-sqlite-input.test.ts` passes an injected-shaped handle cell as a `run_pattern` input to a pattern typed `mail: SqliteDb`; the piece settles on a real query result. Reverting the pre-flight change fails it.

## Follow-ups

`docs/common/capabilities/sqlite.md` "Declaring the input" section lands with #7021's copy. The emitted value-schema for `SqliteDatabase` (`{properties:{}}` vs the spec's descriptor) is CT-2267, landed separately in #7042.
