### PR TITLE
style(runner): `//` notes that documented a class member are doc comments, in `storage/`

### DIFF
--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -333,51 +333,73 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   >();
   #statusOverride?: StorageTransactionStatus;
   #commitCallbacksDispatched = false;
-  // Verdict callbacks fire when the commit's fate is sealed — the accept
-  // verdict or the rejection receipt — BEFORE the coverage / read-repair
-  // waits the commit promise (and commit callbacks) additionally sit out.
+
+  /**
+   * Verdict callbacks, which fire when the commit's fate is sealed — the accept
+   * verdict or the rejection receipt — _before_ the coverage and read-repair
+   * waits the commit promise (and commit callbacks) additionally sit out.
+   */
   #verdictCallbacks = new Set<
     (
       tx: IExtendedStorageTransaction,
       result: Result<Unit, CommitError>,
     ) => void
   >();
+
   #verdictCallbacksDispatched = false;
-  // Post-commit effects this transaction staged and then discarded, held for
-  // the moment the code that owns its retries stops retrying it — a decision no
-  // rejection carries on its own, since a refusal one attempt cannot get past
-  // is often one a later attempt can. Effects handed to a seal destination are
-  // not here: that clears the outbox too, and it is a handover rather than an
-  // ending.
+
+  /**
+   * Post-commit effects this transaction staged and then discarded, held for
+   * the moment the code that owns its retries stops retrying it — a decision no
+   * rejection carries on its own, since a refusal one attempt cannot get past
+   * is often one a later attempt can. Effects handed to a seal destination are
+   * not here: that clears the outbox too, and it is a handover rather than an
+   * ending.
+   */
   #abandonableEffects: PostCommitSideEffect[] = [];
+
   #abandonDispatched = false;
-  // Set when a commit of this transaction succeeded. Abandonment is what the
-  // staged work hears instead of a commit, so a transaction that committed has
-  // nothing to abandon, and saying otherwise would report a request as never
-  // sent after the outbox flushed it.
+
+  /**
+   * Whether a commit of this transaction succeeded. Abandonment is what the
+   * staged work hears instead of a commit, so a transaction that committed has
+   * nothing to abandon, and saying otherwise would report a request as never
+   * sent after the outbox flushed it.
+   */
   #committed = false;
-  // The verdict-time effect run of the current commit(): verdict callbacks
-  // plus the CFC outbox flush. What settled()-style barriers wait on in
-  // place of the commit promise, whose resolution additionally waits for
-  // view coverage.
+
+  /**
+   * The verdict-time effect run of the current `commit()`: verdict callbacks
+   * plus the CFC outbox flush. What `settled()`-style barriers wait on in place
+   * of the commit promise, whose resolution additionally waits for view
+   * coverage.
+   */
   #postCommitEffects?: Promise<void>;
+
   #commitPreparationCrash: string | undefined;
-  // The transaction's fate, resolved exactly when the verdict callbacks
-  // dispatch — every fate path (commit verdict, rejection receipt, abort,
-  // pre-storage rejection, internal commit rejection) funnels through that
-  // dispatch.
+
+  /**
+   * The transaction's fate, resolved exactly when the verdict callbacks
+   * dispatch — every fate path (commit verdict, rejection receipt, abort,
+   * pre-storage rejection, internal commit rejection) funnels through that
+   * dispatch.
+   */
   readonly #verdict = Promise.withResolvers<Result<Unit, CommitError>>();
+
   #commitPreconditions = new Map<MemorySpace, CommitPrecondition[]>();
   #createOnlyMarks = new Map<MemorySpace, Set<string>>();
   #outboxIdempotencyKeys = new Set<string>();
   #readOnlySource?: string;
   #narrowestReadScope: CellScope = "space";
-  // ECMAScript-private (#), like #privilegedSystemWriteDepth below: the CFC
-  // state is the enforcement substrate (dials, pins, relevance, trigger
-  // reads, policy inputs, prepare status), and handler code reaching the tx
-  // via `(cell.tx as any)` must not be able to grab the raw object and
-  // mutate it. Reads go through getCfcState(), which returns a read-only
-  // view (see readOnlyCfcView).
+
+  /**
+   * The CFC state. ECMAScript-private (`#`), like `#privilegedSystemWriteDepth`
+   * below: the CFC state is the enforcement substrate (dials, pins, relevance,
+   * trigger reads, policy inputs, prepare status), and handler code reaching
+   * the tx via `(cell.tx as any)` must not be able to grab the raw object and
+   * mutate it. Reads go through `getCfcState()`, which returns a read-only view
+   * (see `readOnlyCfcView`).
+   */
   #cfcState: CfcTxState = {
     relevant: false,
     enforcementMode: DEFAULT_CFC_ENFORCEMENT_MODE,
@@ -404,94 +426,134 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     labelMetadataObservations: [],
     refusalDetails: [],
   };
+
   #reportedCfcRelevant = false;
   #reportedCfcPrepared = false;
-  // The pins below are ECMAScript-private for the same reason as #cfcState:
-  // a TS-`private` pin could be cleared via `(cell.tx as any)` and the dial
-  // then legally weakened through its setter.
-  // Highest enforcing strictness ever set on this tx; mode cannot drop below it.
+
+  /**
+   * Highest enforcing strictness ever set on this tx; the mode cannot drop
+   * below it. This pin and the ones below are ECMAScript-private for the same
+   * reason as `#cfcState`: a TS-`private` pin could be cleared via
+   * `(cell.tx as any)` and the dial then legally weakened through its setter.
+   */
   #cfcEnforcementFloor = 0;
-  // Once flow-label persistence is on for this tx it cannot be turned back
-  // off — same shape as the enforcement floor (audit S3): code holding a
-  // Cell must not disable propagation mid-transaction to launder a value.
+
+  /**
+   * Whether flow-label persistence is pinned on for this tx. Once on it cannot
+   * be turned back off — the same shape as the enforcement floor (audit S3):
+   * code holding a `Cell` must not disable propagation mid-transaction to
+   * launder a value.
+   */
   #cfcFlowLabelsPinned = false;
+
   #cfcWriteFloorPinned = false;
   #cfcTriggerReadGatingPinned = false;
   #cfcPolicyEvaluationPinned = false;
   #cfcLabelMetadataProtectionPinned = false;
   #cfcDeclaredMonotonicityPinned = false;
-  // Write-once pin for the deployment policy snapshot. Distinct from the
-  // slot's value being defined: the Runtime configures MANY tx with NO
-  // policies (`undefined`), and that "no policies" state must be just as
-  // write-once as a configured one — otherwise handler code reaching the
-  // concrete tx via `(cell.tx as any)` could install an attacker-supplied
-  // snapshot after the Runtime's `undefined` call left the slot open
-  // (codex P1 on #4562). Set on the FIRST call (always the Runtime's, in
-  // edit()), regardless of value.
+
+  /**
+   * Write-once pin for the deployment policy snapshot. Distinct from the slot's
+   * value being defined: the `Runtime` configures _many_ tx with _no_ policies
+   * (`undefined`), and that no-policies state must be just as write-once as a
+   * configured one — otherwise handler code reaching the concrete tx via
+   * `(cell.tx as any)` could install an attacker-supplied snapshot after the
+   * `Runtime`'s `undefined` call left the slot open. Set on the _first_ call
+   * (always the `Runtime`'s, in `edit()`), regardless of value.
+   */
   #cfcPolicySnapshotPinned = false;
-  // Write-once pin for the deployment trust config. Distinct from the slot's
-  // value being defined: the Runtime configures many tx with NO trust config
-  // (`undefined`), and that "no config; every concept guard fails closed"
-  // state must be just as write-once as a configured one — otherwise handler
-  // code reaching the concrete tx via `(cell.tx as any)` could install an
-  // arbitrary config before the concept guards read it (codex P2 on #4563).
-  // Set on the FIRST call (always the Runtime's, in edit()), regardless of
-  // value.
+
+  /**
+   * Write-once pin for the deployment trust config. Distinct from the slot's
+   * value being defined: the `Runtime` configures many tx with _no_ trust
+   * config (`undefined`), and that state — no config, every concept guard fails
+   * closed — must be just as write-once as a configured one — otherwise handler
+   * code reaching the concrete tx via `(cell.tx as any)` could install an
+   * arbitrary config before the concept guards read it. Set on the _first_ call
+   * (always the `Runtime`'s, in `edit()`), regardless of value.
+   */
   #cfcTrustConfigPinned = false;
+
   #cfcModuleDelegationsPinned = false;
-  // Depth of the runtime's privileged system-write scope. The runtime's own
-  // label/schema persistence (prepareBoundaryCommit) runs inside it; any write
-  // to a protected system path outside it is recorded as unprivileged (S18).
-  // ECMAScript-private (#) so handler code reaching cell.tx cannot enter the
-  // scope via `(cell.tx as any)` — `as any` cannot touch a `#private` member.
+
+  /**
+   * Depth of the runtime's privileged system-write scope. The runtime's own
+   * label/schema persistence (`prepareBoundaryCommit`) runs inside it; any
+   * write to a protected system path outside it is recorded as unprivileged
+   * (S18). ECMAScript-private (`#`) so handler code reaching `cell.tx` cannot
+   * enter the scope via `(cell.tx as any)` — `as any` cannot touch a `#private`
+   * member.
+   */
   #privilegedSystemWriteDepth = 0;
 
-  // The write-policy inputs the runtime recorded, by reference to the frozen
-  // record. `#`-private, so nothing outside this class can add to it; the one
-  // writer is `recordCfcWritePolicyInput` handed the runtime's mark.
+  /**
+   * The write-policy inputs the runtime recorded, by reference to the frozen
+   * record. `#`-private, so nothing outside this class can add to it; the one
+   * writer is `recordCfcWritePolicyInput()` handed the runtime's mark.
+   */
   #runtimeWritePolicyInputs = new WeakSet<WritePolicyInput>();
-  // The stores the runtime owns that a marker named on THIS transaction, by
-  // {@link runtimeOwnedStoreKey}. A store the runtime mints and fills in one
-  // go needs no more than this.
+
+  /**
+   * The stores the runtime owns that a marker named on _this_ transaction, by
+   * {@link runtimeOwnedStoreKey}. A store the runtime mints and fills in one go
+   * needs no more than this.
+   */
   #markedOwnedStores = new Set<string>();
-  // The stores the runtime owns that outlive the transaction that minted them,
-  // shared with every other transaction of the same runtime (`Runtime.edit`
-  // hands the same object to each). Absent on a transaction the runtime did
-  // not configure, which leaves only this transaction's own markers.
+
+  /**
+   * The stores the runtime owns that outlive the transaction that minted them,
+   * shared with every other transaction of the same runtime (`Runtime.edit()`
+   * hands the same object to each). Absent on a transaction the runtime did not
+   * configure, which leaves only this transaction's own markers.
+   */
   #runtimeOwnedStores: RuntimeOwnedStores | undefined;
-  // Per-transaction cache of `Cell.get()` results, keyed by stable cell view.
-  // Replaced wholesale on any write (see `#invalidateReadResultCache`), so a hit
-  // is only ever served when nothing has been written since the cached read.
-  // This is a Map rather than a WeakMap, but the transaction owns it and writes
-  // drop it wholesale, bounding retention to reads-without-writes in one tx.
+
+  /**
+   * Per-transaction cache of `Cell.get()` results, keyed by stable cell view.
+   * Replaced wholesale on any write (see `#invalidateReadResultCache()`), so a
+   * hit is only ever served when nothing has been written since the cached
+   * read. This is a `Map` rather than a `WeakMap`, but the transaction owns it
+   * and writes drop it wholesale, bounding retention to reads-without-writes in
+   * one tx.
+   */
   #readResultCache = new Map<string, Map<string, { value: unknown }>>();
+
   #readResultCacheHits = 0;
   #readResultCacheMisses = 0;
   #readResultCacheSets = 0;
-  // Per-transaction memo for derivations that read only this snapshot -- link
-  // resolution and CFC label views, each under its own key prefix. Dropped on
-  // any write alongside the read cache above, and bounded the same way: it
-  // retains only what was derived since this transaction's last write.
+
+  /**
+   * Per-transaction memo for derivations that read only this snapshot — link
+   * resolution and CFC label views, each under its own key prefix. Dropped on
+   * any write alongside the read cache above, and bounded the same way: it
+   * retains only what was derived since this transaction's last write.
+   */
   #snapshotMemo = new Map<string, unknown>();
 
-  // The seal destination (server-execution v2, serving-loop.md §3d): when
-  // installed, commit() closes by sealing into it instead of committing to
-  // the store — one abstraction, two destinations. ECMAScript-private with a
-  // write-once pin, same shape as #cfcPolicySnapshotPinned: the Runtime
-  // configures every tx exactly once in edit() (usually with `undefined` —
-  // every client, and the OFF arm always), and that state must be just as
-  // write-once as an installed destination, or handler code reaching the
-  // concrete tx via `(cell.tx as any)` could hijack the commit path.
+  /**
+   * The seal destination (`serving-loop.md` §3d): when installed, `commit()`
+   * closes by sealing into it instead of committing to the store — one
+   * abstraction, two destinations. ECMAScript-private with a write-once pin,
+   * the same shape as `#cfcPolicySnapshotPinned`: the `Runtime` configures
+   * every tx exactly once in `edit()` (usually with `undefined` — every client,
+   * and the OFF arm always), and that state must be just as write-once as an
+   * installed destination, or handler code reaching the concrete tx via
+   * `(cell.tx as any)` could hijack the commit path.
+   */
   #sealDestination: TransactionSealDestination | undefined;
+
   #sealDestinationPinned = false;
 
-  // Stage C tuning T1 (see IExtendedStorageTransaction.probeFlowLabelWork):
-  // the activity epoch counts every journaled read, write, dereference
-  // trace and trigger read; the memo holds the last NEGATIVE probe verdict
-  // with the epoch it was taken at (stamped AFTER the probe, whose own
-  // metadata reads are internal-verifier reads that never change the
-  // verdict but do move the epoch).
+  /**
+   * The activity epoch (see `IExtendedStorageTransaction.probeFlowLabelWork`),
+   * which counts every journaled read, write, dereference trace, and trigger
+   * read. The memo beside it holds the last _negative_ probe verdict with the
+   * epoch it was taken at (stamped _after_ the probe, whose own metadata reads
+   * are internal-verifier reads that never change the verdict but do move the
+   * epoch).
+   */
   #cfcActivityEpoch = 0;
+
   #flowLabelProbeMemo: { epoch: number } | undefined;
 
   #cfcInstrumentation: CfcInstrumentationHooks;
@@ -606,10 +668,12 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.#cfcInstrumentation.onSinkReleaseReject?.(info);
   }
 
-  // Append-only diagnostics seam for the CFC machinery outside this class
-  // (prepare's observe-mode notes). getCfcState() is a read-only view, so
-  // this is the one sanctioned write path; diagnostics are advisory text and
-  // never feed an enforcement decision, so exposing append is harmless.
+  /**
+   * Appends a diagnostic, as the one seam for the CFC machinery outside this
+   * class (prepare's observe-mode notes). `getCfcState()` is a read-only view,
+   * so this is the one sanctioned write path; diagnostics are advisory text and
+   * never feed an enforcement decision, so exposing append is harmless.
+   */
   noteCfcDiagnostic(message: string): void {
     this.#cfcState.diagnostics.push(message);
   }
@@ -873,10 +937,13 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     }
   }
 
-  // Per-sink confidentiality ceilings, set once by the Runtime at tx creation
-  // (before any handler code runs). Write-once: a later call is ignored, so
-  // code holding a Cell can't relax a configured ceiling mid-transaction. Not
-  // on the public tx interface for the same reason (audit S3 posture).
+  /**
+   * Sets the per-sink confidentiality ceilings, once, by the `Runtime` at tx
+   * creation (before any handler code runs). Write-once: a later call is
+   * ignored, so code holding a `Cell` can't relax a configured ceiling
+   * mid-transaction. Not on the public tx interface for the same reason (audit
+   * S3 posture).
+   */
   setCfcSinkMaxConfidentiality(map: SinkMaxConfidentiality): void {
     if (this.#cfcState.sinkMaxConfidentiality !== undefined) return;
     // Deep-freeze on store so the ceiling is immutable regardless of caller —
@@ -886,13 +953,16 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.#cfcState.sinkMaxConfidentiality = deepFreeze(map);
   }
 
-  // set once by the Runtime at tx creation. Write-once, off the public tx
-  // interface, deep-frozen on store. The pin (not the slot value) is what
-  // enforces write-once: the FIRST call — always the Runtime's, even when it
-  // configures no policies (`undefined`) — pins the slot, so a later
-  // `(cell.tx as any).setCfcPolicySnapshot(attackerSnapshot)` is ignored.
-  // (`buildCfcPolicySnapshot` already froze a configured snapshot; this
-  // deepFreeze is the cheap short-circuiting backstop for any other caller.)
+  /**
+   * Sets the deployment policy snapshot, once, by the `Runtime` at tx creation.
+   * Write-once, off the public tx interface, deep-frozen on store. The pin (not
+   * the slot value) is what enforces write-once: the _first_ call — always the
+   * `Runtime`'s, even when it configures no policies (`undefined`) — pins the
+   * slot, so a later `(cell.tx as any).setCfcPolicySnapshot(attackerSnapshot)`
+   * is ignored. (`buildCfcPolicySnapshot()` already froze a configured
+   * snapshot; this `deepFreeze()` is the cheap short-circuiting backstop for
+   * any other caller.)
+   */
   setCfcPolicySnapshot(snapshot: PolicySnapshot | undefined): void {
     if (this.#cfcPolicySnapshotPinned) return;
     this.#cfcPolicySnapshotPinned = true;
@@ -901,11 +971,14 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       : deepFreeze(snapshot);
   }
 
-  // Deployment trust config for concept-guard satisfaction (Epic B3). The pin
-  // (not the slot value) enforces write-once: the FIRST call — always the
-  // Runtime's, even when it configures no trust (`undefined`) — pins the slot,
-  // so a later `(cell.tx as any).setCfcTrustConfig(attackerConfig)` is
-  // ignored and the "no config; concept guards fail closed" state holds.
+  /**
+   * Sets the deployment trust config for concept-guard satisfaction. The pin
+   * (not the slot value) enforces write-once: the _first_ call — always the
+   * `Runtime`'s, even when it configures no trust (`undefined`) — pins the
+   * slot, so a later `(cell.tx as any).setCfcTrustConfig(attackerConfig)` is
+   * ignored and the state where there is no config and concept guards fail
+   * closed holds.
+   */
   setCfcTrustConfig(config: CfcTrustConfig | undefined): void {
     if (this.#cfcTrustConfigPinned) return;
     this.#cfcTrustConfigPinned = true;
@@ -914,9 +987,12 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       : deepFreeze(config);
   }
 
-  // Module-update authority is runtime-learned trust state. Snapshot and pin
-  // it once at transaction creation: later module loads affect future
-  // transactions, never an authorization decision already in flight.
+  /**
+   * Sets the module-update delegations, which are runtime-learned trust state.
+   * Snapshotted and pinned once at transaction creation: later module loads
+   * affect future transactions, never an authorization decision already in
+   * flight.
+   */
   setCfcModuleDelegations(
     delegations: ReadonlyMap<
       MemorySpace,
@@ -950,15 +1026,18 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     }
   }
 
-  // Runs `fn` with writes to protected system paths (a document's ["cfc"]
-  // label-map) permitted. The runtime's own label/schema persistence in
-  // prepareBoundaryCommit is the only legitimate such writer; `prepareCfc`
-  // wraps that call in this scope via `this`. ECMAScript-private (#) and absent
-  // from IExtendedStorageTransaction, so handler code reaching `cell.tx` cannot
-  // enter the scope — `(cell.tx as any).#runPrivilegedSystemWrite` is a
-  // TypeError, not a bypass (audit S18 review). Tests that need stored ["cfc"]
-  // metadata seed it instead via an ungated path-[] full-document write (the
-  // same shape hydration delivers), never through this scope.
+  /**
+   * Runs `fn` with writes to protected system paths (a document's `["cfc"]`
+   * label-map) permitted. The runtime's own label/schema persistence in
+   * `prepareBoundaryCommit` is the only legitimate such writer; `prepareCfc()`
+   * wraps that call in this scope via `this`. ECMAScript-private (`#`) and
+   * absent from `IExtendedStorageTransaction`, so handler code reaching
+   * `cell.tx` cannot enter the scope —
+   * `(cell.tx as any).#runPrivilegedSystemWrite` is a `TypeError`, not a bypass
+   * (audit S18). Tests that need stored `["cfc"]` metadata seed it instead via
+   * an ungated path-`[]` full-document write (the same shape hydration
+   * delivers), never through this scope.
+   */
   #runPrivilegedSystemWrite<T>(fn: () => T): T {
     this.#privilegedSystemWriteDepth += 1;
     try {
@@ -968,25 +1047,27 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     }
   }
 
-  // Record a write that reaches a document's ["cfc"] label map from outside
-  // the privileged scope, whether by naming that path or by replacing the
-  // whole document envelope. Such a write forges or erases the metadata that
-  // drives CFC derivation for OTHER writes, bypassing the commit-boundary
-  // derivation + mint-gating (audit S18). prepareBoundaryCommit turns each
-  // recorded address into a fail-closed reason, so the violation surfaces
-  // uniformly with every other CFC reason (enforce rejects, observe
-  // diagnoses). Recording (and relevance marking) is deliberately
-  // unconditional on the enforcement mode, like every other CFC signal:
-  // setCfcEnforcementMode permits raising the mode mid-transaction
-  // (disabled/observe impose no floor), so a forgery in a disabled window must
-  // still be on record when a later escalation evaluates it. A transaction
-  // still `disabled` at commit never runs prepareBoundaryCommit, so the record
-  // stays inert there.
+  /**
+   * Records a write that reaches a document's `["cfc"]` label map from outside
+   * the privileged scope, whether by naming that path or by replacing the whole
+   * document envelope. Such a write forges or erases the metadata that drives
+   * CFC derivation for _other_ writes, bypassing the commit-boundary derivation
+   * and mint-gating (audit S18). `prepareBoundaryCommit` turns each recorded
+   * address into a fail-closed reason, so the violation surfaces uniformly with
+   * every other CFC reason (enforce rejects, observe diagnoses).
+   */
   #noteSystemWrite(
     address: IMemorySpaceAddress,
     value?: FabricValue,
     options?: IWriteOptions,
   ): void {
+    // Recording (and relevance marking) is deliberately unconditional on the
+    // enforcement mode, like every other CFC signal: setCfcEnforcementMode
+    // permits raising the mode mid-transaction (disabled/observe impose no
+    // floor), so a forgery in a disabled window must still be on record when
+    // a later escalation evaluates it. A transaction still `disabled` at
+    // commit never runs prepareBoundaryCommit, so the record stays inert
+    // there.
     if (this.#privilegedSystemWriteDepth > 0) return;
     if (address.id.startsWith(CFC_POLICY_MANIFEST_ID_PREFIX)) {
       throw new Error(
@@ -1093,61 +1174,63 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     );
   }
 
-  // Record a path-[] whole-document write that erases the stored ["cfc"] label
-  // map. Such a write replaces every sibling of `value`, so an envelope that
-  // leaves the document without a label map erases the one it held, and a
-  // labeled document reads afterwards as an unlabeled one. That is the
-  // downgrade the ["cfc"]-path arm above catches, reached by omission rather
-  // than by overwrite, so it lands in the same record and yields the same
-  // fail-closed reason.
-  //
-  // Both halves ask `cfcMetadataPresent`, the reader's own account of what
-  // presents a label map, so the arm fires on the change a reader would see
-  // rather than on the presence of a key. An envelope carrying `cfc: null`, or
-  // any other value the reader reports as absent, erases the map as surely as
-  // one carrying no `cfc` at all. A stored value the reader reports as absent
-  // is not a map to erase.
-  //
-  // What this does NOT reach is a root write that leaves a label map behind
-  // but not the stored one — minting a map where the document had none, or
-  // substituting one for another. Both are the S18 forgery this seam still
-  // stands open on, and the CFC test suite seeds stored label state through
-  // exactly those shapes, so closing them means giving those fixtures another
-  // way to seed first.
-  //
-  // The arm fires only when a map is there to erase: creating a document, and
-  // replacing one that carries no label map, pass through. Hydration passes
-  // through as well — an envelope delivered from storage carries the `cfc` it
-  // was stored with — and the runtime's own root writes (`cid:` schema
-  // documents) return at the privileged-scope check above before reaching
-  // here.
-  //
-  // The read carries no weight of its own, the way the meta seam's guard read
-  // above carries none. It goes through the inner transaction, so it stays out
-  // of the outer transaction's reactivity log and flow join; it names the
-  // ["cfc"] member rather than the document root, so it does not widen what
-  // the transaction counts as consumed; and `ignoreReadForCommit` keeps it out
-  // of the conflict set, so a blind root write stays blind rather than
-  // becoming a read-modify-write that loses the race against any advance of
-  // the document it replaces. `internalVerifierRead` says what the read is:
-  // the runtime resolving a label, the same mark `readStoredCfcMetadata`
-  // carries.
-  //
-  // That read is transaction-local, and it bounds what this arm establishes. A
-  // transaction whose view does not hold the document answers the same "no map
-  // here" that a document with no map answers, so a writer that has not synced
-  // the document erases its label map and commits. There is no race in that:
-  // the map is present throughout, and the writer simply never looked. What
-  // the arm establishes is that a root envelope write cannot erase a label map
-  // THIS TRANSACTION HAS LOADED, which is narrower than the seam needs.
-  // Closing the rest means forcing the document into view before deciding —
-  // the read-modify-write this design declines — or making the commit boundary
-  // establish what the space holds. `cfc-privileged-system-write.test.ts` pins
-  // the bypass, so it fails when either lands.
+  /**
+   * Records a path-`[]` whole-document write that erases the stored `["cfc"]`
+   * label map. Such a write replaces every sibling of `value`, so an envelope
+   * that leaves the document without a label map erases the one it held, and a
+   * labeled document reads afterwards as an unlabeled one. That is the
+   * downgrade the `["cfc"]`-path arm of `#noteSystemWrite()` catches, reached
+   * by omission rather than by overwrite, so it lands in the same record and
+   * yields the same fail-closed reason.
+   *
+   * Both halves ask `cfcMetadataPresent()`, the reader's own account of what
+   * presents a label map, so the arm fires on the change a reader would see
+   * rather than on the presence of a key. An envelope carrying `cfc: null`, or
+   * any other value the reader reports as absent, erases the map as surely as
+   * one carrying no `cfc` at all. A stored value the reader reports as absent
+   * is not a map to erase.
+   */
   #noteRootEnvelopeWrite(
     address: IMemorySpaceAddress,
     value: FabricValue | undefined,
   ): void {
+    // What this does NOT reach is a root write that leaves a label map behind
+    // but not the stored one — minting a map where the document had none, or
+    // substituting one for another. Both are the S18 forgery this seam still
+    // stands open on, and the CFC test suite seeds stored label state through
+    // exactly those shapes, so closing them means giving those fixtures
+    // another way to seed first.
+    //
+    // The arm fires only when a map is there to erase: creating a document,
+    // and replacing one that carries no label map, pass through. Hydration
+    // passes through as well — an envelope delivered from storage carries the
+    // `cfc` it was stored with — and the runtime's own root writes (`cid:`
+    // schema documents) return at the privileged-scope check above before
+    // reaching here.
+    //
+    // The read carries no weight of its own, the way the meta seam's guard
+    // read above carries none. It goes through the inner transaction, so it
+    // stays out of the outer transaction's reactivity log and flow join; it
+    // names the ["cfc"] member rather than the document root, so it does not
+    // widen what the transaction counts as consumed; and `ignoreReadForCommit`
+    // keeps it out of the conflict set, so a blind root write stays blind
+    // rather than becoming a read-modify-write that loses the race against
+    // any advance of the document it replaces. `internalVerifierRead` says
+    // what the read is: the runtime resolving a label, the same mark
+    // `readStoredCfcMetadata` carries.
+    //
+    // That read is transaction-local, and it bounds what this arm
+    // establishes. A transaction whose view does not hold the document
+    // answers the same "no map here" that a document with no map answers, so
+    // a writer that has not synced the document erases its label map and
+    // commits. There is no race in that: the map is present throughout, and
+    // the writer simply never looked. What the arm establishes is that a root
+    // envelope write cannot erase a label map THIS TRANSACTION HAS LOADED,
+    // which is narrower than the seam needs. Closing the rest means forcing
+    // the document into view before deciding — the read-modify-write this
+    // design declines — or making the commit boundary establish what the
+    // space holds. `cfc-privileged-system-write.test.ts` pins the bypass, so
+    // it fails when either lands.
     const carried = isObjectOrArray(value)
       ? (value as { cfc?: unknown }).cfc
       : undefined;
@@ -1164,16 +1247,18 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.#cfcState.unprivilegedSystemWrites.push(`${address.id}/cfc`);
   }
 
-  // Capture the implementation identity active at this write into the per-tx
-  // uniformity summary (§8.9.3 TransformedBy — see `CfcTxState.writeIdentity`).
-  // The flow join is one per-tx label, so derivation provenance is minted only
-  // when every non-privileged write was authored under the same defined
-  // identity: identities are captured at write time, like
-  // `recordCfcWritePolicyInput()` does, so a later run in the same transaction
-  // cannot lend its identity to earlier writes (and an unattributed write
-  // cannot borrow a later one). Privileged persistence writes (label maps,
-  // `cid:` schema docs) are bookkeeping, not authorship, and are skipped —
-  // also keeping the summary stable across prepare/invalidate/re-prepare.
+  /**
+   * Captures the implementation identity active at this write into the per-tx
+   * uniformity summary (§8.9.3 TransformedBy — see `CfcTxState.writeIdentity`).
+   * The flow join is one per-tx label, so derivation provenance is minted only
+   * when every non-privileged write was authored under the same defined
+   * identity: identities are captured at write time, like
+   * `recordCfcWritePolicyInput()` does, so a later run in the same transaction
+   * cannot lend its identity to earlier writes (and an unattributed write
+   * cannot borrow a later one). Privileged persistence writes (label maps,
+   * `cid:` schema docs) are bookkeeping, not authorship, and are skipped — also
+   * keeping the summary stable across prepare, invalidate, and re-prepare.
+   */
   #noteWriteIdentity(): void {
     if (this.#privilegedSystemWriteDepth > 0) return;
     const summary = this.#cfcState.writeIdentity;
@@ -1210,10 +1295,12 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     }
   }
 
-  // Ambient metadata merged into every read issued inside a
-  // runWithAmbientReadMeta scope. Used by scheduler dependency seeding to
-  // tag its materialization reads without threading meta through every
-  // cell/traverse API in between.
+  /**
+   * Ambient metadata merged into every read issued inside a
+   * `runWithAmbientReadMeta()` scope. Used by scheduler dependency seeding to
+   * tag its materialization reads without threading meta through every
+   * cell/traverse API in between.
+   */
   #ambientReadMeta?: Metadata;
 
   runWithAmbientReadMeta<T>(meta: Metadata, fn: () => T): T {
@@ -1275,9 +1362,11 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.tx.exitReadEpoch?.(previous);
   }
 
-  // Mirrors the epoch pushed down to the storage transaction, so the caches
-  // this class owns can tell whether the value they are about to keep, or
-  // hand out, describes the current state or an earlier one.
+  /**
+   * Mirrors the epoch pushed down to the storage transaction, so the caches
+   * this class owns can tell whether the value they are about to keep, or hand
+   * out, describes the current state or an earlier one.
+   */
   #readEpoch: number | undefined;
 
   noteSchemaRefusal(refusal: unknown): void {
@@ -1957,10 +2046,12 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     };
   }
 
-  // `"<space>|<hash>"` pairs this transaction has already materialized (or
-  // decided it cannot), so repeat passes never re-call writeOrThrow — a
-  // repeat write, even an elided one, would invalidate a prepared CFC
-  // digest (`write-after-prepare`).
+  /**
+   * `"<space>|<hash>"` pairs this transaction has already materialized (or
+   * decided it cannot), so repeat passes never re-call `writeOrThrow()` — a
+   * repeat write, even an elided one, would invalidate a prepared CFC digest
+   * (`write-after-prepare`).
+   */
   #ensuredSchemaDocs = new Set<string>();
 
   /**
@@ -3103,11 +3194,13 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     return this.#wrapped.tx;
   }
 
-  // Effect-completion writebacks can be marked through a wrapper
-  // (markEffectCompletion calls these on whatever tx shape it is
-  // handed). Forward both, or a wrapped completion silently skips
-  // authoritative mode and the F2 no-op-elision wedge reopens for
-  // exactly those paths (stage-G round-2 thread 18).
+  /**
+   * Forwards to the wrapped transaction. Effect-completion writebacks can be
+   * marked through a wrapper (`markEffectCompletion()` calls this and
+   * `isAuthoritativeWrites()` on whatever tx shape it is handed), so both
+   * forward, or a wrapped completion silently skips authoritative mode and the
+   * no-op-elision wedge reopens for exactly those paths.
+   */
   markAuthoritativeWrites(): void {
     this.#wrapped.markAuthoritativeWrites?.();
   }

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -466,8 +466,8 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   /**
    * Write-once pin for the deployment trust config. Distinct from the slot's
    * value being defined: the `Runtime` configures many tx with _no_ trust
-   * config (`undefined`), and that state — no config, every concept guard fails
-   * closed — must be just as write-once as a configured one — otherwise handler
+   * config (`undefined`), and that state (no config; every concept guard fails
+   * closed) must be just as write-once as a configured one. Otherwise handler
    * code reaching the concrete tx via `(cell.tx as any)` could install an
    * arbitrary config before the concept guards read it. Set on the _first_ call
    * (always the `Runtime`'s, in `edit()`), regardless of value.
@@ -478,7 +478,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
 
   /**
    * Depth of the runtime's privileged system-write scope. The runtime's own
-   * label/schema persistence (`prepareBoundaryCommit`) runs inside it; any
+   * label/schema persistence (`prepareBoundaryCommit()`) runs inside it; any
    * write to a protected system path outside it is recorded as unprivileged
    * (S18). ECMAScript-private (`#`) so handler code reaching `cell.tx` cannot
    * enter the scope via `(cell.tx as any)` — `as any` cannot touch a `#private`
@@ -536,24 +536,27 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
    * abstraction, two destinations. ECMAScript-private with a write-once pin,
    * the same shape as `#cfcPolicySnapshotPinned`: the `Runtime` configures
    * every tx exactly once in `edit()` (usually with `undefined` — every client,
-   * and the OFF arm always), and that state must be just as write-once as an
-   * installed destination, or handler code reaching the concrete tx via
-   * `(cell.tx as any)` could hijack the commit path.
+   * and the server-execution OFF arm always), and that state must be just as
+   * write-once as an installed destination, or handler code reaching the
+   * concrete tx via `(cell.tx as any)` could hijack the commit path.
    */
   #sealDestination: TransactionSealDestination | undefined;
 
   #sealDestinationPinned = false;
 
   /**
-   * The activity epoch (see `IExtendedStorageTransaction.probeFlowLabelWork`),
-   * which counts every journaled read, write, dereference trace, and trigger
-   * read. The memo beside it holds the last _negative_ probe verdict with the
-   * epoch it was taken at (stamped _after_ the probe, whose own metadata reads
-   * are internal-verifier reads that never change the verdict but do move the
-   * epoch).
+   * The activity epoch (see
+   * `IExtendedStorageTransaction.probeFlowLabelWork()`), which counts every
+   * journaled read, write, dereference trace, and trigger read.
    */
   #cfcActivityEpoch = 0;
 
+  /**
+   * The last _negative_ flow-label probe verdict, with the activity epoch it
+   * was taken at (stamped _after_ the probe, whose own metadata reads are
+   * internal-verifier reads that never change the verdict but do move the
+   * epoch).
+   */
   #flowLabelProbeMemo: { epoch: number } | undefined;
 
   #cfcInstrumentation: CfcInstrumentationHooks;
@@ -1029,10 +1032,10 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   /**
    * Runs `fn` with writes to protected system paths (a document's `["cfc"]`
    * label-map) permitted. The runtime's own label/schema persistence in
-   * `prepareBoundaryCommit` is the only legitimate such writer; `prepareCfc()`
-   * wraps that call in this scope via `this`. ECMAScript-private (`#`) and
-   * absent from `IExtendedStorageTransaction`, so handler code reaching
-   * `cell.tx` cannot enter the scope —
+   * `prepareBoundaryCommit()` is the only legitimate such writer;
+   * `prepareCfc()` wraps that call in this scope via `this`. ECMAScript-private
+   * (`#`) and absent from `IExtendedStorageTransaction`, so handler code
+   * reaching `cell.tx` cannot enter the scope —
    * `(cell.tx as any).#runPrivilegedSystemWrite` is a `TypeError`, not a bypass
    * (audit S18). Tests that need stored `["cfc"]` metadata seed it instead via
    * an ungated path-`[]` full-document write (the same shape hydration
@@ -1052,22 +1055,22 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
    * the privileged scope, whether by naming that path or by replacing the whole
    * document envelope. Such a write forges or erases the metadata that drives
    * CFC derivation for _other_ writes, bypassing the commit-boundary derivation
-   * and mint-gating (audit S18). `prepareBoundaryCommit` turns each recorded
+   * and mint-gating (audit S18). `prepareBoundaryCommit()` turns each recorded
    * address into a fail-closed reason, so the violation surfaces uniformly with
    * every other CFC reason (enforce rejects, observe diagnoses).
+   *
+   * Recording (and relevance marking) is deliberately unconditional on the
+   * enforcement mode, like every other CFC signal: `setCfcEnforcementMode()`
+   * permits raising the mode mid-transaction (disabled/observe impose no
+   * floor), so a forgery in a disabled window must still be on record when a
+   * later escalation evaluates it. A transaction still `disabled` at commit
+   * never runs `prepareBoundaryCommit()`, so the record stays inert there.
    */
   #noteSystemWrite(
     address: IMemorySpaceAddress,
     value?: FabricValue,
     options?: IWriteOptions,
   ): void {
-    // Recording (and relevance marking) is deliberately unconditional on the
-    // enforcement mode, like every other CFC signal: setCfcEnforcementMode
-    // permits raising the mode mid-transaction (disabled/observe impose no
-    // floor), so a forgery in a disabled window must still be on record when
-    // a later escalation evaluates it. A transaction still `disabled` at
-    // commit never runs prepareBoundaryCommit, so the record stays inert
-    // there.
     if (this.#privilegedSystemWriteDepth > 0) return;
     if (address.id.startsWith(CFC_POLICY_MANIFEST_ID_PREFIX)) {
       throw new Error(
@@ -1189,18 +1192,31 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
    * any other value the reader reports as absent, erases the map as surely as
    * one carrying no `cfc` at all. A stored value the reader reports as absent
    * is not a map to erase.
+   *
+   * What this does _not_ reach is a root write that leaves a label map behind
+   * but not the stored one — minting a map where the document had none, or
+   * substituting one for another. Both are the S18 forgery this seam still
+   * stands open on, and the CFC test suite seeds stored label state through
+   * exactly those shapes, so closing them means giving those fixtures another
+   * way to seed first.
+   *
+   * The guard read is transaction-local, and it bounds what this arm
+   * establishes. A transaction whose view does not hold the document answers
+   * the same no-map-here that a document with no map answers, so a writer that
+   * has not synced the document erases its label map and commits. There is no
+   * race in that: the map is present throughout, and the writer simply never
+   * looked. What the arm establishes is that a root envelope write cannot erase
+   * a label map _this transaction has loaded_, which is narrower than the seam
+   * needs. Closing the rest means forcing the document into view before
+   * deciding — the read-modify-write this design declines — or making the
+   * commit boundary establish what the space holds.
+   * `cfc-privileged-system-write.test.ts` pins the bypass, so it fails when
+   * either lands.
    */
   #noteRootEnvelopeWrite(
     address: IMemorySpaceAddress,
     value: FabricValue | undefined,
   ): void {
-    // What this does NOT reach is a root write that leaves a label map behind
-    // but not the stored one — minting a map where the document had none, or
-    // substituting one for another. Both are the S18 forgery this seam still
-    // stands open on, and the CFC test suite seeds stored label state through
-    // exactly those shapes, so closing them means giving those fixtures
-    // another way to seed first.
-    //
     // The arm fires only when a map is there to erase: creating a document,
     // and replacing one that carries no label map, pass through. Hydration
     // passes through as well — an envelope delivered from storage carries the
@@ -1211,26 +1227,13 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // The read carries no weight of its own, the way the meta seam's guard
     // read above carries none. It goes through the inner transaction, so it
     // stays out of the outer transaction's reactivity log and flow join; it
-    // names the ["cfc"] member rather than the document root, so it does not
+    // names the `["cfc"]` member rather than the document root, so it does not
     // widen what the transaction counts as consumed; and `ignoreReadForCommit`
     // keeps it out of the conflict set, so a blind root write stays blind
     // rather than becoming a read-modify-write that loses the race against
     // any advance of the document it replaces. `internalVerifierRead` says
     // what the read is: the runtime resolving a label, the same mark
-    // `readStoredCfcMetadata` carries.
-    //
-    // That read is transaction-local, and it bounds what this arm
-    // establishes. A transaction whose view does not hold the document
-    // answers the same "no map here" that a document with no map answers, so
-    // a writer that has not synced the document erases its label map and
-    // commits. There is no race in that: the map is present throughout, and
-    // the writer simply never looked. What the arm establishes is that a root
-    // envelope write cannot erase a label map THIS TRANSACTION HAS LOADED,
-    // which is narrower than the seam needs. Closing the rest means forcing
-    // the document into view before deciding — the read-modify-write this
-    // design declines — or making the commit boundary establish what the
-    // space holds. `cfc-privileged-system-write.test.ts` pins the bypass, so
-    // it fails when either lands.
+    // `readStoredCfcMetadata()` carries.
     const carried = isObjectOrArray(value)
       ? (value as { cfc?: unknown }).cfc
       : undefined;
@@ -3195,11 +3198,11 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
   }
 
   /**
-   * Forwards to the wrapped transaction. Effect-completion writebacks can be
-   * marked through a wrapper (`markEffectCompletion()` calls this and
-   * `isAuthoritativeWrites()` on whatever tx shape it is handed), so both
-   * forward, or a wrapped completion silently skips authoritative mode and the
-   * no-op-elision wedge reopens for exactly those paths.
+   * Forwards to the wrapped transaction, as `isAuthoritativeWrites()` below
+   * does. `markEffectCompletion()` marks whatever tx shape it is handed, and
+   * the write path asks that same shape whether the mark is on, so a wrapper
+   * forwarding only one of the two silently skips authoritative mode and
+   * reopens the no-op-elision wedge for exactly those paths.
    */
   markAuthoritativeWrites(): void {
     this.#wrapped.markAuthoritativeWrites?.();

--- a/packages/runner/src/storage/query.ts
+++ b/packages/runner/src/storage/query.ts
@@ -14,7 +14,8 @@ import {
 export class StoreObjectManager implements ObjectStorageManager {
   #store: Map<string, Revision<State>>;
   #readValues = new Map<string, IAttestation>();
-  // Cache our read labels, and any docs we can't read
+
+  /** The docs we can't read, by store key. */
   public missingDocs = new Map<string, BaseMemoryAddress>();
 
   constructor(store = new Map<string, Revision<State>>()) {
@@ -29,7 +30,10 @@ export class StoreObjectManager implements ObjectStorageManager {
     return this.missingDocs.values();
   }
 
-  // Returns null if there is no matching state
+  /**
+   * Loads the state at `address`, or returns `null` if there is no matching
+   * state.
+   */
   load(address: BaseMemoryAddress): IAttestation | null {
     const key = `${address.id}/${address.type ?? "application/json"}`;
     if (this.#readValues.has(key)) {

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -925,35 +925,52 @@ export class V2StorageTransaction implements IStorageTransaction {
   readonly journal = new V2TransactionJournal(this);
 
   #state: TxState = { status: "ready" };
-  // The commit's fate — server verdict or local rejection — which commit()
-  // itself may resolve later than: commit() additionally waits for the
-  // subscribed view to reflect the committed write (CT-1950 coverage).
-  // Post-commit effects gated on durability alone hook this via
-  // commitVerdict(). Resolved with the same result commit() returns.
+
+  /**
+   * The commit's fate — server verdict or local rejection — which `commit()`
+   * itself may resolve later than: `commit()` additionally waits for the
+   * subscribed view to reflect the committed write. Post-commit effects gated
+   * on durability alone hook this via `commitVerdict()`. Resolved with the same
+   * result `commit()` returns.
+   */
   readonly #verdict = Promise.withResolvers<Result<Unit, CommitError>>();
+
   #branches = new Map<MemorySpace, SpaceBranch>();
   #readActivities: IReadActivity[] = [];
-  // Per-transaction monotonic activity clock, shared between read activities
-  // and write attempts so their relative order (the read|write interleaving)
-  // is recoverable without a journal scan — V2 journals don't support
-  // activity(). Stamped at the two record points: the read() activity push
-  // and recordPatchIntent(). Consumed by CFC write-prefix provenance
-  // (docs/specs/cfc-write-prefix-provenance.md §4/§6).
+
+  /**
+   * Per-transaction monotonic activity clock, shared between read activities
+   * and write attempts so their relative order (the read/write interleaving) is
+   * recoverable without a journal scan — V2 journals don't support
+   * `activity()`. Stamped at the two record points: the `read()` activity push
+   * and `recordPatchIntent()`. Consumed by CFC write-prefix provenance
+   * (`docs/specs/cfc-write-prefix-provenance.md` §4/§6).
+   */
   #activityClock = 0;
-  // How many times this transaction has replaced a document root. A read taken
-  // at epoch E describes the state after E replacements, which is what lets a
-  // materialized read keep answering for the moment it was taken while the
-  // reader goes on writing. Zero writes means every document still stands at
-  // its `initial` attestation, so every epoch describes the same state and
-  // nothing below has to run.
+
+  /**
+   * How many times this transaction has replaced a document root. A read taken
+   * at epoch E describes the state after E replacements, which is what lets a
+   * materialized read keep answering for the moment it was taken while the
+   * reader goes on writing. Zero writes means every document still stands at
+   * its `initial` attestation, so every epoch describes the same state and
+   * nothing below has to run.
+   */
   #writeEpoch = 0;
-  // The epoch reads resolve against while a materialized read is walking, or
-  // undefined for the transaction's current state.
+
+  /**
+   * The epoch reads resolve against while a materialized read is walking, or
+   * `undefined` for the transaction's current state.
+   */
   #readEpoch: number | undefined;
-  // The newest epoch handed to a reader, or undefined where none has been. A
-  // replacement keeps the root it displaces only when a reader could still ask
-  // for it, and this is what decides that.
+
+  /**
+   * The newest epoch handed to a reader, or `undefined` where none has been. A
+   * replacement keeps the root it displaces only when a reader could still ask
+   * for it, and this is what decides that.
+   */
   #lastIssuedEpoch: number | undefined;
+
   #writeAttemptLog: IWriteAttempt[] = [];
   #reactivityLogCache?: TransactionReactivityLog;
   #commitPreconditions = new Map<MemorySpace, CommitPrecondition[]>();
@@ -961,33 +978,52 @@ export class V2StorageTransaction implements IStorageTransaction {
     MemorySpace,
     Map<string, { id: string; scope: CellScope }>
   >();
-  // Folded SQLite write ops per space, applied in the same commit as cell ops.
+
+  /**
+   * Folded SQLite write ops per space, applied in the same commit as cell ops.
+   */
   #sqliteOps = new Map<MemorySpace, SqliteOperation[]>();
+
   #writeSpace?: MemorySpace;
-  // Multi-space write opt-in (see enableMultiSpaceWrites). When disabled the
-  // transaction rejects writes to a second space; when enabled commit() splits
-  // into one per-space commit.
+
+  /**
+   * Whether multi-space writes are enabled (see `enableMultiSpaceWrites()`).
+   * When disabled the transaction rejects writes to a second space; when
+   * enabled `commit()` splits into one per-space commit.
+   */
   #multiSpaceWrites = false;
-  // Authoritative-writes mode (see IStorageTransaction.markAuthoritativeWrites
-  // and the F2 rationale there): value writes are recorded and committed even
-  // when equal to the currently-visible state — the no-op elision in
-  // writeWithinBranch/writeBatchRun yields, the doc-level elision in
-  // getNativeCommit yields, and the commit is emitted as a WHOLE-DOC
-  // set/delete rather than patches (round-2 thread 17: a patch base
-  // extrapolated over a doomed sealed overlay can name ancestors durable
-  // state never had, and `replace` cannot create them).
-  // Set by effect-completion writebacks under the serving posture; one-way.
+
+  /**
+   * Whether authoritative-writes mode is on (see
+   * `IStorageTransaction.markAuthoritativeWrites` and the rationale there):
+   * value writes are recorded and committed even when equal to the
+   * currently-visible state — the no-op elision in
+   * `writeWithinBranch`/`writeBatchRun` yields, the doc-level elision in
+   * `getNativeCommit` yields, and the commit is emitted as a _whole-doc_
+   * set/delete rather than patches (a patch base extrapolated over a doomed
+   * sealed overlay can name ancestors durable state never had, and `replace`
+   * cannot create them). Set by effect-completion writebacks under the serving
+   * posture; one-way.
+   */
   #authoritativeWrites = false;
-  // Whole-document-writes mode (see
-  // IStorageTransaction.markWholeDocumentWrites): the emission half of
-  // authoritative mode on its own — set/delete rather than patches and
-  // mergeable ops — with the no-op elision left in place. Set by the client
-  // speculation overlay's seal, whose entries layer their ops over a
-  // confirmed value that moves under them. One-way.
+
+  /**
+   * Whether whole-document-writes mode is on (see
+   * `IStorageTransaction.markWholeDocumentWrites`): the emission half of
+   * authoritative mode on its own — set/delete rather than patches and
+   * mergeable ops — with the no-op elision left in place. Set by the client
+   * speculation overlay's seal, whose entries layer their ops over a confirmed
+   * value that moves under them. One-way.
+   */
   #wholeDocumentWrites = false;
+
   #commitOrder?: readonly MemorySpace[];
-  // Spaces written to, in first-write order. Used as the default commit order.
+
+  /**
+   * Spaces written to, in first-write order. Used as the default commit order.
+   */
   #writtenSpaces: MemorySpace[] = [];
+
   #readOnlySource?: string;
   #lastDocument?: {
     branch: SpaceBranch;
@@ -1160,10 +1196,12 @@ export class V2StorageTransaction implements IStorageTransaction {
     });
   }
 
-  // Records one mergeable-op delta at a path. Which ops exist, whether a delta
-  // records nothing, how repeated deltas fold into one intent, and how an intent
-  // becomes wire ops are all defined once in ./mergeable-ops.ts — this method
-  // just accumulates, deferring the per-op questions to that registry.
+  /**
+   * Records one mergeable-op delta at a path. Which ops exist, whether a delta
+   * records nothing, how repeated deltas fold into one intent, and how an
+   * intent becomes wire ops are all defined once in `./mergeable-ops.ts` — this
+   * method just accumulates, deferring the per-op questions to that registry.
+   */
   recordMergeableOp(
     address: IMemorySpaceAddress,
     delta: MergeableOpDelta,
@@ -1200,26 +1238,29 @@ export class V2StorageTransaction implements IStorageTransaction {
     );
   }
 
-  // Abandon the mergeable fast path for `address`: a foreign write (a reshape
-  // that is not itself a mergeable op) has rewritten the array after an op was
-  // recorded, so the recorded tail no longer identifies the appended elements.
-  // Drop any covered intent and mark its path poisoned so the commit emits the
-  // whole-array diff (the correct local value) instead.
-  //
-  // The reshape reaches every intent AT or BENEATH the written path: a write to
-  // an enclosing object (`doc.set({rows})`) rewrites the array inside it just as
-  // surely as a write to the array itself, and the intent's recorded tail then
-  // spans elements the reshape supplied rather than ones an op appended. Intents
-  // ABOVE the write are untouched, which is what keeps an element edit
-  // (`cell.key(i).set(...)`, a write beneath the array) composing with a push,
-  // and leaves a write to a sibling field alone.
-  //
-  // A path carrying no intent yet is left alone — but that is not a statement
-  // that a reshape before an op is harmless. It is caught later instead, by each
-  // builder's own check at commit that its intent still describes the local
-  // value (see ./mergeable-ops.ts). The same goes for an element edit, which is
-  // beneath the array and so passes through here untouched: harmless to a tail
-  // op, fatal to a remove-by-value, and the builders are what tell them apart.
+  /**
+   * Abandons the mergeable fast path for `address`: a foreign write (a reshape
+   * that is not itself a mergeable op) has rewritten the array after an op was
+   * recorded, so the recorded tail no longer identifies the appended elements.
+   * Drops any covered intent and marks its path poisoned so the commit emits
+   * the whole-array diff (the correct local value) instead.
+   *
+   * The reshape reaches every intent _at_ or _beneath_ the written path: a
+   * write to an enclosing object (`doc.set({rows})`) rewrites the array inside
+   * it just as surely as a write to the array itself, and the intent's recorded
+   * tail then spans elements the reshape supplied rather than ones an op
+   * appended. Intents _above_ the write are untouched, which is what keeps an
+   * element edit (`cell.key(i).set(...)`, a write beneath the array) composing
+   * with a push, and leaves a write to a sibling field alone.
+   *
+   * A path carrying no intent yet is left alone — but that is not a statement
+   * that a reshape before an op is harmless. It is caught later instead, by
+   * each builder's own check at commit that its intent still describes the
+   * local value (see `./mergeable-ops.ts`). The same goes for an element edit,
+   * which is beneath the array and so passes through here untouched: harmless
+   * to a tail op, fatal to a remove-by-value, and the builders are what tell
+   * them apart.
+   */
   poisonMergeableOp(address: IMemorySpaceAddress): void {
     // Only ever called right after a write on this transaction, so the tx is
     // editable — no editable() re-check. The write also made the address's
@@ -1238,9 +1279,12 @@ export class V2StorageTransaction implements IStorageTransaction {
     }
   }
 
-  // The caller wrote through this same transaction, so the entry is writable.
-  // A missing writable entry is an invariant violation the record methods throw
-  // on rather than silently dropping the operation.
+  /**
+   * Returns the writable mergeable entry for `address`. The caller wrote
+   * through this same transaction, so the entry is writable; a missing writable
+   * entry is an invariant violation the record methods throw on rather than
+   * silently dropping the operation.
+   */
   #writableMergeableTarget(
     address: IMemorySpaceAddress,
   ): WritableDocumentEntry | undefined {
@@ -3311,28 +3355,31 @@ export class V2StorageTransaction implements IStorageTransaction {
     return { op: "patch", id, type, scope, patches, value: doc.current.value };
   }
 
-  // Builds the mergeable ops for a document's recorded intents, plus the paths
-  // each covers so the diff candidates the op replaces can be suppressed. The
-  // per-op payload/suppression rules live in ./mergeable-ops.ts; here we only
-  // supply each intent the working/initial array state its builder needs.
-  //
-  // A builder can also abandon its intent — the recorded op no longer describes
-  // the transaction's local value (see `buildTailOp` / `buildRemoveByValue`).
-  // Abandoning must poison the path here rather than just skip the op, because a
-  // surviving intent still narrows the op's reads out of the commit's conflict
-  // set (v2.ts) and would hand the replacing whole-value diff a read set it has
-  // not earned. This runs inside getNativeCommit, which precedes that narrowing,
-  // so both sides see the same intents.
-  //
-  // One intent is also abandoned for what its SIBLINGS carry, which is why the
-  // contexts are computed for all of them before any is built: a tail op's
-  // payload is live values read out of the working document, so an intent whose
-  // target sits inside that payload has already had its change applied by the
-  // covering op, and sending it too would apply it twice (see
-  // `mergeableOpPayloadContains`). Coverage is judged on what each intent
-  // RECORDED, not on which ops survived — an intent contained by an op that is
-  // itself abandoned must fall back with it, so that the whole-value diff is the
-  // only thing carrying that region.
+  /**
+   * Builds the mergeable ops for a document's recorded intents, plus the paths
+   * each covers so the diff candidates the op replaces can be suppressed. The
+   * per-op payload/suppression rules live in `./mergeable-ops.ts`; here we only
+   * supply each intent the working/initial array state its builder needs.
+   *
+   * A builder can also abandon its intent — the recorded op no longer describes
+   * the transaction's local value (see `buildTailOp()` /
+   * `buildRemoveByValue()`). Abandoning must poison the path here rather than
+   * just skip the op, because a surviving intent still narrows the op's reads
+   * out of the commit's conflict set (`v2.ts`) and would hand the replacing
+   * whole-value diff a read set it has not earned. This runs inside
+   * `getNativeCommit()`, which precedes that narrowing, so both sides see the
+   * same intents.
+   *
+   * One intent is also abandoned for what its _siblings_ carry, which is why
+   * the contexts are computed for all of them before any is built: a tail op's
+   * payload is live values read out of the working document, so an intent whose
+   * target sits inside that payload has already had its change applied by the
+   * covering op, and sending it too would apply it twice (see
+   * `mergeableOpPayloadContains()`). Coverage is judged on what each intent
+   * _recorded_, not on which ops survived — an intent contained by an op that
+   * is itself abandoned must fall back with it, so that the whole-value diff is
+   * the only thing carrying that region.
+   */
   #buildMergeableOps(
     doc: WritableDocumentEntry,
   ): { ops: PatchOp[]; suppress: OpSuppression[] } {
@@ -3367,21 +3414,22 @@ export class V2StorageTransaction implements IStorageTransaction {
     return { ops, suppress };
   }
 
-  // Abandons every mergeable intent a document recorded, for a commit that
-  // emits the document whole. An intent narrows the reads incidental to its op
-  // out of the commit's read set (`SpaceReplica.#commitReadActivities` in
-  // ./v2.ts), which is sound only while the op is what carries that region:
-  // a mergeable op
-  // resolves against durable state, so the value it read does not constrain
-  // it. A whole-document set carries the region instead, and it is the value
-  // the run computed from what it read — so those reads are real dependencies
-  // and have to stay. Abandoning is the delete-and-poison shape
-  // `poisonMergeableOp` uses, and it runs inside getNativeCommit, which
-  // precedes the narrowing, so both sides see the same intents.
-  //
-  // For a speculative seal the read set is what the entry's retirement floor
-  // and its pending-read documents are built from, so an intent surviving here
-  // retires the entry against a watermark that never covered what the run read.
+  /**
+   * Abandons every mergeable intent a document recorded, for a commit that
+   * emits the document whole. An intent narrows the reads incidental to its op
+   * out of the commit's read set (`SpaceReplica.#commitReadActivities` in
+   * `./v2.ts`), which is sound only while the op is what carries that region: a
+   * mergeable op resolves against durable state, so the value it read does not
+   * constrain it. A whole-document set carries the region instead, and it is
+   * the value the run computed from what it read — so those reads are real
+   * dependencies and have to stay. Abandoning is the delete-and-poison shape
+   * `poisonMergeableOp()` uses, and it runs inside `getNativeCommit()`, which
+   * precedes the narrowing, so both sides see the same intents.
+   *
+   * For a speculative seal the read set is what the entry's retirement floor
+   * and its pending-read documents are built from, so an intent surviving here
+   * retires the entry against a watermark that never covered what the run read.
+   */
   #abandonMergeableOps(doc: WritableDocumentEntry): void {
     if (!doc.mergeableOps?.size) {
       return;
@@ -3392,8 +3440,10 @@ export class V2StorageTransaction implements IStorageTransaction {
     }
   }
 
-  // The working / initial state at one intent's path, which its builder turns
-  // into wire ops.
+  /**
+   * Returns the working/initial state at one intent's path, which its builder
+   * turns into wire ops.
+   */
   #mergeableBuildContext(
     doc: WritableDocumentEntry,
     intent: MergeableOpIntent,

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -943,7 +943,7 @@ export class V2StorageTransaction implements IStorageTransaction {
    * and write attempts so their relative order (the read/write interleaving) is
    * recoverable without a journal scan — V2 journals don't support
    * `activity()`. Stamped at the two record points: the `read()` activity push
-   * and `recordPatchIntent()`. Consumed by CFC write-prefix provenance
+   * and `#recordPatchIntent()`. Consumed by CFC write-prefix provenance
    * (`docs/specs/cfc-write-prefix-provenance.md` §4/§6).
    */
   #activityClock = 0;
@@ -995,11 +995,11 @@ export class V2StorageTransaction implements IStorageTransaction {
 
   /**
    * Whether authoritative-writes mode is on (see
-   * `IStorageTransaction.markAuthoritativeWrites` and the rationale there):
+   * `IStorageTransaction.markAuthoritativeWrites()` and the rationale there):
    * value writes are recorded and committed even when equal to the
    * currently-visible state — the no-op elision in
-   * `writeWithinBranch`/`writeBatchRun` yields, the doc-level elision in
-   * `getNativeCommit` yields, and the commit is emitted as a _whole-doc_
+   * `#writeWithinBranch()`/`#writeBatchRun()` yields, the doc-level elision
+   * in `getNativeCommit()` yields, and the commit is emitted as a _whole-doc_
    * set/delete rather than patches (a patch base extrapolated over a doomed
    * sealed overlay can name ancestors durable state never had, and `replace`
    * cannot create them). Set by effect-completion writebacks under the serving
@@ -1009,7 +1009,7 @@ export class V2StorageTransaction implements IStorageTransaction {
 
   /**
    * Whether whole-document-writes mode is on (see
-   * `IStorageTransaction.markWholeDocumentWrites`): the emission half of
+   * `IStorageTransaction.markWholeDocumentWrites()`): the emission half of
    * authoritative mode on its own — set/delete rather than patches and
    * mergeable ops — with the no-op elision left in place. Set by the client
    * speculation overlay's seal, whose entries layer their ops over a confirmed
@@ -1280,10 +1280,10 @@ export class V2StorageTransaction implements IStorageTransaction {
   }
 
   /**
-   * Returns the writable mergeable entry for `address`. The caller wrote
-   * through this same transaction, so the entry is writable; a missing writable
-   * entry is an invariant violation the record methods throw on rather than
-   * silently dropping the operation.
+   * Returns the writable document entry for `address`, or `undefined` when it
+   * is not writable. The caller wrote through this same transaction, so the
+   * entry is writable; a missing writable entry is an invariant violation the
+   * record methods throw on rather than silently dropping the operation.
    */
   #writableMergeableTarget(
     address: IMemorySpaceAddress,

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -948,7 +948,7 @@ export class StorageManager implements IStorageManager {
 
   /**
    * In-flight commits, registered synchronously by the transaction layer at
-   * `commit()` entry (see `IStorageManager.trackPendingCommit`). This is the
+   * `commit()` entry (see `IStorageManager.trackPendingCommit()`). This is the
    * write-durability barrier: distinct from `#crossSpacePromises`, which also
    * carries cross-space _read_ work (link-target loads) and so must not gate
    * questions of whether there are unconfirmed writes.
@@ -3174,7 +3174,7 @@ export class SpaceReplica
 
   /**
    * Issued-but-unsettled commits that carry pending reads, keyed by `localSeq`.
-   * Scanned by `cascadeDroppedDependency()` when a dependency's optimistic
+   * Scanned by `#cascadeDroppedDependency()` when a dependency's optimistic
    * writes are dropped. See the `InFlightCommit` doc for why zero-pending-read
    * commits are never registered.
    */
@@ -3182,13 +3182,13 @@ export class SpaceReplica
 
   /**
    * Commits whose rejection verdict is known but whose optimistic layer is
-   * still standing in `record.pending`, because `finalizeRejection()` holds the
-   * drop until the conflict read repair completes. `buildReads()` names every
-   * layer it finds, so a commit minted in that window names a layer the server
-   * will never resolve. Maps the dead `localSeq` to a promise that settles when
-   * its drop completes: the pre-send checkpoint rejects such a commit locally
-   * and gates its retry on that promise, so the retry rebuilds against the
-   * repaired base rather than the dead one.
+   * still standing in `record.pending`, because `#finalizeRejection()` holds
+   * the drop until the conflict read repair completes. `buildReads()` names
+   * every layer it finds, so a commit minted in that window names a layer the
+   * server will never resolve. Maps the dead `localSeq` to a promise that
+   * settles when its drop completes: the pre-send checkpoint rejects such a
+   * commit locally and gates its retry on that promise, so the retry rebuilds
+   * against the repaired base rather than the dead one.
    */
   readonly #rejectedPendingLayers = new Map<number, Promise<void>>();
 
@@ -3214,7 +3214,7 @@ export class SpaceReplica
   readonly #syncPromises = new Set<Promise<Result<Unit, PullError>>>();
 
   /**
-   * Schema-hash hydration dedupe (`hydrateArrivedCfcSchemaRefs()`): hashes
+   * Schema-hash hydration dedupe (`#hydrateArrivedCfcSchemaRefs()`): hashes
    * whose `cid:` pull is in flight or has succeeded; a failed pull removes its
    * entry so a later frame can retry.
    */
@@ -3322,7 +3322,7 @@ export class SpaceReplica
 
   /**
    * Foreign novelty whose _visibility_ is still shadowed by own pending writes
-   * (the settle input barrier — see `unappliedForeignSeqFloor` on
+   * (the settle input barrier — see `unappliedForeignSeqFloor()` on
    * `ISpaceReplica`): docKey → the set of shadowed inbound seqs. A _set_, not
    * one extremum: the floor must be the doc's _lowest_ hidden seq — every
    * derivation in the wave read the view from before the _earliest_ hidden
@@ -3339,10 +3339,10 @@ export class SpaceReplica
 
   /**
    * The settle input barrier's _wake_ (`ISpaceReplica.shadowFlipObserver`):
-   * invoked synchronously whenever a `confirmPending()` promotion touched a doc
-   * with a standing shadow (flag ON — the flip checkout's own condition), value
-   * diff or not: the _floor_ lifts either way, and the floor is what the wake
-   * exists for. The `SpaceServer` installs it at activation so a
+   * invoked synchronously whenever a `#confirmPending()` promotion touched a
+   * doc with a standing shadow (flag ON — the flip checkout's own condition),
+   * value diff or not: the _floor_ lifts either way, and the floor is what the
+   * wake exists for. The `SpaceServer` installs it at activation so a
    * clamped-then-quiet space's catch-up wave runs at the flip instead of
    * waiting out the idle window — the flip is the one input whose dirtiness
    * arrives _without_ a new admitted commit on the host feed (the commit was
@@ -3373,8 +3373,8 @@ export class SpaceReplica
    * `localSeq`s of live _speculative_ sealed commits (`speculation.md` §1/§6):
    * overlay entries exist only in this process — the client never pushes them —
    * so a _pushed_ commit whose read basis names one can _never_ have that
-   * dependency resolve server-side. `commitOperations()` refuses such an export
-   * loudly; membership ends when the speculative commit settles
+   * dependency resolve server-side. `#commitOperations()` refuses such an
+   * export loudly; membership ends when the speculative commit settles
    * (retirement/withdrawal drops its pending layers first, so no stack names a
    * seq after it leaves this set).
    */
@@ -7315,7 +7315,7 @@ export class SpaceReplica
   /**
    * Makes a locally-fabricated rejection for a commit whose doom is provable
    * client-side (dropped pending dependency, dependency rejected but not yet
-   * dropped, or replica reset). Modeled on `makePreemptRejection()`.
+   * dropped, or replica reset). Modeled on `#makePreemptRejection()`.
    * `readyToRetry` defaults to resolving immediately, which is right once the
    * _primary_ rejection's `#finalizeRejection()` has awaited its read repair
    * (or reset wiped the replica outright): the victim adds no wait of its own.
@@ -7615,7 +7615,7 @@ export class SpaceReplica
    * conflicts, so parking would hang).
    *
    * _Pushed_ (socket) commits only: sealed commits — engine-plane commits by
-   * the co-hosted executor — settle through `settleSealedCommit()`, which
+   * the co-hosted executor — settle through `#settleSealedCommit()`, which
    * confirms immediately (no marker is ever staged for an engine-plane commit,
    * so parking them would wedge permanently).
    */

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -905,40 +905,56 @@ export class StorageManager implements IStorageManager {
   readonly id: string;
   readonly as: Signer;
 
-  // One authenticated session identity is shared by every space opened during
-  // a manager lifecycle. close() invalidates those server sessions, so a later
-  // sequential Runtime reusing this manager must start a fresh identity rather
-  // than attempting to resurrect an invalidated token.
+  /**
+   * The one authenticated session identity, shared by every space opened during
+   * a manager lifecycle. `close()` invalidates those server sessions, so a
+   * later sequential `Runtime` reusing this manager must start a fresh identity
+   * rather than attempting to resurrect an invalidated token.
+   */
   #sessionId: string;
+
   #settings: IRemoteStorageProviderSettings;
   #providers = new Map<MemorySpace, Provider>();
   #subscription = SubscriptionManager.create();
   #crossSpacePromises = new Set<Promise<void>>();
-  // Schema-registry retention lease: held for the manager's open lifetime,
-  // released on close (idempotent), re-acquired when a closed manager is
-  // reused through open(). Last lease out clears the realm's registry — the
-  // session-lifetime retention contract in schema-registry.ts.
+
+  /**
+   * Schema-registry retention lease: held for the manager's open lifetime,
+   * released on close (idempotent), re-acquired when a closed manager is reused
+   * through `open()`. Last lease out clears the realm's registry — the
+   * session-lifetime retention contract in `schema-registry.ts`.
+   */
   #schemaRegistryLease?: () => void;
-  // Docs already offered a link-target pull via shouldPullDoc. One entry per
-  // (space, scope, id) for the manager's lifetime: the first pull registers a
-  // server-side watch that keeps the doc flowing afterwards, so a second kick
-  // is never needed — and never re-kicking is what keeps reads of genuinely
-  // absent targets (dangling links, deleted docs) from churning the
-  // cross-space convergence loop on every read.
+
+  /**
+   * Docs already offered a link-target pull via `shouldPullDoc()`. One entry
+   * per (space, scope, id) for the manager's lifetime: the first pull registers
+   * a server-side watch that keeps the doc flowing afterwards, so a second kick
+   * is never needed — and never re-kicking is what keeps reads of genuinely
+   * absent targets (dangling links, deleted docs) from churning the cross-space
+   * convergence loop on every read.
+   */
   #docPullKicks = new Set<string>();
-  // Data URIs whose linked targets this manager has already pulled, keyed by a
-  // hash of the URI, schema, path, space, and scope. Per manager rather than
-  // per process: a hit skips the pull, and a manager that inherited another
-  // manager's hit would leave its own replica without those documents.
+
+  /**
+   * Data URIs whose linked targets this manager has already pulled, keyed by a
+   * hash of the URI, schema, path, space, and scope. Per manager rather than
+   * per process: a hit skips the pull, and a manager that inherited another
+   * manager's hit would leave its own replica without those documents.
+   */
   #dataURISyncs = new BoundedKeyMap<string, Promise<void>>(
     DATA_URI_SYNC_CACHE_MAX,
   );
-  // In-flight commits, registered synchronously by the transaction layer at
-  // commit() entry (see IStorageManager.trackPendingCommit). This is the
-  // write-durability barrier: distinct from #crossSpacePromises, which also
-  // carries cross-space READ work (link-target loads) and so must not gate
-  // "are there unconfirmed writes" questions.
+
+  /**
+   * In-flight commits, registered synchronously by the transaction layer at
+   * `commit()` entry (see `IStorageManager.trackPendingCommit`). This is the
+   * write-durability barrier: distinct from `#crossSpacePromises`, which also
+   * carries cross-space _read_ work (link-target loads) and so must not gate
+   * questions of whether there are unconfirmed writes.
+   */
   #pendingCommits = new Set<Promise<unknown>>();
+
   #pendingCommitsSubscribers = new Set<(pending: boolean) => void>();
   #sessionFactory: SessionFactory;
   #eventAppendQueueStore?: EventAppendQueueStore;
@@ -1014,16 +1030,18 @@ export class StorageManager implements IStorageManager {
   /** Late-bound marker sink (the Runtime's telemetry bus); see setTelemetry. */
   #telemetry?: TelemetrySink;
 
-  // In-flight document loads keyed `space/scope_key/id` (the scheduler's
-  // entityKey format — one entry per scope INSTANCE, key-vocabulary.md §1
-  // site 7: two instances of one doc are two loads, and collapsing them
-  // would make one waiter observe another's failure). Keys are BUILT with
-  // entityKey so the strings cross-match the scheduler's
-  // (collectPendingLoadParkKeys correlates the two maps); both sides
-  // resolve against this manager's own session identity.
-  // Refcounted: concurrent syncCell calls for the same
-  // document share one entry. Waiters resolve when the count returns to zero
-  // — whether the load produced a value or found the document absent.
+  /**
+   * In-flight document loads keyed `space/scope_key/id` (the scheduler's
+   * `entityKey` format — one entry per scope _instance_, `key-vocabulary.md` §1
+   * site 7: two instances of one doc are two loads, and collapsing them would
+   * make one waiter observe another's failure). Keys are _built_ with
+   * `entityKey()` so the strings cross-match the scheduler's
+   * (`collectPendingLoadParkKeys()` correlates the two maps); both sides
+   * resolve against this manager's own session identity. Refcounted: concurrent
+   * `syncCell()` calls for the same document share one entry. Waiters resolve
+   * when the count returns to zero — whether the load produced a value or found
+   * the document absent.
+   */
   #pendingLoads = new Map<string, {
     count: number;
     generation: number;
@@ -1036,12 +1054,16 @@ export class StorageManager implements IStorageManager {
     failure: unknown;
     waiters: Set<(failure: unknown) => void>;
   }>();
-  // A positive recovery signal is key-specific: successful settlement of a
-  // new generation for one doc names that doc's stable failed boundary. Only a
-  // durable checkpoint carrying the same boundary wakes, so unrelated loads
-  // remain inert. The boundary is stable across manager recreation; the
-  // replacement epoch remains unique.
+
+  /**
+   * The next pending-load generation. A positive recovery signal is
+   * key-specific: successful settlement of a new generation for one doc names
+   * that doc's stable failed boundary. Only a durable checkpoint carrying the
+   * same boundary wakes, so unrelated loads remain inert. The boundary is
+   * stable across manager recreation; the replacement epoch remains unique.
+   */
   #nextPendingLoadGeneration = 1;
+
   readonly #loadRecoveryIdentity = crypto.randomUUID();
   #loadRecoveryObserver:
     | ((recovery: {
@@ -1049,13 +1071,19 @@ export class StorageManager implements IStorageManager {
       recoveryEpoch: string;
     }) => void)
     | undefined = undefined;
-  // Sync failures already logged, keyed by (space, error identity). A denied
-  // space repeats the identical failure for every doc pulled from it; one line
-  // per distinct failure keeps the surfacing readable. Bounded: at the cap the
-  // set resets, trading a repeated line for an unbounded set.
+
+  /**
+   * Sync failures already logged, keyed by (space, error identity). A denied
+   * space repeats the identical failure for every doc pulled from it; one line
+   * per distinct failure keeps the surfacing readable. Bounded: at the cap the
+   * set resets, trading a repeated line for an unbounded set.
+   */
   #loggedSyncFailures = new Set<string>();
-  // The syncer a test supplies in place of the CFC schema document sync;
-  // undefined means the manager's own.
+
+  /**
+   * The syncer a test supplies in place of the CFC schema document sync;
+   * `undefined` means the manager's own.
+   */
   #cfcSchemaDocumentSyncer: CfcSchemaDocumentSyncer | undefined = undefined;
 
   /**
@@ -2616,15 +2644,19 @@ type TelemetrySink = { submit(marker: RuntimeTelemetryMarker): void };
 
 class Provider implements IStorageProvider, IOperationStorageCapability {
   replica: SpaceReplica;
-  // Registered reads to replay when a provisional replica is replaced, keyed
-  // by document and then by the normalized selector. A normalized selector is
-  // either the shared rejecting selector or an interned canonical instance,
-  // and the entry holds it, so structurally equal selectors are the same
-  // object here and identity separates them exactly.
+
+  /**
+   * Registered reads to replay when a provisional replica is replaced, keyed by
+   * document and then by the normalized selector. A normalized selector is
+   * either the shared rejecting selector or an interned canonical instance, and
+   * the entry holds it, so structurally equal selectors are the same object
+   * here and identity separates them exactly.
+   */
   #syncRequests = new Map<
     string,
     Map<SchemaPathSelector, ProviderSyncRequest>
   >();
+
   #destroyed = false;
   #routeAbort = new AbortController();
   #operationSubscriptions = new Set<ProviderOperationSubscription>();
@@ -3139,38 +3171,55 @@ export class SpaceReplica
   readonly #docs = new Map<string, DocumentRecord>();
   readonly #syncTasks = new Map<string, SyncTask>();
   readonly #commitPromises = new Set<Promise<unknown>>();
-  // Issued-but-unsettled commits that carry pending reads, keyed by localSeq.
-  // Scanned by cascadeDroppedDependency when a dependency's optimistic writes
-  // are dropped. See the InFlightCommit doc for why zero-pending-read commits
-  // are never registered.
+
+  /**
+   * Issued-but-unsettled commits that carry pending reads, keyed by `localSeq`.
+   * Scanned by `cascadeDroppedDependency()` when a dependency's optimistic
+   * writes are dropped. See the `InFlightCommit` doc for why zero-pending-read
+   * commits are never registered.
+   */
   readonly #inFlightCommits = new Map<number, InFlightCommit>();
-  // Commits whose rejection verdict is known but whose optimistic layer is
-  // still standing in `record.pending`, because finalizeRejection holds the
-  // drop until the conflict read repair completes. buildReads names every
-  // layer it finds, so a commit minted in that window names a layer the
-  // server will never resolve. Maps the dead localSeq to a promise that
-  // settles when its drop completes: the pre-send checkpoint rejects such a
-  // commit locally and gates its retry on that promise, so the retry rebuilds
-  // against the repaired base rather than the dead one.
+
+  /**
+   * Commits whose rejection verdict is known but whose optimistic layer is
+   * still standing in `record.pending`, because `finalizeRejection()` holds the
+   * drop until the conflict read repair completes. `buildReads()` names every
+   * layer it finds, so a commit minted in that window names a layer the server
+   * will never resolve. Maps the dead `localSeq` to a promise that settles when
+   * its drop completes: the pre-send checkpoint rejects such a commit locally
+   * and gates its retry on that promise, so the retry rebuilds against the
+   * repaired base rather than the dead one.
+   */
   readonly #rejectedPendingLayers = new Map<number, Promise<void>>();
-  // Every unsettled commit's outcome promise, keyed by localSeq (a superset
-  // of #inFlightCommits: zero-read commits appear here too). The old-server
-  // scalarization hold awaits these for the OMITTED lower dependencies —
-  // entries are removed on settlement, so an absent key means "settled".
+
+  /**
+   * Every unsettled commit's outcome promise, keyed by `localSeq` (a superset
+   * of `#inFlightCommits`: zero-read commits appear here too). The old-server
+   * scalarization hold awaits these for the _omitted_ lower dependencies —
+   * entries are removed on settlement, so an absent key means settled.
+   */
   readonly #commitOutcomeBySeq = new Map<
     number,
     Promise<unknown>
   >();
-  // Server verdict promises superseded by a local rejection. Kept OUT of
-  // #commitPromises so synced() never blocks on a verdict the server may
-  // withhold indefinitely; close()/closeNow() drain the set after client
-  // teardown rejects every in-flight request.
+
+  /**
+   * Server verdict promises superseded by a local rejection. Kept _out_ of
+   * `#commitPromises` so `synced()` never blocks on a verdict the server may
+   * withhold indefinitely; `close()`/`closeNow()` drain the set after client
+   * teardown rejects every in-flight request.
+   */
   readonly #suppressedVerdicts = new Set<Promise<void>>();
+
   readonly #syncPromises = new Set<Promise<Result<Unit, PullError>>>();
-  // Schema-hash hydration dedupe (hydrateArrivedCfcSchemaRefs): hashes
-  // whose cid: pull is in flight or has succeeded; a failed pull removes
-  // its entry so a later frame can retry.
+
+  /**
+   * Schema-hash hydration dedupe (`hydrateArrivedCfcSchemaRefs()`): hashes
+   * whose `cid:` pull is in flight or has succeeded; a failed pull removes its
+   * entry so a later frame can retry.
+   */
   readonly #kickedCfcSchemaPulls = new Set<string>();
+
   readonly #updatePromises = new Set<Promise<void>>();
   readonly #sinks = new Map<
     string,
@@ -3182,26 +3231,33 @@ export class SpaceReplica
   >();
   readonly #operationWatchRemovals = new Map<string, Promise<void>>();
   #watchView: MemoryV2Client.WatchView | null = null;
-  // The specific view instance that `#consumeUpdates` is iterating. This can
-  // diverge from `#watchView` (the client may hand back a fresh view instance
-  // on a later refresh while the original consumer keeps running), so teardown
-  // must close *this* view to settle the consumer's pending `next()`. Closing
-  // only `#watchView` can leave the consumer's view open, hanging dispose() on
-  // `Promise.allSettled([...#updatePromises])`.
+
+  /**
+   * The specific view instance that `#consumeUpdates()` is iterating. This can
+   * diverge from `#watchView` (the client may hand back a fresh view instance
+   * on a later refresh while the original consumer keeps running), so teardown
+   * must close _this_ view to settle the consumer's pending `next()`. Closing
+   * only `#watchView` can leave the consumer's view open, hanging `dispose()`
+   * on `Promise.allSettled([...#updatePromises])`.
+   */
   #subscribedWatchView: MemoryV2Client.WatchView | null = null;
+
   #watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>(
     () => this.#scopeKeyIdentity(),
   );
   #watchedIds = new Set<string>();
-  // The last SessionSync snapshot ABSORBED for each watched key — its
-  // address as the frame named it and the seq and deletedness it carried —
-  // kept so the replica can DECLARE its holdings on a reconnect
-  // (`holdings()`). Delivery-backed on purpose: `record.confirmed` also
-  // advances by local promotion (`#confirmPending`, an own accepted write
-  // extrapolated over the pending base), and a holding declared at a
-  // promoted seq would let the server elide the authoritative snapshot at
-  // that seq — a `patch` head's merged foreign content the promotion
-  // cannot reproduce. Only a frame this replica absorbed writes here.
+
+  /**
+   * The last `SessionSync` snapshot _absorbed_ for each watched key — its
+   * address as the frame named it and the seq and deletedness it carried — kept
+   * so the replica can _declare_ its holdings on a reconnect (`holdings()`).
+   * Delivery-backed on purpose: `record.confirmed` also advances by local
+   * promotion (`#confirmPending()`, an own accepted write extrapolated over the
+   * pending base), and a holding declared at a promoted seq would let the
+   * server elide the authoritative snapshot at that seq — a `patch` head's
+   * merged foreign content the promotion cannot reproduce. Only a frame this
+   * replica absorbed writes here.
+   */
   readonly #delivered = new Map<
     string,
     {
@@ -3213,6 +3269,7 @@ export class SpaceReplica
       deleted: boolean;
     }
   >();
+
   #nextLocalSeq = 1;
 
   /** The Phase-3 event-intent queue (events.md §5, LT9), created on the
@@ -3232,15 +3289,18 @@ export class SpaceReplica
   readonly #closeSignal = Promise.withResolvers<void>();
   #getTelemetry: () => TelemetrySink | undefined;
   #caughtUpLocalSeq = 0;
-  // Accepted verdicts PARKED until marker coverage (CT-1927): the server
-  // stages a `caughtUpLocalSeq` obligation for every accept, and the client
-  // holds the commit's promotion — pending overlay to confirmed mirror —
-  // until a frame's marker covers it, so promotion extrapolates over a base
-  // that reflects the foreign novelty the accept was applied on top of
-  // instead of minting a confirmed state from a stale mirror. Verdicts
-  // return inline (the fan-out stays batched); only their state application
-  // waits. Applied in ascending localSeq order by noteCaughtUpLocalSeq;
-  // cleared on reset (the re-pull re-derives the durable state).
+
+  /**
+   * Accepted verdicts _parked_ until marker coverage: the server stages a
+   * `caughtUpLocalSeq` obligation for every accept, and the client holds the
+   * commit's promotion — pending overlay to confirmed mirror — until a frame's
+   * marker covers it, so promotion extrapolates over a base that reflects the
+   * foreign novelty the accept was applied on top of instead of minting a
+   * confirmed state from a stale mirror. Verdicts return inline (the fan-out
+   * stays batched); only their state application waits. Applied in ascending
+   * `localSeq` order by `noteCaughtUpLocalSeq()`; cleared on reset (the re-pull
+   * re-derives the durable state).
+   */
   #parkedAccepts = new Map<number, {
     operations: NativeCommitOperation[];
     applied: AppliedCommit;
@@ -3250,74 +3310,89 @@ export class SpaceReplica
      * subscribed view as one reflecting the committed write. */
     settled: PromiseWithResolvers<void>;
   }>();
-  // Waiters on a parked accept's APPLICATION (server-execution v2 stage
-  // G's read-consistency barrier — see `whenApplied`). Resolved when the
-  // parked accept promotes (marker coverage, marker-channel death) or
-  // dies with the parked set (reset/close — the re-pull re-derives the
-  // durable state, so "applied" is moot and the waiter must not hang).
+
+  /**
+   * Waiters on a parked accept's _application_ (the read-consistency barrier —
+   * see `whenApplied()`). Resolved when the parked accept promotes (marker
+   * coverage, marker-channel death) or dies with the parked set (reset/close —
+   * the re-pull re-derives the durable state, so applied is moot and the waiter
+   * must not hang).
+   */
   #appliedWaiters = new Map<number, PromiseWithResolvers<void>>();
-  // Foreign novelty whose VISIBILITY is still shadowed by own pending
-  // writes (server-execution v2 Phase 2's settle input barrier — see
-  // `unappliedForeignSeqFloor` on ISpaceReplica): docKey -> the set of
-  // shadowed inbound seqs. A SET, not one extremum (review thread
-  // r3739139487): the floor must be the doc's LOWEST hidden seq —
-  // every derivation in the wave read the view from before the
-  // EARLIEST hidden input, so W may not pass it even when later hidden
-  // updates superseded its value (the previous per-doc max let W skip
-  // the earlier one) — while the own-echo verdict repair must remove
-  // EXACTLY its own mis-recorded seq without disturbing genuine
-  // foreign shadows folded around it (a single min would be deleted
-  // whole, losing them). A shadowed REMOVE records the sentinel 1 —
-  // the wire carries no seq for removes, so the floor holds W entirely
-  // until the shadow clears. Entries are pruned lazily when the doc's
-  // pending set empties (promotion, drop, rollback); cleared whole on
-  // reset.
+
+  /**
+   * Foreign novelty whose _visibility_ is still shadowed by own pending writes
+   * (the settle input barrier — see `unappliedForeignSeqFloor` on
+   * `ISpaceReplica`): docKey → the set of shadowed inbound seqs. A _set_, not
+   * one extremum: the floor must be the doc's _lowest_ hidden seq — every
+   * derivation in the wave read the view from before the _earliest_ hidden
+   * input, so W may not pass it even when later hidden updates superseded its
+   * value — while the own-echo verdict repair must remove _exactly_ its own
+   * mis-recorded seq without disturbing genuine foreign shadows folded around
+   * it (a single min would be deleted whole, losing them). A shadowed _remove_
+   * records the sentinel 1 — the wire carries no seq for removes, so the floor
+   * holds W entirely until the shadow clears. Entries are pruned lazily when
+   * the doc's pending set empties (promotion, drop, rollback); cleared whole on
+   * reset.
+   */
   readonly #shadowedForeignSeqs = new Map<string, Set<number>>();
-  // The settle input barrier's WAKE (ISpaceReplica.shadowFlipObserver):
-  // invoked synchronously whenever a confirmPending promotion touched a
-  // doc with a standing shadow (flag ON — the flip checkout's own
-  // condition), value diff or not: the FLOOR lifts either way, and the
-  // floor is what the wake exists for. The SpaceServer installs it at
-  // activation so a clamped-then-quiet space's catch-up wave runs at
-  // the flip instead of waiting out the idle window — the flip is the
-  // one input whose dirtiness arrives WITHOUT a new admitted commit on
-  // the host feed (the commit was drained waves ago; only its
-  // VISIBILITY changed).
-  // Initialized EXPLICITLY (`= undefined`), as are the two overlay wakes
-  // below: the browser worker bundle compiles class fields without define
-  // semantics, so an UNINITIALIZED field is dropped from the class body and
-  // an `"observer" in replica` probe reads false — the overlay's install
-  // silently returned and the wake never fired in browsers (found while
-  // landing stage C tuning T2's arrival wake; the ack wake had the same
-  // shape). The overlay now probes by capability method instead, and the
-  // initializers keep the fields visible either way.
+
+  /**
+   * The settle input barrier's _wake_ (`ISpaceReplica.shadowFlipObserver`):
+   * invoked synchronously whenever a `confirmPending()` promotion touched a doc
+   * with a standing shadow (flag ON — the flip checkout's own condition), value
+   * diff or not: the _floor_ lifts either way, and the floor is what the wake
+   * exists for. The `SpaceServer` installs it at activation so a
+   * clamped-then-quiet space's catch-up wave runs at the flip instead of
+   * waiting out the idle window — the flip is the one input whose dirtiness
+   * arrives _without_ a new admitted commit on the host feed (the commit was
+   * drained waves ago; only its _visibility_ changed).
+   *
+   * Initialized _explicitly_ (`= undefined`), as are the two overlay wakes
+   * below: the browser worker bundle compiles class fields without define
+   * semantics, so an _uninitialized_ field is dropped from the class body and
+   * an `"observer" in replica` probe reads false — the overlay's install would
+   * silently return and the wake never fire in browsers. The overlay probes by
+   * capability method instead, and the initializers keep the fields visible
+   * either way.
+   */
   shadowFlipObserver: (() => void) | undefined = undefined;
-  // localSeq -> the store seq its accept committed at (server-execution
-  // v2 Phase 2, speculation.md §4): the overlay destination's retirement
-  // floor is "the origin ACKED and W ≥ that commit's seq", and the ack
-  // seq is otherwise consumed by promotion. Bounded (insertion-ordered,
-  // oldest pruned) — the overlay only ever asks about recent origins.
+
+  /**
+   * `localSeq` → the store seq its accept committed at (`speculation.md` §4):
+   * the overlay destination's retirement floor is that the origin _acked_ and W
+   * ≥ that commit's seq, and the ack seq is otherwise consumed by promotion.
+   * Bounded (insertion-ordered, oldest pruned) — the overlay only ever asks
+   * about recent origins.
+   */
   readonly #ackedSeqsByLocalSeq = new Map<number, number>();
+
   static readonly #MAX_RETAINED_ACK_SEQS = 4096;
-  // localSeqs of live SPECULATIVE sealed commits (server-execution v2
-  // Phase 2, speculation.md §1/§6): overlay entries exist only in this
-  // process — the client never pushes them — so a PUSHED commit whose
-  // read basis names one can NEVER have that dependency resolve
-  // server-side. commitOperations refuses such an export loudly
-  // (RULED 2026-08-13); membership ends when the speculative commit
-  // settles (retirement/withdrawal drops its pending layers first, so
-  // no stack names a seq after it leaves this set).
+
+  /**
+   * `localSeq`s of live _speculative_ sealed commits (`speculation.md` §1/§6):
+   * overlay entries exist only in this process — the client never pushes them —
+   * so a _pushed_ commit whose read basis names one can _never_ have that
+   * dependency resolve server-side. `commitOperations()` refuses such an export
+   * loudly; membership ends when the speculative commit settles
+   * (retirement/withdrawal drops its pending layers first, so no stack names a
+   * seq after it leaves this set).
+   */
   readonly #speculativeLocalSeqs = new Set<number>();
-  // The overlay destination's retirement WAKE for origin accepts
-  // (ISpaceReplica.speculationAckObserver, speculation.md §4): fired
-  // when a pushed commit's accept records its ack seq. Without it, an
-  // entry whose sweep ran while its origin's verdict was still in
-  // flight (blocked on the unacked layer) — and whose covering
-  // watermark event therefore passed — stayed pending forever on a
-  // then-quiet space: rejected origins cascade into the entry, but
-  // ACCEPTED origins had no client-side wake. Guarded at the call
-  // site — an observer throw must not corrupt accept settlement.
+
+  /**
+   * The overlay destination's retirement _wake_ for origin accepts
+   * (`ISpaceReplica.speculationAckObserver`, `speculation.md` §4): fired when a
+   * pushed commit's accept records its ack seq. Without it, an entry whose
+   * sweep ran while its origin's verdict was still in flight (blocked on the
+   * unacked layer) — and whose covering watermark event therefore passed —
+   * would stay pending forever on a then-quiet space: rejected origins cascade
+   * into the entry, but _accepted_ origins have no other client-side wake.
+   * Guarded at the call site — an observer throw must not corrupt accept
+   * settlement.
+   */
   speculationAckObserver: (() => void) | undefined = undefined;
+
   #speculationArrivalObserver:
     | ((arrived: readonly { id: URI; scope?: CellScope }[]) => void)
     | undefined = undefined;
@@ -3325,25 +3400,37 @@ export class SpaceReplica
     localSeq: number;
     pending: PromiseWithResolvers<void>;
   }[] = [];
-  // docKey -> required caughtUpLocalSeq. An entry means "this id conflicted and
-  // is stale until we observe caughtUpLocalSeq >= value". Pruned as the runner
-  // catches up; only populated while conflict admission control is enabled.
+
+  /**
+   * docKey → required `caughtUpLocalSeq`. An entry means this id conflicted and
+   * is stale until we observe `caughtUpLocalSeq >= value`. Pruned as the runner
+   * catches up; only populated while conflict admission control is enabled.
+   */
   #staleFloor = new Map<string, number>();
+
   #queuedWatchRefresh: WatchRefreshBatch | null = null;
   #queuedWatchRefreshScheduled = false;
-  // Number of watch-refresh round trips currently awaiting a response. Capped
-  // at `#maxWatchRefreshInFlight()` (1 = single-flight; the concurrent window
-  // otherwise) so a large incrementally-discovered wave cannot put an unbounded
-  // number of requests on the wire.
+
+  /**
+   * Number of watch-refresh round trips currently awaiting a response. Capped
+   * at `#maxWatchRefreshInFlight()` (1 = single-flight; the concurrent window
+   * otherwise) so a large incrementally-discovered wave cannot put an unbounded
+   * number of requests on the wire.
+   */
   #watchRefreshInFlight = 0;
-  // The current PERMANENT authorization denial for this space (an ACL shortfall,
-  // an audience or protocol mismatch), or null when the space is authorized. A
-  // non-retriable AuthorizationError from a watch refresh sets it; a successful
-  // refresh clears it; a retriable auth race and a transient transport error
-  // leave it untouched, so a blip or token-refresh window does not register as a
-  // denial. `authorizationError()` reports it as a throwable error; `synced()`
-  // stays silent so a denied cross-space link remains a silent absent read.
+
+  /**
+   * The current _permanent_ authorization denial for this space (an ACL
+   * shortfall, an audience or protocol mismatch), or `null` when the space is
+   * authorized. A non-retriable `AuthorizationError` from a watch refresh sets
+   * it; a successful refresh clears it; a retriable auth race and a transient
+   * transport error leave it untouched, so a blip or token-refresh window does
+   * not register as a denial. `authorizationError()` reports it as a throwable
+   * error; `synced()` stays silent so a denied cross-space link remains a
+   * silent absent read.
+   */
   #lastAuthorizationError: IAuthorizationError | null = null;
+
   readonly #routeState: ProviderRouteState;
   readonly #routeGeneration: number;
   #replacementRead:
@@ -6124,9 +6211,12 @@ export class SpaceReplica
     return { ok: {} };
   }
 
-  // Shared rejection tail for both real conflicts and pre-empted commits: wait
-  // for the caught-up read-repair, drop the optimistic pending write, and emit
-  // the revert notification reflecting repaired confirmed state.
+  /**
+   * Finalizes a rejection, the shared tail for both real conflicts and
+   * pre-empted commits: waits for the caught-up read-repair, drops the
+   * optimistic pending write, and emits the revert notification reflecting
+   * repaired confirmed state.
+   */
   async #finalizeRejection(
     localSeq: number,
     operations: NativeCommitOperation[],
@@ -7146,9 +7236,11 @@ export class SpaceReplica
     }
   }
 
-  // Mark every id this conflicted commit touched (reads + writes) stale until
-  // the runner observes caughtUpLocalSeq >= the commit's localSeq — the seq the
-  // server stages as the post-conflict catch-up point for these ids.
+  /**
+   * Marks every id this conflicted commit touched (reads and writes) stale
+   * until the runner observes `caughtUpLocalSeq >= localSeq` — the seq the
+   * server stages as the post-conflict catch-up point for these ids.
+   */
   #recordStaleFloor(commit: ClientCommit, localSeq: number): void {
     const mark = (id: string, scope?: CellScope) => {
       const key = this.#docKeyOf({ id: id as URI, scope });
@@ -7169,10 +7261,12 @@ export class SpaceReplica
     }
   }
 
-  // If any of this commit's reads are still stale (a recorded floor above our
-  // current caught-up seq), return the highest such floor — the seq we must
-  // reach before a retry can succeed. Only reads gate admission: a stale read
-  // precondition is what the server rejects.
+  /**
+   * Returns the highest stale floor among this commit's reads (a recorded floor
+   * above our current caught-up seq) — the seq we must reach before a retry can
+   * succeed — or `undefined` when none is stale. Only reads gate admission: a
+   * stale read precondition is what the server rejects.
+   */
   #preemptThreshold(commit: ClientCommit): number | undefined {
     if (this.#staleFloor.size === 0) {
       return undefined;
@@ -7218,14 +7312,16 @@ export class SpaceReplica
     };
   }
 
-  // Locally-fabricated rejection for a commit whose doom is provable
-  // client-side (dropped pending dependency, dependency rejected but not yet
-  // dropped, or replica reset). Modeled on makePreemptRejection.
-  // `readyToRetry` defaults to resolving immediately, which is right once the
-  // PRIMARY rejection's finalizeRejection has awaited its read repair (or
-  // reset wiped the replica outright): the victim adds no wait of its own.
-  // A commit rejected against a layer whose repair is still running passes
-  // that repair's completion here instead.
+  /**
+   * Makes a locally-fabricated rejection for a commit whose doom is provable
+   * client-side (dropped pending dependency, dependency rejected but not yet
+   * dropped, or replica reset). Modeled on `makePreemptRejection()`.
+   * `readyToRetry` defaults to resolving immediately, which is right once the
+   * _primary_ rejection's `#finalizeRejection()` has awaited its read repair
+   * (or reset wiped the replica outright): the victim adds no wait of its own.
+   * A commit rejected against a layer whose repair is still running passes that
+   * repair's completion here instead.
+   */
   #makeLocalRejection(
     commit: ClientCommit,
     message: string,
@@ -7273,15 +7369,17 @@ export class SpaceReplica
     return [...named].sort((left, right) => left - right);
   }
 
-  // The loud export refusal (speculation.md §6; RULED 2026-08-13): an
-  // authored/pushed commit whose read basis names a speculative overlay
-  // layer fails OUTRIGHT — terminal, never retried. Only the client can
-  // make this call: it knows which of its layers are speculative, while
-  // the server cannot distinguish a dependency that is never coming
-  // from one that has not arrived yet. Modeled on toRejectedError's
-  // terminal-name arm (RowLabelCommitError): a TransactionError shape
-  // whose name is in TERMINAL_REJECTION_NAMES, so the scheduler's
-  // disposition is `terminal` instead of a doomed backoff window.
+  /**
+   * Makes the loud export refusal (`speculation.md` §6): an authored/pushed
+   * commit whose read basis names a speculative overlay layer fails _outright_
+   * — terminal, never retried. Only the client can make this call: it knows
+   * which of its layers are speculative, while the server cannot distinguish a
+   * dependency that is never coming from one that has not arrived yet. Modeled
+   * on `toRejectedError()`'s terminal-name arm (`RowLabelCommitError`): a
+   * `TransactionError` shape whose name is in `TERMINAL_REJECTION_NAMES`, so
+   * the scheduler's disposition is `terminal` instead of a doomed backoff
+   * window.
+   */
   #makeSpeculativeBasisRefusal(
     commit: ClientCommit,
     speculativeLayers: readonly number[],
@@ -7509,16 +7607,18 @@ export class SpaceReplica
     record.pending.push(pendingVersion(localSeq, pending));
   }
 
-  // CT-1927 client half: an accept's promotion waits for marker coverage.
-  // Immediate application remains for a marker already observed before this
-  // replica begins settlement and for servers that predate per-verdict markers
-  // (verdictCatchUpMarkers absent: an older server stamps markers only for
-  // conflicts, so parking would hang).
-  //
-  // PUSHED (socket) commits only: sealed commits — engine-plane commits by
-  // the co-hosted executor — settle through settleSealedCommit, which
-  // confirms immediately (F1a there explains why parking them wedged
-  // permanently: no marker is ever staged for an engine-plane commit).
+  /**
+   * Settles an accept verdict. An accept's promotion waits for marker coverage.
+   * Immediate application remains for a marker already observed before this
+   * replica begins settlement and for servers that predate per-verdict markers
+   * (`verdictCatchUpMarkers` absent: an older server stamps markers only for
+   * conflicts, so parking would hang).
+   *
+   * _Pushed_ (socket) commits only: sealed commits — engine-plane commits by
+   * the co-hosted executor — settle through `settleSealedCommit()`, which
+   * confirms immediately (no marker is ever staged for an engine-plane commit,
+   * so parking them would wedge permanently).
+   */
   #settleAccept(
     localSeq: number,
     operations: NativeCommitOperation[],
@@ -7616,9 +7716,11 @@ export class SpaceReplica
     return settled.promise;
   }
 
-  // The marker channel died (the subscribed view closed): apply everything
-  // parked immediately — the legacy verdict-time semantics — so promotions
-  // never wait on frames that can no longer arrive.
+  /**
+   * Applies everything parked immediately, for when the marker channel died
+   * (the subscribed view closed), so promotions never wait on frames that can
+   * no longer arrive.
+   */
   #applyParkedAcceptsNow(): void {
     if (this.#parkedAccepts.size === 0) {
       return;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A `//` block sitting directly above a class member and describing that member is a doc comment in the wrong punctuation: it says what the member is or does, which is what `docs/development/code-comment-style.md` § Doc comments has JSDoc form for. This converts the 81 in `packages/runner/src/storage/` (`extended-storage-transaction.ts` 31, `v2.ts` 34, `v2-transaction.ts` 16, `query.ts` 2), one PR of a series that covers the tree outside `packages/patterns`. The rest of `runner` follows in two more PRs.

Each converted member takes the blank line above its doc comment and the blank line below the member that the guide asks for. Most of these fields sat in unbroken runs, so the runs are now spaced.

## What changed inside the comments

The text is carried over as written, with the edits the doc-comment form calls for:

* A method's comment opens with a third-person verb phrase, and a field's with a noun phrase. Where a note opened with rationale and never said what the member is or does, a phrase saying so now opens it: `The CFC state.`, `Whether flow-label persistence is pinned on for this tx.`, `Sets the deployment policy snapshot, once, by the \`Runtime\` at tx creation.`, `Drops the Gantt detail ...`-style openings throughout `v2.ts`'s replica methods (`Finalizes a rejection`, `Marks every id ... stale`, `Returns the highest stale floor`, `Makes a locally-fabricated rejection`, `Settles an accept verdict`, `Applies everything parked immediately`).
* Two long method notes in `extended-storage-transaction.ts`, on `#noteSystemWrite()` and `#noteRootEnvelopeWrite()`, split as § "Where one goes" directs: what the method records and yields stays as the contract, and the paragraphs about how the read is issued, what the arm does not reach, and why the recording is unconditional open the body as `//`.
* `#cfcEnforcementFloor`'s note opened with a remark about "the pins below"; it now opens with what the field holds, and the remark follows.
* Identifiers, callables, and properties take backticks and their parentheses; emphasis by capitals becomes underscores (`_before_`, `_first_`, `_latest_`, `_shadowed_`).
* Labels the guide keeps out of comments are gone, the sentence each sat in saying the same thing without it: `(codex P1 on #4562)`, `(codex P2 on #4563)`, `(stage-G round-2 thread 18)`, `(review thread r3739139487)`, `(CT-1927)`, `(CT-1950)`, `Epic B3`, `Stage C tuning T1`, `Phase 2`, `stage G`, `(RULED 2026-08-13)`, and `(found while landing stage C tuning T2's arrival wake ...)`. Spec pointers stay (`speculation.md` §4, `serving-loop.md` §3d, `key-vocabulary.md` §1, audit items S3 and S18).
* A stale reference is dropped from `TransactionWrapper.markAuthoritativeWrites()`'s note, which said "Forward both" of a pair; the doc names the pair.

## How the sites were found

A TypeScript-AST census over every tracked `.ts`/`.tsx` outside `patterns`, vendored types, and generated declarations: for each class member, the `//` blocks in its leading trivia, minus tool directives, section-marker frames, and `TODO`s. A control fixture of nine planted sites and four decoys reported exactly the nine.

## Verification

* Comment-only, by construction and by proof: each changed file transpiles to byte-identical JavaScript with comments stripped, before and after (4 files, 0 differ).
* The census re-run over the changed files reports zero remaining sites; the blank-line-below detector reports none, on the base files as well as these.
* Every added line is 80 characters or fewer, and no backtick span is broken across lines.
* `deno fmt --check`, `deno lint`, and `deno task check` repo-wide, all green.
* `deno task test` in `runner`: 1390 passed, 0 failed.

## Review

A `cf-review` pass (report only) found one sentence this PR had introduced that was false against the code, fixed: `TransactionWrapper.markAuthoritativeWrites()`'s doc credited `markEffectCompletion()` with calling `isAuthoritativeWrites()`, which the write path in `data-updating.ts` calls, not the completion marker. Also taken: the paragraphs bounding what `#noteRootEnvelopeWrite()` and `#noteSystemWrite()` establish are back in their doc comments, since § "What goes in one" puts the bound on a guarantee in the contract, while the how-the-read-is-issued mechanics stay in the body; `#flowLabelProbeMemo` carries the sentence that was about it; `#` methods are named with their `#` and callables with their parentheses; a four-dash sentence on `#cfcTrustConfigPinned` is two; and `#sealDestination` names which flag's OFF arm it means.
