### PR TITLE
style(runner): `//` notes that documented a class member are doc comments, in the manager, runner, runtime, and scheduler

### DIFF
--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -997,7 +997,7 @@ export class PatternManager {
    * Session-side resolution hints for _keyless_ list-builtin ops, keyed by the
    * node's immutable inputs-doc address (`<space>\0<id>`). A keyless op's
    * durable inputs carry its full embedded graph (the never-durable contract
-   * forbids the `keyless:` `$patternRef` sentinel there), but the embedded
+   * forbids the keyless `$patternRef` sentinel there), but the embedded
    * round-trip corrupts nested output-alias defer levels, so the _same_ session
    * that instantiated the node resolves the pristine artifact through this map
    * instead. Entries are session-lifetime like the artifact index; a fresh

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -378,152 +378,200 @@ type ParkedReplication = {
 
 export class PatternManager {
   #runtime: Runtime;
-  // Maps each storage slot written during this PatternManager session to its
-  // complete module set. One slot can hold only one closure shape at a time.
+
+  /**
+   * Maps each storage slot written during this `PatternManager` session to its
+   * complete module set. One slot can hold only one closure shape at a time.
+   */
   readonly #persistedCompileCacheClosures = new Map<string, string>();
-  // Writes to one storage slot are serialized. Requests for the same closure
-  // share the write that is already running.
+
+  /**
+   * In-flight writes by storage slot. Writes to one storage slot are
+   * serialized, and requests for the same closure share the write that is
+   * already running.
+   */
   #inProgressCompileCacheWrites = new Map<
     string,
     { closureSignature: string; persistence: Promise<void> }
   >();
-  // The writer a test supplies in place of the compile-cache write-back;
-  // undefined means the manager's own.
+
+  /**
+   * The writer a test supplies in place of the compile-cache write-back;
+   * `undefined` means the manager's own.
+   */
   #compileCacheWriter: CompileCacheWriter | undefined = undefined;
-  // A best-effort identity recovery that failed to persist skips the in-memory
-  // artifact shortcuts on the next load so storage recovery runs again.
+
+  /**
+   * Identities whose best-effort recovery failed to persist. Such an identity
+   * skips the in-memory artifact shortcuts on the next load so storage recovery
+   * runs again.
+   */
   #failedCompileCacheRecoveries = new Set<string>();
-  // Single-flight dedup + in-memory result cache for `compileOrGetPattern`,
-  // keyed by a content hash of the program (NOT a cell id, NOT the retired
-  // patternId) so identical source returns one shared, already-compiled pattern
-  // instance. The hash is computed with `createRef` purely as a stable digest
-  // function — no `pattern:` cell is ever minted. Bounded FIFO to cap memory.
+
+  /**
+   * Single-flight dedup and in-memory result cache for `compileOrGetPattern()`,
+   * keyed by a content hash of the program (_not_ a cell id, _not_ the retired
+   * `patternId`) so identical source returns one shared, already-compiled
+   * pattern instance. The hash is computed with `createRef()` purely as a
+   * stable digest function — no `pattern:` cell is ever minted. Bounded FIFO to
+   * cap memory.
+   */
   readonly #inProgressCompilations = new Map<string, Promise<Pattern>>();
-  // Single-flight dedup for the expensive tail of `loadPatternByIdentity`
-  // (storage closure read + SES evaluation), keyed by `${space}\0${identity}`.
-  // Boot references the same entry several times at once (one load per
-  // referencing piece/system pattern); without this every concurrent miss ran
-  // its own full closure evaluation — measured as 4 identical 9-module SES
-  // evals per cold worker boot, the multiplier behind most of the per-module
-  // boot-floor buckets. Followers await the leader and then resolve their own
-  // symbol from the indexes the leader's evaluation populated — the same path
-  // a load arriving after completion takes.
+
+  /**
+   * Single-flight dedup for the expensive tail of `loadPatternByIdentity()`
+   * (storage closure read plus SES evaluation), keyed by
+   * `${space}\0${identity}`. Boot references the same entry several times at
+   * once (one load per referencing piece or system pattern); without this every
+   * concurrent miss would run its own full closure evaluation. Followers await
+   * the leader and then resolve their own symbol from the indexes the leader's
+   * evaluation populated — the same path a load arriving after completion
+   * takes.
+   */
   readonly #inProgressByIdentityLoads = new Map<
     string,
     Promise<Pattern | undefined>
   >();
-  // Session-local negative memo for compile failures that are deterministic
-  // over a fully loaded, Merkle-verified source closure. Verification failure,
-  // absent/incomplete storage, resolution, and evaluation remain retryable.
-  // Keyed by `${space}\0${entryIdentity}` and runtimeVersion so a version bump
-  // re-opens the attempt. Bounded FIFO to cap memory.
+
+  /**
+   * Session-local negative memo for compile failures that are deterministic
+   * over a fully loaded, Merkle-verified source closure. Verification failure,
+   * absent or incomplete storage, resolution, and evaluation remain retryable.
+   * Keyed by `${space}\0${entryIdentity}` and `runtimeVersion` so a version
+   * bump re-opens the attempt. Bounded FIFO to cap memory.
+   */
   #coldLoadNegativeMemo = new ColdLoadNegativeMemo();
-  // Content-hash → { compiled pattern, the space its closure was first written
-  // into }. The space is tracked so a cross-space cache hit can replicate the
-  // source/compiled closure into the requested space (see compileOrGetPattern):
-  // identical source dedupes the expensive TS compile, but every space holding
-  // a piece that points at the pattern still needs the closure persisted there
-  // to reload by { identity, symbol } in a fresh runtime.
+
+  /**
+   * Content hash → the compiled pattern and the space its closure was first
+   * written into. The space is tracked so a cross-space cache hit can replicate
+   * the source/compiled closure into the requested space (see
+   * `compileOrGetPattern()`): identical source dedupes the expensive TS
+   * compile, but every space holding a piece that points at the pattern still
+   * needs the closure persisted there to reload by `{ identity, symbol }` in a
+   * fresh runtime.
+   */
   #compiledByContent = new Map<
     string,
     { pattern: Pattern; space?: MemorySpace }
   >();
-  // The forward value → {identity, symbol} map lives module-level in
-  // builder/pattern-metadata.ts (`setArtifactEntryRef`/`getArtifactEntryRef`)
-  // so builder-layer copy sites can carry refs onto derived copies without a
-  // PatternManager handle.
-  // THE in-memory reverse index for content-addressed builder artifacts: module
-  // identity -> (symbol -> live value). The single source for
-  // `artifactFromIdentitySync` (the inverse of the forward `valueToEntryRef`),
-  // populated by ONE path (`#indexArtifact`) from BOTH a module's `__cfReg`
-  // registrations (hoists + non-exported top-level) AND its exports — so callers
-  // never look in two places. SESSION-LIFETIME, deliberately unbounded (design
-  // § Open questions 2, resolved): the sync resolution the list builtins and
-  // refs-only pattern JSON depend on must never lose an artifact whose module
-  // evaluated this session. Entries are live builder artifacts of evaluated
-  // modules — the same order of retention the engine's strong implementation
-  // index (E1) already committed to for their implementation functions.
+
+  /**
+   * _The_ in-memory reverse index for content-addressed builder artifacts:
+   * module identity → (symbol → live value). The single source for
+   * `artifactFromIdentitySync()` (the inverse of the forward
+   * `valueToEntryRef()`), populated by _one_ path (`#indexArtifact()`) from
+   * _both_ a module's `__cfReg` registrations (hoists and non-exported
+   * top-level) _and_ its exports — so callers never look in two places.
+   * Session-lifetime, deliberately unbounded: the sync resolution the list
+   * builtins and refs-only pattern JSON depend on must never lose an artifact
+   * whose module evaluated this session. Entries are live builder artifacts of
+   * evaluated modules — the same order of retention the engine's strong
+   * implementation index already committed to for their implementation
+   * functions.
+   *
+   * The forward value → `{identity, symbol}` map lives at module level in
+   * `builder/pattern-metadata.ts`
+   * (`setArtifactEntryRef()`/`getArtifactEntryRef()`) so builder-layer copy
+   * sites can carry refs onto derived copies without a `PatternManager` handle.
+   */
   readonly #addressableByIdentity = new Map<string, Map<string, unknown>>();
-  // Bound for the module-NAMESPACE cache below (`#modulesByIdentity`) only; its
-  // misses recover through the async storage-backed load. Instance field so
-  // tests can shrink it.
+
+  /**
+   * Bound for the module-_namespace_ cache (`#modulesByIdentity`) only; its
+   * misses recover through the async storage-backed load. An instance field so
+   * tests can shrink it.
+   */
   #maxEvaluatedModuleCacheSize = MAX_EVALUATED_MODULE_CACHE_SIZE;
-  // ESM content-addressed compile-cache instrumentation.
+
+  /** ESM content-addressed compile-cache instrumentation. */
   #esmCacheStats = { hits: 0, misses: 0, byIdentityHits: 0 };
-  // In-memory identity -> module-namespace cache (CT-1623). Populated for EVERY
-  // module of an evaluated ESM bundle (keyed by prefix-free content identity),
-  // so a by-identity load of a sub-pattern reuses the already-live module from
-  // its parent's bundle instead of re-reading the closure from storage and
-  // re-evaluating it in SES. Content-addressed, so a hit is always the same
-  // bytes — never stale. Bounded (FIFO) to cap memory.
+
+  /**
+   * In-memory identity → module-namespace cache. Populated for _every_ module
+   * of an evaluated ESM bundle (keyed by prefix-free content identity), so a
+   * by-identity load of a sub-pattern reuses the already-live module from its
+   * parent's bundle instead of re-reading the closure from storage and
+   * re-evaluating it in SES. Content-addressed, so a hit is always the same
+   * bytes — never stale. Bounded (FIFO) to cap memory.
+   */
   readonly #modulesByIdentity = new Map<string, { exports: Exports }>();
-  // In-flight compiled-cache write-backs; awaited by flushCompileCacheWrites()
-  // for graceful shutdown / deterministic tests. Cold compile write-backs are
-  // awaited by compilePattern; recovery/replication paths may still run in the
-  // background.
+
+  /**
+   * In-flight compiled-cache write-backs; awaited by
+   * `flushCompileCacheWrites()` for graceful shutdown and deterministic tests.
+   * Cold compile write-backs are awaited by `compilePattern()`; recovery and
+   * replication paths may still run in the background.
+   */
   readonly #compileCacheWrites = new Set<Promise<unknown>>();
-  // Closure write-backs that replication must observe before reading its
-  // origin space. Tracked separately because the replication promise also
-  // lives in `#compileCacheWrites` and cannot await itself.
+
+  /**
+   * Closure write-backs that replication must observe before reading its origin
+   * space. Tracked separately because the replication promise also lives in
+   * `#compileCacheWrites` and cannot await itself.
+   */
   readonly #pendingCacheWriteBacks = new Set<Promise<unknown>>();
-  // In-flight replications keyed by TARGET space, ordered by a monotonic
-  // ticket. A replication's origin may itself be mid-supply by an earlier
-  // replication INTO it (e.g. the content-cache hit's fire-and-forget
-  // sibling ahead of the runner's cross-space child replication in one
-  // handler run); a one-shot origin read would then fail with nothing
-  // ever re-issuing it, and the target space's demanded roots park
-  // `pattern-unloadable` forever (verification-coverage.md OW45, the
-  // lunch forever-park — the incident evidence lives there). The sibling
-  // lives in `#compileCacheWrites`, the one set the origin read must NOT
-  // await wholesale (it would await itself), so replications also
-  // register HERE and the read awaits only the STRICTLY OLDER entries
-  // targeting its origin — registration order keeps the await graph
-  // acyclic (no from/to mutual wait), and genuine absence still throws
-  // loudly after the awaited siblings settle.
+
+  /**
+   * In-flight replications keyed by _target_ space, ordered by a monotonic
+   * ticket. A replication's origin may itself be mid-supply by an earlier
+   * replication _into_ it (e.g. the content-cache hit's fire-and-forget sibling
+   * ahead of the runner's cross-space child replication in one handler run); a
+   * one-shot origin read would then fail with nothing ever re-issuing it, and
+   * the target space's demanded roots would park `pattern-unloadable` forever
+   * (`verification-coverage.md` OW45 carries the incident evidence). The
+   * sibling lives in `#compileCacheWrites`, the one set the origin read must
+   * _not_ await wholesale (it would await itself), so replications also
+   * register _here_ and the read awaits only the _strictly older_ entries
+   * targeting its origin — registration order keeps the await graph acyclic (no
+   * from/to mutual wait), and genuine absence still throws loudly after the
+   * awaited siblings settle.
+   */
   #replicationsIntoSpace = new Map<
     MemorySpace,
     Set<{ ticket: number; settled: Promise<unknown> }>
   >();
+
   #nextReplicationTicket = 0;
-  // Spaces this manager DURABLY persisted an entry's closure into
-  // (recorded at the two tracked persists' success; session-lifetime,
-  // record-only — a later slot invalidation forces a re-verify on read,
-  // and the fallback read below re-verifies fail-closed anyway, so a
-  // stale record costs one failed read, never a wrong copy). These are
-  // `replicateClosures`' FALLBACK ORIGINS: the caller-named origin is a
-  // provenance heuristic — the in-memory artifact index serves patterns
-  // with no per-space persist, so a running piece's space can lack the
-  // closure entirely — while the closure is content-addressed, so any
-  // recorded persist target holds byte-identical, integrity-gated docs
-  // (verification-coverage.md OW45 carries the incident evidence).
-  // Growth: monotonic for the session, bounded by the module identities ×
-  // spaces this manager actually persisted (strings + small DID sets) —
-  // negligible today; revisit with an eviction policy only if serving
-  // sessions get very long-lived.
+
+  /**
+   * Spaces this manager _durably_ persisted an entry's closure into (recorded
+   * at the two tracked persists' success; session-lifetime, record-only — a
+   * later slot invalidation forces a re-verify on read, and the fallback read
+   * re-verifies fail-closed anyway, so a stale record costs one failed read,
+   * never a wrong copy). These are `replicateClosures()`' _fallback origins_:
+   * the caller-named origin is a provenance heuristic — the in-memory artifact
+   * index serves patterns with no per-space persist, so a running piece's space
+   * can lack the closure entirely — while the closure is content-addressed, so
+   * any recorded persist target holds byte-identical, integrity-gated docs
+   * (`verification-coverage.md` OW45 carries the incident evidence). Growth:
+   * monotonic for the session, bounded by the module identities × spaces this
+   * manager actually persisted (strings plus small DID sets).
+   */
   #persistedClosureSpaces = new Map<string, Set<MemorySpace>>();
-  // Failed replications PARKED for event-driven re-supply (the ruled 3b
-  // close — verification-coverage.md OW45, RULING 2026-08-28: the one
-  // supplier-timing geometry no await can see is a supplier that has not
-  // STARTED by consult time, so the failure parks and the supply's own
-  // RECORD re-issues it). Keyed by the WANTED identity — the identity
-  // whose READ failed, which for a dependency-recursion frame is the
-  // DEPENDENCY's identity, not the entry's: the dependency's supplier
-  // records the dependency's own module identities, so an entry-keyed
-  // registry would miss exactly that record event. The inner map keys by
-  // (entry, from, to) so a re-registration after a failed re-issue
-  // REPLACES its predecessor instead of accumulating. Entries drop at
-  // wake time — one wake per matching persist event; a re-issue that
-  // fails again re-parks and waits for the NEXT record, so there is no
-  // self-clocking loop — and otherwise die with the session. Growth:
-  // FIFO-capped at MAX_PARKED_FAILED_REPLICATIONS wanted keys (loud
-  // eviction); a stale park costs one wasted loud re-issue on a matching
-  // record, never a wrong copy (the re-issue re-runs the full verified,
-  // fail-closed read). The cap bounds WANTED KEYS only — the inner
-  // (entry, from, to) map is deliberately not capped in its own right
-  // (cubic PM-2 on #6528, adjudicated LOW): filling one takes that many
-  // DISTINCT real supply failures for a single identity, each carrying
-  // its own loud failure + park line, and ONE matching record wakes the
-  // whole set at once.
+
+  /**
+   * Failed replications _parked_ for event-driven re-supply
+   * (`verification-coverage.md` OW45: the one supplier-timing geometry no await
+   * can see is a supplier that has not _started_ by consult time, so the
+   * failure parks and the supply's own _record_ re-issues it). Keyed by the
+   * _wanted_ identity — the identity whose _read_ failed, which for a
+   * dependency-recursion frame is the _dependency_'s identity, not the entry's:
+   * the dependency's supplier records the dependency's own module identities,
+   * so an entry-keyed registry would miss exactly that record event. The inner
+   * map keys by (entry, from, to) so a re-registration after a failed re-issue
+   * _replaces_ its predecessor instead of accumulating. Entries drop at wake
+   * time — one wake per matching persist event; a re-issue that fails again
+   * re-parks and waits for the _next_ record, so there is no self-clocking loop
+   * — and otherwise die with the session. Growth: FIFO-capped at
+   * `MAX_PARKED_FAILED_REPLICATIONS` wanted keys (loud eviction); a stale park
+   * costs one wasted loud re-issue on a matching record, never a wrong copy
+   * (the re-issue re-runs the full verified, fail-closed read). The cap bounds
+   * _wanted keys_ only — the inner (entry, from, to) map is deliberately not
+   * capped in its own right: filling one takes that many _distinct_ real supply
+   * failures for a single identity, each carrying its own loud failure and park
+   * line, and _one_ matching record wakes the whole set at once.
+   */
   #parkedFailedReplications = new Map<
     string,
     Map<string, ParkedReplication>
@@ -945,16 +993,17 @@ export class PatternManager {
    */
   keylessMintAnomalies = 0;
 
-  // Session-side resolution hints for KEYLESS list-builtin ops, keyed by the
-  // node's immutable inputs-doc address (`<space>\0<id>`). A keyless op's
-  // durable inputs carry its full embedded graph (the never-durable contract
-  // forbids the `keyless:` `$patternRef` sentinel there — L3(a), RULED
-  // 2026-08-27), but the embedded round-trip corrupts nested output-alias
-  // defer levels (CT-1812/CT-1811), so the SAME session that instantiated the
-  // node resolves the pristine artifact through this map instead. Entries are
-  // session-lifetime like the artifact index; a fresh session re-instantiates
-  // the node and re-registers. Content-addressed key, so two structurally
-  // identical nodes share one (equally valid) entry.
+  /**
+   * Session-side resolution hints for _keyless_ list-builtin ops, keyed by the
+   * node's immutable inputs-doc address (`<space>\0<id>`). A keyless op's
+   * durable inputs carry its full embedded graph (the never-durable contract
+   * forbids the `keyless:` `$patternRef` sentinel there), but the embedded
+   * round-trip corrupts nested output-alias defer levels, so the _same_ session
+   * that instantiated the node resolves the pristine artifact through this map
+   * instead. Entries are session-lifetime like the artifact index; a fresh
+   * session re-instantiates the node and re-registers. Content-addressed key,
+   * so two structurally identical nodes share one (equally valid) entry.
+   */
   #keylessOpRefsByInputsDoc = new Map<
     string,
     { identity: string; symbol: string }
@@ -2927,14 +2976,16 @@ export class PatternManager {
     this.#runtime.registerModuleDelegations(space, committedModuleDelegations);
   }
 
-  // Write-target pre-syncs carry the one-hop edge selector (CT-1848): a
-  // schema-less sync delivers only the root doc, leaving the per-edge element
-  // docs unknown to the replica, so a re-write of pre-existing docs touches
-  // them blind and conflicts one engine round per edge (the CT-1824 loop).
-  // With the edge docs materialized up front the write-back diffs against
-  // true state and commits on the first attempt; the retry budget in
-  // `#writeBackCompileCache` remains as a backstop. Same-microtask syncs batch
-  // into a single server round trip.
+  /**
+   * Pre-syncs the write targets, carrying the one-hop edge selector: a
+   * schema-less sync delivers only the root doc, leaving the per-edge element
+   * docs unknown to the replica, so a re-write of pre-existing docs touches
+   * them blind and conflicts one engine round per edge. With the edge docs
+   * materialized up front the write-back diffs against true state and commits
+   * on the first attempt; the retry budget in `#writeBackCompileCache()`
+   * remains as a backstop. Same-microtask syncs batch into a single server
+   * round trip.
+   */
   async #syncSourceCacheWriteTargets(
     space: MemorySpace,
     modules: readonly CacheableModule[],
@@ -2971,7 +3022,7 @@ export class PatternManager {
     );
   }
 
-  // Resolve a Pattern from an evaluate result.
+  /** Resolves a `Pattern` from an evaluate result. */
   #patternFromEvaluation(
     result: EvaluateResult,
     program: RuntimeProgram,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1873,111 +1873,139 @@ export class Runner {
     PieceRegistration
   >();
   #allCancels = new Set<Cancel>();
-  // In-flight unloadable-pointer roll-forward commits (CT-1923). Deliberately
-  // outside the scheduler, like PatternUpdater's checks — dispose() settles
-  // them before the storage sessions they write through close. Bounded
-  // local commits only.
+
+  /**
+   * In-flight unloadable-pointer roll-forward commits. Deliberately outside the
+   * scheduler, like `PatternUpdater`'s checks — `dispose()` settles them before
+   * the storage sessions they write through close. Bounded local commits only.
+   */
   #pendingPointerCommits = new Set<Promise<unknown>>();
-  // In-flight watcher pattern-load attempts. NEVER awaited by dispose(): a
-  // load can be arbitrarily slow or wedged (network), and the
-  // fire-and-forget design guards post-settle work with lifecycle epochs
-  // instead — awaiting them would let one held load hang teardown (proven
-  // by reload-rehydration-safety's held-hot-swap-load test). Tracked solely
-  // so tests can synchronize deterministically under the frozen-clock
-  // preload, where wall-clock polling cannot observe this work.
+
+  /**
+   * In-flight watcher pattern-load attempts. _Never_ awaited by `dispose()`: a
+   * load can be arbitrarily slow or wedged (network), and the fire-and-forget
+   * design guards post-settle work with lifecycle epochs instead — awaiting
+   * them would let one held load hang teardown. Tracked solely so tests can
+   * synchronize deterministically under the frozen-clock preload, where
+   * wall-clock polling cannot observe this work.
+   */
   #pendingWatcherPatternLoads = new Set<Promise<unknown>>();
-  // In-flight catch-up recoveries of commit-gated starts whose transaction
-  // lost its basis to the serving side's own first-hydration materialization
-  // (see `catchUpAndStartOnStaleRead`). NEVER awaited by dispose(), for the
-  // same reason as the watcher loads above: the readiness gate they await is
-  // a session catch-up, which a closing runtime may never reach, and a
-  // cancelled ownership already tombstones the work. Tracked solely so tests
-  // can synchronize deterministically.
+
+  /**
+   * In-flight catch-up recoveries of commit-gated starts whose transaction lost
+   * its basis to the serving side's own first-hydration materialization (see
+   * `catchUpAndStartOnStaleRead()`). _Never_ awaited by `dispose()`, for the
+   * same reason as the watcher loads above: the readiness gate they await is a
+   * session catch-up, which a closing runtime may never reach, and a cancelled
+   * ownership already tombstones the work. Tracked solely so tests can
+   * synchronize deterministically.
+   */
   #pendingDeferredStartCatchUps = new Set<Promise<unknown>>();
-  // Self-minted piece instantiations commit asynchronously. Their local graph
-  // is speculative until the commit and any serving-wave settlement succeed,
-  // so a stale-read refusal or contribution drop tears down that exact node
-  // group and re-instantiates it once against the repaired view. This set is a
-  // deterministic test seam: disposal relies on the registration and
-  // lifecycle guards rather than waiting for a readiness gate or a wave that
-  // a closing serving loop may abandon.
+
+  /**
+   * In-flight settlements of self-minted piece instantiations, which commit
+   * asynchronously. Their local graph is speculative until the commit and any
+   * serving-wave settlement succeed, so a stale-read refusal or contribution
+   * drop tears down that exact node group and re-instantiates it once against
+   * the repaired view. This set is a deterministic test seam: disposal relies
+   * on the registration and lifecycle guards rather than waiting for a
+   * readiness gate or a wave that a closing serving loop may abandon.
+   */
   #pendingPieceInstantiationSettlements = new Set<Promise<unknown>>();
-  // Both maps record that this runner prepared or stopped a result, so a later
-  // start of the same result can reuse the cells it already assembled instead
-  // of re-syncing dependencies and rehydrating a snapshot. They are shortcuts:
-  // a missing entry costs a slower start, never a wrong one. They are bounded
-  // for that reason — a result key names one result document, and a pattern
-  // that keeps starting and stopping children adds keys it will never revisit.
+
+  /**
+   * Results this runner prepared, so a later start of the same result can reuse
+   * the cells it already assembled instead of re-syncing dependencies and
+   * rehydrating a snapshot. This map and `#locallyStoppedResults` are
+   * shortcuts: a missing entry costs a slower start, never a wrong one. They
+   * are bounded for that reason — a result key names one result document, and a
+   * pattern that keeps starting and stopping children adds keys it will never
+   * revisit.
+   */
   readonly #locallyPreparedResults = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     string
   >(RESULT_SHORTCUT_LIMIT);
+
   readonly #locallyStoppedResults = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     string
   >(RESULT_SHORTCUT_LIMIT);
-  // Successful event-result starts that are still live in this runner. This is
-  // intentionally local and bounded by live starts: it lets a sequential
-  // redelivery avoid re-materializing an already-won result before the
-  // create-only receipt guard rejects the duplicate. It is not a replacement
-  // for the system-wide commit precondition.
+
+  /**
+   * Successful event-result starts that are still live in this runner. This is
+   * intentionally local and bounded by live starts: it lets a sequential
+   * redelivery avoid re-materializing an already-won result before the
+   * create-only receipt guard rejects the duplicate. It is not a replacement
+   * for the system-wide commit precondition.
+   */
   #locallyCommittedHandlerResultStarts = new Set<
     `${MemorySpace}/${ScopeKey}/${URI}`
   >();
-  // DIAGNOSTIC counter (tests; the loud-no-op pin): served receipt
-  // writes skipped as write-once CAS losses — the handling's result
-  // cell already held a value when the serving run went to write it
-  // (handleJavaScriptHandlerResult's ruled serving-side write,
-  // events.md §4 "Result carriage"). Each skip also logs a warn line;
-  // this is the machine-readable half.
+
+  /**
+   * Diagnostic counter, for tests (the loud-no-op pin): served receipt writes
+   * skipped as write-once CAS losses — the handling's result cell already held
+   * a value when the serving run went to write it
+   * (`handleJavaScriptHandlerResult()`'s serving-side write, `events.md` §4,
+   * "Result carriage"). Each skip also logs a warn line; this is the
+   * machine-readable half.
+   */
   #servedReceiptCasLosses = 0;
-  // Results started in their own right rather than as part of an enclosing
-  // pattern, which is what navigating to a nested result does. An enclosing
-  // pattern releasing such a result leaves it running; only stopping it
-  // directly ends it.
+
+  /**
+   * Results started in their own right rather than as part of an enclosing
+   * pattern, which is what navigating to a nested result does. An enclosing
+   * pattern releasing such a result leaves it running; only stopping it
+   * directly ends it.
+   */
   #independentlyStartedResults = new Set<
     `${MemorySpace}/${ScopeKey}/${URI}`
   >();
-  // Tombstones for `sessionPatternPointers` entries dropped by CAPACITY
-  // EVICTION — never by the sanctioned removals (a real pattern's durable
-  // stamps superseding the pointer; a failed staging's cleanup). Each
-  // records the POINTER the eviction dropped, and the zero-evidence
-  // restage exemption in `setupInternal` consults it: an evicted pointer
-  // is "evidence unknown", not "no evidence". A re-setup with a DIFFERENT
-  // identity takes the conservative restage the un-evicted state would
-  // have taken — without the tombstone, eviction silently skipped that
-  // revalidation. A re-setup with the SAME identity is evidence AGREEING
-  // with the stored setup (the mint is a stable content hash of the
-  // pattern structure), so it keeps the exemption's protective verdict:
-  // forcing a restage there would strictly validate a stored argument the
-  // original staging never validated — the cf-get replay breakage the
-  // exemption exists to prevent, manufactured in-session past 4096
-  // setups. Entries are never individually removed (the doubt they record
-  // stays true for every state that consults them); bounded like the
-  // pointer map itself, so a doubly-blown bound degrades honestly to the
-  // designed zero-evidence verdict.
+
+  /**
+   * Tombstones for `#sessionPatternPointers` entries dropped by _capacity
+   * eviction_ — never by the sanctioned removals (a real pattern's durable
+   * stamps superseding the pointer; a failed staging's cleanup). Each records
+   * the _pointer_ the eviction dropped, and the zero-evidence restage exemption
+   * in `setupInternal()` consults it: an evicted pointer is evidence unknown,
+   * not no evidence. A re-setup with a _different_ identity takes the
+   * conservative restage the un-evicted state would have taken — without the
+   * tombstone, eviction silently skipped that revalidation. A re-setup with the
+   * _same_ identity is evidence _agreeing_ with the stored setup (the mint is a
+   * stable content hash of the pattern structure), so it keeps the exemption's
+   * protective verdict: forcing a restage there would strictly validate a
+   * stored argument the original staging never validated — the cf-get replay
+   * breakage the exemption exists to prevent, manufactured in-session past 4096
+   * setups. Entries are never individually removed (the doubt they record stays
+   * true for every state that consults them); bounded like the pointer map
+   * itself, so a doubly-blown bound degrades honestly to the designed
+   * zero-evidence verdict.
+   */
   #evictedSessionPatternPointers = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     { identity: string; symbol: string }
   >(RESULT_SHORTCUT_LIMIT);
-  // SESSION-side pattern pointers for KEYLESS pieces. A hand-built pattern's
-  // setup no longer stamps its session-synthetic `keyless:` ref durably
-  // (never-durable contract; L3(a), RULED 2026-08-27), but the in-session
-  // flows that used to read those stamps are sanctioned and keep working
-  // through this map instead: a separate `start(resultCell)` after setup,
-  // `setup`/`run` without a pattern, restart after `stop()`, and the
-  // setup-reuse marker (`storedSetupMarker`) that lets a re-derived
-  // sub-piece (a lift returning a pattern) reuse its running setup rather
-  // than restage it. Written at the same moment the durable stamps would
-  // have been (end of `#applySetupState`), erased when a real pattern's
-  // stamps supersede it or the staging transaction fails, and it dies with
-  // the session — which is the contract's whole point. Bounded like the
-  // shortcut maps beside it. Eviction costs the designed no-pattern-meta
-  // verdict (the piece's producer re-derives it), a restage, or a loud
-  // moved/not-current abort — with one guarded corner: absence alone would
-  // read as the fresh-session ZERO-EVIDENCE state and skip the restage
-  // validation, so evictions leave a tombstone (above) and the exemption
-  // treats "evicted" as evidence-unknown → restage.
+
+  /**
+   * _Session_-side pattern pointers for _keyless_ pieces. A hand-built
+   * pattern's setup does not stamp its session-synthetic `keyless:` ref durably
+   * (the never-durable contract), but the in-session flows that read those
+   * stamps are sanctioned and keep working through this map instead: a separate
+   * `start(resultCell)` after setup, `setup`/`run` without a pattern, restart
+   * after `stop()`, and the setup-reuse marker (`storedSetupMarker`) that lets
+   * a re-derived sub-piece (a lift returning a pattern) reuse its running setup
+   * rather than restage it. Written at the same moment the durable stamps would
+   * have been (end of `#applySetupState()`), erased when a real pattern's
+   * stamps supersede it or the staging transaction fails, and it dies with the
+   * session — which is the contract's whole point. Bounded like the shortcut
+   * maps beside it. Eviction costs the designed no-pattern-meta verdict (the
+   * piece's producer re-derives it), a restage, or a loud moved/not-current
+   * abort — with one guarded corner: absence alone would read as the
+   * fresh-session _zero-evidence_ state and skip the restage validation, so
+   * evictions leave a tombstone (above) and the exemption treats evicted as
+   * evidence-unknown → restage.
+   */
   readonly #sessionPatternPointers = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     { identity: string; symbol: string }
@@ -1986,62 +2014,84 @@ export class Runner {
       this.#evictedSessionPatternPointers.set(key, pointer),
   });
 
-  // SESSION-side pattern-swap channel for RUNNING pieces, the third stamp
-  // stand-in: a re-derived child (a lift returning a pattern) used to reach
-  // its running piece's swap machinery THROUGH the durable stamp — setup
-  // wrote the new `patternIdentity`, the piece's meta watcher fired, and
-  // swapToPattern cancelled the old graph and instantiated the new one.
-  // With keyless stamps gone (L3(a)), a run() over an already-registered
-  // piece requests the swap here instead, handing the LIVE pattern value
-  // straight to the watcher's own swap closure (same guards, same
-  // fail-closed setup). Real patterns keep the durable-stamp path
-  // unchanged. Registered by setupPatternWatcher, removed with the
-  // piece's cancel group.
+  /**
+   * _Session_-side pattern-swap channel for _running_ pieces, the third stamp
+   * stand-in. With keyless stamps never durable, a `run()` over an
+   * already-registered piece requests the swap here, handing the _live_ pattern
+   * value straight to the watcher's own swap closure (same guards, same
+   * fail-closed setup) — the machinery a re-derived child (a lift returning a
+   * pattern) otherwise reaches through the durable stamp: setup writes the new
+   * `patternIdentity`, the piece's meta watcher fires, and `swapToPattern()`
+   * cancels the old graph and instantiates the new one. Real patterns keep the
+   * durable-stamp path. Registered by `setupPatternWatcher()`, removed with the
+   * piece's cancel group.
+   */
   #sessionPatternSwaps = new Map<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     (pattern: Pattern, ref: { identity: string; symbol: string }) => void
   >();
-  // Commit-gated starts that have not installed a registration yet, indexed by
-  // result so an explicit stop can tombstone them before installation.
+
+  /**
+   * Commit-gated starts that have not installed a registration yet, indexed by
+   * result so an explicit stop can tombstone them before installation.
+   */
   readonly #pendingDeferredStarts = new Map<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     Set<DeferredCancelOwnership>
   >();
-  // Two-level memo of what each result cell holds: outer key the result
-  // DOC (space/id), inner key the resolved scope INSTANCE, value a hash
-  // of the pattern's encodable form -- what `#writeJavaScriptActionResult`
-  // compares to decide whether a returned sub-pattern has changed. The
-  // inner key is the SAME per-run resolved ScopeKey that selects the
-  // byScope result cell (review thread r3739139481): a serving runtime
-  // materializes one child per demanded instance, and a doc-level (or
-  // service-identity-resolved) key made the SECOND demanded instance
-  // look "unchanged" and skip its child materialization. The outer
-  // doc key is what change notifications can name (they carry scope by
-  // NAME, which cannot address per-run instances), so eviction drops
-  // the whole doc's entry -- over-eviction across instances is safe:
-  // re-preparing an unchanged pattern is idempotent.
+
+  /**
+   * Two-level memo of what each result cell holds: outer key the result _doc_
+   * (space/id), inner key the resolved scope _instance_, value a hash of the
+   * pattern's encodable form — what `#writeJavaScriptActionResult()` compares
+   * to decide whether a returned sub-pattern has changed. The inner key is the
+   * _same_ per-run resolved `ScopeKey` that selects the byScope result cell: a
+   * serving runtime materializes one child per demanded instance, and a
+   * doc-level (or service-identity-resolved) key would make the _second_
+   * demanded instance look unchanged and skip its child materialization. The
+   * outer doc key is what change notifications can name (they carry scope by
+   * _name_, which cannot address per-run instances), so eviction drops the
+   * whole doc's entry — over-eviction across instances is safe: re-preparing an
+   * unchanged pattern is idempotent.
+   */
   readonly #resultPatternCache = new Map<
     `${MemorySpace}/${URI}`,
     Map<ScopeKey, string>
   >();
-  // Invalidates asynchronous start/resume continuations when stopAll() begins.
-  // A later explicit start captures the new epoch and may proceed normally.
+
+  /**
+   * Epoch which invalidates asynchronous start/resume continuations when
+   * `stopAll()` begins. A later explicit start captures the new epoch and may
+   * proceed normally.
+   */
   #lifecycleEpoch = 0;
-  // Per-result generation for starts that have not installed their cancel
-  // group yet. stop(result) advances it so an in-flight sync/listing cannot
-  // start that piece after the caller has already stopped it. Entries exist
-  // only while at least one tracked start attempt for that doc is unsettled.
+
+  /**
+   * Per-result generation for starts that have not installed their cancel group
+   * yet. `stop(result)` advances it so an in-flight sync or listing cannot
+   * start that piece after the caller has already stopped it. Entries exist
+   * only while at least one tracked start attempt for that doc is unsettled.
+   */
   #startGenerationByDoc = new Map<string, number>();
+
   #activeStartAttemptsByDoc = new Map<string, Set<StartAttempt>>();
-  // Covers the pre-resolution window where a link attempt does not know its
-  // eventual target doc and therefore cannot appear in the per-doc index yet.
+
+  /**
+   * Every unsettled start attempt. Covers the pre-resolution window where a
+   * link attempt does not know its eventual target doc and therefore cannot
+   * appear in the per-doc index yet.
+   */
   readonly #activeStartAttempts = new Set<StartAttempt>();
-  // The attempt a concurrent start() of the same doc joins, keyed by the doc
-  // the call entered through. One entry per doc: the newest attempt that is
-  // still current. Entries are removed when their attempt settles; a stale
-  // entry (stop moved the doc's generation, or the epoch changed) is
-  // overwritten by the fresh attempt that replaces it.
+
+  /**
+   * The attempt a concurrent `start()` of the same doc joins, keyed by the doc
+   * the call entered through. One entry per doc: the newest attempt that is
+   * still current. Entries are removed when their attempt settles; a stale
+   * entry (stop moved the doc's generation, or the epoch changed) is
+   * overwritten by the fresh attempt that replaces it.
+   */
   #inFlightStartsByDoc = new Map<string, StartAttempt>();
+
   #crossSpaceChildSpaces = new WeakMap<
     IExtendedStorageTransaction,
     MemorySpace[]
@@ -5903,10 +5953,12 @@ export class Runner {
     }
   }
 
-  // Result-pattern cache key, per scope INSTANCE (key-vocabulary.md §1
-  // site 2): two instances of one doc may resolve to different patterns,
-  // so the key carries the shared scope_key, resolved against the
-  // runtime's own session (the OFF arm's one identity).
+  /**
+   * Returns the result-pattern cache key for `cell`, per scope _instance_
+   * (`key-vocabulary.md` §1 site 2): two instances of one doc may resolve to
+   * different patterns, so the key carries the shared scope key, resolved
+   * against the runtime's own session (the OFF arm's one identity).
+   */
   #getDocKey(cell: Cell<any>): `${MemorySpace}/${ScopeKey}/${URI}` {
     const { space, id, scope } = cell.getAsNormalizedFullLink();
     return `${space}/${
@@ -6752,15 +6804,17 @@ export class Runner {
     }
   }
 
-  // Walk the pattern tree — this pattern and every nested sub-pattern — and
-  // collect each one's owned (derived internal) cells into `out`, so the resume
-  // pre-sync pulls them before instantiation reads them. A sub-pattern node's
-  // result cell is the cell reserved by the node's resolved output spot, the
-  // same `resultFor` identity instantiatePatternNode mints; deriving owned cells
-  // from it matches what the child's setup will use. The `seen` set keys on the
-  // result cell to bound the walk against a cyclic reference. This only pulls
-  // cells, so a node shape it cannot resolve contributes nothing rather than
-  // misbehaving.
+  /**
+   * Walks the pattern tree — this pattern and every nested sub-pattern — and
+   * collects each one's owned (derived internal) cells into `out`, so the
+   * resume pre-sync pulls them before instantiation reads them. A sub-pattern
+   * node's result cell is the cell reserved by the node's resolved output spot,
+   * the same `resultFor` identity `instantiatePatternNode()` mints; deriving
+   * owned cells from it matches what the child's setup will use. The `seen` set
+   * keys on the result cell to bound the walk against a cyclic reference. This
+   * only pulls cells, so a node shape it cannot resolve contributes nothing
+   * rather than misbehaving.
+   */
   #collectResumeOwnedCells(
     pattern: Pattern,
     resultCell: Cell<any>,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1927,6 +1927,7 @@ export class Runner {
     string
   >(RESULT_SHORTCUT_LIMIT);
 
+  /** Results this runner stopped, paired with `#locallyPreparedResults`. */
   readonly #locallyStoppedResults = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,
     string
@@ -1990,20 +1991,20 @@ export class Runner {
   /**
    * _Session_-side pattern pointers for _keyless_ pieces. A hand-built
    * pattern's setup does not stamp its session-synthetic `keyless:` ref durably
-   * (the never-durable contract), but the in-session flows that read those
-   * stamps are sanctioned and keep working through this map instead: a separate
-   * `start(resultCell)` after setup, `setup`/`run` without a pattern, restart
-   * after `stop()`, and the setup-reuse marker (`storedSetupMarker`) that lets
-   * a re-derived sub-piece (a lift returning a pattern) reuse its running setup
-   * rather than restage it. Written at the same moment the durable stamps would
-   * have been (end of `#applySetupState()`), erased when a real pattern's
-   * stamps supersede it or the staging transaction fails, and it dies with the
-   * session — which is the contract's whole point. Bounded like the shortcut
-   * maps beside it. Eviction costs the designed no-pattern-meta verdict (the
-   * piece's producer re-derives it), a restage, or a loud moved/not-current
-   * abort — with one guarded corner: absence alone would read as the
-   * fresh-session _zero-evidence_ state and skip the restage validation, so
-   * evictions leave a tombstone (above) and the exemption treats evicted as
+   * (the never-durable contract), but the in-session flows that need that
+   * pointer are sanctioned and go through this map instead: a separate
+   * `start(resultCell)` after setup, `setup()`/`run()` without a pattern,
+   * restart after `stop()`, and the setup-reuse marker (`storedSetupMarker()`)
+   * that lets a re-derived sub-piece (a lift returning a pattern) reuse its
+   * running setup rather than restage it. Written at the same moment the
+   * durable stamps would have been (end of `#applySetupState()`), erased when a
+   * real pattern's stamps supersede it or the staging transaction fails, and it
+   * dies with the session — which is the contract's whole point. Bounded like
+   * the shortcut maps beside it. Eviction costs the designed no-pattern-meta
+   * verdict (the piece's producer re-derives it), a restage, or a loud
+   * moved/not-current abort — with one guarded corner: absence alone would read
+   * as the fresh-session _zero-evidence_ state and skip the restage validation,
+   * so evictions leave a tombstone (above) and the exemption treats evicted as
    * evidence-unknown → restage.
    */
   readonly #sessionPatternPointers = new BoundedKeyMap<
@@ -2045,8 +2046,8 @@ export class Runner {
    * (space/id), inner key the resolved scope _instance_, value a hash of the
    * pattern's encodable form — what `#writeJavaScriptActionResult()` compares
    * to decide whether a returned sub-pattern has changed. The inner key is the
-   * _same_ per-run resolved `ScopeKey` that selects the byScope result cell: a
-   * serving runtime materializes one child per demanded instance, and a
+   * _same_ per-run resolved `ScopeKey` that selects the `byScope` result cell:
+   * a serving runtime materializes one child per demanded instance, and a
    * doc-level (or service-identity-resolved) key would make the _second_
    * demanded instance look unchanged and skip its child materialization. The
    * outer doc key is what change notifications can name (they carry scope by
@@ -5954,10 +5955,10 @@ export class Runner {
   }
 
   /**
-   * Returns the result-pattern cache key for `cell`, per scope _instance_
-   * (`key-vocabulary.md` §1 site 2): two instances of one doc may resolve to
-   * different patterns, so the key carries the shared scope key, resolved
-   * against the runtime's own session (the OFF arm's one identity).
+   * Returns the per-scope-_instance_ key under which this runner tracks
+   * `cell`'s document (`key-vocabulary.md` §1 site 2): two instances of one doc
+   * may resolve to different patterns, so the key carries the shared scope key,
+   * resolved against the runtime's own session (the OFF arm's one identity).
    */
   #getDocKey(cell: Cell<any>): `${MemorySpace}/${ScopeKey}/${URI}` {
     const { space, id, scope } = cell.getAsNormalizedFullLink();

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -989,12 +989,16 @@ export class Runtime {
   readonly patternCoverage?: PatternCoverageCollector;
 
   readonly trustSnapshotProvider: () => TrustSnapshot | undefined;
-  // The runtime's trust revision — `<runtime id>` with the trust-config
-  // digest folded in when one is configured. The ONE composition site for
-  // every snapshot this runtime mints (the default provider and
-  // trustSnapshotForPrincipal), so a trust-config change invalidates
-  // per-run served snapshots exactly as it does ambient client ones.
+
+  /**
+   * The runtime's trust revision — `<runtime id>` with the trust-config digest
+   * folded in when one is configured. The _one_ composition site for every
+   * snapshot this runtime mints (the default provider and
+   * `trustSnapshotForPrincipal()`), so a trust-config change invalidates
+   * per-run served snapshots exactly as it does ambient client ones.
+   */
   readonly #trustRevision: string;
+
   readonly telemetry: RuntimeTelemetry;
 
   /** Resolved experimental flags (all properties present with built-in defaults). */
@@ -1016,37 +1020,51 @@ export class Runtime {
   /** Runtime-learned host hints (site table); see registerSpaceHost. */
   #dynamicHosts = new Map<string, string>();
 
-  // The transaction seal destination (server-execution v2, serving-loop.md
-  // §3d): installed only on a serving runtime under
-  // EXPERIMENTAL_SERVER_EXECUTION, by the wave machinery around each wave.
-  // While installed, every transaction edit() creates closes by sealing
-  // into it instead of committing to the store. Never installed on a
-  // client or in the OFF arm — installSealDestination throws off the flag.
+  /**
+   * The transaction seal destination (`serving-loop.md` §3d): installed only on
+   * a serving runtime under `EXPERIMENTAL_SERVER_EXECUTION`, by the wave
+   * machinery around each wave. While installed, every transaction `edit()`
+   * creates closes by sealing into it instead of committing to the store. Never
+   * installed on a client or in the OFF arm — `installSealDestination()` throws
+   * off the flag.
+   */
   #transactionSealDestination: TransactionSealDestination | undefined;
-  // The stores this runtime owns: the documents it materializes to hold a
-  // piece's machinery. Every transaction `edit()` creates gets the same
-  // object, which is what lets a write outside the transaction that minted a
-  // store still find it. See `cfc/runtime-owned-stores.ts`.
+
+  /**
+   * The stores this runtime owns: the documents it materializes to hold a
+   * piece's machinery. Every transaction `edit()` creates gets the same object,
+   * which is what lets a write outside the transaction that minted a store
+   * still find it. See `cfc/runtime-owned-stores.ts`.
+   */
   readonly #runtimeOwnedStores = new RuntimeOwnedStores();
-  // The serving loop's run stamper (installed WITH the destination): the
-  // scheduler hands it each run's durable action id + kind, and it
-  // attaches the wave run context before the tx seals.
+
+  /**
+   * The serving loop's run stamper (installed _with_ the destination): the
+   * scheduler hands it each run's durable action id and kind, and it attaches
+   * the wave run context before the tx seals.
+   */
   #serverRunStamper:
     | ((tx: IExtendedStorageTransaction, info: ServerRunInfo) => void)
     | undefined;
-  // The per-(action × instance) run-supply resolver (installed WITH the
-  // destination, stage P2-F): an action's demand roots (its piece root
-  // plus the ancestor roots that instantiated it — Phase 7) → the
-  // demanded instances the SpaceServer's registry holds for any of them.
+
+  /**
+   * The per-(action × instance) run-supply resolver (installed _with_ the
+   * destination): an action's demand roots (its piece root plus the ancestor
+   * roots that instantiated it) → the demanded instances the `SpaceServer`'s
+   * registry holds for any of them.
+   */
   #serverRunDemanderResolver:
     | ServerRunDemanderResolver
     | undefined;
-  // The client speculation overlay (server-execution v2 Phase 2,
-  // speculation.md): the DEFAULT seal destination of every runtime under
-  // the flag that has no wave destination installed. Created lazily on
-  // the first edit(); derivation-kind runs redirect their writes into
-  // the replica's pending overlay through it — the structural removal of
-  // the client derivation-commit path. Never created in the OFF arm.
+
+  /**
+   * The client speculation overlay (`speculation.md`): the _default_ seal
+   * destination of every runtime under the flag that has no wave destination
+   * installed. Created lazily on the first `edit()`; derivation-kind runs
+   * redirect their writes into the replica's pending overlay through it — the
+   * structural removal of the client derivation-commit path. Never created in
+   * the OFF arm.
+   */
   #speculationOverlay: SpeculationOverlayDestination | undefined;
 
   /** The client-effect channel (server-execution v2 Phase 4,
@@ -1061,17 +1079,21 @@ export class Runtime {
    * subscriptions). */
   #installedSpaceOpenObserver: ((space: MemorySpace) => void) | undefined;
 
-  // Whether THIS runtime explicitly set the serverExecution flag at
-  // construction (the only case its dispose participates in the
-  // process-global ambient lifecycle — see the constructor's propagation
-  // note).
+  /**
+   * Whether _this_ runtime explicitly set the `serverExecution` flag at
+   * construction (the only case its dispose participates in the process-global
+   * ambient lifecycle — see the constructor's propagation note).
+   */
   #explicitServerExecution: boolean | undefined;
-  // The enabler release for an explicitly-ENABLED runtime. The count
-  // itself lives with the flag (memory/v2.ts, shared with the
-  // ExecutorHost): dispose releases and the flag resets only when the
-  // LAST live enabler goes — a parked space's dispose must not un-claim
-  // `derived` for every other owner's in-flight wave commit (the
-  // admission plane reads the ambient value).
+
+  /**
+   * The enabler release for an explicitly-_enabled_ runtime. The count itself
+   * lives with the flag (`memory/v2.ts`, shared with the `ExecutorHost`):
+   * dispose releases and the flag resets only when the _last_ live enabler goes
+   * — a parked space's dispose must not un-claim `derived` for every other
+   * owner's in-flight wave commit (the admission plane reads the ambient
+   * value).
+   */
   #serverExecutionRelease: (() => void) | undefined;
 
   /** Serving posture (RuntimeOptions.servingPosture): true only for the
@@ -1110,13 +1132,16 @@ export class Runtime {
   #cfcStats: CfcRuntimeStats = initialCfcRuntimeStats();
   readonly #policyManifests = new Map<string, PolicyArtifactManifestV1>();
   readonly #policyManifestSpaces = new Map<string, Set<MemorySpace>>();
-  // Attesting space -> successor module identity -> direct predecessor
-  // identities whose writer authority it inherits. Entries come only from
-  // verified source closures or integrity-valid compiled closures in that same
-  // space. Transactions receive a transitive, immutable snapshot at creation
-  // so an in-flight authorization decision cannot change when another module
-  // loads, and authorization in one space can never borrow another space's
-  // delegation metadata.
+
+  /**
+   * Attesting space → successor module identity → direct predecessor identities
+   * whose writer authority it inherits. Entries come only from verified source
+   * closures or integrity-valid compiled closures in that same space.
+   * Transactions receive a transitive, immutable snapshot at creation so an
+   * in-flight authorization decision cannot change when another module loads,
+   * and authorization in one space can never borrow another space's delegation
+   * metadata.
+   */
   readonly #moduleDelegations = new Map<
     MemorySpace,
     Map<string, Set<string>>
@@ -1694,18 +1719,22 @@ export class Runtime {
     return this.scheduler.idle();
   }
 
-  // In-flight async builtin operations — the work async builtins (fetchJson,
-  // fetchProgram, llm/llmDialog, reactive sqlite queries, and navigation)
-  // perform AFTER their handler returns, from a post-commit outbox flush: a
-  // network / LLM / navigation call or a sqlite RPC, plus any result writeback.
-  // `idle()` deliberately does NOT wait for these; `settled()` does.
-  //
-  // Each entry carries the pattern run it belongs to, as the address key of the
-  // run's result cell — the `parentCell` every raw builtin is handed. Entries
-  // with no owner belong to no single run: the scheduler's commit promises,
-  // which are the barrier that a fire-and-forget builtin's outbox flush has
-  // registered its own work. `settledFor` waits for those as well as the run's
-  // own, because that handoff is how the run's work first becomes visible.
+  /**
+   * In-flight async builtin operations — the work async builtins (`fetchJson`,
+   * `fetchProgram`, `llm`/`llmDialog`, reactive sqlite queries, and navigation)
+   * perform _after_ their handler returns, from a post-commit outbox flush: a
+   * network, LLM, or navigation call or a sqlite RPC, plus any result
+   * writeback. `idle()` deliberately does _not_ wait for these; `settled()`
+   * does.
+   *
+   * Each entry carries the pattern run it belongs to, as the address key of the
+   * run's result cell — the `parentCell` every raw builtin is handed. Entries
+   * with no owner belong to no single run: the scheduler's commit promises,
+   * which are the barrier that a fire-and-forget builtin's outbox flush has
+   * registered its own work. `settledFor()` waits for those as well as the
+   * run's own, because that handoff is how the run's work first becomes
+   * visible.
+   */
   #pendingAsyncWork = new Map<Promise<unknown>, string | undefined>();
 
   /**
@@ -2451,11 +2480,13 @@ export class Runtime {
     }
   }
 
-  // (space, scope, id) triples for which a missing-link-target load has been
-  // kicked this session. The kicked sync establishes a live per-doc
-  // subscription, so a later creation of the doc still arrives — one kick per
-  // doc suffices. Scope is part of the key: scoped instances (user/session)
-  // are distinct docs, and a kick for one scope must not suppress another's.
+  /**
+   * (space, scope, id) triples for which a missing-link-target load has been
+   * kicked this session. The kicked sync establishes a live per-doc
+   * subscription, so a later creation of the doc still arrives — one kick per
+   * doc suffices. Scope is part of the key: scoped instances (user/session) are
+   * distinct docs, and a kick for one scope must not suppress another's.
+   */
   #missingDocLoadKicks = new Set<string>();
 
   /**

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -1565,14 +1565,14 @@ export class Scheduler {
     });
 
   /**
-   * Returns the owning pattern instance for an input stream, used to group a
-   * pattern's input across its several streams into one delivery-shaping window
-   * (per-pattern coalescing). The wake shaper's `hold()` runs before the
-   * handler is resolved, so we find it here from the registered handlers;
-   * `undefined` when none is registered yet (the shaper then falls back to
-   * per-stream grouping). The key includes the owning space so two instances of
-   * one pattern in different spaces (same content-addressed `pieceId`) do not
-   * share a bucket (see `shaperInstanceGroupKey()`).
+   * Returns the id of the owning pattern instance for an input stream, used to
+   * group a pattern's input across its several streams into one
+   * delivery-shaping window (per-pattern coalescing). The wake shaper's
+   * `hold()` runs before the handler is resolved, so we find it here from the
+   * registered handlers; `undefined` when none is registered yet (the shaper
+   * then falls back to per-stream grouping). The key includes the owning space
+   * so two instances of one pattern in different spaces (same content-addressed
+   * `pieceId`) do not share a bucket (see `shaperInstanceGroupKey()`).
    */
   #pieceIdForEventLink(
     eventLink: NormalizedFullLink,

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -276,12 +276,17 @@ export class Scheduler {
   readonly #pending = new Set<Action>();
   #dependencies = new WeakMap<Action, ReactivityLog>();
   readonly #cancels = new WeakMap<Action, Cancel>();
-  // Thunk, not a captured value: keys must always resolve against the
-  // runtime's CURRENT authenticated session (one source of truth), and a
-  // field initializer runs before constructor parameter properties assign.
+
+  /**
+   * The trigger index, handed a thunk rather than a captured value: keys must
+   * always resolve against the runtime's _current_ authenticated session (one
+   * source of truth), and a field initializer runs before constructor parameter
+   * properties assign.
+   */
   #triggerIndex = new SchedulerTriggerIndex(
     () => this.runtime.scopeKeyIdentity,
   );
+
   #actionChangeGroups = new WeakMap<Action, ChangeGroup>();
   readonly #retries = new WeakMap<Action, number>();
   #offBudgetRetries = new WeakMap<Action, number>();
@@ -294,14 +299,20 @@ export class Scheduler {
   #activePassId: number | undefined;
   #provisionalDemandThisPass = new Set<SchedulerNode>();
 
-  // Debugger breakpoints: action IDs that should trigger `debugger` before execution
+  /**
+   * Debugger breakpoints: action ids that should trigger `debugger` before
+   * execution.
+   */
   #breakpoints = new Set<string>();
 
-  // Compute time tracking for auto-debounce and diagnostics
-  // Keyed by action ID (source location) to persist stats across action recreation
+  /**
+   * Compute-time stats for auto-debounce and diagnostics, keyed by action id
+   * (source location) to persist stats across action recreation.
+   */
   readonly #actionStats = new BoundedKeyMap<string, ActionStats>(
     MAX_ACTION_STATS,
   );
+
   #actionTimingState: ActionTimingState = {
     actionStats: this.#actionStats,
     getActionId: (action) => this.#getActionId(action),
@@ -314,12 +325,17 @@ export class Scheduler {
 
   #rerunAfterCurrentExecute = false;
 
-  // Non-settling heuristic (Phase 1): detects when the system is churning
+  /** The non-settling heuristic, which detects when the system is churning. */
   #settlingTracker: SettlingTracker = createSettlingTracker();
+
   #autoTriggerDiagnosis = false;
 
-  // Idempotency diagnosis (Phase 2): captures read/write values per action run
+  /**
+   * Whether idempotency diagnosis, which captures read/write values per action
+   * run, is enabled.
+   */
   #diagnosisEnabled = false;
+
   #diagnosisTimeout: ReturnType<typeof setTimeout> | null = null;
   #diagnosisStartTime = 0;
   #diagnosisBusyTime = 0;
@@ -329,18 +345,22 @@ export class Scheduler {
   #diagnosisHistory = new Map<string, DiagnosisRecord[]>();
   #diagnosisNonIdempotent: NonIdempotentReport[] = [];
 
-  // Inline idempotency check mode: when enabled, every computation re-run
-  // in run() is followed by a second synchronous run for comparison.
+  /**
+   * Whether inline idempotency check mode is on: when it is, every computation
+   * re-run in `run()` is followed by a second synchronous run for comparison.
+   */
   #idempotencyCheckMode = false;
+
   #idempotencyViolations: NonIdempotentReport[] = [];
 
-  // Cycle detection (Phase 3): tracks causal edges between actions
+  /** Causal edges between actions, tracked for cycle detection. */
   #causalEdges: {
     writer: string;
     cell: string;
     triggered: string;
     timestamp: number;
   }[] = [];
+
   #changeGroupToActionId = new Map<ChangeGroup, string>();
   #diagnosisControlState!: SchedulerDiagnosisControlState;
 
@@ -361,11 +381,16 @@ export class Scheduler {
     () => this.runtime.scopeKeyIdentity,
   );
   #eventPreflightDependencyState!: EventPreflightDependencyState;
-  // Filter stats for diagnostics
+
+  /** Filter stats, for diagnostics. */
   #filterStats: FilterStatsState = { filtered: 0, executed: 0 };
 
-  // Settle stats for performance analysis (opt-in via enableSettleStats())
+  /**
+   * Whether to collect settle stats for performance analysis (opt-in via
+   * `enableSettleStats()`).
+   */
   #collectSettleStats = false;
+
   #lastSettleStats: SettleStats | null = null;
   #settleStatsHistory: SettleStatsHistoryEntry[] = [];
   #collectActionRunTrace = false;
@@ -375,9 +400,14 @@ export class Scheduler {
   #eventPreflightTelemetryEnabled = false;
   #eventPassDemandRefresh?: (demand: Set<Action>) => void;
   #storageNotificationState!: StorageNotificationState;
-  // Parent-child action tracking for proper execution ordering
-  // When a child action is created during parent execution, parent must run first
+
+  /**
+   * The action currently executing, tracked for parent-child ordering: when a
+   * child action is created during the parent's execution, the parent must run
+   * first.
+   */
   #executingAction: Action | null = null;
+
   #currentActionId?: string;
   #dependencyGraphState!: DependencyGraphState;
   #dependencyUpdateState!: DependencyUpdateState;
@@ -396,36 +426,49 @@ export class Scheduler {
 
   #idlePromises: (() => void)[] = [];
   #backgroundTasks = new Set<Promise<unknown>>();
-  // The single wake-shaping choke point (plan C): holds renderer-originated
-  // input events out of the event queue (W3) and shapable cell-flip wakes out
-  // of the reactive-notification path (plan B), coarsening the cadence a
-  // pattern can observe. Fed via queueEvent's shaping interception and
-  // holdShapedCellNotification() from the invalidation.ts routing of renderer
-  // $value writes and server pushes. See
-  // docs/specs/sandboxing/TIMING_SIDE_CHANNELS.md.
+
+  /**
+   * The single wake-shaping choke point: holds renderer-originated input events
+   * out of the event queue and shapable cell-flip wakes out of the
+   * reactive-notification path, coarsening the cadence a pattern can observe.
+   * Fed via `queueEvent()`'s shaping interception and
+   * `holdShapedCellNotification()` from the `invalidation.ts` routing of
+   * renderer `$value` writes and server pushes. See
+   * `docs/specs/sandboxing/TIMING_SIDE_CHANNELS.md`.
+   */
   #wakeShaper = new WakeShaper();
-  // Head event parked on in-flight document loads (CT-1795). Keyed by event
-  // id; released by loadsSettled, which either re-queues execution on success
-  // or drops the at-most-once event on an explicit load failure.
+
+  /**
+   * Head event parked on in-flight document loads. Keyed by event id; released
+   * by `loadsSettled()`, which either re-queues execution on success or drops
+   * the at-most-once event on an explicit load failure.
+   */
   #headEventLoadPark: {
     eventId: string;
     keys: readonly string[];
     generations: ReadonlyMap<string, number>;
   } | null = null;
-  // Keys whose loads already settled while this event was head. Preflight
-  // itself kicks fire-and-forget pulls (populateDependencies cold reads), so
-  // an address can be freshly in flight on every pass; without this memo the
-  // park re-arms per pass and the event never dispatches. Once a key settled
-  // for this event its replica is warm — a refresh is an ordinary concurrent
-  // update, not a provisional snapshot.
+
+  /**
+   * Keys whose loads already settled while this event was head. Preflight
+   * itself kicks fire-and-forget pulls (`populateDependencies()` cold reads),
+   * so an address can be freshly in flight on every pass; without this memo the
+   * park re-arms per pass and the event never dispatches. Once a key settled
+   * for this event its replica is warm — a refresh is an ordinary concurrent
+   * update, not a provisional snapshot.
+   */
   #headEventLoadParkHistory: {
     eventId: string;
     generations: Map<string, number>;
   } | null = null;
-  // Generations already pending before the current event preflight. Used to
-  // distinguish a genuine concurrent refresh from a load kicked by preflight
-  // itself (the latter must not re-arm the same event forever).
+
+  /**
+   * Generations already pending before the current event preflight. Used to
+   * distinguish a genuine concurrent refresh from a load kicked by preflight
+   * itself (the latter must not re-arm the same event forever).
+   */
   #preflightPendingLoadGenerations = new Map<string, number>();
+
   readonly #errorHandlers = new Set<ErrorHandler>();
   #consoleHandler: ConsoleHandler;
   #running: Promise<unknown> | undefined = undefined;
@@ -435,11 +478,14 @@ export class Scheduler {
   #graphSnapshotState!: SchedulerGraphSnapshotState;
   #settleLoopState!: SchedulerSettleLoopState;
   #executeContinuationState!: ExecuteContinuationState;
-  // The serving posture's cooperative macrotask yield (server-execution
-  // v2 stage C tuning T3, cooperative-yield.ts): constructed ONLY for a
-  // serving runtime, so the OFF arm and flag-ON clients keep their
-  // settle loops' exact microtask shape. Its observer is the runtime's
-  // `servingYieldObserver` seam — the SpaceServer's mid-wave lease renew.
+
+  /**
+   * The serving posture's cooperative macrotask yield (`cooperative-yield.ts`):
+   * constructed _only_ for a serving runtime, so the OFF arm and flag-ON
+   * clients keep their settle loops' exact microtask shape. Its observer is the
+   * runtime's `servingYieldObserver` seam — the `SpaceServer`'s mid-wave lease
+   * renew.
+   */
   readonly #cooperativeYield: CooperativeYield | undefined;
 
   //
@@ -700,10 +746,12 @@ export class Scheduler {
     return cancel;
   }
 
-  // Hold a resumed action's initial run until its space finishes syncing. The
-  // hold is a bounded time gate (worst case the timeout releases it); the sync
-  // completing releases it early. The awaiting task joins backgroundTasks so
-  // idle() waits for the release decision.
+  /**
+   * Holds a resumed action's initial run until its space finishes syncing. The
+   * hold is a bounded time gate (worst case the timeout releases it); the sync
+   * completing releases it early. The awaiting task joins `#backgroundTasks` so
+   * `idle()` waits for the release decision.
+   */
   #holdInitialRunUntilSynced(
     action: Action,
     options: { space: MemorySpace; timeoutMs?: number },
@@ -870,19 +918,21 @@ export class Scheduler {
     return this.#waitForQuiescence(false);
   }
 
-  // Client-facing quiescence: reactive quiescence AND durability of in-flight
-  // commits. Commits are issued fire-and-forget (event handlers, direct cell
-  // writes over IPC, reactive recomputation write-backs), so plain idle()
-  // reports quiescence while a commit is still traveling to the server; a
-  // client that reads idle as a safe point to navigate or reload would then
-  // drop that write when the page and its worker are torn down. The pending
-  // set is sourced from the storage manager — the single chokepoint every
-  // commit flows through — so no write path can be forgotten. A landed commit
-  // also dirties readers of the committed write, which can re-trigger
-  // scheduler work that produces further commits, so durability and reactive
-  // quiescence are one joint fixpoint; this reuses the same recursive
-  // convergence idle() uses (no separate retry loop, no round cap) and, like
-  // idle(), never resolves for a system that genuinely never settles.
+  /**
+   * Returns a promise for client-facing quiescence: reactive quiescence _and_
+   * durability of in-flight commits. Commits are issued fire-and-forget (event
+   * handlers, direct cell writes over IPC, reactive recomputation write-backs),
+   * so plain `idle()` reports quiescence while a commit is still traveling to
+   * the server; a client that reads idle as a safe point to navigate or reload
+   * would then drop that write when the page and its worker are torn down. The
+   * pending set is sourced from the storage manager — the single chokepoint
+   * every commit flows through — so no write path can be forgotten. A landed
+   * commit also dirties readers of the committed write, which can re-trigger
+   * scheduler work that produces further commits, so durability and reactive
+   * quiescence are one joint fixpoint; this reuses the same recursive
+   * convergence `idle()` uses (no separate retry loop, no round cap) and, like
+   * `idle()`, never resolves for a system that genuinely never settles.
+   */
   idleWithPendingCommits(): Promise<void> {
     return this.#waitForQuiescence(true);
   }
@@ -1488,8 +1538,11 @@ export class Scheduler {
     });
   }
 
-  // A released shaped event re-enters the ordinary queue path; the shaper reads
-  // eventQueueState at release time, so it stays correct across state re-init.
+  /**
+   * Delivery for a released shaped event, which re-enters the ordinary queue
+   * path; the shaper reads `eventQueueState` at release time, so it stays
+   * correct across state re-init.
+   */
   #shapedEventDeliver: DeliverFn = (
     eventLink,
     event,
@@ -1511,14 +1564,16 @@ export class Scheduler {
       parentEventId: opts.parentEventId,
     });
 
-  // The owning pattern instance for an input stream, used to group a pattern's
-  // input across its several streams into one delivery-shaping window (per-pattern
-  // coalescing, W3). The wake shaper's hold() runs before the handler is
-  // resolved, so we find it here from the registered handlers; undefined when none
-  // is registered yet (the shaper then falls back to per-stream grouping). The key
-  // includes the owning space so two instances of one pattern in different spaces
-  // (same content-addressed pieceId) do not share a bucket (see
-  // shaperInstanceGroupKey).
+  /**
+   * Returns the owning pattern instance for an input stream, used to group a
+   * pattern's input across its several streams into one delivery-shaping window
+   * (per-pattern coalescing). The wake shaper's `hold()` runs before the
+   * handler is resolved, so we find it here from the registered handlers;
+   * `undefined` when none is registered yet (the shaper then falls back to
+   * per-stream grouping). The key includes the owning space so two instances of
+   * one pattern in different spaces (same content-addressed `pieceId`) do not
+   * share a bucket (see `shaperInstanceGroupKey()`).
+   */
   #pieceIdForEventLink(
     eventLink: NormalizedFullLink,
   ): string | undefined {
@@ -1573,9 +1628,11 @@ export class Scheduler {
     holdShapedCell(this.#wakeShaper, groupKey, itemKey, chargeKey, deliver);
   }
 
-  // Whether any shapable cell-flip wake is currently held out of the scheduler
-  // (plan B). Exposed for tests that need to observe that a change was routed
-  // through the wake shaper's cell path before idle() drains it.
+  /**
+   * Returns whether any shapable cell-flip wake is currently held out of the
+   * scheduler. Exposed for tests that need to observe that a change was routed
+   * through the wake shaper's cell path before `idle()` drains it.
+   */
   hasPendingShapedCellNotifications(): boolean {
     return this.#wakeShaper.hasPending(CELL_GROUP_PREFIX);
   }
@@ -2233,8 +2290,10 @@ export class Scheduler {
   // State wiring
   //
 
-  // Keep state-bundle wiring explicit without making the field declarations
-  // read like one large object graph.
+  /**
+   * Wires the state bundles. Kept explicit here so the field declarations do
+   * not read like one large object graph.
+   */
   #initializeSchedulerState(): void {
     this.#diagnosisControlState = this.#createDiagnosisControlState();
     this.#writeIndex = this.#createWriteIndex();
@@ -2468,11 +2527,14 @@ export class Scheduler {
     }
   }
 
-  // A node is convergence-backoff-deferred iff its `gate.backoffUntil` is in the
-  // future. For an already-ran computation `backoffUntil` is set exclusively by
-  // the settle-cap backoff (planBudgetBackoff); the resume initial-run hold that
-  // also rides `backoffUntil` only applies to never-ran nodes. Throttle and
-  // debounce use their own gate fields, so this cleanly excludes them.
+  /**
+   * Returns whether `action` is convergence-backoff-deferred, which is so iff
+   * its `gate.backoffUntil` is in the future. For an already-ran computation
+   * `backoffUntil` is set exclusively by the settle-cap backoff
+   * (`planBudgetBackoff()`); the resume initial-run hold that also rides
+   * `backoffUntil` only applies to never-ran nodes. Throttle and debounce use
+   * their own gate fields, so this cleanly excludes them.
+   */
   #isConvergenceBackoffDeferred(action: Action): boolean {
     const backoffUntil = this.#nodes.get(action)?.gate.backoffUntil;
     return backoffUntil !== undefined && backoffUntil > performance.now();

--- a/packages/runner/src/scheduler/gates.ts
+++ b/packages/runner/src/scheduler/gates.ts
@@ -234,8 +234,11 @@ export class SchedulerGates {
       : undefined;
   }
 
-  // Pure query: arming happens at invalidation time (the facade's
-  // markActionInvalid → onInvalidated), never as a side effect of asking.
+  /**
+   * Returns whether a debounced computation is waiting. A pure query: arming
+   * happens at invalidation time (the facade's `markActionInvalid()` →
+   * `onInvalidated()`), never as a side effect of asking.
+   */
   isDebouncedComputationWaiting(
     action: Action,
     context: DebouncedComputationContext,

--- a/packages/runner/src/scheduler/node-record.ts
+++ b/packages/runner/src/scheduler/node-record.ts
@@ -63,14 +63,20 @@ export class NodeRegistry {
   #all = new Set<SchedulerNode>();
   #activeEffects = new Set<Action>();
   #activeComputations = new Set<Action>();
-  // Active nodes whose status is `invalid` or `never-ran` — i.e. the nodes
-  // `isInvalidOrNeverRan` would match. Maintained incrementally through
-  // setStatus/activate/remove so the event-preflight gate (decision 15) and
-  // the pull seed scans can iterate the (small) invalid set instead of every
-  // registered node. Membership tracks both status AND active membership:
-  // a removed node drops out even though its record persists in `#records`.
+
+  /**
+   * Active nodes whose status is `invalid` or `never-ran` — i.e. the nodes
+   * `isInvalidOrNeverRan()` would match. Maintained incrementally through
+   * `setStatus()`/`activate()`/`remove()` so the event-preflight gate and the
+   * pull seed scans can iterate the (small) invalid set instead of every
+   * registered node. Membership tracks both status _and_ active membership: a
+   * removed node drops out even though its record persists in `#records`.
+   */
   #invalidNodes = new Set<Action>();
-  // Source of monotonic registration ordinals (see SchedulerNode.ordinal).
+
+  /**
+   * Source of monotonic registration ordinals (see `SchedulerNode.ordinal`).
+   */
   #nextOrdinal = 0;
 
   readonly effects: ReadonlySet<Action> = this.#activeEffects;

--- a/packages/runner/src/scheduler/scheduling-writes.ts
+++ b/packages/runner/src/scheduler/scheduling-writes.ts
@@ -39,25 +39,26 @@ export class SchedulerWriteIndex
     readonly scopeKeyIdentity: () => ScopeKeyIdentity,
   ) {}
 
-  // Current-known writes are the action's static declared write surface.
+  /** Current-known writes: each action's static declared write surface. */
   readonly currentKnownWrites = new WeakMap<Action, IMemorySpaceAddress[]>();
-  // Index: entity -> actions that write to it (for fast dependency lookup).
-  // Updated from the active scheduling write set. Keyed by scope NAME
-  // (entityNameKey — server-execution v2 stage A, the instance-AGNOSTIC
-  // writer index): the reader→writer relation is a NODE-level topology
-  // relation — under C11b one node writes ALL instances of its declared
-  // surface — so a reader whose logged read names one principal's
-  // instance must still find the writer whose surface declares the scope
-  // by name. An instance-keyed index would drop that edge the moment
-  // reads carry non-own instances (today both sides collapse to the
-  // runtime's own instance and match by accident). Cost of the fan-in:
-  // any instance's change re-dirties the (singular) node, so all N
-  // instances re-run — O(N) per input change, equality cutoffs absorb the
-  // unchanged siblings; instance-precise dirtiness is stage B's B7 and
-  // is never a correctness need here (dirtiness/dependency keys stay per
-  // instance via entityKey).
+
+  /**
+   * Index: entity → actions that write to it (for fast dependency lookup).
+   * Updated from the active scheduling write set. Keyed by scope _name_
+   * (`entityNameKey()`, the instance-_agnostic_ writer index): the
+   * reader→writer relation is a _node_-level topology relation — one node
+   * writes _all_ instances of its declared surface — so a reader whose logged
+   * read names one principal's instance must still find the writer whose
+   * surface declares the scope by name. An instance-keyed index would drop that
+   * edge the moment reads carry non-own instances. Cost of the fan-in: any
+   * instance's change re-dirties the (singular) node, so all N instances re-run
+   * — O(N) per input change, equality cutoffs absorb the unchanged siblings;
+   * instance-precise dirtiness is never a correctness need here
+   * (dirtiness/dependency keys stay per instance via `entityKey()`).
+   */
   readonly writersByEntity = new Map<SpaceScopeAndURI, Set<Action>>();
-  // Reverse index: action -> entities it writes to (for cleanup).
+
+  /** Reverse index: action → entities it writes to (for cleanup). */
   readonly actionWriteEntities = new WeakMap<
     Action,
     Set<SpaceScopeAndURI>


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A `//` block sitting directly above a class member and describing that member is a doc comment in the wrong punctuation: it says what the member is or does, which is what `docs/development/code-comment-style.md` § Doc comments has JSDoc form for. This converts the 80 in `pattern-manager.ts` (20), `runner.ts` (19), `runtime.ts` (11), and `scheduler/` (30), one PR of a series that covers the tree outside `packages/patterns`. `storage/` is #7029, and the rest of `runner` follows.

Each converted member takes the blank line above its doc comment and the blank line below the member that the guide asks for. Most of these fields sat in unbroken runs, so the runs are now spaced.

## What changed inside the comments

The text is carried over as written, with the edits the doc-comment form calls for:

* A method's comment opens with a third-person verb phrase, and a field's with a noun phrase. Where a note opened with rationale and never said what the member is, a phrase saying so now opens it: `Identities whose best-effort recovery failed to persist`, `Epoch which invalidates asynchronous start/resume continuations`, `Every unsettled start attempt`, `The trigger index, handed a thunk rather than a captured value`, `Wires the state bundles`.
* Identifiers, callables, and properties take backticks and their parentheses; emphasis by capitals becomes underscores (`_not_`, `_first_`, `_pushed_`, `_siblings_`, `_recorded_`).
* Labels the guide keeps out of comments are gone, the sentence each sat in saying the same thing without it: `(CT-1623)`, `(CT-1795)`, `(CT-1812/CT-1811)`, `(CT-1848)`, `(CT-1923)`, `(CT-1962)`, `L3(a)`, `RULED 2026-08-27`, `(review thread r3739139481)`, `(cubic PM-2 on #6528, adjudicated LOW)`, `design § Open questions 2, resolved`, `(E1)`, `Phase 7`, `stage P2-F`, `stage C tuning T3`, `MINOR-1`, `MINOR-2 / obligation (iii)`, `NIT-1`, `plan B`/`plan C`/`W3`. Spec pointers stay (`key-vocabulary.md` §1, `verification-coverage.md` OW45, `events.md` §4, `serving-loop.md` §3d, `speculation.md`, `TIMING_SIDE_CHANNELS.md`).
* Two notes that compared the code to its own past are stated as the present: `#sessionPatternPointers` ("no longer stamps ... but the flows that used to read those stamps") and `#sessionPatternSwaps` ("used to reach ... through the durable stamp").
* `#nextPendingLoadGeneration` and `#activeStartAttempts` open with what the field is; their notes had opened mid-explanation.

Left as `//`: five labels that head a run of members rather than describing one: `Cell factory methods` (twice) and `Convenience methods that delegate to the runner` in `runtime.ts`, each over an overload set or a run of methods, and `Effect/computation tracking for pull-based scheduling` and `Debounce infrastructure for throttling slow actions` in `facade.ts`, each over a run of fields. The converter had turned all five into doc comments and split the two overload sets with a blank line, which "The blank line below" forbids inside a set; both are restored, and a scan over every branch of the series found no other overload set split.

## How the sites were found

A TypeScript-AST census over every tracked `.ts`/`.tsx` outside `patterns`, vendored types, and generated declarations: for each class member, the `//` blocks in its leading trivia, minus tool directives, section-marker frames, and `TODO`s. A control fixture of nine planted sites and four decoys reported exactly the nine.

## Verification

* Comment-only, by construction and by proof: each changed file transpiles to byte-identical JavaScript with comments stripped, before and after (7 files, 0 differ).
* The census re-run over the changed files reports only the five labels above; the blank-line-below detector reports nine sites, all of which it also reports on `main`.
* Every added line is 80 characters or fewer, and no backtick span is broken across lines.
* `deno fmt --check`, `deno lint`, and `deno task check` repo-wide, all green.
* `deno task test` in `runner`: 1390 passed, 0 failed.

## Review

A `cf-review` pass (report only) found one sentence this PR had introduced that was false against the code, fixed: `#getDocKey()`'s new opening called its result the result-pattern cache key, while that cache is keyed inline by document with the scope instance as its inner key, and `#getDocKey()` keys the session pointer, shortcut, cancel, and start-attempt maps instead. Also taken: `#sessionPatternPointers` describes the flows that need the pointer rather than "the flows that read those stamps", with `setup()`, `run()`, and `storedSetupMarker()` in their parentheses; `#locallyStoppedResults` gets a one-line doc comment of its own; `#pieceIdForEventLink()` says it returns an id; `byScope` and the keyless `$patternRef` sentinel are marked up as the guide asks. The review also notes that `key-vocabulary.md` §1 site 2 still describes `getDocKey()` as the result-pattern cache key, a stale spec row for its own change.
