### PR TITLE
style(runner): `//` notes that documented a class member are doc comments, in the remaining source and tests

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -927,7 +927,7 @@ export class CellImpl<T extends FabricValue>
   #_link: NormalizedLink;
 
   /**
-   * Shared container for entity id and cause; siblings share the same instance.
+   * Shared container for entity ID and cause; siblings share the same instance.
    */
   #causeContainer: CauseContainer;
 

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -923,18 +923,21 @@ export class CellImpl<T extends FabricValue>
   >();
   #cleanup: Cancel | undefined;
 
-  // Each cell has its own link (space, path, schema)
+  /** The cell's own link (space, path, schema). */
   #_link: NormalizedLink;
 
-  // Shared container for entity ID and cause - siblings share the same instance
+  /**
+   * Shared container for entity id and cause; siblings share the same instance.
+   */
   #causeContainer: CauseContainer;
 
   #frame: Frame | undefined;
 
   #kind: CellKind;
 
-  // Self-reference for pattern SELF symbol support
+  /** Self-reference, for pattern `SELF` symbol support. */
   #selfRef?: Reactive<any>;
+
   #viewRefHashCache?: {
     link: NormalizedFullLink;
     cfcLabelView: CfcLabelView | undefined;
@@ -2555,11 +2558,13 @@ export class CellImpl<T extends FabricValue>
     this.tx.recordMergeableOp?.(resolvedLink, { op: "increment", by });
   }
 
-  // Remove every element of this array equal to `ref` by stored value. A cell
-  // ref matches by its (deterministic) link, so the membership entry is removed
-  // without depending on the list's prior contents — concurrent removes of
-  // distinct entries merge. The optimistic local filter and the committed op
-  // both match by the stored value.
+  /**
+   * Removes every element of this array equal to `ref` by stored value. A cell
+   * ref matches by its (deterministic) link, so the membership entry is removed
+   * without depending on the list's prior contents — concurrent removes of
+   * distinct entries merge. The optimistic local filter and the committed op
+   * both match by the stored value.
+   */
   removeByValue(
     ref: T extends (infer U)[] ? (U | AnyCell<U>) : never,
   ): void {
@@ -2636,12 +2641,15 @@ export class CellImpl<T extends FabricValue>
     }
   }
 
-  // Returns a cell for the entity deterministically derived from this array and
-  // `idKey` — the entity a keyed element of this array is identified by. The
-  // derivation is content-only (no per-event cause), so the same `idKey` always
-  // resolves to the same entity. This lets a handler read/edit one keyed element
-  // (e.g. "my vote for this option") and add or remove its membership via
-  // addUnique / removeByValue, without ever reading the whole array.
+  /**
+   * Returns a cell for the entity deterministically derived from this array and
+   * `idKey` — the entity a keyed element of this array is identified by. The
+   * derivation is content-only (no per-event cause), so the same `idKey` always
+   * resolves to the same entity. This lets a handler read/edit one keyed
+   * element (e.g. "my vote for this option") and add or remove its membership
+   * via `addUnique()` / `removeByValue()`, without ever reading the whole
+   * array.
+   */
   elementById(idKey: string, schema?: JSONSchema): Cell<any> {
     const tx = this.runtime.readTx(this.tx);
     const resolvedLink = resolveLink(this.runtime, tx, this.#link, "value", {

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -374,7 +374,7 @@ export class ContextualFlowControl {
     return joined;
   }
 
-  // Get the joined confidentiality atoms from the schema.
+  /** Returns the joined confidentiality atoms from the schema. */
   static lubSchema(
     schema: JSONSchema,
     extraConfidentiality?: Set<unknown>,
@@ -393,7 +393,7 @@ export class ContextualFlowControl {
     return ContextualFlowControl.uniqueAtoms(joined);
   }
 
-  // Return a copy of the schema with joined confidentiality atoms.
+  /** Returns a copy of the schema with joined confidentiality atoms. */
   static schemaWithLub(
     schema: JSONSchema,
     confidentiality: readonly CfcConfClause[],
@@ -501,8 +501,10 @@ export class ContextualFlowControl {
     return resolveCfcSchemaRefsOrThrow(schemaObj, fullSchema);
   }
 
-  // This is a variant of schemaAtPath that allows for an undefined schema.
-  // It will return the empty object instead of true and undefined instead of false.
+  /**
+   * Like `schemaAtPath()`, except it allows an undefined schema, and returns
+   * the empty object instead of `true` and `undefined` instead of `false`.
+   */
   static getSchemaAtPath(
     schema: JSONSchema | undefined,
     path: string[],
@@ -789,14 +791,19 @@ export class ContextualFlowControl {
     return result as JSONSchema;
   }
 
-  // Check to see if the specified schema is one of the special values meaning
-  // it should always validate.
+  /**
+   * Returns whether `schema` is one of the special values meaning it should
+   * always validate.
+   */
   static isTrueSchema(schema: JSONSchema): boolean {
     return cfcSchemaIsTrue(schema);
   }
 
-  // Symbol keys are not included in Object.keys return values, so no
-  // symbol-keyed entry needs checking here.
+  /**
+   * Returns whether `key` is an internal schema key. Symbol keys are not
+   * included in `Object.keys()` return values, so no symbol-keyed entry needs
+   * checking here.
+   */
   static isInternalSchemaKey(key: string): boolean {
     return cfcSchemaIsInternalKey(key);
   }
@@ -805,7 +812,7 @@ export class ContextualFlowControl {
     return cfcSchemaIsFalse(schema);
   }
 
-  // Utility function to handle the asCell array tag.
+  /** Handles the `asCell` array tag. */
   static getAsCellValues(
     schema: JSONSchema | undefined,
   ): readonly AsCellEntry[] {

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -812,7 +812,10 @@ export class ContextualFlowControl {
     return cfcSchemaIsFalse(schema);
   }
 
-  /** Handles the `asCell` array tag. */
+  /**
+   * Returns the `asCell` entries of `schema`, or none when it has no `asCell`
+   * array.
+   */
   static getAsCellValues(
     schema: JSONSchema | undefined,
   ): readonly AsCellEntry[] {

--- a/packages/runner/src/executor/outbox.ts
+++ b/packages/runner/src/executor/outbox.ts
@@ -140,8 +140,9 @@ export class SpaceOutbox {
    * it), and outbox.completed counts only when it settles. */
   #capturing: Array<Promise<unknown>> | undefined;
 
-  // Per-space egress budgets (Phase 6, serving-loop.md §5).
+  /** Per-space egress budgets (`serving-loop.md` §5). */
   readonly #budget: OutboxBudgetPolicy | undefined;
+
   readonly #now: () => number;
 
   /** DISPATCHED-but-unsettled network effects (the outstanding cap's

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -447,10 +447,13 @@ export class SpaceServer implements TransactionSealDestination {
   #sealChain: Promise<unknown> = Promise.resolve();
   #feed: AdmittedCommitNotice[] = [];
   #feedArrived: PromiseWithResolvers<void> | undefined;
-  // A shadow flip that fired while no input waiter was installed
-  // (r3739416418): consumed by the next #waitForInput so the wake is
-  // never dropped between cycles.
+
+  /**
+   * Whether a shadow flip fired while no input waiter was installed; consumed
+   * by the next `#waitForInput()` so the wake is never dropped between cycles.
+   */
   #pendingShadowFlipWake = false;
+
   #inputHead = 0;
 
   /** Highest NON-self-echo seq drained — the watermark's advance
@@ -566,15 +569,18 @@ export class SpaceServer implements TransactionSealDestination {
    * next #waitForInput. */
   #pendingDemandWake = false;
 
-  // MINOR-1: a monotonic demand-note generation, bumped on every
-  // `noteDemandChanged` (watch OR push-growth). A pass snapshots it at its
-  // row read; if a note lands AFTER that snapshot but while the pass is
-  // still in flight (a straddling pass — the note's change is invisible to
-  // the rows this pass already read), the pass's `.finally` re-latches
-  // `#pendingDemandWake` so the NEXT wait runs a FRESH pass instead of
-  // sleeping out the idle window. Bounded: only a note arriving mid-pass
-  // costs one extra pass; steady state (no notes) never re-latches.
+  /**
+   * A monotonic demand-note generation, bumped on every `noteDemandChanged()`
+   * (watch or push-growth). A pass snapshots it at its row read; if a note
+   * lands _after_ that snapshot but while the pass is still in flight (a
+   * straddling pass — the note's change is invisible to the rows this pass
+   * already read), the pass's `.finally` re-latches `#pendingDemandWake` so the
+   * _next_ wait runs a _fresh_ pass instead of sleeping out the idle window.
+   * Bounded: only a note arriving mid-pass costs one extra pass; steady state
+   * (no notes) never re-latches.
+   */
   #demandNoteGeneration = 0;
+
   #passDemandNoteGen = 0;
 
   /** The demand wake's grace timer (see noteDemandChanged). */
@@ -598,21 +604,25 @@ export class SpaceServer implements TransactionSealDestination {
     { id: string; scopeKey: string }
   >();
 
-  // (d′) — server-settle instrumentation (design §6 W4's
-  // metric; §2.8 (c)). Per authored input: admission (the feed notice's
-  // arrival, `enqueueCommit`) → COVERAGE (the wave commit whose
-  // derivedThrough ≥ seq = the value-only settle) → and, when a
-  // push-growth demand wake fires after coverage (the one-push-late
-  // structural-growth path, §2.3), the NEXT derived commit = the
-  // structural-growth landing. Attribution of a growth wake to an input
-  // is by adjacency (the most recently covered input), stated as such.
+  /**
+   * Server-settle instrumentation (design §6 W4's metric; §2.8 (c)). Per
+   * authored input: admission (the feed notice's arrival, `enqueueCommit()`) →
+   * _coverage_ (the wave commit whose `derivedThrough` ≥ seq = the value-only
+   * settle) → and, when a push-growth demand wake fires after coverage (the
+   * one-push-late structural-growth path, §2.3), the _next_ derived commit =
+   * the structural-growth landing. Attribution of a growth wake to an input is
+   * by adjacency (the most recently covered input), stated as such.
+   */
   #growthWakeCounter = 0;
-  // MINOR-2 / obligation (iii): the last-folded demand-root enter/leave
-  // counter values, so the space-lived accumulators fold the FULL delta
-  // since the last fold (capturing between-pass hook transitions), not a
-  // pass-start snapshot. Reset to 0 when the runtime is replaced (its
-  // counters zero on a fresh runtime).
+
+  /**
+   * The last-folded demand-root enter counter value, so the space-lived
+   * accumulators fold the _full_ delta since the last fold (capturing
+   * between-pass hook transitions), not a pass-start snapshot. Reset to 0 when
+   * the runtime is replaced (its counters zero on a fresh runtime).
+   */
   #lastFoldedDemandEnters = 0;
+
   #lastFoldedDemandLeaves = 0;
   #cycleCounter = 0;
   #wavesCommitted = 0;
@@ -624,10 +634,13 @@ export class SpaceServer implements TransactionSealDestination {
     growthAtAdmit: number;
     eventAppend: boolean;
   }>();
-  // NIT-1: the internal growth bookkeeping (`growthWakeAt`,
-  // `wavesAtCoverage`) lives on this WRAPPER, not on the series entry, so
-  // it never leaks into the stats JSON; `entry` is the (clean) series row
-  // that `#recordGrowthLanding` promotes in place.
+
+  /**
+   * The most recently covered input. The internal growth bookkeeping
+   * (`growthWakeAt`, `wavesAtCoverage`) lives on this _wrapper_, not on the
+   * series entry, so it never leaks into the stats JSON; `entry` is the (clean)
+   * series row that `#recordGrowthLanding()` promotes in place.
+   */
   #lastCovered:
     | {
       entry: ServingLoopStats["settle"]["series"][number];
@@ -635,6 +648,7 @@ export class SpaceServer implements TransactionSealDestination {
       wavesAtCoverage: number;
     }
     | undefined;
+
   #growthAwaitingLanding = false;
 
   /** Wave-bound seals CHAINED but not yet applied (the F4 fix, as a

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -605,13 +605,18 @@ export class SpaceServer implements TransactionSealDestination {
   >();
 
   /**
-   * Server-settle instrumentation (design §6 W4's metric; §2.8 (c)). Per
-   * authored input: admission (the feed notice's arrival, `enqueueCommit()`) →
-   * _coverage_ (the wave commit whose `derivedThrough` ≥ seq = the value-only
-   * settle) → and, when a push-growth demand wake fires after coverage (the
-   * one-push-late structural-growth path, §2.3), the _next_ derived commit =
-   * the structural-growth landing. Attribution of a growth wake to an input is
-   * by adjacency (the most recently covered input), stated as such.
+   * Count of push-growth demand wakes, bumped once per
+   * `noteDemandChanged("push-growth")`, snapshotted into each settle record at
+   * admission and differenced at coverage.
+   *
+   * It is part of the server-settle instrumentation (design §6 W4's metric;
+   * §2.8 (c)). Per authored input: admission (the feed notice's arrival,
+   * `enqueueCommit()`) → _coverage_ (the wave commit whose `derivedThrough` ≥
+   * seq = the value-only settle) → and, when a push-growth demand wake fires
+   * after coverage (the one-push-late structural-growth path, §2.3), the _next_
+   * derived commit = the structural-growth landing. Attribution of a growth
+   * wake to an input is by adjacency (the most recently covered input), stated
+   * as such.
    */
   #growthWakeCounter = 0;
 
@@ -623,7 +628,9 @@ export class SpaceServer implements TransactionSealDestination {
    */
   #lastFoldedDemandEnters = 0;
 
+  /** Like `#lastFoldedDemandEnters`, for the leave counter. */
   #lastFoldedDemandLeaves = 0;
+
   #cycleCounter = 0;
   #wavesCommitted = 0;
   readonly #pendingSettles = new Map<number, {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -135,7 +135,10 @@ export class EngineProgramResolver extends InMemoryProgram {
     this.#cache = cache;
   }
 
-  // Add `.d.ts` files for known supported 3P modules.
+  /**
+   * Resolves a source, adding `.d.ts` files for known supported third-party
+   * modules.
+   */
   override async resolveSource(
     identifier: string,
   ): Promise<Source | undefined> {
@@ -1773,8 +1776,10 @@ export class Engine extends EventTarget {
     });
   }
 
-  // Invokes a function that should've came from this SES runtime
-  // (unverifiable). We use this to hook into its source mapping functionality.
+  /**
+   * Invokes a function that should have come from this SES runtime
+   * (unverifiable). We use this to hook into its source mapping functionality.
+   */
   invoke(fn: () => any): any {
     // Scheduler dictates this is a synchronous function,
     // and if we have functions from this source, this should already
@@ -1805,8 +1810,11 @@ export class Engine extends EventTarget {
     this.#executableRegistry.trustHostValue(value, options);
   }
 
-  // Parse an error stack trace, mapping all positions back to original sources.
-  // Returns the original stack if runtime internals haven't been initialized.
+  /**
+   * Parses an error stack trace, mapping all positions back to original
+   * sources. Returns the original stack if runtime internals haven't been
+   * initialized.
+   */
   parseStack(stack: string): string {
     if (!this.#runtimeInternals) {
       return stack;
@@ -1814,7 +1822,7 @@ export class Engine extends EventTarget {
     return this.#runtimeInternals.runtime.parseStack(stack);
   }
 
-  // Returns a map of runtime module types.
+  /** Returns a map of runtime module types. */
   static getRuntimeModuleTypes(cache: StaticCache) {
     return getRuntimeModuleTypes(cache);
   }

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -15,26 +15,32 @@ import type { HarnessedFunction } from "./types.ts";
  * pseudo-modules below.)
  */
 export class ExecutableRegistry {
-  // Content-addressed implementation index: module identity → symbol → the
-  // implementation function recorded by `Engine.#recordModuleProvenance` during
-  // a verified evaluation (and by `trustHostValue` for host pseudo-modules).
-  // Deliberately STRONG and session-unbounded: a serialized module carries
-  // ONLY `$implRef` (no body when the writer proved this index admits the
-  // ref), so resolution must never lose an implementation whose module
-  // evaluated this session. Retention is bounded by the set of DISTINCT
-  // verified implementations evaluated per session.
+  /**
+   * Content-addressed implementation index: module identity → symbol → the
+   * implementation function recorded by `Engine.#recordModuleProvenance()`
+   * during a verified evaluation (and by `trustHostValue()` for host
+   * pseudo-modules). Deliberately _strong_ and session-unbounded: a serialized
+   * module carries _only_ `$implRef` (no body when the writer proved this index
+   * admits the ref), so resolution must never lose an implementation whose
+   * module evaluated this session. Retention is bounded by the set of
+   * _distinct_ verified implementations evaluated per session.
+   */
   readonly #verifiedImplementationsByEntryRef = new Map<
     string,
     Map<string, HarnessedFunction>
   >();
-  // Host pseudo-modules (identity E5, design §5): each `trustHostValue` call
-  // mints a UNIQUE `host:<n>` identity — uniqueness over content-derivation,
-  // deliberately: host functions are closure-bearing, so two with identical
-  // bytes are NOT interchangeable. Host values are in-session only (a live
-  // closure never survives a session), so a session-scoped counter is exactly
-  // the right lifetime, and the session-lifetime index above is exactly the
-  // right resolution home.
+
+  /**
+   * Counter for host pseudo-module identities: each `trustHostValue()` call
+   * mints a _unique_ `host:<n>` identity — uniqueness over content-derivation,
+   * deliberately: host functions are closure-bearing, so two with identical
+   * bytes are _not_ interchangeable. Host values are in-session only (a live
+   * closure never survives a session), so a session-scoped counter is exactly
+   * the right lifetime, and the session-lifetime index above is exactly the
+   * right resolution home.
+   */
   #nextHostModuleId = 0;
+
   readonly #hostRegisteredFunctions = new WeakSet<HarnessedFunction>();
 
   /** The implementation index, which a test reads directly. */

--- a/packages/runner/src/harness/fabric-resolver.ts
+++ b/packages/runner/src/harness/fabric-resolver.ts
@@ -48,9 +48,11 @@ export class FabricAwareResolver implements ProgramResolver {
     return this.#inner.main();
   }
 
-  // Forwarded like the rest of the interface. A wrapper that answers for part
-  // of a resolver and quietly drops the rest is the shape this whole seam
-  // exists to avoid.
+  /**
+   * Forwards to the wrapped resolver, like the rest of the interface. A wrapper
+   * that answers for part of a resolver and quietly drops the rest is the shape
+   * this whole seam exists to avoid.
+   */
   resolveDataFile(name: string): Promise<Source | undefined> {
     return this.#inner.resolveDataFile
       ? this.#inner.resolveDataFile(name)

--- a/packages/runner/src/harness/patterns-route.deno.ts
+++ b/packages/runner/src/harness/patterns-route.deno.ts
@@ -61,10 +61,13 @@ export class PatternsRoute {
   #baseUrl: URL;
   #extraSources: Array<{ routePrefix: string; baseUrl: URL }>;
 
-  // Pattern files are fixed for the process's lifetime (baked into the binary
-  // or static on disk), so each file's content identity is computed once and
-  // cached forever. A rejected computation is evicted so a transient failure
-  // (e.g. an incomplete closure during a partial deploy) can be retried.
+  /**
+   * Each pattern file's content identity, computed once and cached forever:
+   * pattern files are fixed for the process's lifetime (baked into the binary
+   * or static on disk). A rejected computation is evicted so a transient
+   * failure (e.g. an incomplete closure during a partial deploy) can be
+   * retried.
+   */
   #identityCache = new Map<string, Promise<string>>();
 
   /**

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1502,8 +1502,8 @@ class TransformObjectCreator
   }
 
   /**
-   * Adds an optional property. This controls the behavior when `properties` is
-   * specified but `additionalProperties` is not.
+   * Does nothing: when `properties` is specified but `additionalProperties` is
+   * not, a property outside the map is excluded rather than stored.
    */
   addOptionalProperty(
     _obj: Record<string, FabricValue>,

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1501,8 +1501,10 @@ class TransformObjectCreator
     return mergeAnyOfMatches(matches);
   }
 
-  // This controls the behavior when properties is specified, but
-  // additonalProperties is not.
+  /**
+   * Adds an optional property. This controls the behavior when `properties` is
+   * specified but `additionalProperties` is not.
+   */
   addOptionalProperty(
     _obj: Record<string, FabricValue>,
     _key: string,
@@ -1512,6 +1514,7 @@ class TransformObjectCreator
     // in the schema, but it doesn't include our property, and we don't have
     // additionalProperties set. So we don't do `obj[key] = value`;
   }
+
   applyDefault<T>(
     link: NormalizedFullLink,
     value: T | undefined,
@@ -1570,8 +1573,10 @@ class TransformObjectCreator
     );
   }
 
-  // This is an early pass to see if we should just create a proxy or cell
-  // If not, we will actually resolve our links to get to our values.
+  /**
+   * Creates the object. This is an early pass to see if we should just create a
+   * proxy or cell; if not, we actually resolve our links to get to our values.
+   */
   createObject(
     link: NormalizedFullLink,
     value: AnyCellWrapping<FabricValue> | undefined,

--- a/packages/runner/src/traverse-recorder.ts
+++ b/packages/runner/src/traverse-recorder.ts
@@ -280,8 +280,11 @@ export class TraverseCaptureRecorder {
     };
   }
 
-  // Writes plain JSON (this module is bundled for browsers, so no node:zlib
-  // here); gzip the output afterwards to check it in as a fixture.
+  /**
+   * Writes the capture to `path` as plain JSON (this module is bundled for
+   * browsers, so no `node:zlib` here); gzip the output afterwards to check it
+   * in as a fixture.
+   */
   flush(path: string): void {
     const name = path.split("/").pop()?.replace(/\.json(\.gz)?$/, "") ??
       "capture";

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -842,12 +842,14 @@ export function resolveSchemaRefsCanonical(
  */
 export class MapSet<K, V> {
   /**
-   * The hash-based store, used when `hashFunction` is set: key → (hash →
-   * value). When unset, `#setMap` holds a plain set per key instead.
+   * The hash-based store, used when `#hashFunction` is set: key → (hash →
+   * value).
    */
   #hashMap?: Map<K, Map<string, V>>;
 
+  /** The plain-set store, used when no hash function is set: key → values. */
   #setMap?: Map<K, Set<V>>;
+
   #hashFunction?: (value: V) => string;
 
   // Instrumentation counters (kept for diagnostics)
@@ -2000,7 +2002,7 @@ export abstract class BaseObjectTraverser {
   }
 
   /**
-   * Wrapper for `getAtPath()` that provides all the parameters that are class
+   * Helper for `getAtPath()`, which supplies the parameters that are class
    * fields.
    */
   protected getDocAtPath(

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -841,9 +841,12 @@ export function resolveSchemaRefsCanonical(
  * @template V The type of values stored in the sets
  */
 export class MapSet<K, V> {
-  // When hashFunction is set, use hash-based dedup: key → (hash → value)
-  // When unset, use plain Set: key → Set<value>
+  /**
+   * The hash-based store, used when `hashFunction` is set: key → (hash →
+   * value). When unset, `#setMap` holds a plain set per key instead.
+   */
   #hashMap?: Map<K, Map<string, V>>;
+
   #setMap?: Map<K, Set<V>>;
   #hashFunction?: (value: V) => string;
 
@@ -1204,7 +1207,7 @@ export class CompoundCycleTracker<
   ExtraKey extends JSONSchema | undefined,
   Value = unknown,
 > {
-  // partialKey (identity) → Map<interned extraKey hashString, Value?>
+  /** `partialKey` (identity) → `Map<interned extraKey hashString, Value?>`. */
   readonly #partial = new Map<EqualKey, Map<string, Value | undefined>>();
 
   /**
@@ -1246,7 +1249,10 @@ export class CompoundCycleTracker<
     };
   }
 
-  // After a failed include (that returns null), we can use getExisting to find the registered value
+  /**
+   * Returns the registered value for the pair, for use after a failed
+   * `include()` (one that returned `null`).
+   */
   getExisting(partialKey: EqualKey, extraKey: ExtraKey): Value | undefined {
     const existing = this.#partial.get(partialKey);
     if (existing === undefined) {
@@ -1720,9 +1726,12 @@ function getNormalizedLink(
 // Value traversed must be a DAG, though it may have aliases or cell links
 // that make it seem like it has cycles
 export abstract class BaseObjectTraverser {
-  // `context` is required: it carries the traversal's acting identity
-  // (scopeKeyIdentity), which no default could supply — identity arrives
-  // with the work, never from ambient state (key-vocabulary.md §3).
+  /**
+   * Constructs an instance. `context` is required: it carries the traversal's
+   * acting identity (`scopeKeyIdentity`), which no default could supply —
+   * identity arrives with the work, never from ambient state
+   * (`key-vocabulary.md` §3).
+   */
   constructor(
     protected tx: IExtendedStorageTransaction,
     protected selector: SchemaPathSelector = DEFAULT_SELECTOR,
@@ -1733,6 +1742,7 @@ export abstract class BaseObjectTraverser {
     // Identity passthrough unless CF_TRAVERSE_CAPTURE is recording a fixture.
     this.tx = wrapTxForTraverseCapture(tx);
   }
+
   protected dagMemo = new Map<string, FabricValue>();
   traverseDAGCalls = 0;
   getDocAtPathCalls = 0;
@@ -1989,7 +1999,10 @@ export abstract class BaseObjectTraverser {
     }
   }
 
-  // Wrapper for getAtPath that provides all the parameters that are class fields.
+  /**
+   * Wrapper for `getAtPath()` that provides all the parameters that are class
+   * fields.
+   */
   protected getDocAtPath(
     doc: IMemorySpaceValueAttestation,
     path: readonly string[],
@@ -3740,20 +3753,28 @@ export class SchemaObjectTraverser<V extends FabricValue>
   // Track per-doc visit counts and unique paths
   #docVisits = new Map<string, number>();
   #uniquePaths = new Set<string>();
-  // Read once per traversal, so one traversal collects and reports the same
-  // way throughout.
+
+  /**
+   * Whether diagnostics are on, read once per traversal, so one traversal
+   * collects and reports the same way throughout.
+   */
   #diagnostics = traverseDiagnosticsEnabled();
+
   #maxDepth = 0;
   #currentDepth = 0;
-  // Memoization cache for traverseWithSchema: key → result, scoped to one
-  // traverse() call and cleared at the start of each.
-  // The query path may instead use sharedSchemaMemo, which persists across
-  // the traverse() calls of one selectSchema query; the read path never does,
-  // because its entries are only sound within the traversal that made them.
+
+  /**
+   * Memoization cache for `traverseWithSchema()`: key → result, scoped to one
+   * `traverse()` call and cleared at the start of each. The query path may
+   * instead use `sharedSchemaMemo`, which persists across the `traverse()`
+   * calls of one `selectSchema` query; the read path never does, because its
+   * entries are only sound within the traversal that made them.
+   */
   #schemaMemo = new Map<
     string,
     TraverseResult<FabricValue>
   >();
+
   schemaMemoHits = 0;
 
   get #activeMemo(): Map<
@@ -3978,11 +3999,8 @@ export class SchemaObjectTraverser<V extends FabricValue>
     }
   }
 
-  // Generally handles anyOf
-  // TODO(@ubik2): Need to break this up -- it's too long
-
   /**
-   * Traverse the doc with the specified schema.
+   * Traverses the doc with the specified schema. Generally handles `anyOf`.
    *
    * Our doc parameter has been read in nonRecursive mode.
    *
@@ -3998,6 +4016,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     schema: JSONSchema,
     link?: NormalizedFullLink,
   ): TraverseResult<FabricValue> {
+    // TODO(@ubik2): Need to break this up -- it's too long
     this.traverseWithSchemaCalls++;
     this.#currentDepth++;
     if (this.#currentDepth > this.#maxDepth) {
@@ -5290,10 +5309,11 @@ export class SchemaObjectTraverser<V extends FabricValue>
     return filteredObj;
   }
 
-  // This just has a schema, since the doc.address.path should match the
-  // selector.path.
-  // The doc.value should be a primitive cell link, and we've already
-  // done a nonRecursive read on it.
+  /**
+   * Traverses a pointer. This just has a schema, since `doc.address.path`
+   * should match `selector.path`. The `doc.value` should be a primitive cell
+   * link, and we've already done a non-recursive read on it.
+   */
   #traversePointerWithSchema(
     doc: IMemorySpaceValueAttestation,
     schema: JSONSchema,

--- a/packages/runner/test/effect-conflict-recovery.test.ts
+++ b/packages/runner/test/effect-conflict-recovery.test.ts
@@ -40,11 +40,14 @@ const signer = await Identity.fromPassphrase("effect-conflict-recovery");
 const space = signer.did();
 
 class SuppressibleStorageManager extends EmulatedStorageManager {
-  // When set, forward storage notifications to subscribers with their `changes`
-  // emptied, so they raise no reader-dirty — a deterministic stand-in for a
-  // "dataless catch-up" (a conflict whose catch-up carries no diff). Off by
-  // default: a transparent passthrough that leaves the other tests unaffected.
+  /**
+   * Whether to forward storage notifications to subscribers with their
+   * `changes` emptied, so they raise no reader-dirty — a deterministic stand-in
+   * for a dataless catch-up (a conflict whose catch-up carries no diff). Off by
+   * default: a transparent passthrough that leaves the other tests unaffected.
+   */
   suppressReaderDirty = false;
+
   override subscribe(subscription: IStorageNotification): void {
     super.subscribe({
       next: (n: StorageNotification) =>

--- a/packages/runner/test/executor-serving-loop.test.ts
+++ b/packages/runner/test/executor-serving-loop.test.ts
@@ -51,9 +51,11 @@ import { waitUntil } from "./support/wait-until.ts";
 import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 class SharedServerStorageManager extends EmulatedStorageManager {
-  // Delegate to the base connectTo (shared-harness extraction, CT-1962):
-  // `new this` gives back this subclass, and the base clears server
-  // ownership so closing this manager never closes the shared server.
+  /**
+   * Delegates to the base `connectTo()`: `new this` gives back this subclass,
+   * and the base clears server ownership so closing this manager never closes
+   * the shared server.
+   */
   static override connectTo(
     server: MemoryV2Server.Server,
     options: Omit<Options, "memoryHost" | "spaceHostMap">,

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -436,20 +436,26 @@ class ScriptedModelTransport extends ScriptedSessionTransport {
     this.model.connectionCount += 1;
   }
 
-  // The commit payloads carry full FabricValues; decode with a context that
-  // FAILS on cell reconstruction rather than the default memory context.
+  /**
+   * Decodes a commit payload, which carries full `FabricValue`s, with a context
+   * that _fails_ on cell reconstruction rather than the default memory context.
+   */
   protected override decode(payload: string): ScriptedTransportMessage {
     return fabricFromJsonValue(
       payload,
       testLiveEnvironment,
     ) as ScriptedTransportMessage;
   }
+
   protected override encode(message: unknown): string {
     return jsonFromFabricValue(message as FabricValue);
   }
 
-  // The harness owns teardown; closing the session must not signal a
-  // disconnect (which would trigger client reconnect churn mid-assertion).
+  /**
+   * Does nothing: the harness owns teardown, and closing the session must not
+   * signal a disconnect (which would trigger client reconnect churn
+   * mid-assertion).
+   */
   protected override onClose(): void {}
 
   protected override handle(message: ScriptedTransportMessage): void {
@@ -517,10 +523,12 @@ class ScriptedModelTransport extends ScriptedSessionTransport {
     }
   }
 
-  // Verdict callbacks queued by `handle`'s transact case but not yet booked
-  // into the model (their responseGate may still be held). `drainVerdicts`
-  // awaits them so tests can assert on final server-side bookkeeping without
-  // a wall-clock sleep.
+  /**
+   * Verdict callbacks queued by `handle()`'s transact case but not yet booked
+   * into the model (their `responseGate` may still be held). `drainVerdicts()`
+   * awaits them so tests can assert on final server-side bookkeeping without a
+   * wall-clock sleep.
+   */
   readonly #verdictTasks = new Set<Promise<void>>();
 
   /**

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -874,10 +874,12 @@ describe("pattern-binding", () => {
         }
       }
       class Watched extends Array {
-        // `ArrayConstructor` is what the base class declares here, and `Spy`
-        // does not structurally satisfy it (no callable-without-`new` form).
-        // The cast is the point of the fixture: an exotic species is exactly
-        // what is under test.
+        /**
+         * The species, cast: `ArrayConstructor` is what the base class declares
+         * here, and `Spy` does not structurally satisfy it (no
+         * callable-without-`new` form). The cast is the point of the fixture:
+         * an exotic species is exactly what is under test.
+         */
         static override get [Symbol.species](): ArrayConstructor {
           return Spy as unknown as ArrayConstructor;
         }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

A `//` block sitting directly above a class member and describing that member is a doc comment in the wrong punctuation: it says what the member is or does, which is what `docs/development/code-comment-style.md` § Doc comments has JSDoc form for. This converts the 40 in `runner`'s remaining files: `cell.ts` (5), `cfc.ts` (6), `executor/` (5), `harness/` (8), `schema.ts` (2), `traverse.ts` (7), `traverse-recorder.ts` (1), and four test files (6). It is the last of a series that covers the tree outside `packages/patterns`; `storage/` is #7029 and the manager, runner, runtime, and scheduler are #7031.

Each converted member takes the blank line above its doc comment and the blank line below the member that the guide asks for.

## What changed inside the comments

The text is carried over as written, with the edits the doc-comment form calls for:

* A method's comment opens with a third-person verb phrase, and a field's with a noun phrase. Where a note opened with rationale and never said what the member is or does, a phrase saying so now opens it: `Returns the joined confidentiality atoms`, `Handles the \`asCell\` array tag`, `Whether a shadow flip fired while no input waiter was installed`, `Counter for host pseudo-module identities`, `Each pattern file's content identity, computed once and cached forever`, `Forwards to the wrapped resolver`, `Traverses a pointer`, `The species, cast`.
* `getSchemaAtPath()` is stated against its baseline in the `Like <baseline>, except <difference>` form.
* The gapped note above `traverseWithSchema()` (a doc sentence, `Generally handles anyOf`, and a `TODO`) folds into the existing doc comment and the top of the body.
* Identifiers, callables, and properties take backticks and their parentheses; emphasis by capitals becomes underscores.
* Labels the guide keeps out of comments are gone: `(r3739416418)`, `MINOR-1`, `MINOR-2 / obligation (iii)`, `NIT-1`, `(d′)`, `(identity E5, design §5)`, `(CT-1962)`, `Phase 6`. Spec pointers stay (`serving-loop.md` §5, `key-vocabulary.md` §3, design §6 and §2.8).

Left as `//`: four labels that head a run of fields rather than describing one: `Stream-specific fields` in `cell.ts`, and `Instrumentation counters`, `Traversal stats counters`, and `Track per-doc visit counts and unique paths` in `traverse.ts`.

## How the sites were found

A TypeScript-AST census over every tracked `.ts`/`.tsx` outside `patterns`, vendored types, and generated declarations: for each class member, the `//` blocks in its leading trivia, minus tool directives, section-marker frames, and `TODO`s. A control fixture of nine planted sites and four decoys reported exactly the nine.

## Verification

* Comment-only, by construction and by proof: each changed file transpiles to byte-identical JavaScript with comments stripped, before and after (15 files, 0 differ).
* The census re-run over the changed files reports only the four labels above; the blank-line-below detector reports one site in `traverse.ts`, which it also reports on `main`.
* Every added line is 80 characters or fewer, and no backtick span is broken across lines; no overload set gained a blank line.
* `deno fmt --check`, `deno lint`, and `deno task check` repo-wide, all green.
* `deno task test` in `runner`: 1390 passed, 0 failed.

## Review

A `cf-review` pass (report only) found one sentence this PR had introduced that was false against the code, fixed: `TransformObjectCreator.addOptionalProperty()` is empty on purpose, and its doc now says it does nothing and why, rather than "Adds an optional property". Also taken: `#growthWakeCounter` opens with what it counts, ahead of the settle-instrumentation paragraph that had been its whole text; `#lastFoldedDemandLeaves` and `MapSet.#setMap` get the one-line doc comments their neighbors' notes had covered, and `#hashMap`'s names the field `#hashFunction` rather than the constructor parameter; `getAsCellValues()` says what it returns; `getDocAtPath()` opens in the helper form; `entity ID` keeps `cell.ts`'s majority spelling. The review also notes that `IObjectCreator`'s interface members carry the same `//` shape, outside this census's walk.
