### PR TITLE
feat(cf-harness): `/api/task` takes pattern references by id (CT-2265)

### DIFF
--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -164,7 +164,8 @@ provider turn or make a Fabric round trip. A caller needing proven substrate
 liveness must perform a separate probe.
 
 A task body carries the text, optionally the session to continue, and optionally
-the cells the task is to be computed over:
+the cells the task is to be computed over and the published patterns it is to be
+given:
 
 ```json
 {
@@ -172,6 +173,9 @@ the cells the task is to be computed over:
   "sessionId": "…",
   "inputCells": [
     { "name": "itinerary", "ref": "/of:fid1:…/days" }
+  ],
+  "patternRefs": [
+    { "patternId": "…" }
   ]
 }
 ```
@@ -186,6 +190,23 @@ a 400 before any turn starts: a `ref` has to be a link naming an entity
 grammar and still cannot be minted — one in another space, say — fails the turn
 rather than starting it without what the caller attached, and that turn is
 terminal like any other failed one.
+
+A pattern reference names a published pattern by the index's own id, which is
+the content-addressed identity of its source: it names an entry the index holds
+or it names nothing, and the id is the whole of the reference. The turn's run
+resolves each one against the index before its first model turn and seeds what
+comes back as a `search_patterns` hit, so the model runs it with `run_pattern`'s
+`patternId`, composes it through its `cf:pattern:` specifier, or selects it for
+a child with `delegate_task`'s `patternRefs`, without searching for it. What the
+reference grants is what a search hit grants — compose this source by identifier
+— and attaching one asserts nothing about whether the pattern works.
+
+The grammar is the run's, so a value that is not an id is refused with a 400
+before any turn starts, as a bad `ref` is; so are more than eight references and
+the same id twice. Whether the index holds an id is the run's to find out: an id
+it does not hold fails the turn, naming the id, rather than starting it without
+what the caller attached. A task attaching patterns needs a console started with
+a pattern index (`--pattern-index-url`).
 
 The completed-turn result is:
 

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -78,6 +78,11 @@ import {
 } from "../src/contracts/subagent.ts";
 import { parseHostMountSpecs } from "../src/host-mounts.ts";
 import { parseInputCellArgument } from "../src/input-cells.ts";
+import type { HarnessPatternRefSpec } from "../src/contracts/pattern-refs.ts";
+import {
+  checkPatternRefSpec,
+  MAX_HARNESS_PATTERN_REFS,
+} from "../src/pattern-refs.ts";
 import {
   harnessSessionChatPolicy,
   type HarnessSessionConfig,
@@ -345,6 +350,54 @@ const parseTaskInputCells = (
       throw new Error(`inputCells names \`${spec.name}\` twice`);
     }
     names.add(spec.name);
+    specs.push(spec);
+  }
+  return specs;
+};
+
+/**
+ * The pattern references a `/api/task` body attaches to the turn it starts,
+ * each a `{ patternId }`. An id is the index's own — the content-addressed
+ * identity of published source — so it names an entry the index holds or it
+ * names nothing, and the reference is the whole of what the caller says.
+ *
+ * The grammar is the run's, checked by the run's own parser, so a spelling
+ * the run refuses is refused here too, before a turn is spent on the read.
+ * Whether the index holds the id is the run's to find out. A body that names
+ * no patterns yields none, which is the ordinary task.
+ *
+ * @throws Error naming the defect, which the route answers 400 with.
+ */
+const parseTaskPatternRefs = (
+  value: unknown,
+): readonly HarnessPatternRefSpec[] => {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("patternRefs must be an array");
+  }
+  if (value.length > MAX_HARNESS_PATTERN_REFS) {
+    throw new Error(
+      `patternRefs takes at most ${MAX_HARNESS_PATTERN_REFS} references`,
+    );
+  }
+  const specs: HarnessPatternRefSpec[] = [];
+  const ids = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null) {
+      throw new Error("each pattern reference must be an object");
+    }
+    const { patternId } = entry as { patternId?: unknown };
+    if (typeof patternId !== "string") {
+      throw new Error("each pattern reference needs a string patternId");
+    }
+    const spec = { patternId };
+    checkPatternRefSpec(spec);
+    if (ids.has(patternId)) {
+      throw new Error(`patternRefs names \`${patternId}\` twice`);
+    }
+    ids.add(patternId);
     specs.push(spec);
   }
   return specs;
@@ -656,13 +709,14 @@ export const resolveConsoleConfig = async (
     ),
     // The rest of the session description this surface does not vary. Skills
     // are scanned rather than preloaded by name, scripts are not allowlisted,
-    // handles materialize nowhere, and a task's input cells arrive per task
-    // on `/api/task` rather than at startup.
+    // handles materialize nowhere, and a task's input cells and pattern
+    // references arrive per task on `/api/task` rather than at startup.
     skillNames: [],
     allowedSkillScripts: [],
     skillScriptExecutionTarget: "sandbox",
     handleValueOrigins: [],
     inputCells: [],
+    patternRefs: [],
     // The tool surface is left to the session's own backing rather than
     // listed here, so a tool the harness gains reaches this surface with it.
     allowedSubagentProfiles: [
@@ -1256,8 +1310,12 @@ export class ConsoleServer {
         status: 400,
       });
     }
-    const body: { text?: unknown; sessionId?: unknown; inputCells?: unknown } =
-      typeof parsed === "object" && parsed !== null ? parsed : {};
+    const body: {
+      text?: unknown;
+      sessionId?: unknown;
+      inputCells?: unknown;
+      patternRefs?: unknown;
+    } = typeof parsed === "object" && parsed !== null ? parsed : {};
     const text = body.text;
     if (typeof text !== "string" || text.trim() === "") {
       return Response.json({ error: "text is required" }, { status: 400 });
@@ -1268,8 +1326,10 @@ export class ConsoleServer {
       });
     }
     let inputCells: readonly HarnessInputCellSpec[];
+    let patternRefs: readonly HarnessPatternRefSpec[];
     try {
       inputCells = parseTaskInputCells(body.inputCells);
+      patternRefs = parseTaskPatternRefs(body.patternRefs);
     } catch (error) {
       return Response.json({
         error: error instanceof Error ? error.message : String(error),
@@ -1292,6 +1352,7 @@ export class ConsoleServer {
       sessionId,
       input: { text },
       ...(inputCells.length > 0 ? { inputCells } : {}),
+      ...(patternRefs.length > 0 ? { patternRefs } : {}),
     });
     if (!turn.ok) {
       return chatErrorResponse(turn);

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -146,15 +146,26 @@ The current package provides:
   name-based selection retired for the delegated path — and the child's
   activation records `source: "skill-handle"` with the token and the digest of
   the injected text;
-- pattern references by search record: `delegate_task` takes up to eight
-  optional `{ patternId, note? }` entries and resolves each id only from
-  successful `search_patterns` results retained by that parent run and restored
-  from its persisted transcript on resume. A known id contributes a neutral
-  child-context block containing the trusted record's kind, quality,
-  description, match evidence, import hint, argument shape, result shape, and
-  the parent note verbatim; an unknown id is omitted and named in
-  `patternRefRefusals` as `not-searched-by-parent`. Delegation does not refetch
-  the index;
+- pattern references by trusted record: `delegate_task` takes up to eight
+  optional `{ patternId, note? }` entries and resolves each id only from the
+  records that run already holds — successful `search_patterns` results retained
+  by that parent run and restored from its persisted transcript on resume,
+  together with the patterns the task itself attached. A known id contributes a
+  neutral child-context block containing the trusted record's kind and quality
+  where the record carries them, its description, match evidence, import hint,
+  argument shape, result shape, and the parent note verbatim; an unknown id is
+  omitted and named in `patternRefRefusals` as `not-searched-by-parent`.
+  Delegation does not refetch the index;
+- pattern references attached to a task: a run may be configured with up to
+  eight published pattern ids, which it resolves through the index's
+  `getPattern` before its first model turn and seeds as searched hits, so the
+  run names them with no search. The id is the whole of the reference — the
+  content-addressed identity of published source — and a value outside that
+  grammar is refused by the surface it arrives at, while an id the index does
+  not hold fails the run, naming the id, rather than running without what the
+  caller attached. The seeded record carries what the index answers for the id
+  and nothing else: a reference grants what a search hit grants, which is to
+  compose that source by identifier;
 - shape captured where it is free and read back by token: a handle entry may
   carry the schema of its referent — a `run_pattern` result reference records
   the compiled pattern's result schema, marked `schemaSource: "harness"` — while

--- a/packages/cf-harness/docs/system-map/README.md
+++ b/packages/cf-harness/docs/system-map/README.md
@@ -116,6 +116,16 @@ carries is enforced by the runner's `db.query` builtin, on session-scoped query
 results only, with a space-scoped query refused; a shared cell another runtime
 filled is outside it. Redraw that boundary the next time the map is regenerated.
 
+The map also predates a task's pattern references: it draws
+`POST /api/task {text, inputCells}`, and a body may now carry
+`patternRefs: [{ patternId }]` beside those, which the run resolves against the
+index before its first model turn and seeds as searched hits
+([CURRENT_STATE.md](../CURRENT_STATE.md) "pattern references attached to a
+task", and the console's own [README](../../console/README.md)). No boundary
+moves: an id is a content hash the index either holds or does not, and what a
+reference grants is what a search hit grants. Add the field to that edge's label
+the next time the map is regenerated.
+
 ## Relation to the other documents here
 
 The map is a reading aid, not a source of truth. Where it and

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -1955,6 +1955,10 @@ export const parseCfHarnessCliArgs = async (
     ...(browserAccess !== undefined ? { browserAccess } : {}),
     handleValueOrigins,
     inputCells,
+    // A pattern reference is attached per task, and this surface takes one
+    // prompt: a batch run names an indexed pattern in its prompt or finds it
+    // with search_patterns.
+    patternRefs: [],
     maxModelTurns: parsePositiveInteger(
       typeof args["max-model-turns"] === "string"
         ? args["max-model-turns"]

--- a/packages/cf-harness/src/contracts/interactive-chat.ts
+++ b/packages/cf-harness/src/contracts/interactive-chat.ts
@@ -2,6 +2,7 @@ import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessBrowserAccessLease } from "./browser-access.ts";
 import type { HarnessImageAttachment } from "./image.ts";
 import type { HarnessInputCellSpec } from "./input-cells.ts";
+import type { HarnessPatternRefSpec } from "./pattern-refs.ts";
 import type { PromptSlotBinding } from "./prompt-slot.ts";
 import type { LoomLocalHostBinding } from "./run-manifest.ts";
 import {
@@ -192,6 +193,14 @@ export interface HarnessChatStartTurnParams {
    * given are the ones this turn's run minted.
    */
   inputCells?: readonly HarnessInputCellSpec[];
+
+  /**
+   * Published patterns the caller attaches to this turn by index id, resolved
+   * before the turn's first model turn and seeded into its run as searched
+   * hits. Named per turn for the same reason an input cell is: the run that
+   * holds them is this turn's.
+   */
+  patternRefs?: readonly HarnessPatternRefSpec[];
 
   metadata?: Record<string, unknown>;
 }

--- a/packages/cf-harness/src/contracts/pattern-refs.ts
+++ b/packages/cf-harness/src/contracts/pattern-refs.ts
@@ -1,0 +1,32 @@
+/**
+ * The record of a task's pattern references: published patterns the caller
+ * attached to a task by id, resolved against the pattern index before the
+ * run's first model turn so the run names them without searching for them.
+ * `src/pattern-refs.ts` documents the posture and does the grammar check and
+ * the resolution; this contract is what run state persists.
+ */
+
+import type { TrustedPatternRecord } from "../tools/search-patterns.ts";
+
+/** One pattern reference as the caller supplied it, before any resolution. */
+export interface HarnessPatternRefSpec {
+  /**
+   * The index's id for the pattern, which is the content-addressed identity
+   * of its source. It names published source or it names nothing, so it is
+   * the whole of the reference: there is no name, note, or other caller
+   * prose for the model to read alongside it.
+   */
+  patternId: string;
+}
+
+/**
+ * One pattern reference, as resolved and recorded in run state. It is what
+ * the index answered for the id and nothing the caller said about it, which
+ * is why the run may hand it to the model as it stands.
+ */
+export interface HarnessPatternRef {
+  patternId: string;
+
+  /** What the index holds for the pattern, in the shape a hit takes. */
+  record: TrustedPatternRecord;
+}

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -125,6 +125,11 @@ import type {
   HarnessInputCellSpec,
 } from "./contracts/input-cells.ts";
 import { mintInputCellHandles } from "./input-cells.ts";
+import type {
+  HarnessPatternRef,
+  HarnessPatternRefSpec,
+} from "./contracts/pattern-refs.ts";
+import { resolvePatternRefs } from "./pattern-refs.ts";
 import {
   addHarnessDocsQueryFailures,
   appendHarnessCfcModelContextObservations,
@@ -350,6 +355,13 @@ export interface CreateHarnessEngineOptions
   inputCells?: readonly HarnessInputCellSpec[];
 
   /**
+   * Published patterns to resolve against the index at run start; see
+   * `establishPatternRefs`. Requires a pattern index — the ids name entries
+   * it holds.
+   */
+  patternRefs?: readonly HarnessPatternRefSpec[];
+
+  /**
    * The space database the run's cell-label snapshot reads as it ends, for a
    * host where the store is not where the discovery walk looks. Absent, the
    * space named by the fabric session is resolved against the caches on this
@@ -488,6 +500,7 @@ export class CfHarnessEngine {
   #patternIndexPublications?: PatternIndexPublicationLedger;
   readonly #taskText?: string;
   readonly #inputCells: readonly HarnessInputCellSpec[];
+  readonly #patternRefs: readonly HarnessPatternRefSpec[];
   readonly #spaceDbPath?: string;
   readonly #hostMounts: readonly HostSandboxMount[];
   readonly #ownedRunscConfig?: DockerRunscSandboxConfig;
@@ -693,6 +706,7 @@ export class CfHarnessEngine {
         );
     this.#taskText = options.taskText;
     this.#inputCells = options.inputCells ?? [];
+    this.#patternRefs = options.patternRefs ?? [];
     this.#spaceDbPath = options.spaceDbPath;
     const sandboxConfig = options.sandboxRuntime === undefined
       ? resolveSandboxConfig(this.config, {
@@ -1386,6 +1400,40 @@ export class CfHarnessEngine {
     );
     await this.persistRunState();
     return minted.inputCells;
+  }
+
+  /**
+   * Establishes the run's task pattern references: resolves each id against
+   * the pattern index, records the results in run state, and returns them.
+   * Idempotent across resume, like the input cells: references already
+   * recorded are returned as they stand.
+   *
+   * Failure is closed and loud for the same reason an input cell's is —
+   * references are explicit caller configuration — so a run configured with
+   * them and no index, an id outside the index's grammar, and an id the index
+   * does not hold all throw before anything is recorded.
+   */
+  async establishPatternRefs(): Promise<HarnessPatternRef[]> {
+    if (this.#runState.patternRefs !== undefined) {
+      return structuredClone(this.#runState.patternRefs);
+    }
+    if (this.#patternRefs.length === 0) {
+      return [];
+    }
+    if (this.#patternIndexClientFactory === undefined) {
+      throw new Error(
+        "patternRefs requires a pattern index; configure --pattern-index-url",
+      );
+    }
+    const client = await this.#patternIndexClientFactory();
+    const resolved = await resolvePatternRefs(client, this.#patternRefs);
+    this.#runState = patchHarnessRunState(
+      this.#runState,
+      { patternRefs: structuredClone(resolved) },
+      this.#now(),
+    );
+    await this.persistRunState();
+    return resolved;
   }
 
   async ensureRunManifestPersisted(): Promise<string | undefined> {

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -10,6 +10,7 @@ import {
 } from "./prompt-loop.ts";
 import { establishHarnessSessionContext } from "./session-assembly.ts";
 import type { HarnessInputCellSpec } from "./contracts/input-cells.ts";
+import type { HarnessPatternRefSpec } from "./contracts/pattern-refs.ts";
 import {
   createHarnessChatErrorResponse,
   createHarnessChatEventEnvelope,
@@ -1480,12 +1481,13 @@ export class HarnessInteractiveChatService {
           policy,
           browserAccess,
           params.inputCells,
+          params.patternRefs,
         ),
       );
       // The context messages announce what this turn's own run holds — its
-      // preloaded skills, its granted references, its input cells — so they
-      // sit immediately before the request they are held for, after the
-      // history the session already had.
+      // preloaded skills, its granted references, its input cells, its
+      // attached patterns — so they sit immediately before the request they
+      // are held for, after the history the session already had.
       const transcript: HarnessTranscriptMessage[] = [
         ...seededSystemPrompt,
         ...record.transcript,
@@ -1622,7 +1624,8 @@ export class HarnessInteractiveChatService {
       options.fabricSession;
     if (
       options.engine === undefined && skillsRoot === undefined &&
-      fabricSession === undefined
+      fabricSession === undefined &&
+      (options.patternRefs?.length ?? 0) === 0
     ) {
       // Nothing configured needs a run to be brought up before its first model
       // turn, and constructing an engine to discover that would build a
@@ -1651,11 +1654,15 @@ export class HarnessInteractiveChatService {
     policy: HarnessChatPolicy,
     browserAccess?: HarnessChatBrowserAccessLease,
     inputCells?: readonly HarnessInputCellSpec[],
+    patternRefs?: readonly HarnessPatternRefSpec[],
   ): CreateHarnessPromptLoopOptions {
     return {
       ...this.#basePromptLoopOptions,
       ...(inputCells !== undefined && inputCells.length > 0
         ? { inputCells }
+        : {}),
+      ...(patternRefs !== undefined && patternRefs.length > 0
+        ? { patternRefs }
         : {}),
       ...(session.workspace?.hostPath !== undefined
         ? { workspaceHostPath: session.workspace.hostPath }

--- a/packages/cf-harness/src/pattern-refs.ts
+++ b/packages/cf-harness/src/pattern-refs.ts
@@ -1,0 +1,158 @@
+/**
+ * Task pattern references: published patterns the caller attaches to a task
+ * by id, the way `--input-cell` attaches a cell by reference. A pattern id is
+ * the content-addressed identity of published source, so the id itself
+ * discloses nothing and asserts nothing — it either names an entry the index
+ * holds or it names nothing at all.
+ *
+ * The run resolves each id against the index before its first model turn and
+ * seeds what comes back as a searched hit, so `run_pattern`'s `patternId` and
+ * `delegate_task`'s `patternRefs` name the pattern with no search. What the
+ * reference grants is what a search hit grants: compose this source by
+ * identifier. It is provenance, not endorsement — the record carries the
+ * index's own account of the pattern, and attaching one adds nothing to it.
+ *
+ * Like an input cell, a reference is explicit caller configuration, so
+ * failure is closed and loud: an id the index does not know fails the run
+ * rather than leaving it to proceed without what the caller attached.
+ */
+
+import type { PatternIndexClient } from "./pattern-index/client.ts";
+import { PatternIndexError } from "./pattern-index/client.ts";
+import {
+  patternIndexDeclaredType,
+  patternIndexImportHint,
+} from "./tools/search-patterns.ts";
+import type {
+  HarnessPatternRef,
+  HarnessPatternRefSpec,
+} from "./contracts/pattern-refs.ts";
+
+export type {
+  HarnessPatternRef,
+  HarnessPatternRefSpec,
+} from "./contracts/pattern-refs.ts";
+
+/**
+ * The id grammar, which is the grammar a `cf:pattern:` specifier carries: an
+ * index id is a content hash written in these characters and no others.
+ */
+const PATTERN_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * References one task may attach. Each costs an index read before the run's
+ * first model turn, and the same bound `delegate_task` holds a selection to
+ * is what a task carries.
+ */
+export const MAX_HARNESS_PATTERN_REFS = 8;
+
+/**
+ * Holds one pattern reference to the index's id grammar. A value that is not
+ * an id names nothing the index could hold, so it is refused wherever it
+ * first arrives rather than spent on a read.
+ *
+ * @throws Error naming the value and the grammar it missed.
+ */
+export const checkPatternRefSpec = (spec: HarnessPatternRefSpec): void => {
+  if (!PATTERN_ID_PATTERN.test(spec.patternId)) {
+    throw new Error(
+      `patternRefs patternId must match ${PATTERN_ID_PATTERN}, got \`${spec.patternId}\``,
+    );
+  }
+};
+
+/**
+ * Resolves each reference through the index, answering the records a run
+ * seeds as searched hits. Source is never requested: what a composing model
+ * needs is what a pattern is for and what it takes and returns.
+ *
+ * @throws Error naming the failing id on a duplicate, on an id the index does
+ * not hold, and on a read the index refused, and stating the bound when more
+ * references arrive than {@link MAX_HARNESS_PATTERN_REFS} — the caller fails
+ * the run with it, before any model turn.
+ */
+export const resolvePatternRefs = async (
+  client: PatternIndexClient,
+  specs: readonly HarnessPatternRefSpec[],
+): Promise<HarnessPatternRef[]> => {
+  if (specs.length > MAX_HARNESS_PATTERN_REFS) {
+    throw new Error(
+      `patternRefs takes at most ${MAX_HARNESS_PATTERN_REFS} references, got ${specs.length}`,
+    );
+  }
+  const refs: HarnessPatternRef[] = [];
+  const seen = new Set<string>();
+  for (const spec of specs) {
+    // Checked here, not only at the surface the caller wrote to: a library
+    // caller reaches this resolution without passing that surface's grammar.
+    checkPatternRefSpec(spec);
+    if (seen.has(spec.patternId)) {
+      throw new Error(`patternRefs names \`${spec.patternId}\` twice`);
+    }
+    seen.add(spec.patternId);
+    let pattern;
+    try {
+      pattern = await client.getPattern({ patternId: spec.patternId });
+    } catch (error) {
+      // The id is what the caller can act on, so it leads the message; the
+      // index's own words follow it, and the pattern's source is in neither.
+      throw new Error(
+        error instanceof PatternIndexError && error.status === 404
+          ? `patternRefs \`${spec.patternId}\` is not in the pattern index`
+          : `patternRefs \`${spec.patternId}\` could not be read from the pattern index: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+      );
+    }
+    const argumentType = patternIndexDeclaredType(pattern.argumentSchema);
+    const resultType = patternIndexDeclaredType(pattern.resultSchema);
+    refs.push({
+      patternId: pattern.patternId,
+      record: {
+        patternId: pattern.patternId,
+        description: pattern.description,
+        hashtags: pattern.hashtags,
+        importHint: patternIndexImportHint(pattern.patternId),
+        ownerDid: pattern.ownerDid,
+        createdAt: pattern.createdAt,
+        ...(argumentType !== undefined ? { argumentType } : {}),
+        ...(resultType !== undefined ? { resultType } : {}),
+      },
+    });
+  }
+  return refs;
+};
+
+/**
+ * The context message announcing attached patterns to the model, in the terms
+ * a search hit is reported in: what each one is for, the specifier that
+ * composes it, and the shapes to wire against. The message says how to name
+ * them and stops there — an attachment is the caller pointing at published
+ * source, not a claim that the source is any good. An empty list yields no
+ * message at all rather than an empty header.
+ */
+export const patternRefsContextMessage = (
+  patternRefs: readonly HarnessPatternRef[],
+): string | undefined => {
+  if (patternRefs.length === 0) {
+    return undefined;
+  }
+  return [
+    "Published patterns attached to this task by the caller:",
+    ...patternRefs.flatMap(({ record }, index) => [
+      "",
+      `Pattern ${index + 1}: ${record.patternId}`,
+      `Description: ${record.description}`,
+      ...(record.hashtags.length > 0
+        ? [`Hashtags: ${record.hashtags.join(", ")}`]
+        : []),
+      `Import: ${record.importHint}`,
+      "Argument shape:",
+      record.argumentType ?? "Not available.",
+      "Result shape:",
+      record.resultType ?? "Not available.",
+    ]),
+    "",
+    "These are available to name as search_patterns hits are: run one with run_pattern's patternId, compose one through its import specifier, or select one for a child with delegate_task's patternRefs. You do not need to search for them. Attaching a pattern says which published source it is and nothing about whether it works.",
+  ].join("\n");
+};

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -166,8 +166,9 @@ import {
 import { BUILTIN_TOOLS, getBuiltinTool } from "./tools/registry.ts";
 import {
   isSearchPatternsToolSuccessOutput,
-  type SearchPatternsToolResult,
+  type TrustedPatternRecord,
 } from "./tools/search-patterns.ts";
+import type { HarnessPatternRef } from "./contracts/pattern-refs.ts";
 import { isRunPatternToolSuccessOutput } from "./tools/run-pattern.ts";
 import {
   isRunSkillScriptToolSuccessOutput,
@@ -1419,7 +1420,7 @@ const buildSubagentSystemPrompt = (
 
 /** One selected pattern rebuilt from the parent's trusted search record. */
 interface RehydratedDelegatePatternRef {
-  record: SearchPatternsToolResult;
+  record: TrustedPatternRecord;
   note?: string;
 }
 
@@ -1438,8 +1439,8 @@ const PATTERN_REFS_CHILD_CONTEXT = (
     ...patternRefs.flatMap(({ record, note }, index) => [
       "",
       `Pattern ${index + 1}: ${record.patternId}`,
-      `Kind: ${record.kind}`,
-      `Quality: ${record.quality}`,
+      ...(record.kind !== undefined ? [`Kind: ${record.kind}`] : []),
+      ...(record.quality !== undefined ? [`Quality: ${record.quality}`] : []),
       `Description: ${record.description}`,
       ...(record.matchedTerms !== undefined &&
           record.queryTerms !== undefined
@@ -2717,10 +2718,7 @@ export class CfHarnessPromptLoop {
   readonly #reasoningEffort?: string;
   readonly #compactThreshold?: number;
   readonly #subagentCompositionGuidance: boolean;
-  readonly #trustedPatternSearchRecords = new Map<
-    string,
-    SearchPatternsToolResult
-  >();
+  readonly #trustedPatternRecords = new Map<string, TrustedPatternRecord>();
 
   /**
    * The `outputId` of every `run_pattern` call whose source this loop wrote to
@@ -2971,6 +2969,9 @@ export class CfHarnessPromptLoop {
     }
     this.engine.bindRunModel(model);
     const transcript: HarnessTranscriptMessage[] = [...options.transcript];
+    // The attachment first, so a search this run also made — which carries
+    // the ranking evidence a by-id read has none of — refines it.
+    this.#seedAttachedPatternRecords(initialRunState.patternRefs ?? []);
     this.#restorePatternSearchRecords(transcript);
     const maxModelTurns = options.maxModelTurns ?? this.#maxModelTurns;
     const toolActivity: HarnessToolActivity[] = [];
@@ -3393,6 +3394,23 @@ export class CfHarnessPromptLoop {
     }
   }
 
+  /**
+   * Retains the patterns the task attached, which the run resolved against
+   * the index before this loop ran. A reference is a hit the run made rather
+   * than one the model asked for, so it names the same things a search hit
+   * names and grants nothing further.
+   */
+  #seedAttachedPatternRecords(
+    patternRefs: readonly HarnessPatternRef[],
+  ): void {
+    for (const { record } of patternRefs) {
+      this.#trustedPatternRecords.set(
+        record.patternId,
+        structuredClone(record),
+      );
+    }
+  }
+
   /** Retains successful search hits for this parent prompt loop. */
   #recordPatternSearchResult(toolId: BuiltinToolId, output: unknown): void {
     if (
@@ -3402,7 +3420,7 @@ export class CfHarnessPromptLoop {
       return;
     }
     for (const record of output.results) {
-      this.#trustedPatternSearchRecords.set(
+      this.#trustedPatternRecords.set(
         record.patternId,
         structuredClone(record),
       );
@@ -3419,7 +3437,7 @@ export class CfHarnessPromptLoop {
     const records: RehydratedDelegatePatternRef[] = [];
     const refusals: DelegateTaskPatternRefRefusal[] = [];
     for (const patternRef of patternRefs ?? []) {
-      const record = this.#trustedPatternSearchRecords.get(
+      const record = this.#trustedPatternRecords.get(
         patternRef.patternId,
       );
       if (record === undefined) {

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -16,6 +16,7 @@ import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.t
 import type { HarnessHandleTable } from "./contracts/handle-table.ts";
 import type { HarnessWellKnownGrant } from "./contracts/well-known-grants.ts";
 import type { HarnessInputCell } from "./contracts/input-cells.ts";
+import type { HarnessPatternRef } from "./contracts/pattern-refs.ts";
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
 import type {
   HarnessPolicyDecisionRecord,
@@ -195,6 +196,7 @@ export interface HarnessRunState {
   skillsRoot?: HarnessSkillsRootRecord;
   wellKnownGrants?: HarnessWellKnownGrant[];
   inputCells?: HarnessInputCell[];
+  patternRefs?: HarnessPatternRef[];
   policyEvents: HarnessPolicyEvent[];
   policyDecisions?: HarnessPolicyDecisionRecord[];
 
@@ -257,6 +259,7 @@ export interface CreateHarnessRunStateOptions {
   skillsRoot?: HarnessSkillsRootRecord;
   wellKnownGrants?: HarnessWellKnownGrant[];
   inputCells?: HarnessInputCell[];
+  patternRefs?: HarnessPatternRef[];
   policyDecisions?: HarnessPolicyDecisionRecord[];
   docsQueryFailures?: number;
   lineage?: HarnessSubagentLineage;
@@ -384,6 +387,9 @@ export const createHarnessRunState = (
       : {}),
     ...(options.inputCells !== undefined
       ? { inputCells: structuredClone(options.inputCells) }
+      : {}),
+    ...(options.patternRefs !== undefined
+      ? { patternRefs: structuredClone(options.patternRefs) }
       : {}),
     ...(options.lineage !== undefined
       ? { lineage: structuredClone(options.lineage) }

--- a/packages/cf-harness/src/session-assembly.ts
+++ b/packages/cf-harness/src/session-assembly.ts
@@ -31,6 +31,7 @@ import type { HarnessBrowserAccessLease } from "./contracts/browser-access.ts";
 import type { HarnessChatPolicy } from "./contracts/interactive-chat.ts";
 import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
 import type { HarnessInputCellSpec } from "./contracts/input-cells.ts";
+import type { HarnessPatternRefSpec } from "./contracts/pattern-refs.ts";
 import type {
   HarnessAllowedSkillScript,
   HarnessSkillScriptExecutionTarget,
@@ -49,6 +50,7 @@ import {
   hostMountsToAdditionalMounts,
 } from "./host-mounts.ts";
 import { inputCellsContextMessage } from "./input-cells.ts";
+import { patternRefsContextMessage } from "./pattern-refs.ts";
 import type { CreateHarnessPromptLoopOptions } from "./prompt-loop.ts";
 import type { DockerRunscAdditionalMountConfig } from "./sandbox/types.ts";
 import { loadHarnessSkillContext } from "./skills/registry.ts";
@@ -121,6 +123,9 @@ export interface HarnessSessionConfig {
 
   /** Cells the operator passes in by reference, named for the model. */
   inputCells: readonly HarnessInputCellSpec[];
+
+  /** Published patterns the caller attaches to the task by index id. */
+  patternRefs: readonly HarnessPatternRefSpec[];
 
   handleValueOrigins: readonly string[];
 
@@ -259,6 +264,9 @@ export const harnessSessionEngineOptions = (
     ...(config.skillsSh !== undefined ? { skillsSh: config.skillsSh } : {}),
     ...(additionalMounts.length > 0 ? { additionalMounts } : {}),
     ...(config.inputCells.length > 0 ? { inputCells: config.inputCells } : {}),
+    ...(config.patternRefs.length > 0
+      ? { patternRefs: config.patternRefs }
+      : {}),
     ...(config.allowedToolIds !== undefined
       ? { allowedToolIds: config.allowedToolIds }
       : {}),
@@ -374,6 +382,12 @@ const establishContextMessages = async (
   );
   if (inputCellsMessage !== undefined) {
     messages.push(inputCellsMessage);
+  }
+  const patternRefsMessage = patternRefsContextMessage(
+    await engine.establishPatternRefs(),
+  );
+  if (patternRefsMessage !== undefined) {
+    messages.push(patternRefsMessage);
   }
   return messages;
 };

--- a/packages/cf-harness/src/tools/search-patterns.ts
+++ b/packages/cf-harness/src/tools/search-patterns.ts
@@ -70,6 +70,34 @@ export interface SearchPatternsToolResult {
   resultType?: string;
 }
 
+/**
+ * What a run knows about a published pattern it may name by id. A
+ * `search_patterns` hit is one of these, so every field a hit reports is
+ * here; a pattern reference the task attached is another, resolved from the
+ * index by id, and a by-id read answers no ranking evidence — no match
+ * counts, and no tier — because that is what search computes over a query.
+ * Whichever it came from, this is metadata and never source.
+ */
+export interface TrustedPatternRecord {
+  patternId: string;
+  description: string;
+  hashtags: readonly string[];
+  signals?: PatternIndexSignals;
+  kind?: PatternIndexPatternKind;
+  quality?: PatternIndexQuality;
+  matchedTerms?: number;
+  queryTerms?: number;
+  importHint: string;
+  argumentType?: string;
+  resultType?: string;
+
+  /** The identity that published it, where the index reported it. */
+  ownerDid?: string;
+
+  /** When the index recorded it, where the index reported it. */
+  createdAt?: string;
+}
+
 export interface SearchPatternsToolSuccessOutput {
   outputId: string;
   status: "ok";
@@ -238,7 +266,9 @@ const errorMessage = (error: unknown): string =>
  * absent: the search answers with what is known, and a shape it cannot write
  * down is not known.
  */
-const declaredType = (schema: JSONSchema | undefined): string | undefined => {
+export const patternIndexDeclaredType = (
+  schema: JSONSchema | undefined,
+): string | undefined => {
   if (schema === undefined) {
     return undefined;
   }
@@ -306,8 +336,8 @@ export const searchPatternsTool: HarnessToolDefinition<
     );
     const results = hits.map((hit, index): SearchPatternsToolResult => {
       const pattern = detailed[index];
-      const argumentType = declaredType(pattern?.argumentSchema);
-      const resultType = declaredType(pattern?.resultSchema);
+      const argumentType = patternIndexDeclaredType(pattern?.argumentSchema);
+      const resultType = patternIndexDeclaredType(pattern?.resultSchema);
       return {
         patternId: hit.patternId,
         description: hit.description,

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -12,6 +12,7 @@ import { harnessSessionChatPolicy } from "../../src/session-assembly.ts";
 import type { ConsoleSessionListing } from "../../console/sessions.ts";
 import type { HarnessFetch } from "../../src/contracts/http-fetch.ts";
 import { PatternIndexClient } from "../../src/pattern-index/client.ts";
+import { MAX_HARNESS_PATTERN_REFS } from "../../src/pattern-refs.ts";
 import {
   type HarnessInteractiveChatEventListener,
   HarnessInteractiveChatService,
@@ -100,6 +101,16 @@ const advancingClock = () => {
 
 /** The identity the proxied index client signs with in these tests. */
 const signer = await Identity.fromPassphrase("cf-harness console index proxy");
+
+/** What the index answers for the pattern a task attaches by id. */
+const INDEXED_PATTERN = {
+  patternId: "pat-expenses",
+  ownerDid: "did:key:zOwner",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  description: "Totals an expense list",
+  hashtags: ["expenses"],
+  dependencies: [],
+};
 
 /** An entity id of the shape an input-cell reference has to carry. */
 const CELL_ID = `of:fid1:${"A".repeat(43)}`;
@@ -1138,6 +1149,154 @@ describe("console/server", () => {
       const started = await startTask({
         text: "track my books",
         inputCells: null,
+      });
+
+      expect(started.turnId).toBeDefined();
+    });
+
+    it("attaches the task's pattern references to the run that answers it", async () => {
+      // The pill's `use <id>` flow: the caller names published patterns by
+      // the index's own id. What reaches the run is the id; resolving it
+      // against the index is the run's, before its first model turn.
+      const loopOptions: CreateHarnessPromptLoopOptions[] = [];
+      const artifactRoot = await Deno.makeTempDir({
+        prefix: "cf-harness-console-pattern-refs-",
+      });
+      const capturing = new ConsoleServer(
+        await resolveConsoleConfig(
+          [
+            "--fabric-identity",
+            "key.pkcs8",
+            "--fabric-space",
+            "console-test",
+            "--session-db",
+            "none",
+            "--pattern-index-url",
+            "https://index.test/api",
+            "--artifact-root",
+            artifactRoot,
+          ],
+          {},
+          "/console",
+        ),
+        (onEvent) =>
+          new HarnessInteractiveChatService({
+            basePromptLoopOptions: {
+              patternIndexClientFactory: () =>
+                Promise.resolve(
+                  new PatternIndexClient({
+                    baseUrl: "https://index.test/api",
+                    fetchFn: () =>
+                      Promise.resolve(Response.json(INDEXED_PATTERN)),
+                    signer,
+                  }),
+                ),
+            },
+            createPromptLoop: (options) => {
+              loopOptions.push(options);
+              return answeringLoop(options);
+            },
+            now: advancingClock(),
+            onEvent,
+          }),
+      );
+      const page = await capturing.handle(getRequest("/"));
+      await page.body?.cancel();
+      const capturedCookie = page.headers.get("set-cookie")!.split(";")[0];
+
+      try {
+        const response = await capturing.handle(jsonRequest("/api/task", {
+          text: "use pat-expenses for a dice roller app",
+          patternRefs: [{ patternId: "pat-expenses" }],
+        }, { cookie: capturedCookie }));
+        expect(response.status).toBe(200);
+        const started = await response.json();
+        await capturing.service.waitForTurn(started.sessionId, started.turnId);
+
+        expect(
+          capturing.service.events(started.sessionId).map((envelope) =>
+            envelope.event.kind
+          ),
+        ).toContain("turn_completed");
+        expect(loopOptions.at(-1)?.patternRefs).toEqual([
+          { patternId: "pat-expenses" },
+        ]);
+      } finally {
+        await Deno.remove(artifactRoot, { recursive: true });
+      }
+    });
+
+    it("answers 400 for a pattern reference that is not an index id, before any turn starts", async () => {
+      // The prose the person typed after `use` is not an id, and an id is
+      // the whole of the reference grammar.
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "use it for a dice roller app",
+        patternRefs: [{ patternId: "it for a dice roller app" }],
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toContain("patternId must match");
+      expect((await listSessions()).sessions).toHaveLength(0);
+    });
+
+    it("answers 400 for pattern references that are not a list at all", async () => {
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "total my spending",
+        patternRefs: { patternId: "pat-expenses" },
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe(
+        "patternRefs must be an array",
+      );
+    });
+
+    it("answers 400 for a pattern reference that carries no string patternId", async () => {
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "total my spending",
+        patternRefs: [{ id: "pat-expenses" }],
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe(
+        "each pattern reference needs a string patternId",
+      );
+    });
+
+    it("answers 400 for an id the request names twice", async () => {
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "total my spending",
+        patternRefs: [
+          { patternId: "pat-expenses" },
+          { patternId: "pat-expenses" },
+        ],
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe(
+        "patternRefs names `pat-expenses` twice",
+      );
+    });
+
+    it("answers 400 for more pattern references than a task may attach", async () => {
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "total my spending",
+        patternRefs: Array.from(
+          { length: MAX_HARNESS_PATTERN_REFS + 1 },
+          (_unused, index) => ({ patternId: `pat-${index}` }),
+        ),
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toContain(
+        `at most ${MAX_HARNESS_PATTERN_REFS}`,
+      );
+    });
+
+    it("starts a task that names no pattern references at all", async () => {
+      const started = await startTask({
+        text: "track my books",
+        patternRefs: null,
       });
 
       expect(started.turnId).toBeDefined();

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -1251,6 +1251,34 @@ describe("console/server", () => {
       );
     });
 
+    it("answers 400 for a pattern reference that is not an object at all", async () => {
+      // A reference is a `{ patternId }`, so a bare id in the list is a
+      // spelling the route refuses rather than one it reads through.
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "total my spending",
+        patternRefs: ["pat-expenses"],
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe(
+        "each pattern reference must be an object",
+      );
+    });
+
+    it("answers 400 for a `null` sitting in the reference list", async () => {
+      // Distinct from a `null` in place of the list itself, which is how a
+      // body says it attaches no patterns and starts an ordinary task.
+      const response = await server.handle(jsonRequest("/api/task", {
+        text: "total my spending",
+        patternRefs: [null],
+      }, { cookie }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe(
+        "each pattern reference must be an object",
+      );
+    });
+
     it("answers 400 for a pattern reference that carries no string patternId", async () => {
       const response = await server.handle(jsonRequest("/api/task", {
         text: "total my spending",

--- a/packages/cf-harness/test/engine-pattern-refs.test.ts
+++ b/packages/cf-harness/test/engine-pattern-refs.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The engine's task pattern references: what `establishPatternRefs()` writes
+ * into run state, what a second call answers from that record, and the
+ * configurations it refuses before anything is recorded.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+
+import { CfHarnessEngine } from "../src/engine.ts";
+import { PatternIndexClient } from "../src/pattern-index/client.ts";
+import type { HarnessFetch } from "../src/contracts/http-fetch.ts";
+
+const signer = await Identity.fromPassphrase(
+  "cf-harness engine pattern refs",
+);
+
+const PATTERN_RECORD = {
+  patternId: "pat-expenses",
+  ownerDid: "did:key:zOwner",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  description: "Totals an expense list",
+  hashtags: ["expenses", "money"],
+  dependencies: [],
+  argumentSchema: {
+    type: "object",
+    properties: { amounts: { type: "array", items: { type: "number" } } },
+    required: ["amounts"],
+  },
+  resultSchema: {
+    type: "object",
+    properties: { total: { type: "number" } },
+    required: ["total"],
+  },
+  program: { main: "/main.tsx", files: [] },
+};
+
+/** An index answering `getPattern` for one id, counting every read it took. */
+const stubIndex = (): { client: PatternIndexClient; calls: string[] } => {
+  const calls: string[] = [];
+  const fetchFn: HarnessFetch = (input, init) => {
+    calls.push(String(input).split("/").pop() ?? "");
+    const body = JSON.parse(String(init?.body)) as { patternId?: string };
+    return Promise.resolve(
+      body.patternId === PATTERN_RECORD.patternId
+        ? new Response(JSON.stringify(PATTERN_RECORD), { status: 200 })
+        : new Response(JSON.stringify({ error: "no such pattern" }), {
+          status: 404,
+        }),
+    );
+  };
+  return {
+    client: new PatternIndexClient({
+      baseUrl: "https://index.test",
+      fetchFn,
+      signer,
+    }),
+    calls,
+  };
+};
+
+describe("engine-pattern-refs", () => {
+  describe("establishPatternRefs()", () => {
+    it("records the index's record for each attached id in run state", async () => {
+      const index = stubIndex();
+      const engine = new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        patternRefs: [{ patternId: "pat-expenses" }],
+        patternIndexClientFactory: () => Promise.resolve(index.client),
+      });
+
+      const refs = await engine.establishPatternRefs();
+
+      expect(refs).toEqual([{
+        patternId: "pat-expenses",
+        record: {
+          patternId: "pat-expenses",
+          description: "Totals an expense list",
+          hashtags: ["expenses", "money"],
+          importHint: 'import X from "cf:pattern:pat-expenses"',
+          ownerDid: "did:key:zOwner",
+          createdAt: "2026-08-01T00:00:00.000Z",
+          argumentType: "{\n  amounts: number[]\n}",
+          resultType: "{\n  total: number\n}",
+        },
+      }]);
+      expect(engine.getRunState().patternRefs).toEqual(refs);
+    });
+
+    it("returns the recorded references on a second call without reading the index again", async () => {
+      const index = stubIndex();
+      const engine = new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        patternRefs: [{ patternId: "pat-expenses" }],
+        patternIndexClientFactory: () => Promise.resolve(index.client),
+      });
+
+      const established = await engine.establishPatternRefs();
+      const again = await engine.establishPatternRefs();
+
+      expect(again).toEqual(established);
+      expect(index.calls).toEqual(["getPattern"]);
+    });
+
+    it("returns no references for a run that attached none, leaving run state without a record", async () => {
+      const index = stubIndex();
+      const engine = new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        patternIndexClientFactory: () => Promise.resolve(index.client),
+      });
+
+      expect(await engine.establishPatternRefs()).toEqual([]);
+      expect(engine.getRunState().patternRefs).toBeUndefined();
+      expect(index.calls).toEqual([]);
+    });
+
+    it("throws naming the index a run configured with references and none has to have, recording nothing", async () => {
+      const engine = new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        patternRefs: [{ patternId: "pat-expenses" }],
+      });
+
+      await expect(engine.establishPatternRefs()).rejects.toThrow(
+        "patternRefs requires a pattern index",
+      );
+      expect(engine.getRunState().patternRefs).toBeUndefined();
+    });
+
+    it("throws naming an attached id the index does not hold, recording nothing", async () => {
+      const index = stubIndex();
+      const engine = new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        patternRefs: [{ patternId: "pat-nothing" }],
+        patternIndexClientFactory: () => Promise.resolve(index.client),
+      });
+
+      await expect(engine.establishPatternRefs()).rejects.toThrow(
+        "`pat-nothing` is not in the pattern index",
+      );
+      expect(engine.getRunState().patternRefs).toBeUndefined();
+    });
+  });
+});

--- a/packages/cf-harness/test/interactive-chat-session-context.test.ts
+++ b/packages/cf-harness/test/interactive-chat-session-context.test.ts
@@ -2,8 +2,9 @@
  * What an interactive turn opens with.
  *
  * A turn is its own run with its own handle table, so the references that run
- * holds — the well-known grants of its space, the input cells the request
- * attached — have to be established and announced per turn. Without that a
+ * holds — the well-known grants of its space, the input cells and published
+ * patterns the request attached — have to be established and announced per
+ * turn. Without that a
  * console session had a fabric session it could not explore and no way to be
  * handed a cell at all, which is what these tests are about.
  */
@@ -15,6 +16,10 @@ import {
   HARNESS_CHAT_REQUEST_TYPE,
 } from "../src/contracts/interactive-chat.ts";
 import type { HarnessInputCellSpec } from "../src/contracts/input-cells.ts";
+import type {
+  HarnessPatternRef,
+  HarnessPatternRefSpec,
+} from "../src/contracts/pattern-refs.ts";
 import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
 import type { CfHarnessEngine } from "../src/engine.ts";
 import {
@@ -33,7 +38,11 @@ import type {
  * tokens is `engine.test.ts`'s.
  */
 const stubEngine = (
-  established: { inputCells: readonly HarnessInputCellSpec[] },
+  established: {
+    inputCells: readonly HarnessInputCellSpec[];
+    patternRefs?: readonly HarnessPatternRef[];
+    unknownPatternId?: string;
+  },
 ): CfHarnessEngine =>
   ({
     config: { fabricSession: { space: "context-space" } },
@@ -50,6 +59,14 @@ const stubEngine = (
           token: `cfh:a:cell${index}`,
         })),
       ),
+    establishPatternRefs: () =>
+      established.unknownPatternId === undefined
+        ? Promise.resolve(established.patternRefs ?? [])
+        : Promise.reject(
+          new Error(
+            `patternRefs \`${established.unknownPatternId}\` is not in the pattern index`,
+          ),
+        ),
   }) as unknown as CfHarnessEngine;
 
 const recordingLoop = (
@@ -77,6 +94,7 @@ const runTurn = async (
   turnId: string,
   text: string,
   inputCells?: readonly HarnessInputCellSpec[],
+  patternRefs?: readonly HarnessPatternRefSpec[],
 ): Promise<void> => {
   await service.handleRequest({
     type: HARNESS_CHAT_REQUEST_TYPE,
@@ -88,6 +106,7 @@ const runTurn = async (
       turnId,
       input: { text },
       ...(inputCells !== undefined ? { inputCells } : {}),
+      ...(patternRefs !== undefined ? { patternRefs } : {}),
     },
   });
   await service.waitForTurn("session-1", turnId);
@@ -95,7 +114,11 @@ const runTurn = async (
 
 const startedService = async (
   seen: HarnessTranscriptMessage[][],
-  established: { inputCells: readonly HarnessInputCellSpec[] },
+  established: {
+    inputCells: readonly HarnessInputCellSpec[];
+    patternRefs?: readonly HarnessPatternRef[];
+    unknownPatternId?: string;
+  },
 ): Promise<HarnessInteractiveChatService> => {
   const service = new HarnessInteractiveChatService({
     basePromptLoopOptions: { engine: stubEngine(established) },
@@ -217,5 +240,54 @@ describe("interactive chat session context", () => {
       { name: "itinerary", ref: "/of:fid1:x/days" },
     ]);
     expect(options[1]).toBeUndefined();
+  });
+
+  it("announces the patterns the request attached, with the specifier that composes each", async () => {
+    const seen: HarnessTranscriptMessage[][] = [];
+    const service = await startedService(seen, {
+      inputCells: [],
+      patternRefs: [{
+        patternId: "pat-expenses",
+        record: {
+          patternId: "pat-expenses",
+          description: "Totals an expense list",
+          hashtags: ["expenses"],
+          importHint: 'import X from "cf:pattern:pat-expenses"',
+        },
+      }],
+    });
+
+    await runTurn(service, "turn-1", "total my spending", undefined, [
+      { patternId: "pat-expenses" },
+    ]);
+
+    const announced = seen[0].find((message) =>
+      message.content.includes("pat-expenses")
+    );
+    expect(announced?.content).toContain("Totals an expense list");
+    expect(announced?.content).toContain(
+      'import X from "cf:pattern:pat-expenses"',
+    );
+  });
+
+  it("fails a turn whose attached pattern the index does not hold, before a model turn", async () => {
+    const seen: HarnessTranscriptMessage[][] = [];
+    const service = await startedService(seen, {
+      inputCells: [],
+      unknownPatternId: "pat-nothing",
+    });
+
+    await runTurn(service, "turn-1", "total my spending", undefined, [
+      { patternId: "pat-nothing" },
+    ]);
+
+    const failure = service.events("session-1").map((envelope) =>
+      envelope.event
+    )
+      .find((event) => event.kind === "turn_failed");
+    expect(JSON.stringify(failure)).toContain("pat-nothing");
+    // The reference is what the caller attached, so a turn that cannot have
+    // it does not run without it.
+    expect(seen).toEqual([]);
   });
 });

--- a/packages/cf-harness/test/pattern-refs.test.ts
+++ b/packages/cf-harness/test/pattern-refs.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The task pattern-reference seams: the id grammar, resolving an id against
+ * the index into the record a run seeds as a searched hit, and the
+ * announcement text — which reports what a pattern is for and how to name it,
+ * and never its source.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+
+import type { HarnessFetch } from "../src/contracts/http-fetch.ts";
+import { PatternIndexClient } from "../src/pattern-index/client.ts";
+import {
+  checkPatternRefSpec,
+  patternRefsContextMessage,
+  resolvePatternRefs,
+} from "../src/pattern-refs.ts";
+
+const signer = await Identity.fromPassphrase("cf-harness task pattern refs");
+
+const PATTERN_RECORD = {
+  patternId: "pat-expenses",
+  ownerDid: "did:key:zOwner",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  description: "Totals an expense list",
+  hashtags: ["expenses", "money"],
+  dependencies: [],
+  argumentSchema: {
+    type: "object",
+    properties: { amounts: { type: "array", items: { type: "number" } } },
+    required: ["amounts"],
+  },
+  resultSchema: {
+    type: "object",
+    properties: { total: { type: "number" } },
+    required: ["total"],
+  },
+  program: { main: "/main.tsx", files: [] },
+};
+
+/** An index answering `getPattern` for one id and 404 for every other. */
+const stubIndex = (): { client: PatternIndexClient; calls: string[] } => {
+  const calls: string[] = [];
+  const fetchFn: HarnessFetch = async (input, init) => {
+    calls.push(String(input).split("/").pop() ?? "");
+    const body = JSON.parse(String(init?.body)) as { patternId?: string };
+    return await Promise.resolve(
+      body.patternId === PATTERN_RECORD.patternId
+        ? new Response(JSON.stringify(PATTERN_RECORD), { status: 200 })
+        : new Response(JSON.stringify({ error: "no such pattern" }), {
+          status: 404,
+        }),
+    );
+  };
+  return {
+    client: new PatternIndexClient({
+      baseUrl: "https://index.test",
+      fetchFn,
+      signer,
+    }),
+    calls,
+  };
+};
+
+describe("pattern-refs", () => {
+  describe("checkPatternRefSpec()", () => {
+    it("returns for an id in the index's own grammar", () => {
+      expect(checkPatternRefSpec({ patternId: "pat_Expenses-1" }))
+        .toBeUndefined();
+    });
+
+    it("throws for a value carrying characters an id cannot", () => {
+      expect(() => checkPatternRefSpec({ patternId: "for a dice roller" }))
+        .toThrow("patternId must match");
+    });
+
+    it("throws for an empty value", () => {
+      expect(() => checkPatternRefSpec({ patternId: "" })).toThrow(
+        "patternId must match",
+      );
+    });
+  });
+
+  describe("resolvePatternRefs()", () => {
+    it("returns the index's record for an id it holds, with the specifier that composes it", async () => {
+      const index = stubIndex();
+
+      const refs = await resolvePatternRefs(index.client, [
+        { patternId: "pat-expenses" },
+      ]);
+
+      expect(refs).toEqual([{
+        patternId: "pat-expenses",
+        record: {
+          patternId: "pat-expenses",
+          description: "Totals an expense list",
+          hashtags: ["expenses", "money"],
+          importHint: 'import X from "cf:pattern:pat-expenses"',
+          ownerDid: "did:key:zOwner",
+          createdAt: "2026-08-01T00:00:00.000Z",
+          argumentType: "{\n  amounts: number[]\n}",
+          resultType: "{\n  total: number\n}",
+        },
+      }]);
+      expect(index.calls).toEqual(["getPattern"]);
+    });
+
+    it("throws naming the id the index does not hold", async () => {
+      const index = stubIndex();
+
+      await expect(
+        resolvePatternRefs(index.client, [{ patternId: "pat-nothing" }]),
+      ).rejects.toThrow("`pat-nothing` is not in the pattern index");
+    });
+
+    it("throws naming an id given twice", async () => {
+      const index = stubIndex();
+
+      await expect(
+        resolvePatternRefs(index.client, [
+          { patternId: "pat-expenses" },
+          { patternId: "pat-expenses" },
+        ]),
+      ).rejects.toThrow("names `pat-expenses` twice");
+    });
+
+    it("throws before any read for a value that is not an id", async () => {
+      const index = stubIndex();
+
+      await expect(
+        resolvePatternRefs(index.client, [{ patternId: "pat expenses" }]),
+      ).rejects.toThrow("patternId must match");
+      expect(index.calls).toEqual([]);
+    });
+  });
+
+  describe("patternRefsContextMessage()", () => {
+    it("returns `undefined` for no references at all", () => {
+      expect(patternRefsContextMessage([])).toBeUndefined();
+    });
+
+    it("reports each pattern's description, specifier, and declared shapes", async () => {
+      const index = stubIndex();
+      const refs = await resolvePatternRefs(index.client, [
+        { patternId: "pat-expenses" },
+      ]);
+
+      const message = patternRefsContextMessage(refs)!;
+
+      expect(message).toContain("Pattern 1: pat-expenses");
+      expect(message).toContain("Totals an expense list");
+      expect(message).toContain('import X from "cf:pattern:pat-expenses"');
+      expect(message).toContain("amounts: number[]");
+      expect(message).toContain("total: number");
+      // An attachment says which published source, not that it is any good.
+      expect(message).toContain("nothing about whether it works");
+    });
+  });
+});

--- a/packages/cf-harness/test/pattern-refs.test.ts
+++ b/packages/cf-harness/test/pattern-refs.test.ts
@@ -14,6 +14,7 @@ import type { HarnessFetch } from "../src/contracts/http-fetch.ts";
 import { PatternIndexClient } from "../src/pattern-index/client.ts";
 import {
   checkPatternRefSpec,
+  MAX_HARNESS_PATTERN_REFS,
   patternRefsContextMessage,
   resolvePatternRefs,
 } from "../src/pattern-refs.ts";
@@ -52,6 +53,29 @@ const stubIndex = (): { client: PatternIndexClient; calls: string[] } => {
         : new Response(JSON.stringify({ error: "no such pattern" }), {
           status: 404,
         }),
+    );
+  };
+  return {
+    client: new PatternIndexClient({
+      baseUrl: "https://index.test",
+      fetchFn,
+      signer,
+    }),
+    calls,
+  };
+};
+
+/** An index holding every well-formed id, for counting rather than matching. */
+const answeringIndex = (): { client: PatternIndexClient; calls: string[] } => {
+  const calls: string[] = [];
+  const fetchFn: HarnessFetch = (input, init) => {
+    calls.push(String(input).split("/").pop() ?? "");
+    const body = JSON.parse(String(init?.body)) as { patternId?: string };
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({ ...PATTERN_RECORD, patternId: body.patternId }),
+        { status: 200 },
+      ),
     );
   };
   return {
@@ -124,6 +148,48 @@ describe("pattern-refs", () => {
           { patternId: "pat-expenses" },
         ]),
       ).rejects.toThrow("names `pat-expenses` twice");
+    });
+
+    it("throws stating the bound, before any read, for more references than a task may attach", async () => {
+      // The bound is held here and not only at the surface a caller wrote to,
+      // so a library caller reaching this resolution meets the same refusal.
+      const index = stubIndex();
+
+      await expect(
+        resolvePatternRefs(
+          index.client,
+          Array.from(
+            { length: MAX_HARNESS_PATTERN_REFS + 1 },
+            (_unused, position) => ({ patternId: `pat-${position}` }),
+          ),
+        ),
+      ).rejects.toThrow(
+        `takes at most ${MAX_HARNESS_PATTERN_REFS} references, got ${
+          MAX_HARNESS_PATTERN_REFS + 1
+        }`,
+      );
+      expect(index.calls).toEqual([]);
+    });
+
+    it("resolves as many references as the bound allows", async () => {
+      // The refusal above is one reference over the bound, so this states
+      // where the bound actually falls rather than leaving it either side.
+      const index = answeringIndex();
+
+      const refs = await resolvePatternRefs(
+        index.client,
+        Array.from(
+          { length: MAX_HARNESS_PATTERN_REFS },
+          (_unused, position) => ({ patternId: `pat-${position}` }),
+        ),
+      );
+
+      expect(refs.map((ref) => ref.patternId)).toEqual(
+        Array.from(
+          { length: MAX_HARNESS_PATTERN_REFS },
+          (_unused, position) => `pat-${position}`,
+        ),
+      );
     });
 
     it("throws before any read for a value that is not an id", async () => {

--- a/packages/cf-harness/test/prompt-loop-pattern-refs.test.ts
+++ b/packages/cf-harness/test/prompt-loop-pattern-refs.test.ts
@@ -1,6 +1,8 @@
 /**
  * A parent's selected pattern references cross delegation from the trusted
- * search record, not from model-retyped metadata or a delegation-time fetch.
+ * record, not from model-retyped metadata or a delegation-time fetch. The
+ * record is one the parent searched for, or one the task attached by id and
+ * the run resolved before its first model turn.
  */
 
 import { describe, it } from "@std/testing/bdd";
@@ -338,6 +340,77 @@ const runResumedDelegation = async (
   };
 };
 
+/** Runs one delegation over the patterns the task attached, with no search. */
+const runAttachedDelegation = async (): Promise<
+  DelegationFixture & { recorded: readonly string[] }
+> => {
+  const index = stubIndex();
+  const modelRequests: unknown[] = [];
+  const modelTurns = [
+    toolCallTurn("call-delegate", "delegate_task", {
+      goal: "Use the attached pattern to plan the focused task.",
+      patternRefs: [{ patternId: SEARCH_HIT.patternId }],
+    }),
+    assistantTurn("Child completed the focused task."),
+    assistantTurn("Parent received the delegation result."),
+  ];
+  const fetchFn: typeof fetch = (_input, init) => {
+    modelRequests.push(JSON.parse(String(init?.body)));
+    const turn = modelTurns[modelRequests.length - 1];
+    if (turn === undefined) {
+      throw new Error("scripted model ran out of turns");
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(responsesBodyFromChatFixture(turn)), {
+        status: 200,
+      }),
+    );
+  };
+  const engine = new CfHarnessEngine({
+    sandboxRuntime: new FakeSandboxRuntime(),
+    runId: `run-attached-pattern-refs-${crypto.randomUUID()}`,
+    model: "gpt-5.4",
+    cfcEnforcementMode: "disabled",
+    patternRefs: [{ patternId: SEARCH_HIT.patternId }],
+    patternIndexClientFactory: () =>
+      Promise.resolve(
+        new PatternIndexClient({
+          baseUrl: "https://index.test",
+          fetchFn: index.fetchFn,
+          signer,
+        }),
+      ),
+  });
+  // What the session context does before a turn's first model turn.
+  await engine.establishPatternRefs();
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine,
+    allowedToolIds: ["search_patterns", "delegate_task"],
+    allowedSubagentProfiles: ["default"],
+    fetchFn,
+  });
+
+  const result = await loop.runPrompt({ prompt: "Delegate over it." });
+  const delegateMessage = result.transcript.find((message) =>
+    message.role === "tool" && message.toolName === "delegate_task"
+  );
+  if (delegateMessage?.role !== "tool") {
+    throw new Error("expected a `delegate_task` tool result");
+  }
+  const childRequest = modelRequests[1] === undefined
+    ? undefined
+    : chatViewOfRequest(modelRequests[1]);
+
+  return {
+    childPrompt: childRequest?.messages.at(-1)?.content ?? "",
+    indexCalls: index.calls,
+    delegateOutput: JSON.parse(delegateMessage.content),
+    subagentRuns: result.runState.subagentRuns?.length ?? 0,
+    recorded: (result.runState.patternRefs ?? []).map((ref) => ref.patternId),
+  };
+};
+
 describe("prompt-loop pattern references", () => {
   it("rehydrates a selected hit into neutral child context", async () => {
     const result = await runDelegation([{
@@ -418,5 +491,22 @@ Use this as available evidence; do not assume it is mandatory.`,
     expect(result.childPrompt).toContain(SEARCH_HIT.patternId);
     expect(result.delegateOutput.patternRefRefusals).toBeUndefined();
     expect(result.indexCalls).toEqual(["searchPatterns", "getPattern"]);
+  });
+
+  it("rehydrates a pattern the task attached, which no turn searched for", async () => {
+    const result = await runAttachedDelegation();
+
+    expect(result.subagentRuns).toBe(1);
+    expect(result.childPrompt).toContain(SEARCH_HIT.patternId);
+    expect(result.childPrompt).toContain(PATTERN_RECORD.description);
+    expect(result.delegateOutput.patternRefRefusals).toBeUndefined();
+    // The one read is the attachment's own, made before the first model turn.
+    expect(result.indexCalls).toEqual(["getPattern"]);
+  });
+
+  it("records the patterns the task attached in the run's own state", async () => {
+    const result = await runAttachedDelegation();
+
+    expect(result.recorded).toEqual([SEARCH_HIT.patternId]);
   });
 });


### PR DESCRIPTION
Closes CT-2265.

`POST /api/task` accepts `patternRefs: [{ patternId }]` beside `inputCells`. A pattern id is the same kind of thing as an input cell — the caller attaches it, the run resolves it before its first model turn, and a turn that cannot have what was attached does not run without it.

## The request

```json
{
  "text": "use DWl3kXPQ… for a dice roller app",
  "patternRefs": [{ "patternId": "DWl3kXPQ…" }]
}
```

## What happens

- **Grammar first.** An id is the content-addressed identity of published source, so a value outside that grammar is a 400 before any turn starts, the way a bad `ref` is. So are more than eight references, and the same id twice.
- **Then resolution.** The run reads each id through the index's `getPattern` and seeds the result as a searched hit, so `run_pattern`'s `patternId`, a `cf:pattern:` import, and `delegate_task`'s `patternRefs` name the pattern with no `search_patterns` call. An id the index does not hold fails the turn, naming the id — never the source.
- **Model-facing.** One context message beside the input-cell announcement, in the terms a search hit is reported in: what each pattern is for, the specifier that composes it, the declared shapes, and how to name it. No new tool.
- **Provenance, not endorsement.** The seeded record is what the index answered for the id — description, hashtags, owner DID, creation time, declared shapes — and attaching one grants what a search hit grants: compose this source by identifier.

## The one shape change worth reading

The trusted record a run holds for a pattern is now `TrustedPatternRecord`, which a `search_patterns` hit satisfies unchanged. A **by-id read answers no ranking evidence** — the index computes `kind`, `quality` and the match counts over a *query*, and `getPattern` returns none of them — so those fields are optional on the record and the delegation's child context prints them only where the record carries them. Nothing invents a tier. The attachment is seeded before the transcript's own hits, so a search the same run made refines it rather than being overwritten.

## Tests

- `test/pattern-refs.test.ts` — the grammar, the by-id resolve, the unknown id naming itself, the duplicate, the bound, and the announcement text.
- `test/console/server.test.ts` — the route forwards the reference to the run, and five 400s (non-id, not a list, no `patternId`, twice, over the bound); an explicit `null` for `patternRefs` reads as absence, the same as `inputCells`.
- `test/interactive-chat-session-context.test.ts` — the turn announces attached patterns, and a turn whose id the index does not hold fails **before any model turn** (the recording loop never ran).
- `test/prompt-loop-pattern-refs.test.ts` — a `delegate_task` `patternRefs` selection resolves from the attachment with `getPattern` as the run's only index call, and the run state records the attachment.

Each new test was checked to fail without the change it guards.

## Documentation

Console README (the field, the refusal rule, the index requirement), `docs/CURRENT_STATE.md` (both pattern-reference bullets), and the system map's README under "Since the snapshot" — the map's `/api/task` edge label is a stamped snapshot claim, and its own procedure is to record drift there rather than half-update a drawing whose `SNAPSHOT` still names an older commit. `IMPLEMENTATION_PROFILE.md` describes no console route and is untouched.

## Gates

`deno fmt --check` (no new offenders), `deno lint`, `deno task check`, `deno task test` in `packages/cf-harness` (1005 passed, 0 failed), `check-docs`, `check-command-docs`, `check-skill-facts`, `check-no-waitfor`, `check-docs-history-index`.

Weaver side: commontoolsinc/commonfabric-weaver#236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->