### PR TITLE
feat(shuttle): an event loop, `ctrl-c`, and a line above the prompt

### DIFF
--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -256,14 +256,14 @@ Landed:
   in reach.
 
 - **B1c — the prompt, `where`, and the launcher.** A line read off a terminal,
-  handed to the dispatch above, and its outcome written under it. Where a run's
-  output comes from is one place: a verb returns what it did rather than
-  writing it, so everything a line puts on screen passes through the prompt in
-  the order the person caused it, and a case drives the whole loop with a
-  scripted key stream and reads back what it produced. A refusal and a read
-  that failed both land there as text and the loop reads the next line — what
-  the seam's distinction buys here is that a shell whose server went away is
-  still a shell.
+  handed to the dispatch above, and its outcome written where B1f put it.
+  Where a run's output comes from is one place: a verb returns what it did
+  rather than writing it, so everything a line puts on screen passes through
+  the prompt in the order the person caused it, and a case drives the whole
+  loop with a scripted key stream and reads back what it produced. A refusal
+  and a read that failed both land there as text and the loop reads the next
+  line — what the seam's distinction buys here is that a shell whose server
+  went away is still a shell.
 
   The line editor is the view substrate's rather than `node:readline`'s.
   `EditBuffer` holds the motions and `decodeKeys` supplies the key stream a
@@ -395,6 +395,58 @@ Landed:
   operand points, so neither hands back a pending move: a `cd` waits because
   the prompt would go on promising the place, and a read of a cell that is
   not there fails on its own account and in its own words.
+
+- **B1f — the prompt is an event loop, and the out-of-band line.** The keys
+  are read continuously and a running line is a task beside them, so a line
+  waiting on a server holds up neither the keyboard nor the screen. `ctrl-c`
+  reaches a line in flight: an `AbortSignal` rides the deps bag the verbs
+  already read their collaborators through, checked at each boundary between
+  a verb's phases. The rule is that **every read has a check in front of it
+  with nothing awaited in between**, and so does every adoption — an await
+  between the two is a window the cancel lands in and the read goes out of
+  anyway, which is why the settle asks the holder for its connection once and
+  hands it down. What holds the rule is not the enumeration but a case that
+  cancels from inside every read there is, and at each line's first
+  suspension, and asserts nothing was read afterwards; a boundary nobody
+  enumerated fails that too. What a check cannot reach is a read already sent, whose
+  answer is dropped rather than called off; the prompt abandons the line and
+  says so, which is the interruption it can actually deliver.
+
+  A key typed under a running line is drawn as it arrives, into the line that
+  runs next. The two keys that end a line — `enter`, and `ctrl-d` on an empty
+  one — are held instead, along with every key after them, and replayed the
+  moment the prompt is free, so a pasted script runs line by line and each
+  line runs against the place the one before it settled on. Nothing is
+  discarded and nothing runs unseen, which is what B2's `set` and `call` need
+  from a queue that today can only navigate and read.
+
+  `PromptTerminal` gains its third write, the out-of-band line: text above the
+  line being edited, with the prompt drawn again beneath it. A line's own
+  outcome lands through it, because by the time a line settles the person may
+  have gone on typing; decision 28's event lines and A4's `announce` land
+  through the same one when they arrive. It is a door that carries a user
+  program's own strings, so it holds every character a terminal acts on to the
+  glyph naming it — `escapeControlCharacters` exactly, a line feed excepted
+  and let through as a row — at the door in `paint.ts` rather than at each
+  producer, where one of them would be the one that forgot.
+
+  The producers finding 8 names are routed there: `loadPieces` takes a
+  `ConnectionOutput` carrying the sink for what a connection writes for itself
+  and the runtime's `consoleHandler`, and shuttle opens its connection with
+  both aimed at that line. The console it hands the runtime is a proxy rather
+  than a console, and for a reason the enumeration would have missed: a real
+  one raises a *process warning* for a timer or count label it does not hold,
+  which goes to the process's stderr whatever console the call was made on,
+  carrying a label a pattern chose — an escape sequence among the labels it
+  may choose. A proxy answers every property with a function of shuttle's
+  own, so there is no method, named in `ConsoleMethod` or not, that reaches
+  anything but the announce line; the label state those methods read is held
+  beside it, and an ask it cannot answer becomes a line. Item 5's `lib/piece.ts` sweep is finished for every
+  site a v1 verb can reach — the navigate callback's three lines,
+  `withRuntimeCleanupOnFailure`'s two, and `loadPieceForCallables`' bootstrap
+  warning, which no v1 verb reaches yet and which B2's `call` will. The
+  terminal opens before the connection now, since the terminal is where the
+  connection's writing has to land.
 
 Still to come:
 

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -313,22 +313,28 @@ Each of these is small and lands on its own; together they are what decision
 
    The second is **lib-internal warnings no seam reaches**, all in
    `lib/piece.ts`, and the sweep is of every `console.*` there rather
-   than the error ones alone:
+   than the error ones alone. Each site below takes a `report` sink from
+   its caller and keeps the stream it had where a caller names none;
+   `loadPieces` takes a `ConnectionOutput` carrying that sink beside the
+   runtime's `consoleHandler`, which a caller now sets whether or not it
+   asked for JSON:
 
-   - `loadPieceForCallables` warns on `console.warn` when it cannot
-     ensure the default pattern. `call` reaches it through
-     `resolvePieceCallable`, `verbs` through `listPieceCallables`, and
-     `describe` through `describePiece` — three v1 verbs, and the last of
-     them a seam that takes `render`/`hint` and cannot route this.
-   - `withRuntimeCleanupOnFailure` warns twice on `console.warn` when
-     disposal itself fails after a failed connect, and `loadPieces` wraps
-     its whole body in it, so any v1 verb can reach both.
-   - The navigate callback inside `loadPieces` writes three lines, and
-     one of them goes to **`console.log` — raw stdout** — whenever
-     `jsonOutput` is false, which is every `cf piece call` without `--json`.
-     Behind a full-screen frame that corrupts the drawing, and it lands
-     in the machine surface besides. It is the one on this list to fix
-     first.
+   - `loadPieceForCallables` warns when it cannot ensure the default
+     pattern, through `PieceCallableDependencies.report`. `call` reaches
+     it through `resolvePieceCallable`, `verbs` through
+     `listPieceCallables`, and `describe` through `describePiece` — three
+     v1 verbs, none of them built yet, so nothing supplies that sink
+     until B2 does.
+   - `withRuntimeCleanupOnFailure` warns twice when disposal itself fails
+     after a failed connect, through its third parameter, and
+     `loadPieces` wraps its whole body in it and forwards the output's
+     sink — so any v1 verb reaches both, and a shell holding a prompt
+     gets them on its out-of-band line.
+   - The navigate callback inside `loadPieces` writes three lines, one of
+     them to raw stdout whenever `jsonOutput` is false. All three take
+     the output's sink, and keep their streams — the designed line on
+     stdout as prose, the two failure reports on stderr — where there is
+     none.
 
    The rest of that file is off a v1 verb's path: the pin-rewrite report
    belongs to `piece new` and to `setsrc` either side of `--check`, the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -153,6 +153,22 @@ an operand is quoted where it has to be. Every refusal carries its reason. A
 read that failed is different: it is reported and the prompt reads the next
 line, since a shell whose server went away is still a shell.
 
+The keys are read while a line is running, so a slow server holds up neither the
+keyboard nor the screen. What you type during the wait is drawn as you type it,
+into the line that will run next; `enter` under a running line is held and runs
+that line the moment the prompt is free, against the place the line before it
+settled on. `ctrl-c` cancels the line in flight and drops what was typed ahead
+of it. Cancelling reaches the line and not the server: a read already sent
+finishes into nothing, and the checks along the way are what stop it taking
+effect, so a `cd` you cancelled leaves you where you were.
+
+Everything a run writes lands above the line being edited, with the prompt drawn
+again beneath it — a line's own outcome, the warnings a connection writes for
+itself, and a pattern's `console.log` once a piece runs in the session. That one
+door holds every character a terminal acts on to the glyph naming it, a line
+break excepted, so nothing a user program logged can move the cursor off the row
+it was given.
+
 After the split, a token opening with `-` is an option up to a bare `--`, and
 every other token is an operand. `-` on its own stays an operand, being the
 previous place and the stdin sentinel, and a bare `--` ends the options, so a
@@ -167,16 +183,18 @@ Emacs keys: `ctrl-a`/`ctrl-e` and `home`/`end` for the ends of the line,
 `backspace` and `delete`/`ctrl-d` to delete, `ctrl-w`/`alt-backspace` and
 `alt-d` to kill a word, `ctrl-k` and `ctrl-u` to kill to the end of the line and
 to kill the line, `ctrl-y`/`alt-y` to yank and cycle, `ctrl-c` to abandon the
-line, and `ctrl-d` on an empty line to end the session.
+line or cancel the one in flight, and `ctrl-d` on an empty line to end the
+session.
 
 The code is `lib/shuttle/`: `run.ts` composes a session, `place.ts` holds the
 place and what `cd` refuses, `connection.ts` the one `PiecesController` a
 process holds, `line.ts` the split and the printing that inverts it,
 `options.ts` the option grammar over the tokens after a verb, `listing.ts` what
 `ls` reads, `verbs.ts` the dispatch — which writes nothing — `help.ts` the form
-a verb's account of itself prints in, `prompt.ts` the loop that writes,
-`record.ts` the form `where` and `pwd` share, and `paint.ts` and `terminal.ts`
-the escape sequences and the raw mode under it.
+a verb's account of itself prints in, `prompt.ts` the loop that reads keys and
+runs a line beside them, `announce.ts` what a connection and a pattern write
+onto that loop's out-of-band line, `record.ts` the form `where` and `pwd` share,
+and `paint.ts` and `terminal.ts` the escape sequences and the raw mode under it.
 
 ## Cell references
 

--- a/packages/cli/lib/deps.ts
+++ b/packages/cli/lib/deps.ts
@@ -7,3 +7,4 @@ export {
   readSync,
 } from "node:fs";
 export { Writable } from "node:stream";
+export { format, inspect } from "node:util";

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -38,6 +38,7 @@ import {
 } from "@commonfabric/piece/ops";
 import {
   Cell,
+  type ConsoleHandler,
   decomposeSchema,
   deepEqual,
   encodeJsonPointer,
@@ -395,6 +396,14 @@ export interface ResolvedPieceCallable extends CallableResolution {
 export interface PieceCallableDependencies extends CallableExecutionDeps {
   helpCommandPrefix?: string;
 
+  /**
+   * Takes the warning a bootstrap that would not run writes, which is
+   * `console.warn` where a caller names none. It is the same sink
+   * `ConnectionOutput.report` is, for the same reason: a caller drawing its
+   * own screen is corrupted by a line written behind the frame.
+   */
+  report?: (message: string) => void;
+
   loadPieces?: (config: SpaceConfig) => Promise<any>;
   loadPiece?: (
     pieces: any,
@@ -477,9 +486,19 @@ function storageManagerCloseNow(
   return undefined;
 }
 
+/**
+ * Runs `run` over `runtime`, disposing the runtime where it failed and
+ * returning what it returned otherwise.
+ *
+ * Both warnings go to `report`, which is `console.warn` where a caller names
+ * none. A caller drawing its own screen supplies one: a line written behind
+ * the frame corrupts the drawing, and these two are written from inside a
+ * connect that such a caller is holding open.
+ */
 export async function withRuntimeCleanupOnFailure<T>(
   runtime: DisposableRuntime,
   run: () => Promise<T>,
+  report: (message: string) => void = (message) => console.warn(message),
 ): Promise<T> {
   try {
     return await run();
@@ -487,7 +506,7 @@ export async function withRuntimeCleanupOnFailure<T>(
     const closeNow = storageManagerCloseNow(runtime.storageManager);
     if (closeNow) {
       await closeNow().catch((disposeError) => {
-        console.warn(
+        report(
           `loadPieces storage cleanup failed: ${
             disposeError instanceof Error
               ? disposeError.message
@@ -498,7 +517,7 @@ export async function withRuntimeCleanupOnFailure<T>(
     }
     await runtime.dispose().catch(
       (disposeError) => {
-        console.warn(
+        report(
           `loadPieces cleanup failed: ${
             disposeError instanceof Error
               ? disposeError.message
@@ -521,6 +540,31 @@ async function makeSession(config: SpaceConfig): Promise<Session> {
 }
 
 /**
+ * Where a connection sends what it writes while it is open, for a caller that
+ * owns the screen it would otherwise be written on.
+ *
+ * A one-shot command owns its terminal for one invocation and is served by
+ * the process's own streams, which is what both fields default to. A caller
+ * drawing a frame — a shell holding a prompt, a full-screen view — is
+ * corrupted by any line written behind it, so it takes these instead and
+ * places what arrives.
+ */
+export interface ConnectionOutput {
+  /**
+   * Takes each line the connection writes for itself: the navigate callback's
+   * three, and the two warnings a failed connect's own cleanup writes.
+   */
+  readonly report?: (message: string) => void;
+
+  /**
+   * Takes what a pattern running on this connection writes to its console.
+   * Where a caller names none, the machine surface is protected under
+   * `jsonOutput` and the process's console serves everything else.
+   */
+  readonly consoleHandler?: ConsoleHandler;
+}
+
+/**
  * Opens a connection to the deployment at `config.apiUrl` and returns the
  * controller over it: a space session, a runtime carrying that deployment's
  * experimental options, and a server proven live before it returns.
@@ -532,9 +576,23 @@ async function makeSession(config: SpaceConfig): Promise<Session> {
  */
 export async function loadPieces(
   config: SpaceConfig,
+  output: ConnectionOutput = {},
 ): Promise<PiecesController> {
   claimProcessDeployment(config.apiUrl);
   setLLMUrl(config.apiUrl);
+  // The navigate callback's designed line and its two failure reports both
+  // go to the caller's sink where there is one, and keep the streams they
+  // have where there is not: the designed line is prose except under
+  // `jsonOutput`, which reserves stdout for the machine surface, and a
+  // failure to write it is not prose at all.
+  const navigateLine = output.report ??
+    ((message: string) => {
+      (config.jsonOutput ? console.error : console.log)(message);
+    });
+  const navigateFailure = output.report ??
+    ((message: string) => console.error(message));
+  const consoleHandler = output.consoleHandler ??
+    (config.jsonOutput ? stderrConsoleHandler : undefined);
   // The deployment's own flag posture, with this process's explicit
   // EXPERIMENTAL_* still winning per flag: a cf binary is installed
   // independently of the server it talks to, so left to the environment alone
@@ -590,19 +648,21 @@ export async function loadPieces(
             try {
               const id = pieceId(target);
               if (!id) {
-                console.error("navigateTo: target missing piece id");
+                navigateFailure("navigateTo: target missing piece id");
                 return;
               }
               // Emit greppable line immediately so scripts can capture without waiting
-              (config.jsonOutput ? console.error : console.log)(
-                `navigateTo new piece id ${id}`,
-              );
+              navigateLine(`navigateTo new piece id ${id}`);
             } catch (e) {
-              console.error("navigateTo callback error:", e);
+              navigateFailure(
+                `navigateTo callback error: ${
+                  e instanceof Error ? e.message : String(e)
+                }`,
+              );
             }
           },
         }),
-        ...(config.jsonOutput ? { consoleHandler: stderrConsoleHandler } : {}),
+        ...(consoleHandler === undefined ? {} : { consoleHandler }),
       }),
   );
   (runtime as Runtime & { [CF_RUNTIME_ERROR_LOG]?: CliRuntimeErrorRecord[] })[
@@ -649,7 +709,7 @@ export async function loadPieces(
     }
     throwOnSpaceAuthorizationError(runtime.storageManager, session.space);
     return pieces;
-  });
+  }, output.report);
 }
 
 export function getProgramFromFile(
@@ -2142,7 +2202,7 @@ async function loadPieceForCallables(
     try {
       await pieces.ensureDefaultPattern();
     } catch (error) {
-      console.warn(
+      (deps.report ?? ((message: string) => console.warn(message)))(
         `Warning: Could not ensure default pattern: ${
           error instanceof Error ? error.message : String(error)
         }`,

--- a/packages/cli/lib/shuttle/announce.ts
+++ b/packages/cli/lib/shuttle/announce.ts
@@ -1,0 +1,241 @@
+/**
+ * The out-of-band line's other producers: what a connection writes for itself,
+ * and what a pattern writes to its console.
+ *
+ * Neither is shuttle's own output and neither passes through a verb. A
+ * connect's cleanup warns, the navigate callback writes the line a script
+ * greps for, and a pattern calls `console.log` from inside the runtime — all
+ * of them while a prompt is painted, in raw mode, where a line written to the
+ * process's own streams lands in the middle of the drawing without the
+ * carriage return raw mode needs. So the connection is opened with these
+ * instead, and everything they take goes where a line's outcome goes
+ * (`prompt.ts`).
+ *
+ * What holds them to the class a terminal acts on is the door rather than this
+ * module: `above` (`paint.ts`) glyphs every character of that class before any
+ * of it is sent, which is what a producer authored by a user program needs and
+ * what nothing here could be trusted to remember.
+ */
+
+import type { ConsoleHandler } from "@commonfabric/runner";
+
+import { format, inspect } from "../deps.ts";
+import type { ConnectionOutput } from "../piece.ts";
+
+/** Where a line lands: the prompt's out-of-band write, or a case's record. */
+export type Announce = (text: string) => void;
+
+/**
+ * The connection output that sends everything to `announce`.
+ *
+ * One sink for all of it, because all of it is the same thing to a person
+ * reading a transcript: something happened that no line of theirs asked for.
+ * Telling a warning from a pattern's own logging is what the text says, not
+ * what the stream it arrived on says — and a shell holding one screen has one
+ * stream anyway.
+ */
+export function announcingOutput(announce: Announce): ConnectionOutput {
+  return { report: announce, consoleHandler: announcingConsole(announce) };
+}
+
+/**
+ * Helper for {@link announcingOutput}, which is the handler that sends a
+ * pattern's console output to `announce`.
+ *
+ * The console it names is a proxy rather than an object with methods on it,
+ * and that is the whole of how this module keeps its promise. The promise is
+ * that **nothing a pattern can call reaches a terminal except through
+ * `announce`**, and a promise of that shape cannot be kept by handling the
+ * methods somebody listed: the proxy answers *every* property with a function
+ * that ends in `announce`, so there is no name — in `ConsoleMethod` or
+ * outside it — that reaches anything else, and no method left over to be the
+ * one nobody thought of.
+ *
+ * A real console cannot keep it. Node's writes some of its output through a
+ * path of its own that no stream a caller supplies is on: `timeLog` and
+ * `timeEnd` on a label no timer holds, `time` on one it already holds, and
+ * `countReset` on a count that is not there each raise a *process warning*,
+ * which goes to the process's stderr whatever console the message was written
+ * to. The label is a pattern's own string, so a pattern that picked one
+ * carrying an escape sequence would have written that sequence, raw and
+ * unglyphed, straight onto the operator's terminal. Those four are the ones
+ * that do it today, and the reason for the proxy is that the list is Node's
+ * to change.
+ *
+ * So the state those methods read is held here, and an ask they cannot answer
+ * becomes a line of shuttle's own — announced, and glyphed at the door like
+ * everything else.
+ */
+function announcingConsole(announce: Announce): ConsoleHandler {
+  const saying: Saying = {
+    timers: new Map(),
+    counts: new Map(),
+    depth: 0,
+    announce,
+  };
+  const console = new Proxy({}, {
+    get: (_held, property) => (...args: unknown[]) =>
+      said(String(property), args, saying),
+  }) as unknown as Console;
+  return ({ method, args }) => ({ target: console, method, args });
+}
+
+/** What a console call needs beside its arguments to say anything. */
+interface Saying {
+  /** When each running timer was started, by the label naming it. */
+  readonly timers: Map<string, number>;
+
+  /** How far each count has got, by the label naming it. */
+  readonly counts: Map<string, number>;
+
+  /** How many groups are open, which is how far a line is indented. */
+  depth: number;
+
+  /** Where the line goes. */
+  readonly announce: Announce;
+}
+
+/**
+ * Helper for {@link said}, which announces `text` at the depth the open
+ * groups put it.
+ *
+ * The indent is this console's rather than the door's, so it is added here
+ * and not in `above` (`paint.ts`): a line shuttle writes for itself is not
+ * inside a pattern's group.
+ */
+function line(saying: Saying, text: string): void {
+  saying.announce(`${"  ".repeat(saying.depth)}${text}`);
+}
+
+/**
+ * Helper for the label-taking methods, which is the label `args` names.
+ *
+ * It is asked for by the five methods that take one and by nothing else. A
+ * console coerces its label to a string, and a coercion is a thing a value
+ * can refuse — `Object.create(null)` has no `toString` and throws rather than
+ * converting — so a method that takes no label must never reach this. What it
+ * takes instead is the formatter, which inspects such a value rather than
+ * converting it.
+ */
+function labelOf(args: unknown[]): string {
+  return args.length === 0 ? "default" : String(args[0]);
+}
+
+/**
+ * Helper for {@link announcingConsole}, which says what a call to `method`
+ * with `args` says.
+ *
+ * The formatting is `node:util`'s, which is what a console composes its own
+ * line with, so what a pattern sees is what it would have seen written
+ * anywhere else. What the arms below carry is the part formatting does not:
+ * the methods whose meaning is more than "write the arguments".
+ *
+ * The survey behind them was measured against a real console rather than
+ * remembered, and it divides that surface three ways.
+ *
+ * **Given its meaning here.** `assert` is silent when it holds and writes
+ * `Assertion failed` when it does not; `dir` inspects its first argument
+ * under the options its second gives and ignores the rest; `group` writes its
+ * heading and indents what follows, `groupEnd` un-indents; `trace` carries
+ * its `Trace:` prefix; and the five labelled methods keep the state they
+ * read. Those are the ones a caller can tell apart from `log`.
+ *
+ * **Flattened on purpose.** `table` draws a box on a real console, and what
+ * arrives here instead is the same rows as the formatter writes them — the
+ * data is the same and a table renderer is not something a shell should be
+ * carrying a second copy of. `trace`'s stack is dropped for a harder reason:
+ * the runtime hands this a method and its arguments and no call site, so
+ * there is no stack here to write. `dirxml` is not flattened at all — a
+ * console's own is `log`, which is the arm it falls to.
+ *
+ * **Refused on purpose.** `clear` empties a terminal, and a pattern emptying
+ * an operator's terminal is the harm this module exists to stop. It is
+ * answered and does nothing, which is also what a console over a stream does.
+ * `timeStamp` is a profiler mark that writes nowhere.
+ *
+ * Every other name — the rest of `ConsoleMethod`, and any name at all that is
+ * not in it — falls to the last arm and is announced. That arm is what makes
+ * the proxy's promise good: a method this function has never heard of is a
+ * line, not a way out.
+ */
+function said(method: string, args: unknown[], saying: Saying): void {
+  switch (method) {
+    case "clear":
+    case "timeStamp":
+      return;
+    case "group":
+    case "groupCollapsed":
+      if (args.length > 0) line(saying, format(...args));
+      saying.depth += 1;
+      return;
+    case "groupEnd":
+      saying.depth = Math.max(saying.depth - 1, 0);
+      return;
+    case "assert": {
+      const [held, ...rest] = args;
+      if (held) return;
+      line(
+        saying,
+        rest.length === 0
+          ? "Assertion failed"
+          : `Assertion failed: ${format(...rest)}`,
+      );
+      return;
+    }
+    case "dir":
+      line(
+        saying,
+        inspect(args[0], (args[1] ?? {}) as Parameters<typeof inspect>[1]),
+      );
+      return;
+    case "trace":
+      line(
+        saying,
+        args.length === 0 ? "Trace" : `Trace: ${format(...args)}`,
+      );
+      return;
+    case "time": {
+      // A console writes nothing for a timer it starts, so neither does this;
+      // one it cannot start is the ask it cannot answer, and that is a line.
+      const label = labelOf(args);
+      if (saying.timers.has(label)) {
+        line(saying, `A timer called \`${label}\` is already running.`);
+        return;
+      }
+      saying.timers.set(label, performance.now());
+      return;
+    }
+    case "timeLog":
+    case "timeEnd": {
+      const label = labelOf(args);
+      const started = saying.timers.get(label);
+      if (started === undefined) {
+        line(saying, `No timer called \`${label}\` is running.`);
+        return;
+      }
+      if (method === "timeEnd") saying.timers.delete(label);
+      const rest = args.slice(1);
+      line(
+        saying,
+        `${label}: ${(performance.now() - started).toFixed(3)}ms` +
+          (rest.length === 0 ? "" : ` ${format(...rest)}`),
+      );
+      return;
+    }
+    case "count": {
+      const label = labelOf(args);
+      const next = (saying.counts.get(label) ?? 0) + 1;
+      saying.counts.set(label, next);
+      line(saying, `${label}: ${next}`);
+      return;
+    }
+    case "countReset": {
+      const label = labelOf(args);
+      if (saying.counts.has(label)) saying.counts.set(label, 0);
+      else line(saying, `No count called \`${label}\` is being kept.`);
+      return;
+    }
+    default:
+      line(saying, format(...args));
+  }
+}

--- a/packages/cli/lib/shuttle/paint.ts
+++ b/packages/cli/lib/shuttle/paint.ts
@@ -1,5 +1,6 @@
 /**
- * What a terminal has to be sent to show the line being typed, and to end it.
+ * What a terminal has to be sent to show the line being typed, to end it, and
+ * to put a line above it.
  *
  * A line being edited is redrawn where it stands, so a terminal is told where
  * the last drawing put the cursor as well as what to draw. That bookkeeping is
@@ -26,6 +27,7 @@
  */
 
 import { CSI, ESC } from "../view/ansi.ts";
+import { escapeControlCharacters } from "./place.ts";
 
 /** A line as it was last drawn: what it said, where its cursor sat, how wide. */
 export interface PaintedLine {
@@ -55,9 +57,8 @@ export const NOTHING_PAINTED: PaintedLine = { text: "", column: 0, columns: 1 };
  * behind on the rows below.
  */
 export function repaint(from: PaintedLine, to: PaintedLine): string {
-  const back = Math.floor(from.column / from.columns);
   return [
-    back > 0 ? `${CSI}${back}A` : "",
+    up(Math.floor(from.column / from.columns)),
     "\r",
     `${ESC}7`,
     `${CSI}0J`,
@@ -69,33 +70,76 @@ export function repaint(from: PaintedLine, to: PaintedLine): string {
 }
 
 /**
- * Returns what to send to end `painted` and write `text` under it, at the
- * width `painted` was drawn at.
+ * Returns what to send to end `painted`, at the width it was drawn at.
  *
  * The line stays where it was drawn, so what a run leaves behind is each line
- * with what it produced under it. A terminal in raw mode moves the cursor down
- * on a line break without returning it to the left, so every break in `text`
- * is sent with the return that a terminal not in raw mode would have supplied.
+ * with whatever was written under it. Ending it is all this does: what a line
+ * produced lands through {@link above}, because between the two the person may
+ * have gone on typing and a terminal writes where its cursor is.
  */
-export function finish(painted: PaintedLine, text: string): string {
+export function finish(painted: PaintedLine): string {
   const cursorRow = Math.floor(painted.column / painted.columns);
   const lastRow = Math.floor(
     Math.max(width(painted.text) - 1, 0) / painted.columns,
   );
+  return [down(lastRow - cursorRow), up(cursorRow - lastRow), "\r\n"].join("");
+}
+
+/**
+ * Returns what to send to put `text` above `painted` and draw `painted` again
+ * beneath it, at the width it was drawn at.
+ *
+ * This is the third write, and what comes through it is not what comes through
+ * the other two. A drawn line is what a person typed, held to the class a
+ * terminal acts on as each key arrives (`prompt.ts`); a line ending carries no
+ * text at all. This one carries what a pattern wrote to its console and what
+ * the runtime warned about — strings a user program authored, which passed no
+ * door of shuttle's and were never held to anything. So the holding is here,
+ * at the door itself, where no producer can be the one that forgot:
+ * {@link escapeControlCharacters} shows every character a terminal acts on as
+ * the glyph naming it, which is the treatment a message gets everywhere else
+ * in the shell (`place.ts`).
+ *
+ * The line feed is the one character of that class this lets through, and it
+ * lets it through as a row rather than as content: what arrives here is
+ * already laid out in lines by whoever composed it, and a terminal in raw mode
+ * moves the cursor down on a break without returning it to the left, so every
+ * break is sent with the return a terminal not in raw mode would have
+ * supplied. Every other character of the class is a picture of itself, the
+ * carriage return and the escape among them, so nothing that arrives here can
+ * move the cursor off the row it was given or start a sequence.
+ */
+export function above(painted: PaintedLine, text: string): string {
   return [
-    down(lastRow - cursorRow),
-    up(cursorRow - lastRow),
+    up(Math.floor(painted.column / painted.columns)),
+    "\r",
+    `${CSI}0J`,
+    inert(text),
     "\r\n",
-    text === "" ? "" : `${text.replaceAll("\n", "\r\n")}\r\n`,
+    repaint(NOTHING_PAINTED, painted),
   ].join("");
 }
 
-/** Helper for the two above, which moves the cursor down `rows`, or nowhere. */
+/**
+ * Helper for {@link above}, which is `text` with nothing left in it that a
+ * terminal acts on, and its breaks written as a terminal in raw mode needs
+ * them.
+ *
+ * The class is walked a line at a time so that the glyphing is
+ * {@link escapeControlCharacters} exactly — one question with one answer —
+ * rather than a second predicate standing beside it that would have to be kept
+ * in step.
+ */
+function inert(text: string): string {
+  return text.split("\n").map(escapeControlCharacters).join("\r\n");
+}
+
+/** Helper for the writes above, which moves the cursor down `rows`, or nowhere. */
 function down(rows: number): string {
   return rows > 0 ? `${CSI}${rows}B` : "";
 }
 
-/** Helper for {@link finish}, which moves the cursor up `rows`, or nowhere. */
+/** Helper for the writes above, which moves the cursor up `rows`, or nowhere. */
 function up(rows: number): string {
   return rows > 0 ? `${CSI}${rows}A` : "";
 }

--- a/packages/cli/lib/shuttle/prompt.ts
+++ b/packages/cli/lib/shuttle/prompt.ts
@@ -1,6 +1,6 @@
 /**
  * The prompt: a line read off the keyboard, handed to the dispatch, and its
- * outcome written under it.
+ * outcome written above the line being typed next.
  *
  * This is where a run's output comes from. A verb returns what it did rather
  * than writing it, so everything a line puts on screen passes through here, in
@@ -8,6 +8,14 @@
  * cause and effect rather than of whatever reached the terminal first. The one
  * thing shuttle writes outside this loop is the entry's own report of a run
  * that could not start.
+ *
+ * It is an event loop rather than a read-then-run: the keys are read
+ * continuously and a running line is a task beside them, so a line that is
+ * waiting on a server holds up neither the keyboard nor the screen. Two things
+ * follow, and they are the whole reason for the shape. `ctrl-c` reaches a line
+ * that is already running, which is the only way a shell whose server has gone
+ * quiet is still a shell. And a key typed during that wait is drawn as it
+ * arrives instead of being queued unseen and run blind afterwards.
  *
  * The line editor is the view substrate's rather than `node:readline`'s.
  * `EditBuffer` (`lib/view/editbuffer.ts`) holds the motions and `decodeKeys`
@@ -34,18 +42,23 @@ import {
   holdsControlCharacter,
   messageOf,
 } from "./place.ts";
-import { runLine, type Shuttle, type VerbDeps } from "./verbs.ts";
+import { type Outcome, runLine, type Shuttle, type VerbDeps } from "./verbs.ts";
 
 /** What the prompt opens every line with, before the place it carries. */
 const PROMPT_NAME = "shuttle";
 
+/** What a line that was cancelled leaves behind it. */
+const INTERRUPTED = "Interrupted.";
+
 /**
  * Where the prompt reads its keys and writes what it has to write.
  *
- * The two writes are different acts and not one. {@link PromptTerminal.edit}
+ * The three writes are different acts and not one. {@link PromptTerminal.edit}
  * shows a line that is still being typed, and may be called any number of
- * times for one line; {@link PromptTerminal.finish} ends that line and puts
- * what it produced under it, once.
+ * times for one line; {@link PromptTerminal.finish} ends that line, once; and
+ * {@link PromptTerminal.announce} puts a line above the one being typed, which
+ * is where everything a run has to say lands, whether or not a line is in
+ * flight when it is said.
  */
 export interface PromptTerminal {
   /**
@@ -61,29 +74,59 @@ export interface PromptTerminal {
    */
   edit(text: string, column: number): void;
 
+  /** Ends the line being edited, leaving it where it was shown. */
+  finish(): void;
+
   /**
-   * Ends the line being edited, leaving it where it was shown, and writes
-   * `text` under it — nothing under it where `text` is empty.
+   * Writes `text` above the line being edited, and draws that line again
+   * beneath it.
+   *
+   * This is the out-of-band line, and it is one door with three producers: a
+   * line's own outcome, written when the line settles rather than when it was
+   * typed; the runtime's console and the warnings a connection writes for
+   * itself (`announce.ts`); and, when watches arrive, an event line per
+   * settled change. What the last two carry is a user program's own output,
+   * which passed no door of shuttle's, so an implementation holds `text` to
+   * the class a terminal acts on before any of it is sent — `above`
+   * (`paint.ts`) is where the one this package uses does it. A line feed in
+   * `text` is a row, and every other character of that class is shown as the
+   * glyph naming it.
    */
-  finish(text: string): void;
+  announce(text: string): void;
 }
 
 /**
  * Reads lines against `shuttle` until `terminal` runs out of keys, and returns
- * once it has.
+ * once it has and once the line it was running has settled.
  *
- * Every line goes to `runLine`, and what comes back is written under it: text
- * a verb composed, a value the fabric holds, or the reason a line was refused.
- * A read that failed reaches here as a throw rather than as an outcome, and is
- * written under the line the same way — the difference the seam draws is that
- * a shell whose server went away is still a shell, so this reports it and
- * reads the next line where a one-shot command would exit.
+ * Every line goes to `runLine`, and what comes back is written above the line
+ * being typed next: text a verb composed, a value the fabric holds, or the
+ * reason a line was refused. A read that failed reaches here as a throw rather
+ * than as an outcome, and is written the same way — the difference the seam
+ * draws is that a shell whose server went away is still a shell, so this
+ * reports it and reads the next line where a one-shot command would exit.
  *
- * Two keys end a line rather than editing it. `enter` runs it. `ctrl-d` on an
- * empty line ends the run, which is the end-of-input every shell spells that
- * way, and on a line with anything on it deletes forward instead. `ctrl-c`
- * abandons the line and starts a new one, so what it interrupts is the typing
- * and never the run.
+ * One line runs at a time, and the keys keep arriving while it does. Three
+ * keys mean something other than editing:
+ *
+ * - `enter` runs the line. Pressed while a line is in flight it is held,
+ *   along with every key after it, and the held keys are replayed the moment
+ *   the prompt is free — so a pasted script runs line by line, each against
+ *   the place the line before it settled on, and nothing runs against a
+ *   prompt that has already moved.
+ * - `ctrl-d` on an empty line ends the run, which is the end-of-input every
+ *   shell spells that way, and on a line with anything on it deletes forward
+ *   instead. On an empty line while a line is in flight it is held, as
+ *   `enter` is.
+ * - `ctrl-c` cancels: the line in flight, or the line being typed where none
+ *   is. It is never held, and it drops what was typed ahead of it, which is
+ *   what a terminal does with type-ahead when the interrupt arrives.
+ *
+ * Cancelling is honest about what it can reach. The line is abandoned and the
+ * prompt comes back, but a read already sent to the server is not something
+ * this can call off: it finishes into nothing, and the checks along the way
+ * are what stop it taking effect — a `cd` cancelled after its read returned
+ * does not move (`verbs.ts`).
  */
 export async function runPrompt(
   shuttle: Shuttle,
@@ -98,23 +141,144 @@ export async function runPrompt(
       codePoints(prompt) + buffer.col,
     );
   show();
-  for await (const key of terminal.keys) {
-    if (key.name === "ctrl-d" && buffer.text() === "") break;
-    if (key.name === "enter") {
-      terminal.finish(await report(buffer.text(), shuttle, deps));
+
+  const keys = terminal.keys[Symbol.asyncIterator]();
+  /** The key stream's next answer, once asked for and until it is used. */
+  let typing: Promise<Arrival> | undefined;
+  /** The line in flight, and the whole of what may cancel it. */
+  let running: Running | undefined;
+  /** Keys read while a line was in flight, from the first line-ender on. */
+  let held: Key[] = [];
+  /** Whether the keys have run out, which ends the run once nothing is left. */
+  let ended = false;
+
+  /** Acts on `key` at a prompt with no line in flight. */
+  const act = (key: Key): void => {
+    if (key.name === "ctrl-c") {
+      terminal.finish();
       buffer.setText("");
-      // After the line, not before it: `cd` is what moves the place, so the
-      // prompt a line is typed at is the place it is read against.
-      prompt = promptFor(shuttle);
-    } else if (key.name === "ctrl-c") {
-      terminal.finish("");
+    } else if (endsLine(key, buffer)) {
+      if (key.name === "ctrl-d") {
+        ended = true;
+        held = [];
+        return;
+      }
+      const line = buffer.text();
+      terminal.finish();
       buffer.setText("");
+      running = start(line, shuttle, deps);
+      // Nothing is drawn: the prompt for the next line appears when the line
+      // settles, or when a key is typed before it does, so a line that
+      // answers before anyone types looks exactly as it did when the loop
+      // waited for it.
+      return;
     } else {
       apply(buffer, key);
     }
     show();
+  };
+
+  while (!(ended && running === undefined && held.length === 0)) {
+    if (running === undefined && held.length > 0) {
+      act(held.shift()!);
+      continue;
+    }
+    if (!ended) typing ??= nextKey(keys);
+    const arrival = await (
+      ended
+        ? running!.settled
+        : running === undefined
+        ? typing!
+        : Promise.race([typing!, running.settled])
+    );
+    if (arrival.kind === "ran") {
+      running = undefined;
+      if (arrival.text !== "") terminal.announce(arrival.text);
+      // After the line, not before it: `cd` is what moves the place, so the
+      // prompt a line is typed at is the place it was read against.
+      prompt = promptFor(shuttle);
+      show();
+      continue;
+    }
+    typing = undefined;
+    if (arrival.step.done) {
+      ended = true;
+      continue;
+    }
+    const key = arrival.step.value;
+    if (running === undefined) {
+      act(key);
+    } else if (key.name === "ctrl-c") {
+      running.stop();
+      held = [];
+      buffer.setText("");
+      show();
+    } else if (held.length > 0 || endsLine(key, buffer)) {
+      held.push(key);
+    } else {
+      apply(buffer, key);
+      show();
+    }
   }
-  terminal.finish("");
+  terminal.finish();
+}
+
+/** What the loop is waiting on: the next key, or the line it is running. */
+type Arrival =
+  /** The key stream answered, with a key or with the end of the keys. */
+  | { readonly kind: "typed"; readonly step: IteratorResult<Key> }
+  /** The line in flight settled, and `text` is what it produced. */
+  | { readonly kind: "ran"; readonly text: string };
+
+/** A line in flight: what it will produce, and how to cancel it. */
+interface Running {
+  /** Settles with what the line produced, cancelled or not. */
+  readonly settled: Promise<Arrival>;
+
+  /** Cancels the line, which settles it with what a cancelled line says. */
+  stop(): void;
+}
+
+/**
+ * Helper for {@link runPrompt}, which asks `keys` for the next one.
+ *
+ * It is a function so that the answer is a value the loop holds until it uses
+ * it: a key asked for while a line was running is still the next key when that
+ * line settles, and asking twice would drop one.
+ */
+function nextKey(keys: AsyncIterator<Key>): Promise<Arrival> {
+  return keys.next().then((step) => ({ kind: "typed", step }) as const);
+}
+
+/**
+ * Helper for {@link runPrompt}, which starts `line` and returns what running
+ * it is.
+ *
+ * The signal rides the deps bag the verbs already read their collaborators
+ * through, so a verb honors it wherever it has a phase to stop between and
+ * nothing else has to be threaded to reach one.
+ */
+function start(line: string, shuttle: Shuttle, deps: VerbDeps): Running {
+  const stopper = new AbortController();
+  return {
+    stop: () => stopper.abort(),
+    settled: report(line, shuttle, { ...deps, signal: stopper.signal })
+      .then((text) => ({ kind: "ran", text }) as const),
+  };
+}
+
+/**
+ * Helper for {@link runPrompt}, which is whether `key` ends the line `buffer`
+ * holds rather than editing it.
+ *
+ * These are the two keys a prompt cannot honor while a line is in flight —
+ * one would run a second line and the other would end the run under the first
+ * — so they are the two that are held, and this is the one place that says
+ * which they are.
+ */
+function endsLine(key: Key, buffer: EditBuffer): boolean {
+  return key.name === "enter" ||
+    (key.name === "ctrl-d" && buffer.text() === "");
 }
 
 /**
@@ -177,8 +341,8 @@ function promptFor(shuttle: Shuttle): string {
 }
 
 /**
- * Helper for {@link runPrompt}, which runs `line` and returns what to write
- * under it — the empty string where it produced nothing to say.
+ * Helper for {@link start}, which runs `line` and returns what to write above
+ * the next one — the empty string where it produced nothing to say.
  *
  * A value prints as indented JSON, and what cannot be written that way is
  * said rather than shown — by {@link written} for a value the writer declines,
@@ -191,10 +355,19 @@ function promptFor(shuttle: Shuttle): string {
  * rejection can carry, and a throw raised while answering a failure is the
  * failure this catch exists to stop.
  *
+ * A cancelled line is answered by whichever of two things happens first, and
+ * the answer is the same word either way. The line may reach a phase boundary
+ * and stop there, which is the arm `runLine` returns; or it may be waiting on
+ * a read that nothing can call off, and then the signal answers for it and the
+ * read finishes into nothing. What the second delivers is the prompt, which is
+ * what a person pressing `ctrl-c` at a server that has gone quiet is asking
+ * for; what it does not deliver is a server that stopped working, and no
+ * caller of a read here can deliver that.
+ *
  * The two prose answers are escaped here rather than where they were written.
  * A refusal's reason and a thrown read's message both carry text the fabric
  * wrote, which passed no door and so was never held to the class a terminal
- * acts on; and both reach a person only by becoming the line under this one.
+ * acts on; and both reach a person only by becoming a line of their own.
  * Escaping at that point covers a refusal built as a literal rather than
  * through `refuse`, and a message from a `throw` this module never sees, in a
  * way that escaping at each site cannot. It leaves the other two arms alone
@@ -208,11 +381,16 @@ async function report(
   deps: VerbDeps,
 ): Promise<string> {
   try {
-    const outcome = await runLine(line, shuttle, deps);
+    const running = runLine(line, shuttle, deps);
+    const outcome = await (deps.signal === undefined
+      ? running
+      : Promise.race([running, abandoned(deps.signal)]));
     switch (outcome.kind) {
       case "nothing":
       case "moved":
         return "";
+      case "interrupted":
+        return INTERRUPTED;
       case "text":
         return outcome.text;
       case "refused":
@@ -223,6 +401,23 @@ async function report(
   } catch (thrown) {
     return escapeControlCharacters(messageOf(thrown));
   }
+}
+
+/**
+ * Helper for {@link report}, which settles once `signal` is aborted and never
+ * otherwise.
+ *
+ * A promise that never settles is exactly what is wanted for a line nobody
+ * cancels: it loses every race it is in and is collected with the controller
+ * the line held. Nothing here waits on a clock, so a line that is slow is a
+ * line that is still running.
+ */
+function abandoned(signal: AbortSignal): Promise<Outcome> {
+  return new Promise((resolve) => {
+    signal.addEventListener("abort", () => resolve({ kind: "interrupted" }), {
+      once: true,
+    });
+  });
 }
 
 /**

--- a/packages/cli/lib/shuttle/run.ts
+++ b/packages/cli/lib/shuttle/run.ts
@@ -2,18 +2,23 @@
  * Running a shuttle: one connection, one place, and the prompt over both, for
  * as long as the person keeps typing.
  *
- * This is what `cf sh` calls. The connection opens here rather than on the
- * first read, because the place cannot be built without it: a space written as
- * a name is a DID only once a session has resolved it, and a place stands in a
- * space. That is the connect a shell pays once where a one-shot command pays
- * it per invocation.
+ * This is what `cf sh` calls. The terminal opens first and the connection
+ * inside it, because the terminal is where the connection's own writing has to
+ * land: a pattern's console output and the lines a connect writes for itself
+ * would otherwise reach the process's streams, which is the middle of the
+ * drawing once a prompt is painted (`announce.ts`). The connect then happens
+ * before the first line rather than on it, because the place cannot be built
+ * without it: a space written as a name is a DID only once a session has
+ * resolved it, and a place stands in a space. That is the connect a shell pays
+ * once where a one-shot command pays it per invocation.
  *
  * Nothing here reads the command line. What a person wrote is read by the
  * command, in the words every other command reads a space and an identity in,
  * and what arrives is the connection it settled on.
  */
 
-import type { SpaceConfig } from "../piece.ts";
+import { loadPieces, type SpaceConfig } from "../piece.ts";
+import { announcingOutput } from "./announce.ts";
 import { type ConnectionOpener, HeldConnection } from "./connection.ts";
 import { CurrentPlace } from "./place.ts";
 import { runPrompt } from "./prompt.ts";
@@ -22,8 +27,12 @@ import type { Shuttle } from "./verbs.ts";
 
 /** What a run reaches the world through, so that a case can stand for it. */
 export interface ShuttleDeps {
-  /** Opens the connection; `loadPieces` where a caller names none. */
-  readonly open?: ConnectionOpener;
+  /**
+   * Opens the connection; `loadPieces` where a caller names none. It takes
+   * the output bag as well as the config, because where the connection's own
+   * writing goes is this module's decision rather than the holder's.
+   */
+  readonly open?: typeof loadPieces;
 
   /** Holds a terminal open for the prompt to read and write through. */
   readonly terminal?: typeof withPromptTerminal;
@@ -33,29 +42,33 @@ export interface ShuttleDeps {
  * Runs a shuttle over `config`, returning when the person ends the session.
  *
  * The connection is this call's to close, so it is closed on the way out
- * whatever ended the run — a line that ended it, a terminal that could not be
- * opened, or a throw from anywhere under the prompt.
+ * whatever ended the run — a line that ended it, or a throw from anywhere
+ * under the prompt. A terminal that will not open is the one way out that
+ * closes nothing, and closes nothing because nothing was opened: the terminal
+ * is what the connection is opened inside.
  *
- * @throws Whatever opening the connection throws, and whatever the prompt
- * throws that it did not report as a line's own failure — a terminal that is
- * not one among them.
+ * @throws Whatever opening the terminal or the connection throws, and whatever
+ * the prompt throws that it did not report as a line's own failure.
  */
 export async function runShuttle(
   config: SpaceConfig,
   deps: ShuttleDeps = {},
 ): Promise<void> {
-  await using connection = new HeldConnection({
-    kind: "owned",
-    record: config,
-    open: deps.open,
+  await (deps.terminal ?? withPromptTerminal)(async (terminal) => {
+    const opening = deps.open ?? loadPieces;
+    const output = announcingOutput((text) => terminal.announce(text));
+    const open: ConnectionOpener = (opened) => opening(opened, output);
+    await using connection = new HeldConnection({
+      kind: "owned",
+      record: config,
+      open,
+    });
+    const pieces = await connection.pieces();
+    const shuttle: Shuttle = {
+      config,
+      place: new CurrentPlace(pieces.getSpace()),
+      connection,
+    };
+    await runPrompt(shuttle, terminal);
   });
-  const pieces = await connection.pieces();
-  const shuttle: Shuttle = {
-    config,
-    place: new CurrentPlace(pieces.getSpace()),
-    connection,
-  };
-  await (deps.terminal ?? withPromptTerminal)((terminal) =>
-    runPrompt(shuttle, terminal)
-  );
 }

--- a/packages/cli/lib/shuttle/terminal.ts
+++ b/packages/cli/lib/shuttle/terminal.ts
@@ -14,7 +14,13 @@
  */
 
 import { decodeKeys, type Key } from "../view/keys.ts";
-import { finish, NOTHING_PAINTED, type PaintedLine, repaint } from "./paint.ts";
+import {
+  above,
+  finish,
+  NOTHING_PAINTED,
+  type PaintedLine,
+  repaint,
+} from "./paint.ts";
 import type { PromptTerminal } from "./prompt.ts";
 
 /** How many bytes one read off the keyboard takes at a time. */
@@ -185,9 +191,21 @@ class StandardTerminal implements PromptTerminal {
   }
 
   /** @inheritDoc */
-  finish(text: string): void {
-    this.#send(finish(this.#painted, text));
+  finish(): void {
+    this.#send(finish(this.#painted));
     this.#painted = NOTHING_PAINTED;
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * The line stays as it was drawn, because what is written above it is
+   * written above it: the drawing is composed against the same width and the
+   * same cursor it already carries, so a run of these leaves one transcript
+   * with the line being typed at the bottom of it.
+   */
+  announce(text: string): void {
+    this.#send(above(this.#painted, text));
   }
 
   /**

--- a/packages/cli/lib/shuttle/verbs.ts
+++ b/packages/cli/lib/shuttle/verbs.ts
@@ -88,7 +88,18 @@ export type Outcome =
   /** The verb read `value` out of the fabric. */
   | { readonly kind: "value"; readonly value: unknown }
   /** The line is refused, for the reason given. */
-  | { readonly kind: "refused"; readonly reason: string };
+  | { readonly kind: "refused"; readonly reason: string }
+  | Interruption;
+
+/**
+ * What a line that was cancelled comes back as: it stopped where it was, and
+ * whatever it had not done yet it did not do.
+ *
+ * It is neither a refusal nor a failure. A refusal is a fact about the line —
+ * it would have been wrong whenever it ran — and a failure is a fact about the
+ * read; this is a fact about the person, who stopped waiting.
+ */
+export type Interruption = { readonly kind: "interrupted" };
 
 /**
  * The running shuttle a verb acts on: where it stands, what it connects as,
@@ -125,6 +136,89 @@ export interface VerbDeps {
 
   /** The reads `ls` composes. */
   readonly listing?: ListingDeps;
+
+  /**
+   * Cancels the line, which the prompt aborts on `ctrl-c`.
+   *
+   * What it can stop is what has not started, and the rule that makes that
+   * a property rather than a list is: **every read has a check in front of
+   * it with nothing awaited in between**, and so does every adoption. An
+   * await between the two is a window the cancel lands in and the read goes
+   * out of anyway, which is why the settle asks the holder for its
+   * connection once and hands it down rather than asking again before each
+   * read.
+   *
+   * The rule is what a caller can check, and it is checked: a case cancels
+   * from inside each read there is and at each line's first suspension, and
+   * asserts that nothing was read afterwards (`shuttle-verbs.test.ts`). That
+   * observes the property instead of enumerating the boundaries, so a
+   * boundary nobody thought of fails it too.
+   *
+   * What it cannot stop is a read already sent: the runtime's reads take no
+   * signal, so one in flight finishes and its answer is dropped, and the
+   * checks are what stop it taking effect on the way back.
+   */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Whether the line running under `deps` has been cancelled, as the outcome
+ * that says so.
+ *
+ * A cancelled line's phases are checked rather than raced, so what comes back
+ * from a verb is always something the verb actually decided. Racing is the
+ * prompt's to do and it does it one layer up, where abandoning a line costs
+ * nothing that a place could later be moved by.
+ */
+function stopped(deps: VerbDeps): Interruption | undefined {
+  return deps.signal?.aborted === true ? { kind: "interrupted" } : undefined;
+}
+
+/** What an act guarded against a cancel did, where it was allowed to run. */
+type Ran<T> = { readonly kind: "ran"; readonly answer: T };
+
+/**
+ * Performs `act` over `args` unless the line has been cancelled, and is what
+ * it answered where it was allowed to.
+ *
+ * Every read this module sends and every move it adopts goes through here,
+ * and the reason is that the rule they are held to is not one discipline can
+ * keep. The rule is that **nothing is awaited between the check and the act
+ * it guards** — an await there is a window the cancel lands in and the act
+ * happens anyway — and a rule of that shape is invisible: the code reads
+ * correctly whether or not the window is there, no case can see it, and the
+ * next author to insert a line between two statements has no way to know
+ * which two they are.
+ *
+ * So the two are one expression here instead. The arguments are evaluated
+ * before this is entered, so a caller that awaits while composing them still
+ * has the check on the far side of its own await; and there is no statement
+ * position between the check and the call for an await to occupy, because
+ * there are no statements between them. Passing `act` and its arguments
+ * separately rather than as a closure is what leaves nowhere to hide one: a
+ * closure has a body, and a body can await.
+ *
+ * What that is worth, stated at its actual size: it stops an await written as
+ * a *statement*, which is how one gets written. It does not stop every
+ * insertion an expression admits — `await (await something(), act(...args))`
+ * reopens the window inside this very line, and nothing here would notice.
+ * So this is a guarantee against the edit somebody makes, not against the
+ * edit somebody constructs, and the cases are what cover the second: a line
+ * cancelled at its first suspension reaches this function before its read,
+ * and every verb that reads has such a case (`shuttle-verbs.test.ts`).
+ *
+ * What is left to the caller is which arm it returns, and the arms are the
+ * outcome's own, so a cancelled act is handed back rather than tested for.
+ */
+async function guarded<A extends readonly unknown[], T>(
+  deps: VerbDeps,
+  act: (...args: A) => T | Promise<T>,
+  ...args: A
+): Promise<Ran<T> | Interruption> {
+  // One expression, so that the check and the act it guards have no statement
+  // position between them here either. This is the one place the rule lives
+  // now, which is the point of it living somewhere rather than at every site.
+  return stopped(deps) ?? { kind: "ran", answer: await act(...args) };
 }
 
 /**
@@ -150,6 +244,11 @@ export interface VerbDeps {
  * raises, so that a server that cannot be reached is told apart from a line
  * that was wrong.
  *
+ * A line cancelled through `deps.signal` comes back interrupted, which is a
+ * third fact and not either of those. What that arm promises is what a check
+ * can promise: nothing further was sent, and nothing was adopted. A read
+ * already in flight is outside it and finishes into nothing.
+ *
  * @throws Whatever a read throws — an unreachable server, an identity that
  * will not load, a path the piece refuses.
  */
@@ -172,7 +271,12 @@ export async function runLine(
       return { kind: "text", text: renderVerbPage(entry) };
     case "read": {
       const wrong = wrongOperandCount(word, entry.arity, reading.operands);
-      return wrong ?? await entry.run(shuttle, reading.operands, deps);
+      // A line already cancelled does not start. Everything above this is a
+      // decision about the words, which is worth making either way — a line
+      // that named no verb, or gave one the wrong number of operands, is not
+      // a verb that was interrupted.
+      return wrong ?? stopped(deps) ??
+        await entry.run(shuttle, reading.operands, deps);
     }
   }
 }
@@ -267,9 +371,8 @@ async function get(
   }
   const aim = shuttle.place.aim(operand);
   const at = await reading(shuttle, aim.move, deps);
-  return at.kind === "refused"
-    ? at
-    : await read(shuttle, at.place, aim.input, deps);
+  if (at.kind !== "place") return at;
+  return await read(shuttle, at.place, aim.input, deps);
 }
 
 /**
@@ -298,13 +401,17 @@ async function ls(
   _operands: readonly string[],
   deps: VerbDeps,
 ): Promise<Outcome> {
-  const listing = await listPlace(
+  const listed = await guarded(
+    deps,
+    listPlace,
     shuttle.config,
     shuttle.place.place,
     shuttle.connection,
     deps.listing,
   );
-  return { kind: "text", text: renderListing(listing) };
+  return listed.kind !== "ran"
+    ? listed
+    : { kind: "text", text: renderListing(listed.answer) };
 }
 
 /** Returns where shuttle stands, both halves of the pair. */
@@ -326,10 +433,12 @@ async function wish(
   deps: VerbDeps,
 ): Promise<Outcome> {
   const target = operands[0];
-  const { result, error } = await (deps.readWish ?? readWish)({
+  const answered = await guarded(deps, deps.readWish ?? readWish, {
     ...shuttle.config,
     query: target,
   }, { loadPieces: () => shuttle.connection.pieces() });
+  if (answered.kind !== "ran") return answered;
+  const { result, error } = answered.answer;
   if (result === null && error !== undefined) {
     return refuse(`\`${target}\` resolved to nothing: ${error}`);
   }
@@ -479,6 +588,15 @@ const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
  * settled the way any other is. A confirmed piece lands or refuses, so this
  * calls itself twice at most, and a space named by name is the operand that
  * takes both.
+ *
+ * The cancellation check on each arm comes before the adoption, and that is
+ * the order that matters: adopting is what makes a `cd` a promise, so a line
+ * the person stopped waiting for leaves the place where it was, however far
+ * its reads had got. On the pending arm it is the check *after the settle's
+ * own last read* — the walk of the path, which nothing inside {@link
+ * settlePiece} follows — so it is the one a cancel arriving there meets, and
+ * the earlier reads are stopped by the settle's own checks before they ever
+ * reach here.
  */
 async function landing(
   shuttle: Shuttle,
@@ -492,27 +610,42 @@ async function landing(
       return move;
     case "wish": {
       const resolved = await resolveTarget(shuttle, move.target, deps);
-      return resolved.kind === "refused" ? resolved : await landing(
-        shuttle,
-        shuttle.place.enter(resolved.target, move.target),
+      if (resolved.kind !== "target") return resolved;
+      const entered = await guarded(
         deps,
+        shuttle.place.enter.bind(shuttle.place),
+        resolved.target,
+        move.target,
       );
+      return entered.kind !== "ran"
+        ? entered
+        : await landing(shuttle, entered.answer, deps);
     }
     case "space-by-name": {
       const named = await connectedSpace(shuttle, move.name);
-      return named.kind === "refused" ? named : await landing(
-        shuttle,
-        shuttle.place.settle(move, named.space),
+      if (named.kind === "refused") return named;
+      const settled = await guarded(
         deps,
+        shuttle.place.settle.bind(shuttle.place),
+        move,
+        named.space,
       );
+      return settled.kind !== "ran"
+        ? settled
+        : await landing(shuttle, settled.answer, deps);
     }
     case "pending": {
       const settled = await settlePiece(shuttle, move, deps);
-      return settled.kind === "refused" ? settled : await landing(
-        shuttle,
-        shuttle.place.confirm(move, settled.place),
+      if (settled.kind !== "settled") return settled;
+      const confirmed = await guarded(
         deps,
+        shuttle.place.confirm.bind(shuttle.place),
+        move,
+        settled.place,
       );
+      return confirmed.kind !== "ran"
+        ? confirmed
+        : await landing(shuttle, confirmed.answer, deps);
     }
   }
 }
@@ -530,13 +663,15 @@ type Reading =
 type Targeting =
   /** The target resolved to the address `target` names. */
   | { readonly kind: "target"; readonly target: ResolvedTarget }
-  | Refusal;
+  | Refusal
+  | Interruption;
 
 /** What settling a place against the fabric produced. */
 type Settling =
   /** The fabric holds the place, as `place` resolved it. */
   | { readonly kind: "settled"; readonly place: ResolvedPlace }
-  | Refusal;
+  | Refusal
+  | Interruption;
 
 /** What the piece and path a pending move spelled turned out to be. */
 type Resolved =
@@ -554,7 +689,8 @@ type Resolved =
      */
     readonly held: boolean;
   }
-  | Refusal;
+  | Refusal
+  | Interruption;
 
 /**
  * Helper for {@link landing}, which asks the fabric whether it holds the place
@@ -588,6 +724,13 @@ type Resolved =
  * a handle the space does not hold is adopted — the bound `grammar.md`
  * records.
  *
+ * Three reads means two boundaries between them, and a cancelled line is
+ * checked at both: after the resolution, and after the lookup that only a
+ * piece the resolution did not prove goes through. What each check promises
+ * is what a check can — the read after it was never sent — and the walk, being
+ * last, is followed by {@link landing}'s check instead, so a cancel arriving
+ * during it stops the move rather than a read.
+ *
  * @throws Whatever the read throws — an unreachable server, an identity that
  * will not load. A slug that names nothing is not one of those: it is a fact
  * about the line, so it comes back as a refusal.
@@ -597,13 +740,25 @@ async function settlePiece(
   move: PendingMove,
   deps: VerbDeps,
 ): Promise<Settling> {
-  const resolved = await resolvedPiece(shuttle, move, deps);
-  if (resolved.kind === "refused") return resolved;
+  // The connection is asked for once and handed down, so that every read
+  // below has a check in front of it with nothing awaited in between. Asking
+  // twice would put an await between a check and the read it guards, which is
+  // a window a cancel can land in — and the second ask answers off the
+  // holder's memo anyway, the connection having been opened before the prompt
+  // read its first line (`run.ts`).
+  const pieces = await shuttle.connection.pieces();
+  const resolved = await resolvedPiece(pieces, shuttle, move, deps);
+  if (resolved.kind !== "piece") return resolved;
   const place = resolved.place;
   const settled: Settling = { kind: "settled", place };
   if (!resolved.held) {
-    const pieces = await shuttle.connection.pieces();
-    if (await pieces.entityIdExists(place.piece) === false) {
+    const held = await guarded(
+      deps,
+      pieces.entityIdExists.bind(pieces),
+      place.piece,
+    );
+    if (held.kind !== "ran") return held;
+    if (held.answer === false) {
       return refuse(
         `\`${move.operand}\` reaches no piece: this space holds none by the ` +
           `handle \`${place.piece}\`.`,
@@ -617,12 +772,16 @@ async function settlePiece(
     scope,
   });
   if (from.length === path.length) return settled;
-  let level = await (deps.getCellValue ?? getCellValue)(
+  const walked = await guarded(
+    deps,
+    deps.getCellValue ?? getCellValue,
     { ...shuttle.config, piece: place.piece, pieceScope: scope },
     [...from],
     {},
     { loadPieces: () => shuttle.connection.pieces() },
   );
+  if (walked.kind !== "ran") return walked;
+  let level = walked.answer;
   for (const segment of path.slice(from.length).map(String)) {
     const keys = keysOf(level);
     if (!keys.includes(segment)) {
@@ -661,6 +820,7 @@ async function settlePiece(
  * it.
  */
 async function resolvedPiece(
+  pieces: Awaited<ReturnType<HeldConnection["pieces"]>>,
   shuttle: Shuttle,
   move: PendingMove,
   deps: VerbDeps,
@@ -674,10 +834,12 @@ async function resolvedPiece(
   ) {
     return { kind: "piece", place: { piece: spelled, path }, held: true };
   }
-  let reference;
+  let resolved;
   try {
-    reference = await (deps.resolvePieceReference ?? resolvePieceReference)(
-      await shuttle.connection.pieces(),
+    resolved = await guarded(
+      deps,
+      deps.resolvePieceReference ?? resolvePieceReference,
+      pieces,
       spelled,
       path,
     );
@@ -687,6 +849,8 @@ async function resolvedPiece(
       `\`${move.operand}\` reaches no piece: ${messageOf(thrown)}`,
     );
   }
+  if (resolved.kind !== "ran") return resolved;
+  const reference = resolved.answer;
   return {
     kind: "piece",
     place: {
@@ -928,13 +1092,17 @@ async function read(
     piece: position.piece,
     pieceScope: place.scope,
   };
-  const value = await (deps.getCellValue ?? getCellValue)(
+  const answered = await guarded(
+    deps,
+    deps.getCellValue ?? getCellValue,
     pieceConfig,
     [...position.path],
     { input },
     { loadPieces: () => shuttle.connection.pieces() },
   );
-  return { kind: "value", value };
+  return answered.kind !== "ran"
+    ? answered
+    : { kind: "value", value: answered.answer };
 }
 
 /**
@@ -955,11 +1123,13 @@ async function resolveTarget(
   deps: VerbDeps,
 ): Promise<Targeting> {
   const selection = await parseCellSelectionOptions({ select: ADDRESS_SELECT });
-  const { result, error } = await (deps.readWish ?? readWish)({
+  const answered = await guarded(deps, deps.readWish ?? readWish, {
     ...shuttle.config,
     query: target,
     selection,
   }, { loadPieces: () => shuttle.connection.pieces() });
+  if (answered.kind !== "ran") return answered;
+  const { result, error } = answered.answer;
   const address = addressIn(result);
   if (address === undefined) {
     return {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -181,6 +181,46 @@ describe("executePieceCallable", () => {
     expect(harness.tracker.handlerWrites).toEqual([]);
   });
 
+  it("reports a bootstrap that would not run through the sink a caller supplied", async () => {
+    // The one warning on the dispatch path that no other seam carries: the
+    // root's bootstrap failed and the call goes on anyway. A caller drawing
+    // its own screen takes it here rather than finding it written behind the
+    // frame, and a caller that names no sink still gets it on the process's
+    // own stream.
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "refresh",
+      inputSchema: { type: "object", properties: {} },
+    });
+    const reported: string[] = [];
+    const manager = {
+      ...harness.pieces,
+      ensureDefaultPattern: () => Promise.reject(new Error("no root")),
+      get: () => Promise.resolve(harness.piece),
+    };
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "refresh",
+      ["--help"],
+      {
+        loadPieces: () => Promise.resolve(manager as never),
+        report: (message) => {
+          reported.push(message);
+        },
+      },
+    );
+
+    expect(reported).toEqual([
+      "Warning: Could not ensure default pattern: no root",
+    ]);
+  });
+
   it("preserves plain-text mode while resolving a callable", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -200,6 +200,34 @@ describe("cli piece parsing", () => {
     expect(disposeCalls).toBe(1);
   });
 
+  it("reports both cleanup failures through the sink a caller supplied", async () => {
+    // The two warnings a failed connect's own cleanup writes. A caller
+    // drawing its own screen — the shell holding a prompt in raw mode — takes
+    // them here instead of finding them written behind its frame; a caller
+    // that names no sink still gets them on the process's own stream.
+
+    const reported: string[] = [];
+    const originalError = new Error("sync failed");
+
+    await expect(withRuntimeCleanupOnFailure(
+      {
+        dispose: () => Promise.reject(new Error("dispose failed")),
+        storageManager: {
+          closeNow: () => Promise.reject(new Error("closeNow failed")),
+        },
+      },
+      () => Promise.reject(originalError),
+      (message) => {
+        reported.push(message);
+      },
+    )).rejects.toBe(originalError);
+
+    expect(reported).toEqual([
+      "loadPieces storage cleanup failed: closeNow failed",
+      "loadPieces cleanup failed: dispose failed",
+    ]);
+  });
+
   it("does not dispose loadPieces runtime after successful initialization", async () => {
     let disposeCalls = 0;
 

--- a/packages/cli/test/shuttle-announce.test.ts
+++ b/packages/cli/test/shuttle-announce.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for the out-of-band line's other producers: what a connection
+ * writes for itself, and what a pattern writes to its console.
+ *
+ * A case drives the console handler the way the runtime does — it asks the
+ * handler where to write and writes there — because the handler names a
+ * destination rather than writing to one, and what a case is asking about is
+ * where the writing ends up.
+ *
+ * Nothing here escapes anything. The class a terminal acts on is held to at
+ * the door these feed (`above`, `paint.ts`), where every producer meets it
+ * whether or not it went through this module, and that is where the cases for
+ * it are.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { type ConsoleHandler, ConsoleMethod } from "@commonfabric/runner";
+
+import { announcingOutput } from "../lib/shuttle/announce.ts";
+
+/**
+ * Helper for the cases below, which writes `args` through `handler` the way
+ * the scheduler does: the handler names a console and a method, and the
+ * arguments go to that method on that console (`scheduler/facade.ts`).
+ */
+function through(
+  handler: ConsoleHandler,
+  method: string,
+  ...args: unknown[]
+): unknown {
+  const answered = handler(
+    { metadata: undefined, method: method as ConsoleMethod, args },
+  );
+  const output = Array.isArray(answered)
+    ? { method: method as ConsoleMethod, args: answered }
+    : answered;
+  const target = output.target ?? console;
+  // deno-lint-ignore no-explicit-any
+  (target as any)[output.method].apply(target, output.args);
+  return target;
+}
+
+/** Helper for the cases below, which is an output collecting what it took. */
+function collecting(): {
+  lines: string[];
+  output: ReturnType<
+    typeof announcingOutput
+  >;
+} {
+  const lines: string[] = [];
+  return { lines, output: announcingOutput((text) => lines.push(text)) };
+}
+
+describe("announce", () => {
+  describe("announcingOutput()", () => {
+    it("takes each line the connection writes for itself", () => {
+      const { lines, output } = collecting();
+      output.report?.("loadPieces cleanup failed: the socket was gone");
+      expect(lines).toEqual(["loadPieces cleanup failed: the socket was gone"]);
+    });
+
+    it("takes what a pattern wrote to its console", () => {
+      const { lines, output } = collecting();
+      through(output.consoleHandler!, ConsoleMethod.Log, "counted", 3);
+      expect(lines).toEqual(["counted 3"]);
+    });
+
+    it("answers every method a pattern's console can call, on one console of its own", () => {
+      // `ConsoleMethod` is the whole surface a pattern reaches, so the claim
+      // is about all twenty rather than the handful anybody logs with. But
+      // twenty is still a list, and a list is what a console's own surface
+      // stops being the moment Node adds to it — so the last row is a name
+      // that is in no enum at all, and it has to be answered too. That is the
+      // property the proxy has and an object with methods on it does not.
+      //
+      // The console each answer names is compared, not merely counted: an
+      // assertion over what `through` returned reads as a set of one however
+      // the routing behaves if what it returns is nothing.
+
+      const { lines, output } = collecting();
+      const targets = new Set<unknown>();
+      for (
+        const method of [...Object.values(ConsoleMethod), "notAConsoleMethod"]
+      ) {
+        let target: unknown = "never called";
+        expect(() => {
+          target = through(output.consoleHandler!, method, "x");
+        }, `console.${method}`).not.toThrow();
+        targets.add(target);
+      }
+      expect(targets.size).toBe(1);
+      expect([...targets][0]).not.toBe(console);
+      expect([...targets][0]).not.toBe(undefined);
+      // And the ones that do write wrote here: a handler naming one console
+      // that writes nothing would pass every assertion above.
+      expect(lines.length).toBeGreaterThan(0);
+    });
+
+    it("writes a value that refuses to be a string, rather than throwing on it", () => {
+      // A null-prototype object has no `toString`, so coercing one throws —
+      // and a console does not coerce, it inspects. Asking every method for a
+      // label was what put a coercion in front of `log`, where a value that
+      // is perfectly loggable then announced nothing at all.
+
+      const { lines, output } = collecting();
+      const held = Object.create(null);
+      held.a = 1;
+      expect(() => through(output.consoleHandler!, ConsoleMethod.Log, held))
+        .not.toThrow();
+      expect(lines).toEqual(["[Object: null prototype] { a: 1 }"]);
+    });
+
+    it("says nothing for an assertion that holds, and names one that does not", () => {
+      // `assert` is the method whose meaning is a condition. Formatting its
+      // arguments the way `log` does turns a silent success into the line
+      // `true should be silent`, which is worse than losing it: it reads as
+      // something a pattern chose to say.
+
+      const { lines, output } = collecting();
+      through(output.consoleHandler!, ConsoleMethod.Assert, true, "silent");
+      expect(lines).toEqual([]);
+      through(output.consoleHandler!, ConsoleMethod.Assert, false, "loud");
+      through(output.consoleHandler!, ConsoleMethod.Assert, false);
+      expect(lines).toEqual(["Assertion failed: loud", "Assertion failed"]);
+    });
+
+    it("gives each method whose meaning is more than its arguments that meaning", () => {
+      // The survey, as the rows a caller can tell apart from `log`. Each was
+      // measured against a real console rather than remembered, and each is
+      // here because a blanket answer got it wrong: a blanket answer with the
+      // two that were caught patched into it would be the same defect with
+      // two fewer instances.
+
+      const { lines, output } = collecting();
+      // `dir` inspects its first argument and ignores what follows it.
+      through(
+        output.consoleHandler!,
+        ConsoleMethod.Dir,
+        { a: { b: 1 } },
+        {},
+        "ignored",
+      );
+      // `trace` carries its prefix.
+      through(output.consoleHandler!, ConsoleMethod.Trace, "why");
+      // `group` writes its heading, then indents what follows until the end.
+      through(output.consoleHandler!, ConsoleMethod.Group, "heading");
+      through(output.consoleHandler!, ConsoleMethod.Log, "inside");
+      through(output.consoleHandler!, ConsoleMethod.GroupEnd);
+      through(output.consoleHandler!, ConsoleMethod.Log, "outside");
+      expect(lines).toEqual([
+        "{ a: { b: 1 } }",
+        "Trace: why",
+        "heading",
+        "  inside",
+        "outside",
+      ]);
+    });
+
+    it("writes nothing for the two a pattern must not be able to write with", () => {
+      // `clear` empties a terminal, and a pattern emptying an operator's
+      // terminal is the harm this module exists to stop, so it is answered
+      // and does nothing. `timeStamp` is a profiler mark that writes nowhere
+      // on any console. Both are refusals rather than omissions.
+
+      const { lines, output } = collecting();
+      through(output.consoleHandler!, ConsoleMethod.Clear);
+      through(output.consoleHandler!, ConsoleMethod.TimeStamp);
+      expect(lines).toEqual([]);
+    });
+
+    it("flattens a table to the rows the formatter writes, which is deliberate", () => {
+      // Recorded rather than implemented: a console draws a box, and the same
+      // rows written by the formatter carry the same data. A table renderer
+      // is not a thing a shell should hold a second copy of, and this case is
+      // here so that the flattening is a decision somebody made.
+
+      const { lines, output } = collecting();
+      through(output.consoleHandler!, ConsoleMethod.Table, [{ a: 1 }, {
+        a: 2,
+      }]);
+      expect(lines).toEqual(["[ { a: 1 }, { a: 2 } ]"]);
+    });
+
+    it("keeps the label state Node would have warned about, and says so itself", () => {
+      // The path that reached a terminal without passing the door. Node's
+      // console raises a *process warning* for a label it has no timer or
+      // count for, and a process warning goes to the process's stderr
+      // whatever console the call was made on — carrying the label, which is
+      // a pattern's own string. A pattern picking a label made of an escape
+      // sequence would have cleared the operator's screen with it.
+      //
+      // So the state is held here and the ask that cannot be answered is a
+      // line of shuttle's own. Each row below is an ask Node warns for.
+
+      for (
+        const [method, said] of [
+          ["timeEnd", "No timer called `missing` is running."],
+          ["timeLog", "No timer called `missing` is running."],
+          ["countReset", "No count called `missing` is being kept."],
+        ] as const
+      ) {
+        const { lines, output } = collecting();
+        through(output.consoleHandler!, method, "missing");
+        expect({ method, lines }).toEqual({ method, lines: [said] });
+      }
+
+      // The fourth: a timer started twice. The first start says nothing, as a
+      // console says nothing for one it takes.
+      const { lines, output } = collecting();
+      through(output.consoleHandler!, "time", "twice");
+      through(output.consoleHandler!, "time", "twice");
+      expect(lines).toEqual(["A timer called `twice` is already running."]);
+    });
+
+    it("announces a label carrying an escape rather than letting it out", () => {
+      // The harm the case above prevents, named as the thing it is: the label
+      // is the pattern's, it reaches the announce line, and the door glyphs
+      // it there (`above`, `paint.ts`). What must not happen is that it goes
+      // anywhere else, which is what a warning did.
+
+      const { lines, output } = collecting();
+      through(output.consoleHandler!, "timeLog", "missing\u001b[2J");
+      expect(lines).toEqual(["No timer called `missing\u001b[2J` is running."]);
+    });
+
+    it("keeps a timer and a count for a pattern that uses them properly", () => {
+      // The other side of the state: holding it is not only about the ask
+      // that fails, and a pattern timing its own work still gets its line.
+
+      const { lines, output } = collecting();
+      through(output.consoleHandler!, "time", "work");
+      through(output.consoleHandler!, "timeEnd", "work");
+      through(output.consoleHandler!, "count", "hits");
+      through(output.consoleHandler!, "count", "hits");
+      expect(lines.length).toBe(3);
+      expect(lines[0]).toMatch(/^work: [0-9]+\.[0-9]{3}ms$/);
+      expect(lines.slice(1)).toEqual(["hits: 1", "hits: 2"]);
+    });
+
+    it("takes one line per console call, with no ending of its own", () => {
+      // The destination separates its own lines, so the break the console put
+      // at the end of the message would be a blank row under every one of
+      // them.
+
+      const { lines, output } = collecting();
+      through(output.consoleHandler!, ConsoleMethod.Log, "one");
+      through(output.consoleHandler!, ConsoleMethod.Log, "two");
+      expect(lines).toEqual(["one", "two"]);
+    });
+
+    it("keeps a break inside a message, which is the message's own", () => {
+      const { lines, output } = collecting();
+      through(output.consoleHandler!, ConsoleMethod.Log, "one\ntwo");
+      expect(lines).toEqual(["one\ntwo"]);
+    });
+
+    it("formats what a pattern passed the way a console does", () => {
+      // The arguments are whatever a pattern handed `console.log`, and turning
+      // those into a line is a console's own job rather than a job this
+      // module should be doing a second way.
+
+      const { lines, output } = collecting();
+      through(output.consoleHandler!, ConsoleMethod.Log, { a: 1 }, [2, 3]);
+      expect(lines[0]).toContain("a: 1");
+      expect(lines[0]).toContain("2");
+    });
+
+    it("answers a `timeStamp`, which a console over a stream has none of", () => {
+      // A profiler mark is not a write, and Node's console over a stream
+      // carries no method for it — so a pattern calling it would find nothing
+      // there and the runtime would throw inside its own console dispatch.
+
+      const { lines, output } = collecting();
+      expect(() => through(output.consoleHandler!, ConsoleMethod.TimeStamp))
+        .not.toThrow();
+      expect(lines).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/test/shuttle-paint.test.ts
+++ b/packages/cli/test/shuttle-paint.test.ts
@@ -1,6 +1,6 @@
 /**
- * Unit tests for what a terminal is sent to show the line being typed, and to
- * end it.
+ * Unit tests for what a terminal is sent to show the line being typed, to end
+ * it, and to put a line above it.
  *
  * The expectations are the escape sequences themselves, written out. That is
  * the whole point of the module being separate from the writing: what a
@@ -15,11 +15,13 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import {
+  above,
   finish,
   NOTHING_PAINTED,
   type PaintedLine,
   repaint,
 } from "../lib/shuttle/paint.ts";
+import { glyphFor } from "../lib/view/display.ts";
 
 /** The width every case below draws at, unless it says otherwise. */
 const WIDTH = 10;
@@ -83,32 +85,101 @@ describe("paint", () => {
   });
 
   describe("finish()", () => {
-    it("returns the line ending alone where the line produced nothing", () => {
-      expect(finish(line("abc", 3), "")).toBe("\r\n");
-    });
-
-    it("returns what the line produced under it, with an ending of its own", () => {
-      expect(finish(line("abc", 3), "gone")).toBe("\r\ngone\r\n");
-    });
-
-    it("returns each break in what it writes with the return raw mode needs", () => {
-      expect(finish(NOTHING_PAINTED, "one\ntwo")).toBe("\r\none\r\ntwo\r\n");
+    it("returns the line ending alone, whatever the line said", () => {
+      expect(finish(line("abc", 3))).toBe("\r\n");
     });
 
     it("moves down to the last row of a wrapped line before ending it", () => {
-      expect(finish(line("a".repeat(25), 3), "")).toBe("\x1b[2B\r\n");
+      expect(finish(line("a".repeat(25), 3))).toBe("\x1b[2B\r\n");
     });
 
     it("moves up where the cursor sits past the last row a wrap filled", () => {
       // A line whose length is a whole number of rows leaves its cursor, at
       // the end, on a row holding none of it. Ending there would leave that
-      // row blank above what the line produced.
+      // row blank above whatever is written next.
 
-      expect(finish(line("a".repeat(20), 20), "")).toBe("\x1b[1A\r\n");
+      expect(finish(line("a".repeat(20), 20))).toBe("\x1b[1A\r\n");
     });
 
     it("ends a wrapped line at the width it was drawn at", () => {
-      expect(finish(line("a".repeat(25), 3, 20), "")).toBe("\x1b[1B\r\n");
+      expect(finish(line("a".repeat(25), 3, 20))).toBe("\x1b[1B\r\n");
+    });
+  });
+
+  describe("above()", () => {
+    it("clears the drawn line, writes the text, and draws the line again", () => {
+      expect(above(line("abc", 3), "gone"))
+        .toBe("\r\x1b[0Jgone\r\n\r\x1b7\x1b[0Jabc\x1b8\x1b[3C");
+    });
+
+    it("climbs to the row the drawn line started on before it clears", () => {
+      // The text goes above the whole of the drawn line, so a line that
+      // wrapped is climbed to its first row: written from where the cursor
+      // sits, the text would land in the middle of it.
+
+      expect(above(line("a".repeat(25), 25), "gone"))
+        .toContain("\x1b[2A\r\x1b[0Jgone");
+    });
+
+    it("writes each break in the text with the return raw mode needs", () => {
+      expect(above(NOTHING_PAINTED, "one\ntwo"))
+        .toBe("\r\x1b[0Jone\r\ntwo\r\n\r\x1b7\x1b[0J\x1b8");
+    });
+
+    it("shows every character a terminal acts on as the glyph naming it", () => {
+      // The contract names a class and exempts one character of it, which is
+      // a claim about all sixty-five: C0, `DEL`, and C1. So the case drives
+      // all sixty-five rather than the handful a person thinks of — a raw tab
+      // let through would break the contract and fail no sampled case, and a
+      // tab is the one of these a value plausibly holds.
+      //
+      // Two assertions per character and the first is the load-bearing one.
+      // That the raw character is gone is the property a terminal cares about
+      // and it names no glyph, so it holds whatever `glyphFor` draws; that
+      // the glyph is there is what makes the character still readable, and it
+      // asks `glyphFor` for the answer rather than restating it, the glyph
+      // being that function's to decide (`view-display.test.ts` pins which).
+
+      const acted = [
+        ...Array.from({ length: 0x20 }, (_, code) => code),
+        0x7f,
+        ...Array.from({ length: 0x20 }, (_, code) => 0x80 + code),
+      ];
+      expect(acted.length).toBe(65);
+
+      for (const code of acted) {
+        const character = String.fromCodePoint(code);
+        const sent = above(NOTHING_PAINTED, `a${character}b`);
+        if (character === "\n") continue;
+        expect({ code, raw: sent.includes(`a${character}b`) })
+          .toEqual({ code, raw: false });
+        expect({ code, shown: sent.includes(`a${glyphFor(character)}b`) })
+          .toEqual({ code, shown: true });
+      }
+    });
+
+    it("passes the line feed, which is the one of that class that is layout", () => {
+      // The exemption the case above steps over, asserted where it can be
+      // read: a break in the text arrived as a row from whoever composed the
+      // line, and it is sent as the row it is rather than as a picture of a
+      // character.
+
+      const sent = above(NOTHING_PAINTED, "a\nb");
+      expect(sent).toContain("a\r\nb");
+      expect(sent).not.toContain(glyphFor("\n"));
+    });
+
+    it("leaves a text holding nothing of that class alone", () => {
+      expect(above(NOTHING_PAINTED, "a b")).toContain("\r\x1b[0Ja b\r\n");
+    });
+
+    it("draws the line again at the width it was drawn at", () => {
+      expect(above(line("a".repeat(25), 25, 20), "gone"))
+        .toBe(
+          `\x1b[1A\r\x1b[0Jgone\r\n\r\x1b7\x1b[0J${
+            "a".repeat(25)
+          }\x1b8\x1b[1B\x1b[5C`,
+        );
     });
   });
 });

--- a/packages/cli/test/shuttle-prompt.test.ts
+++ b/packages/cli/test/shuttle-prompt.test.ts
@@ -1,10 +1,16 @@
 /**
- * Unit tests for the prompt: the loop that reads a line and writes what it
- * produced.
+ * Unit tests for the prompt: the loop that reads a line, runs it beside the
+ * keys, and writes what it produced.
  *
  * Every case drives the whole loop with a scripted key stream and reads back
  * the writes it made, so what is under test is the loop and the bindings — the
  * terminal, the keyboard and the escape sequences are all somewhere else.
+ *
+ * A case that needs a line to still be running while it types the next keys
+ * scripts the keys against the read itself ({@link gated}) rather than against
+ * a clock: the stream waits for the read to have started, and the read answers
+ * when the stream says so, so which of the two the loop sees first is decided
+ * by the case and not by how many microtasks a verb happens to take.
  *
  * The connection is a borrowed one throughout and no case reaches it: a verb
  * that reads stands its read in through the deps bag, so what the prompt does
@@ -38,12 +44,17 @@ const CONFIG: SpaceConfig = {
 /** The prompt a shuttle standing at the space root carries. */
 const AT_ROOT = "shuttle / @space> ";
 
+/** The prompt a shuttle standing at {@link HANDLE} carries. */
+const AT_PIECE = `shuttle ${HANDLE} @space> `;
+
 /** What the prompt wrote, in the order it wrote it. */
 type Write =
   /** It drew `text` as the line being edited, the cursor `column` into it. */
   | { readonly kind: "edit"; readonly text: string; readonly column: number }
-  /** It ended that line and wrote `text` under it. */
-  | { readonly kind: "finish"; readonly text: string };
+  /** It ended the line it was drawing. */
+  | { readonly kind: "finish" }
+  /** It wrote `text` above the line being edited. */
+  | { readonly kind: "announce"; readonly text: string };
 
 /** Helper for the cases below, which is a shuttle at the space root. */
 function shuttleIn(): Shuttle {
@@ -87,25 +98,66 @@ function alt(letter: string): Key {
 }
 
 /**
+ * Helper for the cases below, which is a read a case starts and answers, and
+ * the two events either side of it.
+ *
+ * A line is in flight for exactly as long as its read has not answered, so a
+ * case that wants to type into a running line waits on {@link Gated.started}
+ * and then calls {@link Gated.answer}. Neither wait is a poll and neither is a
+ * clock: the read resolves the first promise as it is called, and the case
+ * resolves the second.
+ */
+interface Gated {
+  /** Settles once the read has been called. */
+  readonly started: Promise<void>;
+
+  /** Answers the read with `value`, which settles the line. */
+  answer(value: unknown): void;
+
+  /** The read itself, for the deps bag. */
+  readonly read: () => Promise<unknown>;
+}
+
+/** Helper for the cases below, which is a read a case drives. */
+function gated(): Gated {
+  const started = Promise.withResolvers<void>();
+  const answered = Promise.withResolvers<unknown>();
+  return {
+    started: started.promise,
+    answer: (value) => answered.resolve(value),
+    read: () => {
+      started.resolve();
+      return answered.promise;
+    },
+  };
+}
+
+/**
  * Helper for the cases below, which runs `keys` against `shuttle` and returns
  * what the prompt wrote.
  *
  * The keys are a stream that ends, which is the only thing that ends a run
- * that no key ended: a case says what it types and the loop returns.
+ * that no key ended: a case says what it types and the loop returns once the
+ * line it was running has settled.
  */
 async function running(
-  keys: readonly Key[],
+  keys: readonly Key[] | AsyncIterable<Key>,
   shuttle: Shuttle = shuttleIn(),
   deps: VerbDeps = {},
 ): Promise<Write[]> {
   const writes: Write[] = [];
   const terminal: PromptTerminal = {
-    keys: ReadableStream.from(keys),
+    keys: Array.isArray(keys)
+      ? ReadableStream.from(keys as readonly Key[])
+      : keys as AsyncIterable<Key>,
     edit: (text, column) => {
       writes.push({ kind: "edit", text, column });
     },
-    finish: (text) => {
-      writes.push({ kind: "finish", text });
+    finish: () => {
+      writes.push({ kind: "finish" });
+    },
+    announce: (text) => {
+      writes.push({ kind: "announce", text });
     },
   };
   await runPrompt(shuttle, terminal, deps);
@@ -119,7 +171,7 @@ function drawn(writes: readonly Write[]): Write | undefined {
 
 /** Helper for the cases below, which is what each line produced, in order. */
 function produced(writes: readonly Write[]): string[] {
-  return writes.filter((write) => write.kind === "finish")
+  return writes.filter((write) => write.kind === "announce")
     .map((write) => write.text);
 }
 
@@ -128,43 +180,44 @@ describe("prompt", () => {
     it("draws the prompt before a key is typed", async () => {
       expect(await running([])).toEqual([
         { kind: "edit", text: AT_ROOT, column: AT_ROOT.length },
-        { kind: "finish", text: "" },
+        { kind: "finish" },
       ]);
     });
 
     it("draws the line as it is typed, and writes what it produced under it", async () => {
       // The one case reading the whole log. What it pins is the order: the
-      // line is drawn where it was typed and its result lands under it, which
-      // is what makes a transcript a record of what happened.
+      // line is drawn where it was typed, ended where it was run, and its
+      // result written above the prompt that came next — which is what makes
+      // a transcript a record of what happened.
 
       expect(await running([...typed("pw"), ENTER])).toEqual([
         { kind: "edit", text: AT_ROOT, column: 18 },
         { kind: "edit", text: `${AT_ROOT}p`, column: 19 },
         { kind: "edit", text: `${AT_ROOT}pw`, column: 20 },
+        { kind: "finish" },
         {
-          kind: "finish",
+          kind: "announce",
           text: "`pw` is not a verb. The verbs are `cd`, `get`, `help`, " +
             "`ls`, `pwd`, `where`, and `wish`.",
         },
         { kind: "edit", text: AT_ROOT, column: 18 },
-        { kind: "finish", text: "" },
+        { kind: "finish" },
       ]);
     });
 
     it("writes the text a verb composed", async () => {
       expect(produced(await running([...typed("pwd"), ENTER]))).toEqual([
         `position  @${SPACE}/\nscope     @space`,
-        "",
       ]);
     });
 
     it("writes nothing under a line naming no verb at all", async () => {
-      expect(produced(await running([ENTER]))).toEqual(["", ""]);
+      expect(produced(await running([ENTER]))).toEqual([]);
     });
 
     it("writes nothing under a line that moved the place", async () => {
       expect(produced(await running([...typed("cd slugs"), ENTER])))
-        .toEqual(["", ""]);
+        .toEqual([]);
     });
 
     it("draws the place a line moved to at the next prompt", async () => {
@@ -180,7 +233,7 @@ describe("prompt", () => {
       const writes = await running([...typed("get"), ENTER], atPiece(), {
         getCellValue: () => Promise.resolve({ title: "a" }),
       });
-      expect(produced(writes)).toEqual(['{\n  "title": "a"\n}', ""]);
+      expect(produced(writes)).toEqual(['{\n  "title": "a"\n}']);
     });
 
     it("writes `undefined` for a value nothing else can be written for", async () => {
@@ -191,7 +244,7 @@ describe("prompt", () => {
       const writes = await running([...typed("get"), ENTER], atPiece(), {
         getCellValue: () => Promise.resolve(undefined),
       });
-      expect(produced(writes)).toEqual(["undefined", ""]);
+      expect(produced(writes)).toEqual(["undefined"]);
     });
 
     it("writes a value's acted-on characters as the escapes JSON spells them with", async () => {
@@ -359,13 +412,12 @@ describe("prompt", () => {
       expect(produced(writes)).toEqual([
         "The server cannot be reached.",
         `position  /@${SPACE}/${HANDLE}@space\nscope     @space`,
-        "",
       ]);
     });
 
     it("ends the run on `ctrl-d` at an empty line", async () => {
       expect(produced(await running([control("d"), ...typed("pwd"), ENTER])))
-        .toEqual([""]);
+        .toEqual([]);
     });
 
     it("deletes forward on `ctrl-d` with something on the line", async () => {
@@ -382,19 +434,205 @@ describe("prompt", () => {
     });
 
     it("abandons the line on `ctrl-c` and reads the next one", async () => {
-      expect(produced(await running([...typed("pwd"), control("c"), ENTER])))
-        .toEqual(["", "", ""]);
+      // The next line is a whole line rather than the rest of one: were the
+      // abandoned text still there, what ran would be `pwdpwd`, which is no
+      // verb.
+
+      const writes = await running(
+        [...typed("pwd"), control("c"), ...typed("pwd"), ENTER],
+      );
+      expect(produced(writes))
+        .toEqual([`position  @${SPACE}/\nscope     @space`]);
     });
 
     it("ends the line it was drawing when the keys run out", async () => {
-      expect(produced(await running([...typed("pwd")]))).toEqual([""]);
+      const writes = await running([...typed("pwd")]);
+      expect(writes.at(-1)).toEqual({ kind: "finish" });
+      expect(produced(writes)).toEqual([]);
+    });
+  });
+
+  describe("a line in flight", () => {
+    // The loop's other half: the keys are read while a line is running, so a
+    // slow server holds up neither the keyboard nor the screen. Each case
+    // below scripts its keys against the read rather than against a clock —
+    // the stream waits for the read to have started and answers it when the
+    // case is done typing — so what the loop saw and in what order is the
+    // case's to decide.
+
+    /** Helper for the cases below, which is the read `get` at a piece makes. */
+    function reading(read: Gated): VerbDeps {
+      return { getCellValue: read.read };
+    }
+
+    it("draws a key typed while a line is in flight, before the line answers", async () => {
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get");
+          yield ENTER;
+          await read.started;
+          yield* typed("pw");
+          read.answer({ title: "a" });
+        })(),
+        atPiece(),
+        reading(read),
+      );
+      const shown = writes.findIndex((write) =>
+        write.kind === "edit" && write.text === `${AT_PIECE}pw`
+      );
+      const answered = writes.findIndex((write) => write.kind === "announce");
+      expect(shown).toBeGreaterThan(-1);
+      expect(answered).toBeGreaterThan(shown);
+    });
+
+    it("keeps what was typed while a line was in flight, under the prompt the line left", async () => {
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get");
+          yield ENTER;
+          await read.started;
+          yield* typed("pw");
+          read.answer({ title: "a" });
+        })(),
+        atPiece(),
+        reading(read),
+      );
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: `${AT_PIECE}pw`,
+        column: [...AT_PIECE].length + 2,
+      });
+    });
+
+    it("holds `enter` typed while a line is in flight, and runs it once the prompt is free", async () => {
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get");
+          yield ENTER;
+          await read.started;
+          yield* typed("pwd");
+          yield ENTER;
+          read.answer({ title: "a" });
+        })(),
+        atPiece(),
+        reading(read),
+      );
+      expect(produced(writes)).toEqual([
+        '{\n  "title": "a"\n}',
+        `position  /@${SPACE}/${HANDLE}@space\nscope     @space`,
+      ]);
+    });
+
+    it("runs a held line against the place the line before it settled on", async () => {
+      // What holding buys over running the line where it was typed: the `cd`
+      // is what moves the place, and the `pwd` behind it names the place the
+      // `cd` reached rather than the one the prompt showed while it ran.
+
+      const board = "of:fid1:qrstuvwxyz012345";
+      const resolution = gated();
+      const shuttle = shuttleIn();
+      moved(shuttle.place, "slugs");
+      const writes = await running(
+        (async function* () {
+          yield* typed("cd board");
+          yield ENTER;
+          await resolution.started;
+          yield* typed("pwd");
+          yield ENTER;
+          resolution.answer(board);
+        })(),
+        shuttle,
+        {
+          resolvePieceReference: async (_pieces, _token, path) => ({
+            piece: (await resolution.read()) as string,
+            pathAfter: [...path],
+          }),
+        },
+      );
+      expect(produced(writes)).toEqual([
+        `position  /@${SPACE}/${board}@space\nscope     @space`,
+      ]);
+    });
+
+    it("cancels the line in flight on `ctrl-c`, and reads the next line", async () => {
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get");
+          yield ENTER;
+          await read.started;
+          yield control("c");
+          yield* typed("pwd");
+          yield ENTER;
+          // The read the person stopped waiting for still answers, into
+          // nothing: what a cancel reaches is the line, never the server.
+          read.answer({ title: "a" });
+        })(),
+        atPiece(),
+        reading(read),
+      );
+      expect(produced(writes)).toEqual([
+        "Interrupted.",
+        `position  /@${SPACE}/${HANDLE}@space\nscope     @space`,
+      ]);
+    });
+
+    it("drops what was typed ahead when `ctrl-c` cancels the line", async () => {
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get");
+          yield ENTER;
+          await read.started;
+          yield* typed("pw");
+          yield control("c");
+          read.answer({ title: "a" });
+        })(),
+        atPiece(),
+        reading(read),
+      );
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: AT_PIECE,
+        column: [...AT_PIECE].length,
+      });
+    });
+
+    it("holds `ctrl-d` on an empty line, and ends the run once the prompt is free", async () => {
+      // The key that ends a run would leave a line in flight with nothing to
+      // report it to, so it is held like the other line-ender and acts once
+      // the line it was typed under has answered.
+      //
+      // The `pwd` behind it is what makes the holding readable rather than
+      // merely harmless: keys after a held one are held too, so what the
+      // `ctrl-d` ends the run over is a line already typed, and it never
+      // runs. Were the `ctrl-d` merely ignored, it would.
+
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get");
+          yield ENTER;
+          await read.started;
+          yield control("d");
+          yield* typed("pwd");
+          yield ENTER;
+          read.answer({ title: "a" });
+        })(),
+        atPiece(),
+        reading(read),
+      );
+      expect(produced(writes)).toEqual(['{\n  "title": "a"\n}']);
     });
   });
 
   describe("text the fabric wrote", () => {
     // Neither a refusal's reason nor a thrown read's message passed a door, so
     // neither has been held to the class a terminal acts on. Both are held to
-    // it here, where each becomes the line under the one that was typed, and
+    // it here, where each becomes the line above the prompt that follows, and
     // these cases are at that point rather than at either writer for the
     // reason the escaping is: a refusal built as a literal and a `throw` from
     // a module the verbs never see reach the same place by paths no writer
@@ -454,7 +692,7 @@ describe("prompt", () => {
         atPiece(),
         { getCellValue: () => Promise.reject(Object.create(null)) },
       );
-      expect(produced(writes).length).toBe(3);
+      expect(produced(writes).length).toBe(2);
       expect(produced(writes)[1]).toContain("position");
     });
 

--- a/packages/cli/test/shuttle-run.test.ts
+++ b/packages/cli/test/shuttle-run.test.ts
@@ -14,8 +14,9 @@ import { describe, it } from "@std/testing/bdd";
 
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import type { PiecesController } from "@commonfabric/piece/ops";
+import { ConsoleMethod } from "@commonfabric/runner";
 
-import type { SpaceConfig } from "../lib/piece.ts";
+import type { ConnectionOutput, SpaceConfig } from "../lib/piece.ts";
 import type { PromptTerminal } from "../lib/shuttle/prompt.ts";
 import { runShuttle, type ShuttleDeps } from "../lib/shuttle/run.ts";
 import type { Key } from "../lib/view/keys.ts";
@@ -70,7 +71,8 @@ async function running(
   const terminal: PromptTerminal = {
     keys: ReadableStream.from([...typed(line), { name: "enter" }]),
     edit: () => {},
-    finish: (text) => {
+    finish: () => {},
+    announce: (text) => {
       produced.push(text);
     },
   };
@@ -107,6 +109,51 @@ describe("runShuttle()", () => {
     expect(ran.closed()).toBe(1);
   });
 
+  it("opens the connection writing onto the prompt's own line", async () => {
+    // Finding 8's wiring, read at the seam the connection is opened through:
+    // what the connection writes for itself and what a pattern writes to its
+    // console both reach the terminal's out-of-band line, which is the only
+    // place a line can land while a prompt is painted in raw mode.
+
+    const announced: string[] = [];
+    let output: ConnectionOutput | undefined;
+    const pieces = {
+      dispose: () => Promise.resolve(),
+      getSpace: () => SPACE,
+      getSpaceName: () => "board",
+    } as unknown as PiecesController;
+    await runShuttle(CONFIG, {
+      open: (_config, opened) => {
+        output = opened;
+        return Promise.resolve(pieces);
+      },
+      terminal: (body) =>
+        body({
+          keys: ReadableStream.from([]),
+          edit: () => {},
+          finish: () => {},
+          announce: (text) => {
+            announced.push(text);
+          },
+        }),
+    });
+    output?.report?.("navigateTo new piece id of:fid1:whatever");
+    // What the runtime does with a handler's answer: it writes the arguments
+    // to the console the handler named. Where that console writes is what
+    // `announce.ts` decides and what its own cases pin.
+    const routed = output?.consoleHandler?.({
+      metadata: undefined,
+      method: ConsoleMethod.Log,
+      args: ["a pattern said so"],
+    });
+    const target = Array.isArray(routed) ? undefined : routed?.target;
+    target?.log("a pattern said so");
+    expect(announced).toEqual([
+      "navigateTo new piece id of:fid1:whatever",
+      "a pattern said so",
+    ]);
+  });
+
   it("closes the connection where the session threw", async () => {
     let closed = 0;
     const pieces = {
@@ -119,18 +166,44 @@ describe("runShuttle()", () => {
     } as unknown as PiecesController;
     await expect(runShuttle(CONFIG, {
       open: () => Promise.resolve(pieces),
-      terminal: () => Promise.reject(new Error("No terminal.")),
-    })).rejects.toThrow("No terminal.");
+      terminal: (body) =>
+        body({
+          keys: ReadableStream.from([]),
+          edit: () => {
+            throw new Error("No screen.");
+          },
+          finish: () => {},
+          announce: () => {},
+        }),
+    })).rejects.toThrow("No screen.");
     expect(closed).toBe(1);
   });
 
-  it("reports the connection that would not open, and reaches no terminal", async () => {
+  it("opens no connection at all where the terminal would not open", async () => {
+    // The terminal is opened first, because it is where the connection's own
+    // writing has to land. So a terminal that will not open closes nothing —
+    // there is nothing to close, which is a stronger property than closing
+    // what there was.
+
+    let opened = 0;
+    await expect(runShuttle(CONFIG, {
+      open: () => {
+        opened += 1;
+        return Promise.reject(new Error("Never asked."));
+      },
+      terminal: () => Promise.reject(new Error("No terminal.")),
+    })).rejects.toThrow("No terminal.");
+    expect(opened).toBe(0);
+  });
+
+  it("reports the connection that would not open, from inside the terminal", async () => {
     // What the name does not claim is that nothing was closed. With no
     // connection there is no controller to close, so a case asserting a
     // close count would be asserting on a stub nothing could reach. What is
     // observable is that the opener's own failure is what comes back — a
     // disposal that raised over it would say something else — and that the
-    // run stops before the terminal.
+    // terminal was already open when it happened, which is what puts the
+    // connection's own writing on the screen the shell holds.
 
     let reached = false;
     await expect(runShuttle(CONFIG, {
@@ -141,9 +214,10 @@ describe("runShuttle()", () => {
           keys: ReadableStream.from([]),
           edit: () => {},
           finish: () => {},
+          announce: () => {},
         });
       },
     })).rejects.toThrow("The server refused.");
-    expect(reached).toBe(false);
+    expect(reached).toBe(true);
   });
 });

--- a/packages/cli/test/shuttle-terminal.test.ts
+++ b/packages/cli/test/shuttle-terminal.test.ts
@@ -22,7 +22,12 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
-import { finish, NOTHING_PAINTED, repaint } from "../lib/shuttle/paint.ts";
+import {
+  above,
+  finish,
+  NOTHING_PAINTED,
+  repaint,
+} from "../lib/shuttle/paint.ts";
 import type { PromptTerminal } from "../lib/shuttle/prompt.ts";
 import { withPromptTerminal } from "../lib/shuttle/terminal.ts";
 import type { Key } from "../lib/view/keys.ts";
@@ -453,12 +458,43 @@ describe("terminal", () => {
 
       const watched = await watching({ consoleSize: wide(40) }, (terminal) => {
         terminal.edit("ab", 2);
-        terminal.finish("gone");
+        terminal.finish();
         return Promise.resolve();
       });
       expect(watched.written()).toBe(
         repaint(NOTHING_PAINTED, { text: "ab", column: 2, columns: 40 }) +
-          finish({ text: "ab", column: 2, columns: 40 }, "gone"),
+          finish({ text: "ab", column: 2, columns: 40 }),
+      );
+    });
+
+    it("writes an out-of-band line above the line it is drawing", async () => {
+      const watched = await watching({ consoleSize: wide(40) }, (terminal) => {
+        terminal.edit("ab", 2);
+        terminal.announce("gone");
+        return Promise.resolve();
+      });
+      const drawn = { text: "ab", column: 2, columns: 40 };
+      expect(watched.written()).toBe(
+        repaint(NOTHING_PAINTED, drawn) + above(drawn, "gone"),
+      );
+    });
+
+    it("leaves the line drawn after writing above it", async () => {
+      // The whole log rather than its tail: the second announcement is
+      // composed against the line the first one redrew, so a terminal that
+      // forgot the line was still there would climb over a line it thinks is
+      // gone and write the second one a row too high.
+
+      const watched = await watching({ consoleSize: wide(40) }, (terminal) => {
+        terminal.edit("a".repeat(45), 45);
+        terminal.announce("one");
+        terminal.announce("two");
+        return Promise.resolve();
+      });
+      const drawn = { text: "a".repeat(45), column: 45, columns: 40 };
+      expect(watched.written()).toBe(
+        repaint(NOTHING_PAINTED, drawn) + above(drawn, "one") +
+          above(drawn, "two"),
       );
     });
 
@@ -469,7 +505,7 @@ describe("terminal", () => {
 
       const watched = await watching({ consoleSize: wide(40) }, (terminal) => {
         terminal.edit("a".repeat(45), 45);
-        terminal.finish("");
+        terminal.finish();
         terminal.edit("b", 1);
         return Promise.resolve();
       });
@@ -479,7 +515,7 @@ describe("terminal", () => {
       const wrapped = { text: "a".repeat(45), column: 45, columns: 40 };
       expect(watched.written()).toBe(
         repaint(NOTHING_PAINTED, wrapped) +
-          finish(wrapped, "") +
+          finish(wrapped) +
           repaint(NOTHING_PAINTED, { text: "b", column: 1, columns: 40 }),
       );
     });

--- a/packages/cli/test/shuttle-verbs.test.ts
+++ b/packages/cli/test/shuttle-verbs.test.ts
@@ -2119,4 +2119,542 @@ describe("verbs", () => {
       ).toEqual({ kind: "value", value: null });
     });
   });
+
+  describe("a line the prompt cancelled", () => {
+    // What an `AbortSignal` on the deps bag buys, which is a check at each
+    // boundary between a verb's phases rather than anything that reaches a
+    // read already sent. Two properties follow and both are pinned here: a
+    // cancelled line sends no read it had not sent, and it adopts no place.
+    //
+    // `cd` is the verb with boundaries to check, and it has three reads to
+    // sit between: the resolution, the handle lookup, and the walk of the
+    // path. Every case below aborts from inside one of them, which is where a
+    // `ctrl-c` really arrives — while something is in flight. A signal
+    // aborted before the line starts is the one case that does not need a
+    // read to arrange it.
+
+    /** Helper for the cases below, which is a signal already aborted. */
+    function cancelled(): AbortSignal {
+      const stopper = new AbortController();
+      stopper.abort();
+      return stopper.signal;
+    }
+
+    /**
+     * Every read this module can issue, by the name a case knows it by.
+     *
+     * It is the whole set rather than a selection, and what closes it is that
+     * each is a seam a case stands in for: a read this module makes through
+     * anything else is a read no case could have stood in for, which is a
+     * different defect and one `READS_NOTHING` catches on every case in this
+     * file. The one await that reaches the world and is not here is
+     * `connection.pieces()`, which answers off the holder's memo — shuttle
+     * opens its connection before the prompt reads its first line
+     * (`run.ts`), so within a line it sends nothing.
+     */
+    const READS = [
+      "getCellValue",
+      "readWish",
+      "resolvePieceReference",
+      "listSpaceSlugs",
+      "listPieces",
+      "listCellKeys",
+      "entityIdExists",
+    ] as const;
+
+    /** One of {@link READS}. */
+    type Read = typeof READS[number];
+
+    /** Where a case puts the cancel. */
+    type Cancel =
+      /** Inside that read, as it is issued. */
+      | Read
+      /**
+       * The moment the line first gives up control, whatever it was waiting
+       * on. A verb runs synchronously to its first `await`, so the abort
+       * lands in that window without a case having to name what opens it —
+       * which is what lets these cases cover a boundary nobody enumerated.
+       */
+      | "suspend";
+
+    /** What a cancelled line was seen to do. */
+    interface Watched {
+      /** Every read it issued, in order. */
+      readonly reached: Read[];
+
+      /** Every read it issued after the cancel, which must be none. */
+      readonly afterCancel: Read[];
+    }
+
+    /**
+     * Helper for the cases below, which runs `line` against the shuttle
+     * `standing` builds, cancels it at `at`, and returns what it read.
+     *
+     * Every read is stood in for and every one is counted, so what comes back
+     * is the whole of what the line asked the world for. A read is recorded
+     * as after the cancel when the signal was already aborted as it was
+     * issued — the read that carries the cancel is not one of those, the
+     * abort being raised as it is entered rather than before.
+     */
+    async function cancelling(
+      line: string,
+      standing: (pieces: PiecesController) => Shuttle,
+      at: Cancel,
+    ): Promise<Watched> {
+      const stopper = new AbortController();
+      const reached: Read[] = [];
+      const afterCancel: Read[] = [];
+      const note = (name: Read) => {
+        reached.push(name);
+        if (stopper.signal.aborted) afterCancel.push(name);
+        if (name === at) stopper.abort();
+      };
+      const shuttle = standing(
+        {
+          dispose: () => Promise.resolve(),
+          getSpace: () => SPACE,
+          getSpaceName: () => SPACE_NAME,
+          entityIdExists: () => {
+            note("entityIdExists");
+            return Promise.resolve(true);
+          },
+        } as unknown as PiecesController,
+      );
+      const running = runLine(line, shuttle, {
+        getCellValue: () => {
+          note("getCellValue");
+          return Promise.resolve({ title: "a" });
+        },
+        readWish: () => {
+          note("readWish");
+          return Promise.resolve({
+            result: { [LINK_MARKER_KEY]: `/${HANDLE}` },
+          });
+        },
+        resolvePieceReference: (_pieces, token, path) => {
+          note("resolvePieceReference");
+          return Promise.resolve({
+            piece: token === "board" ? BOARD : token,
+            pathAfter: [...path],
+          });
+        },
+        listing: {
+          listSpaceSlugs: () => {
+            note("listSpaceSlugs");
+            return Promise.resolve([]);
+          },
+          listPieces: () => {
+            note("listPieces");
+            return Promise.resolve([]);
+          },
+          listCellKeys: () => {
+            note("listCellKeys");
+            return Promise.resolve([]);
+          },
+        },
+        signal: stopper.signal,
+      });
+      if (at === "suspend") stopper.abort();
+      await running;
+      return { reached, afterCancel };
+    }
+
+    /** Helper for the cases below, which stands at the space root. */
+    const atRoot = (pieces: PiecesController) => shuttleIn(pieces);
+
+    /** Helper for the cases below, which stands at the facet `facet`. */
+    const atFacet = (facet: string) => (pieces: PiecesController) => {
+      const shuttle = shuttleIn(pieces);
+      moved(shuttle.place, facet);
+      return shuttle;
+    };
+
+    /** Helper for the cases below, which stands on a piece. */
+    const onPiece = (pieces: PiecesController) => {
+      const shuttle = shuttleIn(pieces);
+      moved(shuttle.place, `/${HANDLE}`);
+      return shuttle;
+    };
+
+    /**
+     * Every line and cancel these cases drive, which is what closes the claim
+     * they make.
+     *
+     * The claim is a universal — *no* read is issued after a cancel — and the
+     * risk in one is a case that samples the boundaries somebody thought of.
+     * So the rows are not boundaries at all: each names a read to cancel from
+     * inside, or asks for the cancel at the line's first suspension without
+     * naming what that is. A boundary nobody enumerated still fails here,
+     * provided a row reaches it, and the case below the table is what holds
+     * the rows to reaching every read there is.
+     */
+    const CANCELLED: readonly (readonly [
+      string,
+      (pieces: PiecesController) => Shuttle,
+      Cancel,
+    ])[] = [
+      ["cd board/title", atFacet("slugs"), "suspend"],
+      ["cd board/title", atFacet("slugs"), "resolvePieceReference"],
+      ["cd board/title", atFacet("slugs"), "getCellValue"],
+      [`cd /${BOARD}/title`, atRoot, "resolvePieceReference"],
+      [`cd /${BOARD}/title`, atRoot, "entityIdExists"],
+      ["cd #favorites", atRoot, "suspend"],
+      ["cd #favorites", atRoot, "readWish"],
+      ["cd .@session", onPiece, "suspend"],
+      ["get title", onPiece, "suspend"],
+      ["get", onPiece, "suspend"],
+      ["wish #favorites", atRoot, "suspend"],
+      ["ls", atFacet("slugs"), "suspend"],
+      ["get title", onPiece, "getCellValue"],
+      ["wish #favorites", atRoot, "readWish"],
+      ["ls", atFacet("slugs"), "listSpaceSlugs"],
+      ["ls", atFacet("pieces"), "listPieces"],
+      ["ls", onPiece, "listCellKeys"],
+    ];
+
+    it("issues no read after the cancel, on any line and from any read", async () => {
+      // The contract's universal half, driven rather than enumerated. Each
+      // row is reported with the line and the cancel that produced it, so a
+      // row that fails names the boundary that lost its guard rather than
+      // leaving the whole table red with nothing said.
+
+      for (const [line, standing, at] of CANCELLED) {
+        const watched = await cancelling(line, standing, at);
+        expect({ line, at, after: watched.afterCancel })
+          .toEqual({ line, at, after: [] });
+      }
+    });
+
+    /**
+     * The verbs that read nothing, and so have no read for a cancel to stop.
+     *
+     * It is asserted rather than asserted about: the case below runs each
+     * with every read standing in as a throw, so a verb listed here that
+     * reaches one fails instead of being excused by this list.
+     */
+    const READS_NOTHING_AT_ALL = ["help", "pwd", "where"];
+
+    it("cancels a line of every verb, or says why the verb has no read", async () => {
+      // What closes the set of verbs, which is the gap the rows above had:
+      // `wish` and `ls` reach `guarded` with nothing awaited in front of it,
+      // so a cancel at the first suspension is the only cancel that can catch
+      // a guard that has drifted — and neither had a row.
+      //
+      // The list is the module's own answer rather than a list kept here: a
+      // word that is no verb is refused with the verbs named, so a verb added
+      // to the dispatch is a verb this case demands a row for.
+
+      const refusal = await runLine("frob", shuttleIn(), READS_NOTHING);
+      const named = [...reasonOf(refusal).matchAll(/`([a-z]+)`/g)]
+        .map((found) => found[1])
+        .filter((word) => word !== "frob");
+      const suspended = CANCELLED
+        .filter(([, , at]) => at === "suspend")
+        .map(([line]) => line.split(" ")[0]);
+      expect([...new Set(named)].sort())
+        .toEqual([...new Set([...suspended, ...READS_NOTHING_AT_ALL])].sort());
+
+      // And the excused ones are excused truthfully: every read throws, so a
+      // verb that reached one would raise rather than answer.
+      for (const verb of READS_NOTHING_AT_ALL) {
+        const outcome = await runLine(verb, shuttleIn(), READS_NOTHING);
+        expect({ verb, kind: outcome.kind }).toEqual({ verb, kind: "text" });
+      }
+    });
+
+    it("drives every read there is, which is what closes the case above", async () => {
+      // Without this the table would be a sample wearing a universal's
+      // words: rows reaching six of the seven reads would pass while the
+      // seventh went unguarded. A read added to the module is added to
+      // `READS`, and this fails until a row reaches it.
+
+      const reached = new Set<Read>();
+      for (const [line, standing, at] of CANCELLED) {
+        for (const read of (await cancelling(line, standing, at)).reached) {
+          reached.add(read);
+        }
+      }
+      expect([...reached].sort()).toEqual([...READS].sort());
+    });
+
+    it("sends no wish where the cancel arrived while the selection parsed", async () => {
+      // `resolveTarget` parses the selection `--select @` spells before it
+      // sends the wish, and the parse is an await. So a cancel lands in that
+      // window, and what it must stop is the read the parse was preparing.
+
+      const watched = await cancelling("cd #favorites", atRoot, "suspend");
+      expect(watched.reached).toEqual([]);
+    });
+
+    it("resolves no piece where the cancel arrived while the connection was asked for", async () => {
+      // The settle asks the holder for the connection before it resolves
+      // anything, and that ask is an await of its own. The resolution behind
+      // it is a read, so the window the ask opens is a boundary.
+
+      const watched = await cancelling(
+        "cd board/title",
+        atFacet("slugs"),
+        "suspend",
+      );
+      expect(watched.reached).toEqual([]);
+    });
+
+    it("reads no cell where the cancel arrived while the operand was placed", async () => {
+      // Where a `get`'s operand points can itself be a read — a space
+      // written as a name is asked of the connection — so placing the
+      // operand and reading the cell are two phases, and this is the
+      // boundary between them.
+
+      const watched = await cancelling("get title", onPiece, "suspend");
+      expect(watched.reached).toEqual([]);
+    });
+
+    it("runs no verb at all for a line already cancelled", async () => {
+      // The check at the dispatch, which is the only one a verb that reads
+      // nothing ever meets: `pwd` composes its answer out of what the process
+      // is already holding, so no guarded read stands between the cancel and
+      // an answer, and without this check a cancelled line would get one.
+
+      expect(
+        await runLine("pwd", shuttleIn(), {
+          ...READS_NOTHING,
+          signal: cancelled(),
+        }),
+      ).toEqual({ kind: "interrupted" });
+    });
+
+    it("sends no read for a line already cancelled", async () => {
+      let read = 0;
+      const outcome = await runLine("get", atPiece(), {
+        ...READS_NOTHING,
+        getCellValue: () => {
+          read += 1;
+          return Promise.resolve(null);
+        },
+        signal: cancelled(),
+      });
+      expect(outcome).toEqual({ kind: "interrupted" });
+      expect(read).toBe(0);
+    });
+
+    it("still refuses a line that was wrong, cancelled or not", async () => {
+      // The reading of the words happens before the check, and it is worth
+      // making either way: a line that named no verb is not a verb that was
+      // interrupted, and telling a person their line was cancelled when it
+      // was misspelled would send them back to a line that never could run.
+
+      expect(
+        await runLine("frob", shuttleIn(), {
+          ...READS_NOTHING,
+          signal: cancelled(),
+        }),
+      ).toEqual({
+        kind: "refused",
+        reason: "`frob` is not a verb. The verbs are `cd`, `get`, `help`, " +
+          "`ls`, `pwd`, `where`, and `wish`.",
+      });
+    });
+
+    it("walks no path where the cancel arrived during the resolution", async () => {
+      // The first boundary a settle has: the resolution has answered and the
+      // walk has not been asked for. The slug resolves to a piece other than
+      // the one it was spelled as, which is what proves it held — so this
+      // move has no lookup between the two, and the check after the
+      // resolution is the one that stops the walk.
+
+      const shuttle = shuttleIn();
+      moved(shuttle.place, "slugs");
+      const stopper = new AbortController();
+      let walked = 0;
+      const outcome = await runLine("cd board/title", shuttle, {
+        ...READS_NOTHING,
+        resolvePieceReference: (_pieces, _token, path) => {
+          stopper.abort();
+          return Promise.resolve({ piece: BOARD, pathAfter: [...path] });
+        },
+        getCellValue: () => {
+          walked += 1;
+          return Promise.resolve({ title: "a" });
+        },
+        signal: stopper.signal,
+      });
+      expect(outcome).toEqual({ kind: "interrupted" });
+      expect(walked).toBe(0);
+    });
+
+    it("looks no handle up where the cancel arrived during the resolution", async () => {
+      // The lookup's own guard, which the walk's guard would otherwise stand
+      // in for: a cancel arriving during the resolution must stop the lookup,
+      // not merely the walk behind it. The piece is spelled as a handle, so
+      // the resolution proves nothing and the lookup is the read that would
+      // have gone out next.
+
+      const shuttle = shuttleIn(lookingUp(true));
+      const stopper = new AbortController();
+      let looked = 0;
+      const outcome = await runLine(`cd /${BOARD}/title`, {
+        ...shuttle,
+        connection: new HeldConnection({
+          kind: "borrowed",
+          pieces: {
+            dispose: () => Promise.resolve(),
+            getSpace: () => SPACE,
+            getSpaceName: () => SPACE_NAME,
+            entityIdExists: () => {
+              looked += 1;
+              return Promise.resolve(true);
+            },
+          } as unknown as PiecesController,
+        }),
+      }, {
+        ...READS_NOTHING,
+        resolvePieceReference: (_pieces, token, path) => {
+          stopper.abort();
+          return Promise.resolve({ piece: token, pathAfter: [...path] });
+        },
+        signal: stopper.signal,
+      });
+      expect(outcome).toEqual({ kind: "interrupted" });
+      expect(looked).toBe(0);
+    });
+
+    it("walks no path where the cancel arrived during the handle lookup", async () => {
+      // The second boundary, and the one only a move with a handle to look up
+      // reaches: `entityIdExists` has answered and the walk has not been asked
+      // for. A handle is a spelling that proves nothing, so this is the move
+      // that pays for the lookup — and a lookup is a round trip a person is as
+      // likely to be waiting on as any other.
+
+      const shuttle = shuttleIn();
+      const stopper = new AbortController();
+      let walked = 0;
+      const outcome = await runLine(`cd /${BOARD}/title`, {
+        ...shuttle,
+        connection: new HeldConnection({
+          kind: "borrowed",
+          pieces: {
+            dispose: () => Promise.resolve(),
+            getSpace: () => SPACE,
+            getSpaceName: () => SPACE_NAME,
+            entityIdExists: () => {
+              stopper.abort();
+              return Promise.resolve(true);
+            },
+          } as unknown as PiecesController,
+        }),
+      }, {
+        ...READS_NOTHING,
+        resolvePieceReference: (_pieces, token, path) =>
+          Promise.resolve({ piece: token, pathAfter: [...path] }),
+        getCellValue: () => {
+          walked += 1;
+          return Promise.resolve({ title: "a" });
+        },
+        signal: stopper.signal,
+      });
+      expect(outcome).toEqual({ kind: "interrupted" });
+      expect(walked).toBe(0);
+    });
+
+    it("moves nowhere where the cancel arrived during the last read", async () => {
+      // The check before the place is adopted, which is the one that matters:
+      // `cd` is the verb whose success means something, and a line the person
+      // stopped waiting for must not go on to promise a place.
+      //
+      // The cancel arrives during the walk, which is the settle's last read
+      // and the one no check inside the settle follows — it answers, the path
+      // is found, and the settle says the fabric holds the place. So nothing
+      // but the check at the adoption stands between this cancel and a move,
+      // which is why the case aims here rather than at an earlier read: an
+      // earlier one is stopped by a check of its own, and would pass with the
+      // adoption unguarded.
+
+      const shuttle = shuttleIn();
+      moved(shuttle.place, "slugs");
+      const stopper = new AbortController();
+      const outcome = await runLine("cd board/title", shuttle, {
+        ...READS_NOTHING,
+        resolvePieceReference: (_pieces, _token, path) =>
+          Promise.resolve({ piece: BOARD, pathAfter: [...path] }),
+        getCellValue: () => {
+          stopper.abort();
+          return Promise.resolve({ title: "a" });
+        },
+        signal: stopper.signal,
+      });
+      expect(outcome).toEqual({ kind: "interrupted" });
+      expect(shuttle.place.place.position).toEqual({
+        kind: "facet",
+        space: SPACE,
+        facet: "slugs",
+      });
+    });
+
+    it("changes no scope where the cancel arrived during a scope's own settle", async () => {
+      // A scope on its own settles, because a scope selects which document a
+      // piece's id names and the place at the new one is a place nothing has
+      // read. So it reaches the fabric like any other move onto a piece, and
+      // a person waiting on it can stop waiting — and what a cancel has to
+      // leave alone here is the scope rather than the position, which is the
+      // half of a place the other cases do not assert.
+
+      const shuttle = shuttleIn();
+      await runLine(`cd /${HANDLE}/topics`, shuttle, settling({ topics: 1 }));
+      const stopper = new AbortController();
+      const outcome = await runLine("cd .@session", shuttle, {
+        ...settling({ topics: 1 }),
+        getCellValue: () => {
+          stopper.abort();
+          return Promise.resolve({ topics: 1 });
+        },
+        signal: stopper.signal,
+      });
+      expect(outcome).toEqual({ kind: "interrupted" });
+      expect(shuttle.place.place.scope).toBe("space");
+    });
+
+    it("enters no target where the cancel arrived while it was resolving", async () => {
+      // The same check on the arm a `#name` target takes: the fabric answered
+      // with an address, and the place is not moved into it.
+
+      const shuttle = shuttleIn();
+      const stopper = new AbortController();
+      const outcome = await runLine("cd #favorites", shuttle, {
+        ...READS_NOTHING,
+        readWish: () => {
+          stopper.abort();
+          return Promise.resolve({
+            result: { [LINK_MARKER_KEY]: `/${HANDLE}` },
+          });
+        },
+        signal: stopper.signal,
+      });
+      expect(outcome).toEqual({ kind: "interrupted" });
+      expect(shuttle.place.place.position).toEqual({
+        kind: "root",
+        space: SPACE,
+      });
+    });
+
+    it("runs the line to the end where nothing cancelled it", async () => {
+      // The other side of every case above: a signal that is merely present
+      // stops nothing, so what the checks cost a line nobody interrupted is
+      // nothing at all.
+
+      const shuttle = shuttleIn();
+      moved(shuttle.place, "slugs");
+      const outcome = await runLine("cd board", shuttle, {
+        ...settling(null, { board: BOARD }),
+        signal: new AbortController().signal,
+      });
+      expect(outcome.kind).toBe("moved");
+      expect(shuttle.place.place.position).toEqual({
+        kind: "piece",
+        space: SPACE,
+        piece: BOARD,
+        name: "board",
+        path: [],
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Why

`runPrompt` is `for await (const key of terminal.keys)` with `await report(...)`
inside it, so the run has one event source at a time. With the toolshed paused,
a `get` blocks; `ctrl-c` and `pwd` typed during the wait are not echoed and do
nothing; when the server resumes, the queued keys execute blind. In raw mode
the terminal generates no `SIGINT` for `ctrl-c` — it is a key, and the key is
not read until the awaited verb returns, so `terminal.ts`'s signal listeners
never fire.

For an operator, a server being slow is the normal condition of a debugging
session, and a shell that freezes with it has to be killed. Today the blind
queue can only navigate and read. **In B2 it can `set` and `call`**, which is
why this lands before the writing verbs rather than after.

The same restructuring supplies a primitive nothing else has: a line that
lands *above* the one being edited. That is decision 28's event line, A4's
`announce` sink, and the home for the runtime's own console output — a
pattern's `console.log`, the traverse warnings, and the navigate line, all of
which currently write into the middle of a painted prompt in raw mode.

Architecture-review findings 4 and 8.

## What Changed

- **The key stream is read continuously and a running line is a task beside
  it.** `ctrl-c` cancels the line in flight through an `AbortSignal` threaded
  into `VerbDeps`; other keys are held and replayed after the settle redraw, so
  a held line runs against the place the previous one reached.
- **`PromptTerminal` gains a third write**, `announce`. `finish` loses its text
  parameter: a line's result can no longer be written by the call that ends the
  line, because between them the person may have typed.
- **`run.ts` routes the runtime's `consoleHandler` and the navigate callback**
  to that line, and the `console.warn` sweep in `lib/piece.ts` that
  `runtime-integration.md` item 5 lists is finished.
- **Everything reaching the out-of-band line is glyphed for control
  characters**, reusing `escapeControlCharacters` rather than growing a second
  predicate. The newline is the one exception, deliberately: runtime output and
  stack traces are multi-line, and `\n` is layout. This matters because what
  comes through this door is a pattern's `console.log` — arbitrary text
  authored by user programs.

### Design calls, flagged

- **Keys are held, never belled.** The brief allowed a bell; bell-on-`enter`
  turns out to depend on a microtask race — after `enter`, `report` and
  `keys.next()` both settle in microtasks — and `typedKeys` yields a pasted
  batch synchronously, so every paste races. A pasted `pwd\nls\n` would also
  leave `pwdls` in the buffer. Holding is ordering-independent, so no bell
  exists.
- **`ctrl-c` races rather than only checking phase boundaries.** Phase checks
  alone deliver nothing for `get`, which has one read — the observed case. The
  race abandons the *line* and returns the prompt; a read already sent finishes
  into nothing, and the doc comment says so rather than implying otherwise. The
  phase checks still earn their place: they stop the abandoned continuation
  adopting a place, which would be a silent `cd` after "Interrupted."
- **A hung read still wedges the connection, not the shell.** `ctrl-c` returns
  the prompt; the abandoned read runs on and nothing in shuttle can call it
  off. No timeout was added to fake it.

## Test plan

- `deno task check` exit 0. `packages/cli`: **parallel 1808 / 0 failed, serial
  215 / 0 failed**, exit 0. `deno fmt --check` (5769 files) and `deno lint`
  (5607) clean. All eight `check-*` gates exit 0.
- **32 mutations, each run, each redding the case designated for it.**
- **This branch rebased across the `cd`-settles slice, which rewrote every
  function its cancellation checks sit in — and one check had gone dead.**
  M17's check survived textually and still sat before `place.confirm`, but its
  case aborted during the resolution, where `settlePiece`'s own newer check now
  returns first; deleting M17's check changed no test. It has been re-aimed at
  the read nothing inside `settlePiece` follows — the path walk — and reds
  again. M16 would likewise have been parked *after* `entityIdExists` by the
  merge, leaving the resolution-to-lookup boundary unguarded.
- **Two read paths that did not exist when this was written now have checks**:
  after the resolution and after the handle lookup. A wedged `entityIdExists`
  is a round trip on the plainest `cd` there is, and is exactly the hang
  `ctrl-c` is for. New mutations M31 and M32, both red.
- `check-no-waitfor` scans only `packages/*/integration/`, so **its green says
  nothing about these unit tests**. The absence of timers, sleeps, polls and
  retries was verified by hand instead; the in-flight cases wait on
  `Promise.withResolvers` deferreds the read itself resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

