### PR TITLE
fix(runner): a `db` input that is not a handle settles as the query's error rather than killing the action

### DIFF
--- a/docs/common/capabilities/sqlite.md
+++ b/docs/common/capabilities/sqlite.md
@@ -53,6 +53,21 @@ export default pattern<{ orders: SqliteDb }>(({ orders }) => {
 });
 ```
 
+The call returns an envelope, not the rows:
+`{ pending, result?, error?, withheld? }`. `result` holds the rows once there
+are any, so a field typed as the rows themselves — `PerSession<Row[]>` — cannot
+take the call's value, and reading `.result` is what gets from one to the
+other. `withheld` counts the rows a read-time clearance kept from this reader,
+and is absent unless the query asked for one.
+
+Render the failure, not just the wait. A pattern that branches only on
+`pending` shows a loading view for as long as the query stays broken, because a
+query that failed is settled — `pending` is `false` and `error` holds the
+reason — and nothing further arrives to move it on. `error` reaches the pattern
+for a statement the database refuses and for a handle that does not read back
+as one, so a view that shows it is the difference between a page that says what
+went wrong and a page that spins.
+
 The `<Row>` type argument names the columns the statement projects, and is what
 turns a result into something typed. Without it the rows come back as
 `Record<string, unknown>`, and a `_cf_link` column comes back as a raw link

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -901,7 +901,19 @@ export function sqliteQuery(
       );
     }
 
-    const db = readDbRef(inputs.db);
+    // A `db` that does not read back as a handle reaches the result cell as
+    // this query's error, on the same terms as an unencodable parameter
+    // below. The guard above admits any truthy value, and an object read
+    // that resolved to nothing is `{}` — truthy, and not a handle — so the
+    // throw would otherwise leave the action dead and the query pending for
+    // good, with no later reactive pass to recover it once the handle reads.
+    let db: SqliteDbRef;
+    try {
+      db = readDbRef(inputs.db);
+    } catch (error) {
+      result.withTx(tx).set({ pending: false, error: errMsg(error) });
+      return;
+    }
     const linkCols = asCellColumnsFromRowSchema(inputs.rowSchema);
     let params: WireParams;
     try {

--- a/packages/runner/test/sqlite-query-invalid-handle.test.ts
+++ b/packages/runner/test/sqlite-query-invalid-handle.test.ts
@@ -17,6 +17,8 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { Identity } from "@commonfabric/identity";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
+import { table } from "@commonfabric/memory/sqlite/schema";
+import type { SqliteDbRef } from "@commonfabric/memory/v2";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import { createBuilder } from "../src/builder/factory.ts";
@@ -98,6 +100,75 @@ describe("sqliteQuery()", () => {
     it("settles a string `db` with the same `error`", async () => {
       const state = await settledQueryOver("string", "of:fid1:not-a-handle");
       expect(state.error).toBe("sqlite: invalid database handle");
+    });
+  });
+
+  describe("a `db` that becomes a handle after the error", () => {
+    // The other half of the contract the reported error buys. Settling the
+    // error rather than throwing is only worth anything if the action that
+    // settled it is still subscribed to its inputs: an action killed by a
+    // throw reports the same first state and never reaches the second. So the
+    // case drives one query across both, through a single input cell.
+
+    it("re-runs the same action and settles a successful result once the input reads back as a handle", async () => {
+      const dbRef: SqliteDbRef = {
+        id: `of:recovers-${crypto.randomUUID()}`,
+        tables: { notes: table({ id: "integer primary key", body: "text" }) },
+      };
+      // Seeded through the real write path, so a recovered read that returns
+      // this row cannot be confused with a query answering over no table.
+      const seedTx = runtime.edit();
+      seedTx.recordSqliteWrite!(space, {
+        op: "sqlite",
+        db: dbRef,
+        sql: "INSERT INTO notes (body) VALUES (?)",
+        params: ["recovered"],
+      });
+      expect((await seedTx.commit()).error).toBeUndefined();
+
+      // `{}` is what an object read that resolved to nothing produces, and is
+      // the state the handle arrives late from.
+      const inputs = runtime.getCell<{ db: unknown }>(
+        space,
+        "sqlite-invalid-handle-recovers-inputs",
+        undefined,
+        tx,
+      );
+      inputs.set({ db: {} });
+
+      const queryPattern = cf.pattern<{ db: unknown }>(({ db }) =>
+        cf.sqliteQuery({
+          db: db as never,
+          sql: "SELECT body FROM notes",
+          reactOn: db as never,
+        })
+      );
+      const resultCell = runtime.getCell(
+        space,
+        "sqlite-invalid-handle-recovers-result",
+        queryPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, queryPattern, inputs, resultCell);
+      await tx.commit();
+
+      const failed = await waitForCellValue<QueryState>(
+        runtime,
+        result,
+        (value) => value?.pending === false,
+      );
+      expect(failed.error).toBe("sqlite: invalid database handle");
+
+      await runtime.editWithRetry((edit) => {
+        inputs.withTx(edit).key("db").set(dbRef);
+      });
+
+      const recovered = await waitForCellValue<QueryState>(
+        runtime,
+        result,
+        (value) => value?.pending === false && value?.error === undefined,
+      );
+      expect(recovered.result).toEqual([{ body: "recovered" }]);
     });
   });
 });

--- a/packages/runner/test/sqlite-query-invalid-handle.test.ts
+++ b/packages/runner/test/sqlite-query-invalid-handle.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `sqliteQuery` over a `db` input that does not read back as a database
+ * handle: the failure reaches the query result as its `error` rather than
+ * throwing out of the reactive action.
+ *
+ * The truthiness guard admits any non-empty value, and an object read that
+ * resolved to nothing is `{}` — truthy, and not a handle. A throw there kills
+ * the action for good: the scheduler logs one failure and no later pass
+ * re-runs the query once the handle does read, so the piece stays pending
+ * with nothing to show for it. Reported as the result's `error` — the state
+ * an unencodable parameter already produces — the pattern can render it and a
+ * later pass can still succeed.
+ */
+
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+interface QueryState {
+  pending: boolean;
+  result?: unknown;
+  error?: unknown;
+}
+
+describe("sqliteQuery()", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let cf: ReturnType<typeof createBuilder>["commonfabric"];
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    tx = runtime.edit();
+    ({ commonfabric: cf } = createTrustedBuilder(runtime));
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime.idle();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /**
+   * Runs a query whose `db` is `dbInput` and returns the settled result. The
+   * cause names the case so each `it()` gets a result cell of its own.
+   */
+  async function settledQueryOver(
+    label: string,
+    dbInput: unknown,
+  ): Promise<QueryState> {
+    const queryPattern = cf.pattern(() =>
+      // The cast is the subject: each case supplies a `db` the handle type
+      // excludes, which is what a read resolving to nothing produces at
+      // runtime whatever the declaration says.
+      cf.sqliteQuery({ db: dbInput as never, sql: "SELECT body FROM notes" })
+    );
+    const resultCell = runtime.getCell(
+      space,
+      `sqlite-invalid-handle-${label}`,
+      queryPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, queryPattern, {}, resultCell);
+    await tx.commit();
+    return await waitForCellValue<QueryState>(
+      runtime,
+      result,
+      (value) => value?.pending === false,
+    );
+  }
+
+  describe("a `db` that is not a database handle", () => {
+    it("settles an empty object with `error` naming the invalid handle", async () => {
+      const state = await settledQueryOver("empty-object", {});
+      expect(state.error).toBe("sqlite: invalid database handle");
+      expect(state.result).toBeUndefined();
+      expect(state.pending).toBe(false);
+    });
+
+    it("settles a handle missing its `id` with the same `error`", async () => {
+      const state = await settledQueryOver("no-id", { tables: {} });
+      expect(state.error).toBe("sqlite: invalid database handle");
+    });
+
+    it("settles a string `db` with the same `error`", async () => {
+      const state = await settledQueryOver("string", "of:fid1:not-a-handle");
+      expect(state.error).toBe("sqlite: invalid database handle");
+    });
+  });
+});


### PR DESCRIPTION
## What

`sqliteQuery` guards its inputs with `!inputs?.db`, which admits any truthy
value. An object read that resolved to nothing is `{}` — truthy, and not a
handle — so `readDbRef` threw out of the reactive action
(`packages/runner/src/builtins/sqlite-builtins.ts:904`, throwing at `:183`).

A thrown reactive action is dead. The scheduler logs one `schedule-error` and
no later pass re-runs the query once the handle does read, so the piece stays
pending for good with nothing to show for it.

This reports it on the result cell instead, on the same terms as an
unencodable parameter a few lines below: `{ pending: false, error }`. The
pattern can render it, and a later pass can still succeed.

## Why this, and not the thing the ticket described

CT-2189 / CT-2066 probe A run 3 ended with the deployed piece reporting its
`mail` input as `{}` and the scheduler logging
`TypeError: sqlite: invalid database handle`. The reading was that the
`SqliteDb` input had failed to bind. It had not:

- The piece's stored `mail` is a correct link to the handle cell, and
  `cf inspect overlay` shows that cell holding `{id, rev, tables}` inline in a
  single `space` scope — not a link-to-a-link.
- Reproduced end to end without a model against the same live handle, the same
  posture, and run 18's exact source: `run_pattern` returns `ok` and
  `sqliteQuery` receives `inputs.db` fully populated.
- The `mail` = `{}` reading is an artifact of `cf cell get --input`, which
  reads through the pattern's argument schema. A *working* piece reports `{}`
  the same way.

What is real is the *permanence*: a `db` that reads as `{}` at some pass kills
the query forever instead of surfacing. That is what this fixes. The trigger
that produced `{}` in run 3 is timing-dependent and is **not** reproduced here;
the fix does not depend on reproducing it.

A separate, spec-level defect found on the way — `SqliteDb`'s emitted value
schema is `{type: "object", properties: {}}`, which contradicts
`docs/specs/sqlite-builtin/01-api.md:46` ("not an empty object") and is what
filters those reads to `{}` — is deliberately **not** in this PR. It is a
cross-package schema-generator/ts-transformers change that widens a CFC-visible
surface, and is being filed separately for a foundation ruling.

## Docs

`docs/common/capabilities/sqlite.md` gains the `query()` return shape
(`{ pending, result?, error?, withheld? }`) and the rule that a pattern renders
the error state rather than branching on `pending` alone — a query that failed
is settled, so a view that waits on `pending` waits forever. Run 3's piece
stuck on a loading card is exactly that.

## Tests

`packages/runner/test/sqlite-query-invalid-handle.test.ts` drives the guard
directly with `{}`, a handle missing its `id`, and a string, asserting a
settled `error` rather than a throw. Reverting the fix fails all three with the
same `schedule-error` signature run 3 logged.

## Checks

- `deno fmt --check` (5768 files), `deno lint` — clean
- `deno task check`, `deno task check-docs` (594 blocks), `deno task check-no-waitfor` — pass
- `packages/runner`: `deno task test` — 1391 passed, 0 failed
- `packages/cf-harness`: 23 failures, all pre-existing — the identical 23 fail
  on `origin/main` content (skills.sh discovery, Codex model client, delegate
  persistence; none sqlite-related)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

