### PR TITLE
fix(llm): `generateObject`'s default names a model the gateway serves

### DIFF
--- a/docs/features/llm-provider-boundary.md
+++ b/docs/features/llm-provider-boundary.md
@@ -92,13 +92,17 @@ repeated here.
 Two places where the division is less clean than the above, both worth knowing
 before relying on it:
 
-- `DEFAULT_GENERATE_OBJECT_MODELS` in
+- `DEFAULT_GENERATE_OBJECT_MODEL` in
   [`packages/llm/src/types.ts`](../../packages/llm/src/types.ts) is a
-  provider-qualified model name on the caller's side, and
+  qualified model name on the caller's side, and
   `packages/toolshed/routes/ai/llm/generateObject.ts` imports it back to use as
-  a default. It names an OpenAI model, which registers only where
-  `CFTS_AI_LLM_OPENAI_API_KEY` is set, so on a deployment without that key the
-  `generateObject` default names a model nothing registered.
+  a default. The server's own answer to "which model when the caller names
+  none" is the `default` alias; this constant sits beside that answer rather
+  than deferring to it, because `generateObject` wants a cheaper model than a
+  deployment's general default. What it costs is that the name is a guess about
+  what the deployment serves: it names a `gateway:` model, so a deployment
+  whose gateway does not answer, or does not serve that name, has a
+  `generateObject` default naming a model nothing registered.
 - The response shape of `GET /api/ai/llm/models` is caller-facing vocabulary
   written three times on the server's side — `Capabilities` and
   `GatewayModelCapabilities` in `models.ts`, and the response schema in

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -562,11 +562,13 @@ export class LLMClient {
   /**
    * Sends a request to the LLM service.
    *
-   * @param userRequest The LLM request object.
-   * @param partialCB Optional callback for streaming text responses.
-   * @param toolCallCB Optional callback for tool call events.
+   * @param request The LLM request object.
+   * @param callback Optional callback for streaming text responses.
+   * @param abortSignal Optional signal that abandons the request.
+   * @param opts Optional per-call overrides, currently the endpoint.
    * @returns The full LLM response with content and tool information.
-   * @throws If the request fails after retrying with fallback models.
+   * @throws If the request fails. The request is issued once, against the
+   *   model `request` names; no other model is tried in its place.
    */
   async sendRequest(
     request: LLMRequest,

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -19,9 +19,20 @@ import { isObjectNotArray } from "@commonfabric/utils/types";
  */
 export const DEFAULT_MODEL_NAME: ModelName = "default";
 
-// NOTE(ja): This should be an array of models, the first model will be tried, if it
-// fails, the second model will be tried, etc.
-export const DEFAULT_GENERATE_OBJECT_MODELS: ModelName = "openai:gpt-5-mini";
+/**
+ * The model a `generateObject` request names when it names none. What those
+ * requests mostly do is pull structured data out of text against a schema, and
+ * a mini-tier model is cheap enough to be a default for that and accurate
+ * enough to hold the schema.
+ *
+ * The name is gateway-qualified because that is what a deployment can be
+ * relied on to serve: the toolshed discovers the gateway's models from the
+ * gateway itself, where a name qualified by a direct provider registers only
+ * where that provider's key is set. Which models exist is decided in
+ * `packages/toolshed/routes/ai/llm/models.ts`, and
+ * `docs/features/llm-provider-boundary.md` describes the boundary in full.
+ */
+export const DEFAULT_GENERATE_OBJECT_MODEL: ModelName = "gateway:gpt-5.4-mini";
 
 export type LLMResponse = BuiltInLLMMessage & {
   // The trace span ID

--- a/packages/llm/test/types.test.ts
+++ b/packages/llm/test/types.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { BuiltInLLMContent, BuiltInLLMMessage } from "@commonfabric/api";
 import {
+  DEFAULT_GENERATE_OBJECT_MODEL,
   DEFAULT_MODEL_NAME,
   GOOGLE_SEARCH_NATIVE_MODEL_TOOL,
   isLLMTool,
@@ -169,6 +170,17 @@ describe("types", () => {
       }));
       expect(problem).toContain("Message 1");
       expect(problem).toContain(`not "wizard"`);
+    });
+  });
+
+  describe("DEFAULT_GENERATE_OBJECT_MODEL", () => {
+    it("names a gateway model", () => {
+      // A deployment's catalog is discovered at run time, so no list here can
+      // say the name is served. What this holds is the weaker property the
+      // name has to have to be servable at all: the toolshed registers the
+      // gateway's models wherever the gateway answers, where a name qualified
+      // by a direct provider registers only where that provider's key is set.
+      expect(DEFAULT_GENERATE_OBJECT_MODEL.startsWith("gateway:")).toBe(true);
     });
   });
 

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -12,7 +12,7 @@ import {
 } from "@commonfabric/data-model-schema";
 import { hashOf } from "@commonfabric/data-model";
 import {
-  DEFAULT_GENERATE_OBJECT_MODELS,
+  DEFAULT_GENERATE_OBJECT_MODEL,
   DEFAULT_MODEL_NAME,
   extractTextFromLLMResponse,
   GOOGLE_SEARCH_NATIVE_MODEL_TOOL,
@@ -1428,7 +1428,7 @@ export function generateText(
  * @param schema - JSON Schema to validate the response against.
  * @param system - Optional system message.
  * @param maxTokens - Maximum number of tokens to generate.
- * @param model - Model to use (defaults to DEFAULT_GENERATE_OBJECT_MODELS).
+ * @param model - Model to use (defaults to DEFAULT_GENERATE_OBJECT_MODEL).
  * @param cache - Whether to cache the response (defaults to true).
  * @param metadata - Additional metadata to pass to the LLM.
  * @param tools - Optional tools to make available to the LLM.
@@ -1618,7 +1618,7 @@ export function generateObject<T extends Record<string, unknown>>(
         stop: "",
         maxTokens: maxTokens ?? 8192,
         stream: true,
-        model: model ?? DEFAULT_GENERATE_OBJECT_MODELS,
+        model: model ?? DEFAULT_GENERATE_OBJECT_MODEL,
         metadata: {
           ...readyMetadata,
           context: "piece",
@@ -2053,7 +2053,7 @@ export function generateObject<T extends Record<string, unknown>>(
         schema: llmToolExecutionHelpers.prepareSchemaForLLM(
           toDeepFrozenSchema(schema),
         ),
-        model: model ?? DEFAULT_GENERATE_OBJECT_MODELS,
+        model: model ?? DEFAULT_GENERATE_OBJECT_MODEL,
         metadata: {
           ...readyMetadata,
           context: "piece",

--- a/packages/toolshed/routes/ai/llm/generateObject.test.ts
+++ b/packages/toolshed/routes/ai/llm/generateObject.test.ts
@@ -58,7 +58,7 @@ describe("generateObject server-side", () => {
               properties: { value: { type: "number" } },
             },
             messages: [{ role: "user", content: "give me a number" }],
-            // No model specified — falls back to DEFAULT_GENERATE_OBJECT_MODELS
+            // No model specified — falls back to DEFAULT_GENERATE_OBJECT_MODEL
           }),
         Error,
       );

--- a/packages/toolshed/routes/ai/llm/generateObject.ts
+++ b/packages/toolshed/routes/ai/llm/generateObject.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_GENERATE_OBJECT_MODELS } from "@commonfabric/llm";
+import { DEFAULT_GENERATE_OBJECT_MODEL } from "@commonfabric/llm";
 import {
   type LLMGenerateObjectRequest,
   type LLMGenerateObjectResponse,
@@ -38,7 +38,7 @@ async function generateObjectCall(
       string,
       unknown
     >;
-    const modelName = params.model ?? DEFAULT_GENERATE_OBJECT_MODELS;
+    const modelName = params.model ?? DEFAULT_GENERATE_OBJECT_MODEL;
     const modelConfig = await resolveModel(modelName);
     if (!modelConfig) {
       throw new LLMRequestError(`Unsupported model: ${modelName}`);


### PR DESCRIPTION
## What

`generateObject`'s default now names a model the gateway serves: `DEFAULT_GENERATE_OBJECT_MODEL = "gateway:gpt-5.4-mini"`.

The default was `openai:gpt-5-mini`, which no deployment registers: the toolshed's catalog is the gateway's, discovered from it, and a direct-provider name registers only where that provider's key is set. Every `generateObject` call that named no model was answered `400 Unsupported model`.

`gateway:gpt-5.4-mini` is the cheap OpenAI-family model the gateway serves, which is the tier structured extraction wants (mini over nano: nano is the classification tier).

The constant's plural name went with a NOTE describing an array of models tried in turn, which is not what it holds and not what either caller does with it, so the name is singular and the note is gone. `docs/features/llm-provider-boundary.md` updated to match.

`sendRequest`'s doc comment now describes the one request it makes: the `@throws` line promised retries with fallback models, but `sendRequest` issues a single fetch and the toolshed resolves exactly `payload.model`; neither side substitutes another model. Its `@param` names also named parameters the method does not have; corrected against the signature (Codex review finding, taken).

## Why

CT-2268. Found by CT-2189 probe A run 3: the bills extraction went through `generateObject` with no explicit model and died on the unsupported default, independently of the handle question.

## Not in this PR

The `"default"` model sentinel is also unresolvable on the loom gateway (`DEFAULT_MODEL_CANDIDATES` names `claude-sonnet-4-6`, the gateway serves `claude-sonnet-5`) — CT-2271, deployment config. The gateway also currently returns `429 no credits remaining`, which is billing, not this.

## Tests

`packages/llm/test/types.test.ts` pins that the default names a `gateway:`-qualified model; verified to fail on `openai:gpt-5-mini`. The catalog is discovered at run time, so no static list asserts it is served.
