### PR TITLE
fix(schema-generator): a SqliteDb's emitted schema is the handle descriptor

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -154,6 +154,7 @@ by any repo test.
 | `FabricSpecialObject` nominal brand (the `"@commonfabric/FabricSpecialObject"` key, `FABRIC_SPECIAL_OBJECT_BRAND` in `packages/data-model/src/api.ts`) on any other branded type | property skipped entirely (not in `properties`, not in `required`) — the key exists only in the type system, so no runtime value could ever satisfy it; e.g. a field typed as the `FabricPrimitive` base emits `{ type: "object", properties: {} }` | `shouldSkipInternalProperty`, `object-formatter.ts` | fixture `fabric-special-object-brand` |
 | TS `enum` declaration | hoisted under the enum name with **no `type` key** (all-literal union path, §8): numeric → `$defs: { Color: { enum: [0,1,2] } }` + `$ref`; string → `$defs: { Mode: { enum: ["on","off"] } }` | union path `union-formatter.ts`; hoisting §5 | `test/enum-schema-rows.test.ts` |
 | Single enum member type (`Mode.On`) | inline literal schema, e.g. `{ type: "string", enum: ["on"] }`; enum-member symbols are excluded from named-type hoisting so same-named members and unrelated named types cannot collide in `$defs` | `getNamedTypeKey`, `type-utils.ts`; pinned by `test/enum-member-hoisting.test.ts` | — |
+| `SqliteDatabase` (the `SqliteDb` handle's value, carrying the `SQLITE_DB_BRAND` unique symbol) | the handle descriptor `{ id, tables, rev }` with `additionalProperties: true` (§5.2), hoisted under `SqliteDatabase`; the brand's own members describe nothing, so a structural schema would shape a handle read down to `{}` | `native-type-formatter.ts` | `test/schema/cell-type.test.ts`; end-to-end: ts-transformers `handler-schema/sqlite-db-handler-state`, `schema-injection/scoped-sqlite-factory` |
 | `Date` / `URL` / typed arrays / etc. | native table, §5.2 | `native-type-formatter.ts` | date-types fixture, native-type tests |
 | `Map`/`WeakMap`/`Set`/`WeakSet` | **throws** (§13) | `type-utils.ts` | `schema-generator.test.ts` |
 | `Reactive<T>` | erases to `<T>`'s schema, **no marker** (§6.4) | — | `capability-wrapper-types.test.ts` |
@@ -238,6 +239,21 @@ emits that class's schema-vocabulary name, a leaf with no `properties`, no
 (`schemaTypeOfFabricPrimitive`,
 `packages/data-model-schema/src/schemaTypeOfFabricPrimitive.ts`); the dialect side is
 specified in `docs/specs/json_schema.md`.
+
+`NativeTypeFormatter` also claims one type that is not in the name table: the
+`SqliteDb` handle's readable value, recognized by the `SQLITE_DB_BRAND` unique
+symbol its type carries (`declaresSqliteDbBrand`). It emits the handle
+descriptor the SQLite spec defines
+(`docs/specs/sqlite-builtin/01-api.md`) —
+`{ type: "object", properties: { id: { type: "string" }, tables: { type: "object", additionalProperties: true }, rev: { type: "number" } }, additionalProperties: true }`.
+The type's own members describe nothing (a nominal brand is a single symbol
+key), so a structural schema would shape every read of a handle down to `{}`.
+`tables` carries the author-declared table schemas, whose per-column `ifc`
+labels are what a pattern reads to write a query, and `additionalProperties`
+keeps the fields outside the descriptor (`scope`, `owner`) from being dropped.
+Because the claim is by brand rather than by name, this one keeps its ordinary
+`$defs` hoisting: every `SqliteDb` position emits
+`$ref: "#/$defs/SqliteDatabase"` against one descriptor.
 
 The remaining typed arrays and the buffer types map to `true` (accept
 anything), which overclaims: none of them is representable as a `FabricValue`,

--- a/docs/specs/sqlite-builtin/01-api.md
+++ b/docs/specs/sqlite-builtin/01-api.md
@@ -55,12 +55,20 @@ empty object:
   [05](./05-reactivity.md)). It exists so `reactOn: db` re-runs after a write and
   so concurrent writes serialize; patterns do not read it directly.
 
+That descriptor is what the compiler emits as the schema of a `SqliteDb`
+position (`NativeTypeFormatter`, `packages/schema-generator`), keyed on the
+`SQLITE_DB_BRAND` the handle type carries: the brand's own members describe
+nothing, so a schema derived from them would shape every read of a handle down
+to `{}`. `tables` therefore reads back whole, per-column `ifc` labels included
+— a pattern needs the declared columns to write a query against the database,
+and the disclosure is the same one `describe_handle` makes deliberately.
+
 ```ts
 // Shown at module scope.
 export declare const SQLITE_DB_BRAND: unique symbol;
-/** Opaque database handle value (the SqliteDb cell's readable value). Patterns
- *  forward the SqliteDb cell to db.query / db.exec / reactOn; they do not read
- *  the handle fields directly. */
+/** The SqliteDb cell's readable value: the `{ id, tables, rev }` descriptor
+ *  above, behind a nominal brand. Patterns usually just forward the SqliteDb
+ *  cell to db.query / db.exec / reactOn. */
 export type SqliteDatabase = { readonly [SQLITE_DB_BRAND]: true };
 
 /** Imperative write: records a SQLite write onto the current transaction. */

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2730,9 +2730,13 @@ export type DataFileFunction = (path: string) => string;
 export declare const SQLITE_DB_BRAND: unique symbol;
 
 /**
- * Database handle. Empty to pattern code; a cell reference to the runtime
- * via the `toCell` back-pointer. Patterns only ever *forward* it (to sqliteQuery
- * / sqliteExecute / reactOn), never read it.
+ * Database handle. Nominal to pattern code — the brand is the whole of the
+ * type — and a cell reference to the runtime via the `toCell` back-pointer.
+ * A pattern normally just *forwards* it (to `db.query` / `db.exec` /
+ * `sqliteQuery` / `reactOn`). Its readable value is the descriptor
+ * `{ id, tables, rev }` (docs/specs/sqlite-builtin/01-api.md), which is what
+ * the compiler emits for a `SqliteDb` position, so a pattern that wants the
+ * declared columns can read `tables`.
  */
 export type SqliteDatabase = { readonly [SQLITE_DB_BRAND]: true };
 

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1450,11 +1450,13 @@ export class CellImpl<T extends FabricValue>
     // can call `.exec`); at runtime we validate the actual handle value rather
     // than `#kind`, since handler-input materialization doesn't always stamp the
     // kind onto the delivered cell. Read the handle with `getRaw()` (NOT `get()`):
-    // the delivered cell's schema is the `SqliteDatabase` shape (no declared
-    // properties), so `get()` would shape the handle down to `{}` and drop the
-    // `id`/`tables` fields. Use `lastNode: "value"` so the FINAL link is still
-    // resolved (a handler-delivered handle may sit behind a link at its target) —
-    // getRaw's default `"top"` would stop at the link object and miss `id`.
+    // the delivered cell's schema is whatever the pattern that declared the
+    // handle was compiled against, and a pattern compiled before the descriptor
+    // emission carries the empty `SqliteDatabase` shape, which shapes the handle
+    // down to `{}` and drops the `id`/`tables` fields. Use `lastNode: "value"`
+    // so the FINAL link is still resolved (a handler-delivered handle may sit
+    // behind a link at its target) — getRaw's default `"top"` would stop at the
+    // link object and miss `id`.
     const handle = this.getRaw({ lastNode: "value" }) as
       | { id?: unknown; tables?: unknown; scope?: unknown }
       | undefined;
@@ -1467,8 +1469,8 @@ export class CellImpl<T extends FabricValue>
     // stores the handle inline (self-contained), but a handle written before
     // that fix can still hold doc LINKS where the rule's AST nodes should be,
     // so `getRaw` alone would see links. The permissive schema bypasses the
-    // SqliteDb shape (no declared properties) that would shape `get()` down
-    // to `{}`.
+    // handle's declared shape, which for a pattern compiled before the
+    // descriptor emission has no properties and shapes `get()` down to `{}`.
     const materialized = this.asSchema(
       { type: "object", additionalProperties: true } as JSONSchema,
     ).withTx(this.tx).get() as { tables?: unknown } | undefined;

--- a/packages/runner/test/sqlite-db-exec.test.ts
+++ b/packages/runner/test/sqlite-db-exec.test.ts
@@ -117,9 +117,10 @@ describe("SqliteDb .exec (commit-folded write)", () => {
   });
 
   it("reads the handle via getRaw even when the cell schema shapes it to {}", async () => {
-    // Real handler-input materialization delivers the handle cell with the
-    // `SqliteDatabase` schema (an object type with NO declared properties). A
-    // schema-shaped `get()` would project the handle down to `{}` and drop
+    // A pattern compiled before the handle descriptor landed declares the
+    // handle as an object type with NO properties, and handler-input
+    // materialization delivers the handle cell under that schema. A
+    // schema-shaped `get()` projects the handle down to `{}` and drops
     // `id`/`tables`; `.exec` must read the raw handle (getRaw, lastNode:"value")
     // and still fold the write. Regression guard for the get()->getRaw() fix.
     const dbRef: SqliteDbRef = {
@@ -148,6 +149,46 @@ describe("SqliteDb .exec (commit-folded write)", () => {
     const provider = storageManager.open(space);
     const r = await provider.sqliteQuery!(dbRef, "SELECT body FROM notes");
     expect(r.rows).toEqual([{ body: "hi" }]);
+  });
+
+  it("reads back id/rev/tables through the emitted handle descriptor", async () => {
+    // The schema a pattern now declares for a `SqliteDb` position (the
+    // descriptor emitted by `packages/schema-generator`). A read through it
+    // must return the handle, not `{}` — including the table schemas whose
+    // per-column `ifc` labels a pattern needs to write a query.
+    const dbRef: SqliteDbRef & { rev: number } = {
+      id: `of:exec-descriptor-${crypto.randomUUID()}`,
+      rev: 3,
+      tables: {
+        notes: table({ id: "integer primary key", body: "text" }),
+      },
+    };
+    const tx = runtime.edit();
+    const handle = runtime.getCell(space, "db-descriptor", undefined, tx);
+    handle.set(dbRef);
+    const db = createCell(
+      runtime,
+      {
+        ...handle.getAsNormalizedFullLink(),
+        schema: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            tables: { type: "object", additionalProperties: true },
+            rev: { type: "number" },
+          },
+          additionalProperties: true,
+        },
+      },
+      tx,
+      false,
+      "sqlite",
+    ) as unknown as SqliteDbCell;
+    const value = db.get() as typeof dbRef;
+    expect(value.id).toBe(dbRef.id);
+    expect(value.rev).toBe(3);
+    expect(value.tables).toEqual(dbRef.tables);
+    await tx.commit();
   });
 
   it("throws on an undefined param, allows null", async () => {

--- a/packages/schema-generator/src/formatters/native-type-formatter.ts
+++ b/packages/schema-generator/src/formatters/native-type-formatter.ts
@@ -53,6 +53,40 @@ const NATIVE_TYPE_SCHEMAS: Record<string, MutableJSONSchema> = {
   JSONSchema: true,
 };
 
+/**
+ * The readable value of a `SqliteDb` handle: the descriptor
+ * `{ id, tables, rev }` (`docs/specs/sqlite-builtin/01-api.md`). The handle
+ * type is a nominal brand — a single `unique symbol` member — so the shape its
+ * members describe is empty, and a schema derived from them shapes every read
+ * of the handle down to `{}`.
+ *
+ * `tables` holds the author-declared table schemas, arbitrary JSON Schema
+ * whose per-column `ifc` labels are what a pattern reads to write a query
+ * against the database, so it passes through unfiltered. The handle also
+ * carries fields outside the descriptor the runtime resolves for itself
+ * (`scope`, `owner`); `additionalProperties: true` is what keeps a read
+ * through this schema from dropping them.
+ */
+const SQLITE_DATABASE_SCHEMA: MutableJSONSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    tables: { type: "object", additionalProperties: true },
+    rev: { type: "number" },
+  },
+  additionalProperties: true,
+};
+
+/**
+ * Escaped-name prefix TypeScript gives a property keyed by the exported
+ * `SQLITE_DB_BRAND` unique symbol (`packages/api/index.ts`). Claiming the
+ * handle by its brand rather than by the name `SqliteDatabase` keeps an
+ * unrelated user type of that name on its structural schema — and, unlike the
+ * name-keyed entries above, leaves the branded type its ordinary `$defs`
+ * hoisting, so every `SqliteDb` position keeps referring to one descriptor.
+ */
+const SQLITE_DB_BRAND_PREFIX = "__@SQLITE_DB_BRAND@";
+
 const NATIVE_TYPE_NAMES = new Set(Object.keys(NATIVE_TYPE_SCHEMAS));
 const FABRIC_PRIMITIVE_TYPE_NAMES: ReadonlySet<string> = new Set(
   FABRIC_PRIMITIVE_SCHEMA_TYPES,
@@ -87,6 +121,9 @@ const LIB_DECLARED_NATIVE_TYPES = new Set([
  */
 export class NativeTypeFormatter implements TypeFormatter {
   supportsType(type: ts.Type, context: GenerationContext): boolean {
+    if (NativeTypeFormatter.declaresSqliteDbBrand(type)) {
+      return true;
+    }
     const typeName = NativeTypeFormatter.#getTypeName(type);
     if (!NativeTypeFormatter.isNativeType(typeName)) {
       return false;
@@ -107,7 +144,9 @@ export class NativeTypeFormatter implements TypeFormatter {
     _context: GenerationContext,
   ): MutableJSONSchema {
     const typeName = NativeTypeFormatter.#getTypeName(type);
-    const schema = NATIVE_TYPE_SCHEMAS[typeName!];
+    const schema = NativeTypeFormatter.declaresSqliteDbBrand(type)
+      ? SQLITE_DATABASE_SCHEMA
+      : NATIVE_TYPE_SCHEMAS[typeName!];
     // TODO(danfuzz): `structuredClone()` mangles non-JSON `FabricValue`s —
     // harmless while `NATIVE_TYPE_SCHEMAS` are plain JSON, but a problem once
     // schema-generator covers the full `FabricValue` spectrum. See the matching
@@ -188,6 +227,20 @@ export class NativeTypeFormatter implements TypeFormatter {
    */
   public static declaresFabricSpecialObjectBrand(type: ts.Type): boolean {
     return type.getProperty(FABRIC_SPECIAL_OBJECT_BRAND) !== undefined;
+  }
+
+  /**
+   * Whether the type carries the `SqliteDb` handle's nominal brand, and so IS
+   * the database handle whose readable value is the `{ id, tables, rev }`
+   * descriptor rather than a type that happens to be named for it.
+   */
+  public static declaresSqliteDbBrand(type: ts.Type): boolean {
+    // Members are only resolved for object types, so no other type reaching
+    // this formatter pays for the check.
+    if ((type.flags & ts.TypeFlags.Object) === 0) return false;
+    return type.getProperties().some((property) =>
+      (property.escapedName as string).startsWith(SQLITE_DB_BRAND_PREFIX)
+    );
   }
 
   static #hasLibraryDeclaration(

--- a/packages/schema-generator/test/schema/cell-type.test.ts
+++ b/packages/schema-generator/test/schema/cell-type.test.ts
@@ -48,6 +48,48 @@ describe("Schema: Cell types", () => {
     expect(result.required).toContain("db");
   });
 
+  it("describes a SqliteDb's readable value as the handle descriptor", async () => {
+    const code = `
+      interface X { db: SqliteDb; }
+    `;
+    const { type, checker } = await getTypeFromCode(code, "X");
+    const gen = new SchemaGenerator();
+    const result = asObjectSchema(gen.generateSchema(type, checker));
+    const db = result.properties?.db as Record<string, unknown>;
+    expect(db.$ref).toBe("#/$defs/SqliteDatabase");
+    const handle = (result.$defs?.SqliteDatabase ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(handle.type).toBe("object");
+    const properties = handle.properties as Record<string, unknown>;
+    expect(properties.id).toEqual({ type: "string" });
+    expect(properties.rev).toEqual({ type: "number" });
+    expect(properties.tables).toEqual({
+      type: "object",
+      additionalProperties: true,
+    });
+    // The handle also carries `scope` and `owner`, which a read through this
+    // schema must not drop.
+    expect(handle.additionalProperties).toBe(true);
+  });
+
+  it("leaves a type carrying some other brand structural", async () => {
+    const code = `
+      declare const OTHER_BRAND: unique symbol;
+      interface NotADatabase {
+        readonly [OTHER_BRAND]: true;
+        notAHandle: string;
+      }
+      interface X { db: NotADatabase; }
+    `;
+    const { type, checker } = await getTypeFromCode(code, "X");
+    const gen = new SchemaGenerator();
+    const result = asObjectSchema(gen.generateSchema(type, checker));
+    const other = (result.$defs?.NotADatabase ?? {}) as Record<string, unknown>;
+    expect(other.properties).toEqual({ notAHandle: { type: "string" } });
+  });
+
   it("handles Stream<Cell<number>>", async () => {
     const code = `
       interface X { value: Stream<Cell<number>>; }

--- a/packages/schema-generator/test/utils.ts
+++ b/packages/schema-generator/test/utils.ts
@@ -29,7 +29,10 @@ declare interface Stream<E, R = void> extends BrandedCell<E, "stream"> {
 declare interface ComparableCell<T> extends BrandedCell<T, "comparable"> {}
 declare interface ReadonlyCell<T> extends BrandedCell<T, "readonly"> {}
 declare interface WriteonlyCell<T> extends BrandedCell<T, "writeonly"> {}
-declare type SqliteDatabase = { readonly __sqliteDb: true };
+// Mirrors the real handle type: a nominal brand keyed by an exported unique
+// symbol, which is what the emitted descriptor is recognized by.
+declare const SQLITE_DB_BRAND: unique symbol;
+declare type SqliteDatabase = { readonly [SQLITE_DB_BRAND]: true };
 declare interface SqliteDb<T = SqliteDatabase>
   extends BrandedCell<T, "sqlite"> {}
 

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -3260,9 +3260,13 @@ export type DataFileFunction = (path: string) => string;
 export declare const SQLITE_DB_BRAND: unique symbol;
 
 /**
- * Database handle. Empty to pattern code; a cell reference to the runtime
- * via the `toCell` back-pointer. Patterns only ever *forward* it (to sqliteQuery
- * / sqliteExecute / reactOn), never read it.
+ * Database handle. Nominal to pattern code — the brand is the whole of the
+ * type — and a cell reference to the runtime via the `toCell` back-pointer.
+ * A pattern normally just *forwards* it (to `db.query` / `db.exec` /
+ * `sqliteQuery` / `reactOn`). Its readable value is the descriptor
+ * `{ id, tables, rev }` (docs/specs/sqlite-builtin/01-api.md), which is what
+ * the compiler emits for a `SqliteDb` position, so a pattern that wants the
+ * declared columns can read `tables`.
  */
 export type SqliteDatabase = { readonly [SQLITE_DB_BRAND]: true };
 

--- a/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.expected.jsx
@@ -36,7 +36,19 @@ const writeNote = handler({
     $defs: {
         SqliteDatabase: {
             type: "object",
-            properties: {}
+            properties: {
+                id: {
+                    type: "string"
+                },
+                tables: {
+                    type: "object",
+                    additionalProperties: true
+                },
+                rev: {
+                    type: "number"
+                }
+            },
+            additionalProperties: true
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, { db }) => {

--- a/packages/ts-transformers/test/fixtures/schema-injection/scoped-sqlite-factory.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/scoped-sqlite-factory.expected.jsx
@@ -60,7 +60,19 @@ export default pattern(() => {
     $defs: {
         SqliteDatabase: {
             type: "object",
-            properties: {}
+            properties: {
+                id: {
+                    type: "string"
+                },
+                tables: {
+                    type: "object",
+                    additionalProperties: true
+                },
+                rev: {
+                    type: "number"
+                }
+            },
+            additionalProperties: true
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);


### PR DESCRIPTION
Fixes CT-2267.

## The defect

Every `SqliteDb` position emitted `$defs.SqliteDatabase = { type: "object", properties: {} }`, derived structurally from a type whose only member is the `SQLITE_DB_BRAND` unique symbol. A schema-driven read of a handle was therefore shaped down to `{}` — contradicting `docs/specs/sqlite-builtin/01-api.md`, whose readable value is the descriptor `{ id, tables, rev }`, and making a working piece report as empty (`cf cell get --cell <piece> --input mail` → `{}`).

## The change

`NativeTypeFormatter` (`packages/schema-generator/src/formatters/native-type-formatter.ts`) claims the handle by its brand rather than by name and emits the descriptor:

```json
{
  "type": "object",
  "properties": {
    "id": { "type": "string" },
    "tables": { "type": "object", "additionalProperties": true },
    "rev": { "type": "number" }
  },
  "additionalProperties": true
}
```

`tables` passes through unfiltered — its per-column `ifc` labels are what a pattern reads to write a query against a database it is handed, which Ben ruled is intended disclosure, consistent with `describe_handle` (#7021). `additionalProperties: true` keeps the fields outside the descriptor that the runtime writes onto the handle (`scope`, `owner`) from being dropped by a read through this schema.

Claiming by brand (not by the name `SqliteDatabase`) leaves the type its ordinary `$defs` hoisting, so every `SqliteDb` position keeps referring to one descriptor and the only fixture movement is the `$defs` body.

## Tests

- `packages/schema-generator/test/schema/cell-type.test.ts` — the emitted value-schema exposes `id`/`rev`/`tables`; a type carrying some other brand stays structural. Falsified by disabling the claim.
- `packages/runner/test/sqlite-db-exec.test.ts` — a handle read through the descriptor returns `{id, rev, tables}` with the table schemas intact, beside the existing test that a `properties: {}` schema shapes the same handle to `{}`.
- The schema-generator test prelude's handle stub now mirrors the real brand (it declared a plain `__sqliteDb` key, so no test here ever exercised the shape the api actually emits).

## Docs

`docs/specs/schema-generator/ts_to_json_schema_mapping.md` (a row + §5.2), `docs/specs/sqlite-builtin/01-api.md`, the `SqliteDatabase` JSDoc in `packages/api` (and its generated copy in `packages/static`), and the two `cell.ts` comments that asserted the handle's declared shape has no properties — still true for a pattern compiled before this change, which is why `db.exec` keeps its raw read.

## Gates

`deno fmt` (changed files) · `deno lint` (repo, 5606 files) · `deno task check` · `deno task cfcheck` · `deno task check-docs` · `deno task pattern-compat` (green; the three sqlite-using patterns report no incompatibility) · `deno task test` in schema-generator, ts-transformers, and runner. No live-handle check was run — no live space reachable from here; the fixture and unit proofs are the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

