### PR TITLE
fix(tasks): the full-run lane test holds the store's manifest out too

### DIFF
--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -1020,8 +1020,10 @@ describe("running a lane's work", () => {
 
 describe("planning a lane without running it", () => {
   it("plans the full run against the working tree", async () => {
-    // The full run switches selection off, so this reaches the topology
-    // and the packing without a manifest or a store.
+    // What this reaches is the topology and the packing. Selection is
+    // off, but the manifest is read either way for what things cost, so
+    // the store is held out the way the no-share case holds it out:
+    // otherwise this packs against whatever was published last.
     const lines: string[] = [];
     const log = console.log;
     console.log = (line: string) => lines.push(line);
@@ -1034,6 +1036,9 @@ describe("planning a lane without running it", () => {
         dryRun: true,
         laneCount: false,
         root: REPOSITORY,
+      }, {
+        manifest: (at) =>
+          Promise.resolve({ absent: `no manifest at ${at}: held out here` }),
       });
     } finally {
       console.log = log;


### PR DESCRIPTION
The lane fetches the manifest before it looks at whether this is a full run, because a full run reads it for what things cost. `plans the full run against the working tree` supplies no manifest dependency, so it reads the real store over the network on every run of the suite, and its comment says the opposite: that a full run reaches the topology and the packing without a manifest or a store.

What it costs today is a round trip and a hidden dependency rather than a failure. The test takes 900ms with the network reachable and 186ms without, and passes either way, because a fetch that cannot be made is reported as an absent manifest rather than raised. So the packing it pins is whichever of the two the machine happened to get, and nothing says which.

It is also the sibling of the case that has just been fixed. That one pinned a lane with no share of the work, held only while the store had no manifest, and once the first one was published it drew tests, opened their capabilities and ran them, timing out the eighth test job on every push for half a day. The two differ in what the manifest did to them, not in whether they read it.

The test now hands `runLane()` a manifest dependency reporting the manifest absent, which is the seam `LaneDeps` offers for saying what the store holds, and the comment says what is actually held out. With that, the test takes 173ms with the network reachable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

