### PR TITLE
perf(runner): the meta-seam guard reads one envelope, not each field

### DIFF
--- a/docs/plans/runner_cfc_implementation.md
+++ b/docs/plans/runner_cfc_implementation.md
@@ -345,18 +345,24 @@ therefore carries its own guard:
   meta field and all three are refused: an address naming the field, a
   document-root envelope carrying it as a key, and a document-root write that
   leaves it out, which drops it, since a root write replaces the envelope.
-  The third is decided by reading each meta member of the stored document,
-  never its root: a root read would name a logical path covering every entry
-  in the document's label map, and a guard has no business widening what the
-  transaction around it counts as consumed. Those reads carry no commit
-  precondition, because a precondition would turn a whole-document write into
-  a read-modify-write, and the blind root writes the runtime makes would lose
-  the race against any advance of the document they replace. What that leaves
-  open is an erasure racing the guard, never a forgery: the two shapes that
-  name a field are refused from the write itself, with no read at all. The
-  refusal is also the first of these guards to run, ahead of the ones keyed
-  by target id, so which document a write names cannot decide whether it is
-  asked for an authorization. Meta fields stay readable.
+  The third is decided by one read of the envelope the write replaces, at the
+  document root. What the guard looks at there is which meta keys that envelope
+  has rather than what any of them holds, so the read is `nonRecursive`, and the
+  flow join keys on that: a recursive read consumes every label-map entry at or
+  below the path it names, a `nonRecursive` one consumes only the entry at that
+  path, so this read consumes the document's root entry and nothing else.
+  Reading a meta member instead would consume the user data an entry of the same
+  name covers, because canonicalization strips a leading `value` and a document
+  with a user field named `slug` labels it at the logical path the raw
+  `["slug"]` member reads. The read carries no commit precondition, because a
+  precondition would turn a whole-document write into a read-modify-write, and
+  the blind root writes the runtime makes would lose the race against any
+  advance of the document they replace. What that leaves open is an erasure
+  racing the guard, never a forgery: the two shapes that name a field are
+  refused from the write itself, with no read at all. The refusal is also the
+  first of these guards to run, ahead of the ones keyed by target id, so which
+  document a write names cannot decide whether it is asked for an authorization.
+  Meta fields stay readable.
 - A write addressed at a document's `["cfc"]` label map from outside the
   runtime's privileged persistence scope is recorded, and the commit boundary
   turns each record into a fail-closed reason (audit S18).

--- a/packages/runner/src/meta-seam.ts
+++ b/packages/runner/src/meta-seam.ts
@@ -110,14 +110,12 @@ export function metaFieldsWritten(
 }
 
 /**
- * The meta fields a stored document carries, asked one member at a time.
+ * The meta fields a stored document carries.
  *
  * A write at the document root replaces the envelope, so the fields it does
  * not carry are the fields it drops, and telling which those are means
- * reading what the document holds. `readField` reads one member surface,
- * which is the question the guard asked; a read of the document root asks
- * after the whole document, and a guard has no business widening what the
- * transaction around it counts as consumed.
+ * reading what the document holds. `envelope` is that document root, which
+ * one read answers for every field at once.
  *
  * A field is carried when its value is defined. The storage layer can hold a
  * field that is present and `undefined` — that is what `IWriteOptions.delete`
@@ -125,13 +123,15 @@ export function metaFieldsWritten(
  * read half does too: `getMetaRaw` returns `undefined` for both, and no
  * reader addresses a meta path any other way. A root write that drops such a
  * field redirects no piece, which is what the guard is here to stop.
+ *
+ * An envelope that is not a record carries nothing, which is what a document
+ * the transaction does not hold reads as.
  */
-export function storedMetaFields(
-  readField: (field: MetaField) => unknown,
-): readonly MetaField[] {
+export function storedMetaFields(envelope: unknown): readonly MetaField[] {
+  if (!isObjectNotArray(envelope)) return NO_META_FIELDS;
   let carried: MetaField[] | undefined;
   for (const field of META_FIELDS) {
-    if (readField(field) === undefined) continue;
+    if (envelope[field] === undefined) continue;
     (carried ??= []).push(field);
   }
   return carried ?? NO_META_FIELDS;

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -130,6 +130,7 @@ import { normalizeCellScope, scopeRank } from "../scope.ts";
 import type { MergeableOpDelta } from "./mergeable-ops.ts";
 import { CFC_ENFORCEMENT_REJECTION_PREFIX } from "./rejection.ts";
 import {
+  allowMutableTransactionRead,
   clearSchemaRefusalTx,
   ignoreReadForCommit,
   internalVerifierRead,
@@ -1099,25 +1100,48 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       // write that leaves it out — the root write replaces the envelope, so
       // every stored meta field it does not carry is a field it drops. The
       // first two are settled by the write alone. The third is settled by
-      // reading what the document carries, one meta member at a time,
-      // through the inner transaction and under a read that carries no
-      // weight of its own. Reading through the outer transaction would put
-      // the guard's read in the reactivity log and the flow join. Reading
-      // the document root would name a logical path covering every entry in
-      // the document's label map, widening what the transaction counts as
-      // consumed. And the read takes no commit precondition:
-      // `ignoreReadForCommit` drops it from the conflict set, so the blind
-      // root writes the runtime makes stay blind rather than becoming
-      // read-modify-writes that lose the race against any advance of the
-      // document they replace. What that leaves open is an erasure racing
-      // the guard, never a forgery — the two shapes that name a field are
-      // refused from the write itself, with no read at all.
+      // one read of the envelope the write replaces, at the document root.
+      //
+      // What the guard looks at there is which meta keys that envelope has
+      // rather than what any of them holds, and `nonRecursive` is how the
+      // journal says so. The flow join keys on that: a recursive read
+      // consumes every label-map entry at or below the path it names, and a
+      // `nonRecursive` one consumes only the entry at that path. So this read
+      // consumes the document's root entry and nothing else. A read of a meta
+      // member instead consumes the user data an entry of the same name
+      // covers, because canonicalization strips a leading `value` and a
+      // document with a user field named `slug` labels it at the same logical
+      // path the raw `["slug"]` member reads.
+      //
+      // `allowMutableTransactionRead` takes the stored value as it stands
+      // rather than an isolated copy of it. A guard that tests each meta key
+      // for being defined and keeps nothing has no use for the copy, and the
+      // copy is a clone of the whole document once the transaction has
+      // written into it. `ignoreReadForScheduling` keeps the read out of the
+      // reactivity log. `ignoreReadForCommit` drops it from the conflict set,
+      // so the blind root writes the runtime makes stay blind rather than
+      // becoming read-modify-writes that lose the race against any advance of
+      // the document they replace.
+      //
+      // The read goes through the inner transaction, which is what keeps it
+      // from marking the transaction CFC-relevant, invalidating a prepared
+      // CFC decision, or narrowing the transaction's read scope. It is in the
+      // journal, and so in the flow join, from either transaction.
+      //
+      // What that leaves open is an erasure racing the guard, never a forgery
+      // — the two shapes that name a field are refused from the write itself,
+      // with no read at all.
       const written = metaFieldsWritten(address.path, value);
       const dropped = address.path.length === 0
-        ? storedMetaFields((field) =>
-          this.tx.read({ ...address, path: [field] }, {
-            meta: { ...ignoreReadForScheduling, ...ignoreReadForCommit },
-          }).ok?.value
+        ? storedMetaFields(
+          this.tx.read(address, {
+            nonRecursive: true,
+            meta: {
+              ...ignoreReadForScheduling,
+              ...ignoreReadForCommit,
+              ...allowMutableTransactionRead,
+            },
+          }).ok?.value,
         ).filter((field) => !written.includes(field))
         : NO_META_FIELDS;
       if (written.length > 0 || dropped.length > 0) {

--- a/packages/runner/test/meta-seam-write-authorization.test.ts
+++ b/packages/runner/test/meta-seam-write-authorization.test.ts
@@ -2,7 +2,11 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import type { FabricValue } from "@commonfabric/api";
-import { type MetaField, rawMetaWriteAuthorization } from "../src/meta-seam.ts";
+import {
+  isMetaField,
+  type MetaField,
+  rawMetaWriteAuthorization,
+} from "../src/meta-seam.ts";
 import { Identity } from "@commonfabric/identity";
 import type { URI } from "@commonfabric/memory/interface";
 
@@ -11,6 +15,7 @@ import { Runtime } from "../src/runtime.ts";
 import type { CfcEnforcementMode } from "../src/cfc/types.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { getTransactionReadActivities } from "../src/storage/transaction-inspection.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const signer = await Identity.fromPassphrase("runner-meta-seam-write");
@@ -229,6 +234,40 @@ describe("meta-seam-write-authorization", () => {
         tx.writeOrThrow(documentAddress(id, []), { value: { note: "seeded" } });
 
         expect(cell.get()).toEqual({ note: "seeded" });
+      });
+    });
+
+    it("reads the envelope once to decide what a root write drops", async () => {
+      // Every meta field a root write could drop sits in the one envelope
+      // that write replaces, and the guard reads that envelope.
+      //
+      // Naming no meta path is the part that matters beyond the read count.
+      // Canonicalization strips a leading `value`, so a read of the raw
+      // `["slug"]` member and a label on a user field `value.slug` meet at
+      // the same logical path, and a recursive read there consumes that
+      // user field's label and everything under it. A membership read of the
+      // document root consumes the root entry alone.
+
+      await withRuntime(({ tx, id }) => {
+        const reads = () =>
+          [...getTransactionReadActivities(tx)].filter((read) =>
+            read.id === id
+          );
+        const before = reads().length;
+        tx.writeOrThrow(documentAddress(id, []), { value: { note: "one" } });
+        const added = reads().slice(before);
+
+        const atRoot = added.filter((read) => read.path.length === 0);
+        expect(
+          added.filter((read) => isMetaField(read.path[0] ?? "")).map((
+            read,
+          ) => read.path),
+        ).toEqual([]);
+        expect(atRoot).toHaveLength(1);
+        // The guard observes which meta keys the envelope has, not what any
+        // of them holds. Without this mark the same read consumes every entry
+        // in the document's label map.
+        expect(atRoot[0].nonRecursive).toBe(true);
       });
     });
   });


### PR DESCRIPTION
A document's meta fields are the thirteen root siblings of `value`, the ones naming the program a piece runs and the cells it is wired to, and the write chokepoint refuses an unauthorized write that reaches one. A document-root write reaches them by omission: such a write replaces the envelope, so every stored meta field it does not carry is a field it drops. Deciding which those are means reading what the document holds, and the guard read it one member at a time.

Each of those reads lands in the transaction's journal, so a shape that cost one read cost thirteen more. In the `write-vs-commit` group of `packages/runner/test/storage.bench.ts`, the benchmark timing a hundred writes to new entities stepped up by two and a half times and the one timing a hundred writes to a single entity by three quarters, on every processor the benchmark charts separate.

The per-field reads also consumed user data. `canonicalizeLogicalPath` strips a leading `value`, so the raw member `["slug"]` and a user field `value.slug` meet at the same logical path, and the confidentiality collector counts, for a recursive read, every label-map entry at or below the path it names. So the guard consumed the label of any user field named after one of the thirteen — `result`, `argument`, `schema` and `slug` are ordinary names — together with everything under it, on every unprivileged document-root write, and that join could refuse a later commit that had read none of it. The enforcement matrix already rules the same aliasing out on the write side: an entry reaches the seam only because canonicalization strips a leading `value`, so it is not a declaration about the seam.

Every meta field sits in the one envelope the write replaces, so read that envelope: one read at the document root, and the members come off the value it returns. `storedMetaFields` takes the envelope rather than a per-field reader.

The read is `nonRecursive`, which is how the journal says an observation of membership rather than of a value, and the flow join keys on that: a `nonRecursive` read consumes the entry at the path it names and no other, so this one consumes the document's root entry alone. It also takes `allowMutableTransactionRead`, because a guard that tests each key for being defined and keeps nothing has no use for an isolated copy of the value, and once the transaction has written into the document that copy is a clone of the whole of it.

The comments carried two claims that are false and are corrected here. Going through the inner transaction does not keep a read out of the flow join — `getReadActivities` returns the inner journal and that is what the join reads — it keeps the read from marking the transaction CFC-relevant, from invalidating a prepared CFC decision, and from narrowing the read scope. The same claim stands in the neighboring `["cfc"]` guard's comment, untouched here.

A test counts the reads a document-root write journals against the document it names, and pins `nonRecursive` on the one at the root. Naming no meta path is what keeps the aliased user labels out of the join, and deleting that one word restores the consumption without failing anything else in the suite.

Measured on an Apple M5 Max, 75th percentile, median of five runs interleaved between the two versions so a shared machine's load falls on both: a hundred writes to new entities 268µs before and 155µs after, and a hundred writes to one entity 668µs and 510µs. The same file with the guard's whole arm removed measures 131µs and 459µs, so what is left is the one read the guard still takes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

