### PR TITLE
fix(cf-harness): a resume refuses a contradicting CFC enforcement mode

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -472,11 +472,22 @@ Resume a root run with `--resume-run <run-root-or-run-state.json>`. Codex resume
 keeps the recorded provider, model, exact credential owner, and encrypted
 provider continuation; requesting another model is rejected before credentials
 or provider traffic. Child runs are recorded with their root/parent lineage and
-cannot be resumed directly as top-level runs—resume the root run instead.
-Library callers receive the same guards: `runTranscript()` binds the first
-selected Codex model into run state and cannot override a resumed binding, while
-a whole-tree restorer must supply a matching typed `subagentResumeContext` when
-it reconstructs a child beneath its trusted root/parent session.
+cannot be resumed directly as top-level runs—resume the root run instead. A
+resume also keeps the CFC enforcement mode the run recorded, which is the mode
+its tool policy and sandbox transport floor read: a resume that states no dial
+inherits that mode (recorded as source `inherited`) rather than falling to the
+harness default, and a resume whose configuration resolves any other mode is
+refused naming the recorded mode and the requested one. Both a stated
+`--cfc-enforcement-mode` and a fabric session raised to `enforce-strict` above
+the recorded mode reach this refusal; restating the recorded mode resumes
+silently. The environment forms of the harness dial
+(`CF_HARNESS_CFC_ENFORCEMENT_MODE`, `CF_CFC_MODE`) are ignored on a resume, the
+way `CF_HARNESS_MODEL` is: they name the posture a fleet starts its runs at, not
+a decision about a run whose mode is already recorded. Library callers receive
+the same guards: `runTranscript()` binds the first selected Codex model into run
+state and cannot override a resumed binding, while a whole-tree restorer must
+supply a matching typed `subagentResumeContext` when it reconstructs a child
+beneath its trusted root/parent session.
 
 The gateway and subscription routes have different billing, workspace policy,
 retention, and model availability. The model catalog is read live from the
@@ -1281,8 +1292,10 @@ policy and the sandbox. The two are set independently up to one tie: under a
 session raised to `enforce-strict`, a harness dial nobody set follows the
 session rather than the harness default (recorded as source `fabric-session`),
 and a harness dial stated weaker than the session refuses startup naming both
-flags. Nothing else about the two families is derived; `--fabric-cfc-posture`
-sets the flow-label dial, not the enforcement mode.
+flags. A resume has no such tie to settle: the recorded mode stands, and a
+session that would raise the harness dial above it refuses the resume. Nothing
+else about the two families is derived; `--fabric-cfc-posture` sets the
+flow-label dial, not the enforcement mode.
 
 A run states both postures rather than leaving them to be inferred: the resolved
 fabric-session posture — each dial's value and whether the operator configured

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -598,6 +598,8 @@ Environment:
                                 patterns to search immediately (default: recorded only)
   CF_HARNESS_SANDBOX_IMAGE      Default value for --sandbox-image
   CF_HARNESS_SANDBOX_DOCKER_RUNTIME Default value for --sandbox-docker-runtime
+  CF_HARNESS_CFC_ENFORCEMENT_MODE Default value for --cfc-enforcement-mode (ignored on --resume-run)
+  CF_CFC_MODE                   Fallback for CF_HARNESS_CFC_ENFORCEMENT_MODE
   ${CFC_RESULT_DIR_ENV} Fallback for --cfc-result-dir
   ${CFC_INVOCATION_CONTEXT_DIR_ENV} Fallback for --cfc-invocation-context-dir
 `;
@@ -1608,8 +1610,15 @@ export const parseCfHarnessCliArgs = async (
   const explicitCfcMode = typeof args["cfc-enforcement-mode"] === "string"
     ? args["cfc-enforcement-mode"]
     : undefined;
-  const envCfcMode = nonEmptyEnvValue(env.CF_HARNESS_CFC_ENFORCEMENT_MODE) ??
-    nonEmptyEnvValue(env.CF_CFC_MODE);
+  // The environment forms name a fleet's posture for the runs it starts, and
+  // a resume is not one of those: its mode is already recorded, and the run
+  // enforces at the recorded mode whatever the environment says. Reading them
+  // on a resume would state a dial nobody typed, which a run recorded at
+  // another mode then refuses. `CF_HARNESS_MODEL` is read the same way.
+  const envCfcMode = resumeRun === undefined
+    ? nonEmptyEnvValue(env.CF_HARNESS_CFC_ENFORCEMENT_MODE) ??
+      nonEmptyEnvValue(env.CF_CFC_MODE)
+    : undefined;
   const cfcEnforcementModeOverride = parseCfcEnforcementMode(
     explicitCfcMode ?? envCfcMode,
   );

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -627,16 +627,6 @@ export class CfHarnessEngine {
       ...(options.runState !== undefined && recordedAuthSource !== undefined
         ? { modelAuthSource: recordedAuthSource }
         : {}),
-      // A resume resolves its enforcement mode from the mode the run
-      // recorded, which is the mode the loop enforces at: the sandbox
-      // transport floor and the tool policy both read
-      // `runState.cfcEnforcementMode`. Starting the resolution anywhere else
-      // gives the resolved configuration a mode nothing honors, and the
-      // policy snapshot a source label describing a decision the run never
-      // took.
-      ...(options.runState !== undefined
-        ? { inheritedCfcEnforcementMode: options.runState.cfcEnforcementMode }
-        : {}),
     });
     // A resume that states its own enforcement dials, or that introduces a
     // fabric session whose raise outranks the recorded mode, resolves a mode

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -591,6 +591,14 @@ export class CfHarnessEngine {
         "resumed run credential owner does not match requested credential owner",
       );
     }
+    if (
+      options.runState !== undefined &&
+      options.runState.cfcEnforcementMode === undefined
+    ) {
+      throw new Error(
+        "run state is missing cfcEnforcementMode; older cf-harness runs cannot be resumed",
+      );
+    }
     if (options.runState?.handleTable !== undefined) {
       assertValidHarnessHandleTable(options.runState.handleTable);
     }
@@ -619,7 +627,33 @@ export class CfHarnessEngine {
       ...(options.runState !== undefined && recordedAuthSource !== undefined
         ? { modelAuthSource: recordedAuthSource }
         : {}),
+      // A resume resolves its enforcement mode from the mode the run
+      // recorded, which is the mode the loop enforces at: the sandbox
+      // transport floor and the tool policy both read
+      // `runState.cfcEnforcementMode`. Starting the resolution anywhere else
+      // gives the resolved configuration a mode nothing honors, and the
+      // policy snapshot a source label describing a decision the run never
+      // took.
+      ...(options.runState !== undefined
+        ? { inheritedCfcEnforcementMode: options.runState.cfcEnforcementMode }
+        : {}),
     });
+    // A resume that states its own enforcement dials, or that introduces a
+    // fabric session whose raise outranks the recorded mode, resolves a mode
+    // the run cannot move to: the recorded mode is what the rest of the run
+    // enforces at. Refusing names both, rather than running at one and
+    // labelling the artifacts with the other. A resume that resolves the
+    // recorded mode passes silently, whether it restated it or inherited it.
+    if (
+      options.runState !== undefined &&
+      this.config.cfcEnforcementMode !== options.runState.cfcEnforcementMode
+    ) {
+      throw new Error(
+        this.config.cfcEnforcementModeSource === "fabric-session"
+          ? `resumed run CFC enforcement mode ${options.runState.cfcEnforcementMode} does not match the ${this.config.cfcEnforcementMode} its fabric session raises the harness dial to; lower --fabric-cfc-enforcement-mode to resume this run`
+          : `resumed run CFC enforcement mode ${options.runState.cfcEnforcementMode} does not match requested CFC enforcement mode ${this.config.cfcEnforcementMode}`,
+      );
+    }
     const runId = options.runState?.runId ?? options.runId ??
       crypto.randomUUID();
     // The session behind `run_pattern` is expensive and remote, so it is

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -6554,6 +6554,126 @@ Deno.test("CLI resume keeps the corpus the run recorded and refuses a differing 
   ]);
 });
 
+Deno.test("CLI resume keeps the CFC enforcement mode the run recorded and refuses a differing one", async () => {
+  const transcript = [{ role: "user" as const, content: "Ask" }];
+  const readRunArtifacts = () =>
+    Promise.resolve({
+      runRoot: "/tmp/project/.cf-harness-artifacts/run-cfc-resume",
+      runStatePath:
+        "/tmp/project/.cf-harness-artifacts/run-cfc-resume/run-state.json",
+      transcriptPath:
+        "/tmp/project/.cf-harness-artifacts/run-cfc-resume/transcript.json",
+      runState: {
+        runId: "run-cfc-resume",
+        status: "failed" as const,
+        createdAt: "2026-09-04T12:00:00.000Z",
+        updatedAt: "2026-09-04T12:00:01.000Z",
+        cfcEnforcementMode: "observe" as const,
+        currentDir: "/workspace",
+        model: "gpt-5.4",
+        modelProvider: "openai-compatible-gateway" as const,
+        policyEvents: [],
+        toolOutputs: [],
+      },
+      transcript,
+    });
+
+  // A resume that states no dial runs at the mode the run recorded, rather
+  // than at the harness default the flag would otherwise fall to.
+  const { io, stderr } = createIoBuffers();
+  let resumedMode: unknown;
+  let resumedModeSource: unknown;
+  assertEquals(
+    await runCfHarnessCli(
+      ["--resume-run", "/tmp/project/.cf-harness-artifacts/run-cfc-resume"],
+      {
+        io,
+        cwd: "/tmp/project",
+        env: { CF_HARNESS_API_KEY: "gateway-key" },
+        readRunArtifacts,
+        createPromptLoop: (options) => {
+          resumedMode = options.engine?.config.cfcEnforcementMode;
+          resumedModeSource = options.engine?.config.cfcEnforcementModeSource;
+          return {
+            runPrompt: () => Promise.reject(new Error("unexpected prompt")),
+            runTranscript: () =>
+              Promise.resolve(completedCliResult("run-cfc-resume")),
+          };
+        },
+      },
+    ),
+    0,
+  );
+  assertEquals(stderr, []);
+  assertEquals(resumedMode, "observe");
+  assertEquals(resumedModeSource, "inherited");
+
+  // A fleet's environment pin names the posture for the runs it starts, not a
+  // decision about this one, so a resume ignores it and runs at the recorded
+  // mode — the reading `CF_HARNESS_MODEL` already gets.
+  const pinnedIo = createIoBuffers();
+  let pinnedMode: unknown;
+  assertEquals(
+    await runCfHarnessCli(
+      ["--resume-run", "/tmp/project/.cf-harness-artifacts/run-cfc-resume"],
+      {
+        io: pinnedIo.io,
+        cwd: "/tmp/project",
+        env: {
+          CF_HARNESS_API_KEY: "gateway-key",
+          CF_CFC_MODE: "enforce-strict",
+        },
+        readRunArtifacts,
+        createPromptLoop: (options) => {
+          pinnedMode = options.engine?.config.cfcEnforcementMode;
+          return {
+            runPrompt: () => Promise.reject(new Error("unexpected prompt")),
+            runTranscript: () =>
+              Promise.resolve(completedCliResult("run-cfc-resume")),
+          };
+        },
+      },
+    ),
+    0,
+  );
+  assertEquals(pinnedIo.stderr, []);
+  assertEquals(pinnedMode, "observe");
+
+  // A dial the run cannot move to is refused, naming both modes, and refused
+  // before the run reaches a model client.
+  const mismatchIo = createIoBuffers();
+  let modelClientsCreated = 0;
+  assertEquals(
+    await runCfHarnessCli([
+      "--resume-run",
+      "/tmp/project/.cf-harness-artifacts/run-cfc-resume",
+      "--cfc-enforcement-mode",
+      "disabled",
+    ], {
+      io: mismatchIo.io,
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_API_KEY: "gateway-key" },
+      readRunArtifacts,
+      createModelClient: () => {
+        modelClientsCreated += 1;
+        return {
+          providerId: "openai-compatible-gateway",
+          complete: () => Promise.reject(new Error("must not run")),
+        };
+      },
+      createPromptLoop: () => ({
+        runPrompt: () => Promise.reject(new Error("must not run")),
+        runTranscript: () => Promise.reject(new Error("must not run")),
+      }),
+    }),
+    1,
+  );
+  assertEquals(modelClientsCreated, 0);
+  assertEquals(mismatchIo.stderr, [
+    "resumed run CFC enforcement mode observe does not match requested CFC enforcement mode disabled\n",
+  ]);
+});
+
 Deno.test("top-level CLI resume rejects subagent lineage before creating a model client", async () => {
   const { io, stderr } = createIoBuffers();
   let modelClientsCreated = 0;

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -438,8 +438,12 @@ Deno.test("CfHarnessEngine refuses to resume under a fabric-session posture that
   // A legacy record (no posture ever captured) stays frozen as history:
   // plain session dials may restate the original invocation, but the named
   // bundle cannot have been what the run ran, so a posture resume is refused.
+  // Recorded at the mode the strict dial below resolves, so the session's
+  // raise leaves the harness mode where the run recorded it and the posture
+  // record is the only thing under test here.
   const legacyState = {
     ...runState,
+    cfcEnforcementMode: "enforce-strict" as const,
     fabricSessionCfc: undefined,
   } as typeof runState;
   const legacyWithDials = new CfHarnessEngine({
@@ -462,6 +466,154 @@ Deno.test("CfHarnessEngine refuses to resume under a fabric-session posture that
       }),
     Error,
     "records no fabric-session posture",
+  );
+});
+
+Deno.test("CfHarnessEngine refuses to resume under a harness CFC enforcement dial that contradicts the recorded mode", () => {
+  // `runState.cfcEnforcementMode` is the mode the run enforces at: the
+  // sandbox transport floor and the tool policy both read it. A resume that
+  // states a different one cannot move it, so the run would go on enforcing
+  // the recorded mode while the policy snapshot credited the operator's dial
+  // for it.
+  const runState = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    cfcEnforcementModeOverride: "observe",
+  }).getRunState();
+  assertEquals(runState.cfcEnforcementMode, "observe");
+
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        runState,
+        cfcEnforcementModeOverride: "disabled",
+      }),
+    Error,
+    "resumed run CFC enforcement mode observe does not match requested CFC enforcement mode disabled",
+  );
+
+  // The configured dial the override stands in front of, refused the same
+  // way: what the resume states is what it asked the run to enforce at.
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        runState,
+        cfcEnforcementMode: "enforce-strict",
+      }),
+    Error,
+    "resumed run CFC enforcement mode observe does not match requested CFC enforcement mode enforce-strict",
+  );
+
+  // Restating the recorded mode asks for nothing the run is not already
+  // doing, so it resumes, and the snapshot names the operator's dial.
+  const restated = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    runState,
+    cfcEnforcementModeOverride: "observe",
+  });
+  assertEquals(restated.config.cfcEnforcementMode, "observe");
+  assertEquals(restated.config.cfcEnforcementModeSource, "override");
+
+  // A resume that states nothing inherits the recorded mode rather than
+  // falling to this invocation's default, which would resolve
+  // enforce-explicit and label it a default the run never took.
+  const quiet = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    runState,
+  });
+  assertEquals(quiet.config.cfcEnforcementMode, "observe");
+  assertEquals(quiet.config.cfcEnforcementModeSource, "inherited");
+
+  // A run manifest is outranked by the record, so a manifest whose mode
+  // moved under the run cannot move the resumed run either.
+  const manifested = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    runState,
+    runManifest: {
+      type: "cf-harness.loom-run-manifest",
+      version: 1,
+      source: "loom",
+      cfc: { enforcementMode: "enforce-strict" },
+    },
+  });
+  assertEquals(manifested.config.cfcEnforcementMode, "observe");
+  assertEquals(manifested.config.cfcEnforcementModeSource, "inherited");
+});
+
+Deno.test("CfHarnessEngine refuses to resume under a fabric session raised above the recorded CFC enforcement mode", () => {
+  // A session at enforce-strict raises the harness loop to meet it, which on
+  // a resume is a mode the loop cannot move to. The recorded-posture guard
+  // does not reach this pair: the run recorded no fabric session, and the new
+  // session names no posture bundle.
+  const runState = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    cfcEnforcementModeOverride: "observe",
+  }).getRunState();
+  assertEquals(runState.fabricSessionCfc, undefined);
+
+  const strictSession = {
+    apiUrl: "https://fabric.test",
+    identityKeyPath: "/keys/identity.pkcs8",
+    space: "demo",
+    cfcEnforcementMode: "enforce-strict",
+  } as const;
+  // The message names the session dial, because that is the one to lower:
+  // every value of the harness dial is refused here, the weaker ones by the
+  // resolver and `enforce-strict` by the recorded mode.
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        runState,
+        fabricSession: strictSession,
+        fabricSessionFactory: () =>
+          Promise.reject(new Error("never built in this test")),
+      }),
+    Error,
+    "resumed run CFC enforcement mode observe does not match the enforce-strict its fabric session raises the harness dial to; lower --fabric-cfc-enforcement-mode to resume this run",
+  );
+
+  // The same session over a run that already enforces strictly raises
+  // nothing, so the recorded mode stands and the resume is credited to the
+  // record rather than to the session.
+  const strictRunState = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    cfcEnforcementModeOverride: "enforce-strict",
+  }).getRunState();
+  assertEquals(strictRunState.cfcEnforcementMode, "enforce-strict");
+  const resumed = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    runState: strictRunState,
+    fabricSession: strictSession,
+    fabricSessionFactory: () =>
+      Promise.reject(new Error("never built in this test")),
+  });
+  assertEquals(resumed.config.cfcEnforcementMode, "enforce-strict");
+  assertEquals(resumed.config.cfcEnforcementModeSource, "inherited");
+});
+
+Deno.test("CfHarnessEngine refuses a run state recorded before the CFC enforcement mode was", () => {
+  // The resume reads the recorded mode to resolve against, so a run state too
+  // old to carry one is refused for what it is, rather than reported as a
+  // mismatch against a mode it never named.
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runState: {
+          runId: "run-legacy-cfc",
+          status: "completed",
+          createdAt: "2026-04-20T00:00:00.000Z",
+          updatedAt: "2026-04-20T00:00:01.000Z",
+          currentDir: "/workspace",
+          policyEvents: [],
+          toolOutputs: [],
+          failureRecords: [],
+        } as unknown as HarnessRunState,
+      }),
+    Error,
+    "run state is missing cfcEnforcementMode; older cf-harness runs cannot be resumed",
   );
 });
 

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -415,53 +415,6 @@ Deno.test("CfHarnessPromptLoop persists a fresh Codex model selection before the
   );
 });
 
-Deno.test("CfHarnessPromptLoop attributes a resumed run's enforcement mode to the record", async () => {
-  // The policy snapshot takes its mode from the run state and its source
-  // label from the resolved configuration, so a resume is where those two can
-  // come apart. This is the artifact an auditor reads: the mode the run
-  // enforced at, credited to the record that carries it rather than to a
-  // harness default this resume never took.
-  const resumedState: HarnessRunState = {
-    runId: "run-resumed-cfc-snapshot",
-    status: "failed",
-    createdAt: "2026-09-04T12:00:00.000Z",
-    updatedAt: "2026-09-04T12:00:01.000Z",
-    cfcEnforcementMode: "observe",
-    currentDir: "/workspace",
-    model: "gpt-5.4",
-    modelProvider: "openai-compatible-gateway",
-    policyEvents: [],
-    toolOutputs: [],
-    failureRecords: [],
-  };
-  const loop = new CfHarnessPromptLoop({
-    engine: new CfHarnessEngine({
-      sandboxRuntime: new FakeSandboxRuntime(),
-      runState: resumedState,
-    }),
-    modelClient: {
-      providerId: "openai-compatible-gateway",
-      complete: () =>
-        Promise.resolve({
-          assistant: { role: "assistant", content: "done" },
-        }),
-    },
-  });
-
-  const result = await loop.runTranscript({
-    transcript: [{ role: "user", content: "Continue." }],
-    model: "gpt-5.4",
-  });
-  assertEquals(
-    result.runState.cfcPolicySnapshot?.cfc.enforcementMode,
-    "observe",
-  );
-  assertEquals(
-    result.runState.cfcPolicySnapshot?.cfc.enforcementModeSource,
-    "inherited",
-  );
-});
-
 Deno.test("CfHarnessPromptLoop executes injected model-client tool calls through the shared CFC loop", async () => {
   const sandbox = new FakeSandboxRuntime();
   let turns = 0;

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -415,6 +415,53 @@ Deno.test("CfHarnessPromptLoop persists a fresh Codex model selection before the
   );
 });
 
+Deno.test("CfHarnessPromptLoop attributes a resumed run's enforcement mode to the record", async () => {
+  // The policy snapshot takes its mode from the run state and its source
+  // label from the resolved configuration, so a resume is where those two can
+  // come apart. This is the artifact an auditor reads: the mode the run
+  // enforced at, credited to the record that carries it rather than to a
+  // harness default this resume never took.
+  const resumedState: HarnessRunState = {
+    runId: "run-resumed-cfc-snapshot",
+    status: "failed",
+    createdAt: "2026-09-04T12:00:00.000Z",
+    updatedAt: "2026-09-04T12:00:01.000Z",
+    cfcEnforcementMode: "observe",
+    currentDir: "/workspace",
+    model: "gpt-5.4",
+    modelProvider: "openai-compatible-gateway",
+    policyEvents: [],
+    toolOutputs: [],
+    failureRecords: [],
+  };
+  const loop = new CfHarnessPromptLoop({
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runState: resumedState,
+    }),
+    modelClient: {
+      providerId: "openai-compatible-gateway",
+      complete: () =>
+        Promise.resolve({
+          assistant: { role: "assistant", content: "done" },
+        }),
+    },
+  });
+
+  const result = await loop.runTranscript({
+    transcript: [{ role: "user", content: "Continue." }],
+    model: "gpt-5.4",
+  });
+  assertEquals(
+    result.runState.cfcPolicySnapshot?.cfc.enforcementMode,
+    "observe",
+  );
+  assertEquals(
+    result.runState.cfcPolicySnapshot?.cfc.enforcementModeSource,
+    "inherited",
+  );
+});
+
 Deno.test("CfHarnessPromptLoop executes injected model-client tool calls through the shared CFC loop", async () => {
   const sandbox = new FakeSandboxRuntime();
   let turns = 0;


### PR DESCRIPTION
The engine constructor refuses a resume whose requested settings contradict what the run recorded — the model provider, the Codex model binding, the credential owner, the harness home identity, the model auth source. The CFC enforcement dials had no such check, and the divergences that followed were reported rather than refused.

What enforces during a run is `runState.cfcEnforcementMode`: the sandbox transport floor and the tool policy both read it. `resolveHarnessConfig` separately produces a resolved mode and a source label, and the policy snapshot the run writes takes its mode from the run state and its source label from the resolved configuration. When those two disagree, the snapshot names the executing mode and attributes it to a source that asked for something else.

A resume stating a harness dial was one such pair. Resuming a run recorded at `observe` with `--cfc-enforcement-mode disabled` left the loop at `observe` while the configuration resolved `disabled` from source `override`, so the snapshot said `observe` came from an override that had asked for `disabled`. A resume introducing a fabric session raised to `enforce-strict` was the other: the session's raise moved the resolved mode to `enforce-strict` with source `fabric-session` while the loop stayed at `observe`, so the artifacts read as a run an operator raised to strict that ran without enforcing. The recorded fabric-session posture guard did not reach that pair, because the run recorded no `fabricSessionCfc` and the new session named no posture bundle. A resume that stated nothing was a third: it resolved the harness default and labelled it `default`, for a run enforcing at something else.

One check covers them, because they are readings of the same resolved mode. A resume now hands the recorded mode to the resolver as its inherited mode, and the constructor refuses when the resolution comes back as anything other than the recorded mode, naming both. A resume that states nothing inherits the recorded mode, and one that restates it passes silently, as the neighbouring checks do. The run manifest is outranked by the record, so a manifest whose mode moved under the run cannot move a resumed run either. The resolver's
`inheritedCfcEnforcementMode` input already existed with no caller, and the `inherited` member of the published source contract had no producer.

Three further refusals landed on the wrong person, and are answered here.

The harness dial has two environment forms,
`CF_HARNESS_CFC_ENFORCEMENT_MODE` and `CF_CFC_MODE`, folded into the same override the flag sets. A host that exports one — the README tells hosts without the `runsc-cfc` Docker runtime to export `observe` — states that dial on every invocation, so every resume of a run recorded at another mode would be refused for something nobody typed. The CLI already reads `CF_HARNESS_MODEL` only when there is no `--resume-run`, and says so in its help; the enforcement mode forms now read the same way. An explicit `--cfc-enforcement-mode` still refuses, because that one was typed.

Where a fabric session raised to `enforce-strict` resolves the mismatch, the message named a "requested CFC enforcement mode" nobody requested, and no value of `--cfc-enforcement-mode` resumed the run: the weaker ones are refused by the resolver for being weaker than the session, and `enforce-strict` by the recorded mode. The only way through is to lower `--fabric-cfc-enforcement-mode`, so that branch of the message says it.

A run state too old to carry `cfcEnforcementMode` was reported as a mismatch against a mode it never named, since the resume reads that field to resolve against, and it masked the clearer guard further down the constructor. It is now refused for what it is, in the words the sibling guard uses for a run state with no `currentDir`.

The legacy-record resume case restated the fabric session's own dial as `enforce-strict`, a value that raises the harness mode. Recording that state at `enforce-strict` makes the raise a no-op, so the case keeps the dial it was written with and tests the posture record alone.

The new cases cover the refusal at its source, at the CLI an operator meets, and in the artifact the change exists to fix: a resumed run's persisted policy snapshot, which without this pairs the executing mode with source `default`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

