### PR TITLE
fix(runner): every CFC dial a runtime resolves is a rung of its ladder

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -676,6 +676,25 @@ the same resolution, not a second statement of it — but the field says what it
 is. `deno task cfc-audit --expected-posture` compares a published record
 against a written-down profile, and fails a deployment that publishes a
 projection; see the cf-harness README.
+
+Every value that resolution returns is a rung of its own dial.
+`resolveCfcDials` checks each stated value against the same table of rungs the
+record's `decidesOn` is read from, and throws on one that is not among them,
+naming the dial and its rungs. The two dials that are simply on or off take
+`true` and `false` and nothing else.
+
+A dial off its ladder has no rung to run on, and the record then disagrees with
+the runtime. For a named-rung dial the guards around a gate test for
+`!== "off"` and let the value through, while the gate itself tests for the one
+enforcing rung and declines to act, so the dial runs as `observe` does while
+the published record calls it enforcing. The two on-or-off dials part the other
+way round: the gates read them for truthiness, while the record tests for
+`true`, so a truthy value that is not `true` runs the gate while the record
+says the gate is off. Resolving such a value to the default instead would hand
+a deployment a posture it never stated, so the construction fails. That check
+reaches every host, whether its dials come from a preset, a worker
+initialization message, a command line, or the CFC section of a JSON manifest.
+
 The interactive `cf-harness` and the `fuse` mount expose the enforcement mode
 through `CF_CFC_MODE` for testing. Because these dials are keys of
 `RuntimeOptions`, the exhaustive `RUNTIME_OPTION_KEYS` registry in the same file

--- a/packages/runner/src/cfc/posture-report.ts
+++ b/packages/runner/src/cfc/posture-report.ts
@@ -52,7 +52,6 @@ import {
   SINK_UNGATED_RATIONALES,
   type SinkMaxConfidentiality,
 } from "./sink-inventory.ts";
-import { CFC_ENFORCEMENT_MODES, isCfcEnforcementMode } from "./types.ts";
 import type {
   CfcDeclaredMonotonicityMode,
   CfcDecomposedEnvelopes,
@@ -310,6 +309,84 @@ export const RUNTIME_CFC_DIAL_DEFAULTS: ResolvedCfcDials = Object.freeze({
   cfcDeclaredMonotonicity: "off",
 });
 
+/** A dial whose values are the named rungs of a ladder. */
+type LadderDial = {
+  [K in keyof ResolvedCfcDials]: ResolvedCfcDials[K] extends string ? K : never;
+}[keyof ResolvedCfcDials];
+
+/** A dial that is on or off. */
+type ToggleDial = {
+  [K in keyof ResolvedCfcDials]: ResolvedCfcDials[K] extends boolean ? K
+    : never;
+}[keyof ResolvedCfcDials];
+
+/**
+ * Each ladder dial against the table of what its rungs decide on.
+ *
+ * That table is keyed by the dial's own mode union, so it holds an entry for
+ * every rung and for nothing else. It is therefore the ladder as well as the
+ * words, and a check driven from it accepts a rung the moment the ladder
+ * gains one.
+ */
+const DIAL_LADDERS = {
+  cfcEnforcementMode: ENFORCEMENT_MODE_DECIDES,
+  cfcFlowLabels: FLOW_LABELS_DECIDES,
+  cfcWriteFloor: WRITE_FLOOR_DECIDES,
+  cfcPolicyEvaluation: POLICY_EVALUATION_DECIDES,
+  cfcLabelMetadataProtection: LABEL_METADATA_DECIDES,
+  cfcDeclaredMonotonicity: DECLARED_MONOTONICITY_DECIDES,
+} satisfies { [K in LadderDial]: Record<ResolvedCfcDials[K], string> };
+
+/**
+ * One ladder dial's rung: what `stated` names, or the default when it names
+ * nothing.
+ *
+ * The comparison is against the rung names as values rather than as property
+ * keys, so a value that merely renders as a rung — a one-element array, a
+ * boxed string — is not one.
+ *
+ * @throws If `stated` is not a rung of this dial's ladder.
+ */
+const resolveRung = <K extends LadderDial>(
+  dialName: K,
+  stated: ResolvedCfcDials[K] | undefined,
+): ResolvedCfcDials[K] => {
+  const rungs = Object.keys(DIAL_LADDERS[dialName]);
+  const value = stated === undefined
+    ? RUNTIME_CFC_DIAL_DEFAULTS[dialName]
+    : stated;
+  if (!rungs.includes(value)) {
+    throw new Error(
+      `Runtime \`${dialName}\` is ${JSON.stringify(value)}, not one of ` +
+        rungs.join(", "),
+    );
+  }
+  return value;
+};
+
+/**
+ * One toggle dial's setting: what `stated` says, or the default when it says
+ * nothing.
+ *
+ * @throws If `stated` is neither `true` nor `false`.
+ */
+const resolveToggle = <K extends ToggleDial>(
+  dialName: K,
+  stated: ResolvedCfcDials[K] | undefined,
+): ResolvedCfcDials[K] => {
+  const value = stated === undefined
+    ? RUNTIME_CFC_DIAL_DEFAULTS[dialName]
+    : stated;
+  if (typeof value !== "boolean") {
+    throw new Error(
+      `Runtime \`${dialName}\` is ${
+        JSON.stringify(value)
+      }, not one of true, false`,
+    );
+  }
+  return value;
+};
+
 /**
  * The dial values a runtime constructed with `options` runs at.
  *
@@ -320,48 +397,46 @@ export const RUNTIME_CFC_DIAL_DEFAULTS: ResolvedCfcDials = Object.freeze({
  * its own words. One table: a default moved here moves everywhere at once,
  * and a host cannot fall behind it silently.
  *
- * `cfcEnforcementMode` is a closed set. A stated one must be a member of
- * `CFC_ENFORCEMENT_MODES`; any other name is refused rather than resolved, so
- * no runtime holds a mode `cfcEnforcementStrictness` cannot rank. The type
- * says this too, and the check is what holds it for a name that reached the
+ * Every returned value is a rung of its own dial. A value that reached the
  * options as plain data — a worker's initialization message crosses
- * `postMessage` untyped.
+ * `postMessage` untyped, a command line and a JSON manifest arrive the same
+ * way — is checked here, once, for every host that resolves its dials
+ * through this. The type says the same thing, and says it only to callers
+ * the type checker saw.
  *
- * @throws Error when `options.cfcEnforcementMode` is stated and is not a
- * member of `CFC_ENFORCEMENT_MODES`.
+ * @throws Error when a stated dial value is not one that dial accepts,
+ * naming the dial and the values it takes.
  */
 export const resolveCfcDials = (
   options: CfcDialOptions,
-): ResolvedCfcDials => {
-  if (
-    options.cfcEnforcementMode !== undefined &&
-    !isCfcEnforcementMode(options.cfcEnforcementMode)
-  ) {
-    throw new Error(
-      `Runtime \`cfcEnforcementMode\` is ` +
-        `${String(options.cfcEnforcementMode)}, not one of ` +
-        CFC_ENFORCEMENT_MODES.join(", "),
-    );
-  }
-  return {
-    cfcEnforcementMode: options.cfcEnforcementMode ??
-      RUNTIME_CFC_DIAL_DEFAULTS.cfcEnforcementMode,
-    cfcFlowLabels: options.cfcFlowLabels ??
-      RUNTIME_CFC_DIAL_DEFAULTS.cfcFlowLabels,
-    cfcWriteFloor: options.cfcWriteFloor ??
-      RUNTIME_CFC_DIAL_DEFAULTS.cfcWriteFloor,
-    cfcTriggerReadGating: options.cfcTriggerReadGating ??
-      RUNTIME_CFC_DIAL_DEFAULTS.cfcTriggerReadGating,
-    cfcDecomposedEnvelopes: options.cfcDecomposedEnvelopes ??
-      RUNTIME_CFC_DIAL_DEFAULTS.cfcDecomposedEnvelopes,
-    cfcPolicyEvaluation: options.cfcPolicyEvaluation ??
-      RUNTIME_CFC_DIAL_DEFAULTS.cfcPolicyEvaluation,
-    cfcLabelMetadataProtection: options.cfcLabelMetadataProtection ??
-      RUNTIME_CFC_DIAL_DEFAULTS.cfcLabelMetadataProtection,
-    cfcDeclaredMonotonicity: options.cfcDeclaredMonotonicity ??
-      RUNTIME_CFC_DIAL_DEFAULTS.cfcDeclaredMonotonicity,
-  };
-};
+): ResolvedCfcDials => ({
+  cfcEnforcementMode: resolveRung(
+    "cfcEnforcementMode",
+    options.cfcEnforcementMode,
+  ),
+  cfcFlowLabels: resolveRung("cfcFlowLabels", options.cfcFlowLabels),
+  cfcWriteFloor: resolveRung("cfcWriteFloor", options.cfcWriteFloor),
+  cfcTriggerReadGating: resolveToggle(
+    "cfcTriggerReadGating",
+    options.cfcTriggerReadGating,
+  ),
+  cfcDecomposedEnvelopes: resolveToggle(
+    "cfcDecomposedEnvelopes",
+    options.cfcDecomposedEnvelopes,
+  ),
+  cfcPolicyEvaluation: resolveRung(
+    "cfcPolicyEvaluation",
+    options.cfcPolicyEvaluation,
+  ),
+  cfcLabelMetadataProtection: resolveRung(
+    "cfcLabelMetadataProtection",
+    options.cfcLabelMetadataProtection,
+  ),
+  cfcDeclaredMonotonicity: resolveRung(
+    "cfcDeclaredMonotonicity",
+    options.cfcDeclaredMonotonicity,
+  ),
+});
 
 /** The values of a record, whichever way its provenance was arrived at. */
 const buildReport = (

--- a/packages/runner/test/cfc-posture-report.test.ts
+++ b/packages/runner/test/cfc-posture-report.test.ts
@@ -11,17 +11,19 @@
  * which is the whole reason the table is shared.
  */
 
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import {
   CFC_ENFORCEMENT_MODES,
   type CfcEnforcementMode,
+  type CfcPostureOptions,
   cfcPostureReport,
   inheritedCfcPostureReport,
   KNOWN_SINKS,
   projectedCfcPostureReport,
   resolveCfcDials,
+  type ResolvedCfcDials,
   RUNTIME_CFC_DIAL_DEFAULTS,
 } from "../src/cfc/mod.ts";
 import type { RuntimeOptions } from "../src/runtime.ts";
@@ -31,6 +33,15 @@ import { Runtime, signer, StorageManager } from "./engine-test-support.ts";
 /** The record a surface projects from options alone, with no Runtime. */
 const projected = (options: RuntimeOptions) =>
   projectedCfcPostureReport(options);
+
+/**
+ * One dial set to `value` by a caller the type system never saw: an
+ * initialization message across a worker boundary, a command line, the CFC
+ * section of a JSON manifest. The cast is what those callers do implicitly,
+ * written out so the tests below can hand over the values they hand over.
+ */
+const stated = (dial: string, value: unknown): CfcPostureOptions =>
+  ({ [dial]: value }) as CfcPostureOptions;
 
 describe("the CFC posture record", () => {
   describe("dial rendering", () => {
@@ -59,6 +70,143 @@ describe("the CFC posture record", () => {
       });
       expect(record.policyEvaluation.diagnosticOnly).toBe(false);
       expect(record.policyEvaluation.decidesOn).toContain("rewritten label");
+    });
+  });
+
+  describe("the dial ladders", () => {
+    // A dial off its ladder splits the runtime in two. The consumers of the
+    // named-rung dials test for one rung — `writeFloorMode === "enforce"`,
+    // `flowLabelsMode === "persist"` — while the guards around them test only
+    // for `!== "off"`, so an unrecognized name enters the block and then
+    // decides nothing, running as `observe` does. The record published at
+    // `/api/meta` says the opposite: `diagnosticOnly` is false, because the
+    // name is not one of the diagnostic rungs either, and `decidesOn` is
+    // absent, which `CfcDialReport` declares a `string`. The two on-or-off
+    // dials part the other way round: the gates read them for truthiness
+    // while the record tests for `true`, so a truthy value that is not `true`
+    // runs the gate while the record says the gate is off.
+
+    // Written as a record over every dial, so a dial added to
+    // `ResolvedCfcDials` is a type error here until it has a case of its own.
+    const offLadder: Record<keyof ResolvedCfcDials, unknown> = {
+      cfcEnforcementMode: "enforce-strictly",
+      cfcFlowLabels: "persisted",
+      cfcWriteFloor: "enfroce",
+      cfcPolicyEvaluation: "enforcing",
+      cfcLabelMetadataProtection: "observing",
+      cfcDeclaredMonotonicity: "on",
+      cfcTriggerReadGating: "true",
+      cfcDecomposedEnvelopes: 1,
+    };
+
+    for (const [dial, value] of Object.entries(offLadder)) {
+      it(`throws when a projection states a \`${dial}\` off its ladder`, () => {
+        expect(() => projectedCfcPostureReport(stated(dial, value))).toThrow(
+          new RegExp("^Runtime `" + dial + "` is "),
+        );
+      });
+    }
+
+    it("names the rungs it would have taken", () => {
+      expect(() =>
+        projectedCfcPostureReport(stated("cfcWriteFloor", "enfroce"))
+      )
+        .toThrow(
+          'Runtime `cfcWriteFloor` is "enfroce", not one of off, observe, enforce',
+        );
+      expect(() =>
+        projectedCfcPostureReport(stated("cfcTriggerReadGating", "true"))
+      ).toThrow(
+        'Runtime `cfcTriggerReadGating` is "true", not one of true, false',
+      );
+    });
+
+    it("throws on a `null`, which no dial has a rung for", () => {
+      // `null` is not an unset dial. The option type has no `null` member, so
+      // one that arrives came from a caller the types did not reach, and
+      // resolving it to the default would give that caller a posture it never
+      // stated.
+      expect(() => projectedCfcPostureReport(stated("cfcFlowLabels", null)))
+        .toThrow(/^Runtime `cfcFlowLabels` is null, /);
+    });
+
+    it("throws on a value that merely renders as a rung", () => {
+      // A rung is the string, not everything that prints as it. Every consumer
+      // compares the dial against a rung with `===`, so a one-element array or
+      // a boxed string decides nothing while carrying the rung's name into the
+      // published record.
+      for (
+        const lookalike of [
+          ["enforce"],
+          new String("enforce"),
+          { toString: () => "enforce" },
+        ]
+      ) {
+        expect(() =>
+          projectedCfcPostureReport(stated("cfcWriteFloor", lookalike))
+        ).toThrow(/^Runtime `cfcWriteFloor` is /);
+      }
+    });
+
+    it("returns a stated rung that is not the default", () => {
+      // Both dials are read back out of the record below, so the refusals
+      // above are held to accepting the values a deployment does state.
+      const record = projectedCfcPostureReport({
+        cfcWriteFloor: "enforce",
+        cfcTriggerReadGating: true,
+      });
+      expect(record.writeFloor.rung).toBe("enforce");
+      expect(record.writeFloor.diagnosticOnly).toBe(false);
+      expect(record.triggerReadGating).toBe(true);
+    });
+
+    describe("a constructed Runtime", () => {
+      let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+      beforeEach(() => {
+        storageManager = StorageManager.emulate({ as: signer });
+      });
+
+      afterEach(async () => {
+        await storageManager.close();
+      });
+
+      const construct = (options: CfcPostureOptions) =>
+        new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager,
+          ...options,
+        });
+
+      it("throws on a string dial off its ladder", () => {
+        expect(() => construct(stated("cfcWriteFloor", "enfroce"))).toThrow(
+          /^Runtime `cfcWriteFloor` is /,
+        );
+      });
+
+      it("throws on a boolean dial that is neither `true` nor `false`", () => {
+        expect(() => construct(stated("cfcTriggerReadGating", "true"))).toThrow(
+          /^Runtime `cfcTriggerReadGating` is /,
+        );
+      });
+
+      it("constructs on `enforce-strict`, `enforce` and `true`", async () => {
+        // The refusals above are worth nothing if a rung is refused too, and
+        // these are the settings a deployment states by hand. The claim is
+        // about these three: the ladders are not exported rung by rung, so a
+        // case here cannot exhaust them.
+        const runtime = construct({
+          cfcEnforcementMode: "enforce-strict",
+          cfcWriteFloor: "enforce",
+          cfcDecomposedEnvelopes: true,
+        });
+        try {
+          expect(cfcPostureReport(runtime).writeFloor.rung).toBe("enforce");
+          expect(cfcPostureReport(runtime).decomposedEnvelopes).toBe(true);
+        } finally {
+          await runtime.dispose();
+        }
+      });
     });
   });
 


### PR DESCRIPTION
`resolveCfcDials` is the one function every `Runtime` resolves its eight control-flow-confidentiality dials through. It refuses an off-ladder `cfcEnforcementMode`, and accepted whatever it was handed for the other seven. A dial set to a value outside its own ladder was carried into the runtime unchanged, and the runtime then ran split in two.

The split follows from how the dials are consumed. Each named-rung dial is guarded by a test for `!== "off"` and decided by a separate test for the one enforcing rung. `cfc/prepare.ts` runs the write-side integrity floor when `writeFloorMode !== "off"`, and records a rejecting reason only when that mode is `enforce`;
`storage/extended-storage-transaction.ts` reads the flow dial the same way against `persist`. An unrecognized name passes the first test and fails the second, so the dial does the work of `observe`: it diagnoses, and decides nothing.

The posture record said the opposite. A projection built with `cfcWriteFloor` set to `enfroce` returned that name as the rung, with `diagnosticOnly: false` and no `decidesOn` at all. The flag is false because the name is not one of the diagnostic rungs either, and the phrase is missing although `CfcDialReport` declares it a `string`, so the record violated its own declared type. Toolshed publishes that record at `/api/meta`, where an operator reads the dial as enforcing.

The two dials that are simply on or off part the other way round. `prepare.ts` reads both for truthiness while `buildReport` publishes `=== true`, so a truthy value that is not `true` runs the gate while the record says the gate is off.

Every value `resolveCfcDials` returns is now a rung of its own dial. The six named-rung dials are checked against the tables that say what each rung decides on, which are the tables the record's `decidesOn` is read from. Each is keyed by its dial's own mode union, so it holds an entry for every rung and for nothing else, and a ladder that gains a rung is accepted with no further edit here. The table of tables is pinned with `satisfies`, so one ladder's table placed under another dial does not compile. The two on-or-off dials take `true` and `false`.

The comparison is against the rung names as values rather than as property keys. A property key is a string, so a lookup by key converts whatever it is given: `["enforce"]`, `new String("enforce")` and `{ toString: () => "enforce" }` all name the key `enforce` while none of them is `"enforce"`, which is what every consumer compares against. Accepting one would be worse than no check, because the record would then carry the rung's name together with the phrase saying what that rung decides on.

An off-ladder value throws rather than falling back to the default. There is no rung to put the runtime on, and quietly resolving a misspelled `enforce-strict` would hand a deployment a weaker posture than the word it wrote. A `null` is refused on the same grounds: the option type has no `null` member, so one that arrives came from a caller the types did not reach.

One place is enough because every host resolves its dials here. The browser worker takes `cfcEnforcementMode` and `cfcFlowLabels` off the shell's initialization data across a real worker boundary (`runtime-client/src/backends/runtime-processor.ts`) and passes them into the runtime options unexamined; a command line and the CFC section of a JSON manifest arrive at the same function. Each now fails at construction, naming the dial and the values it takes, in the message shape the enforcement-mode refusal already used.

This replaces that enforcement-mode special case, which the general check covers, so `cfc/types.ts`'s `isCfcEnforcementMode` is no longer imported here. The tests that came with it pass unchanged.

The dials are classified by type rather than by exclusion: a dial of some third type belongs to neither set and fails to compile at the call that resolves it, where "everything that is not a named-rung dial" would have sent it to the boolean check and thrown on its own default, breaking every construction.

Tests: eleven cases fail against the tree without this change, none of them throwing where they expect a refusal. The table of off-ladder cases is a record over `ResolvedCfcDials`, so a dial added there is a type error in the test until it has a case, which is what closes the claim that every dial is checked. The lookalike values above have a case of their own, and both `projectedCfcPostureReport` and `new Runtime(...)` are covered. `docs/development/EXPERIMENTAL_OPTIONS.md` describes this resolution, so it gains the paragraph saying that what comes out of it is a rung, and which way each kind of dial parts when it is not.

Verified by running: the full `packages/runner` suite (1385 tests), cf-harness (1004), runtime-client (28), toolshed's `/api/meta` route and lib-shell, plus repo-wide `deno task check`, `deno fmt --check`, `deno lint` and `deno task check-docs`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

