### PR TITLE
fix(shuttle): the prompt's cursor lands in columns, not code points

### DIFF
--- a/packages/cli/lib/shuttle/announce.ts
+++ b/packages/cli/lib/shuttle/announce.ts
@@ -102,6 +102,19 @@ interface Saying {
  * The indent is this console's rather than the door's, so it is added here
  * and not in `above` (`paint.ts`): a line shuttle writes for itself is not
  * inside a pattern's group.
+ *
+ * The depth follows the calls and nothing bounds it, which is deliberate and
+ * is what a console does with the same calls: a pattern that opens groups it
+ * never closes indents every line it writes after them for the rest of the
+ * run, and so reads here what it would read written anywhere else. What that
+ * costs is a transcript whose pattern lines start further right the more
+ * groups went unclosed, with no way back short of ending the run.
+ *
+ * The lines a connection writes for itself are not among them. They reach the
+ * prompt through {@link announcingOutput}'s `report`, which is the sink
+ * itself, so they stay at the left margin whatever a pattern has opened —
+ * which is what keeps the indent a reading of a pattern's own nesting rather
+ * than of the transcript.
  */
 function line(saying: Saying, text: string): void {
   saying.announce(`${"  ".repeat(saying.depth)}${text}`);

--- a/packages/cli/lib/shuttle/paint.ts
+++ b/packages/cli/lib/shuttle/paint.ts
@@ -4,9 +4,9 @@
  *
  * A line being edited is redrawn where it stands, so a terminal is told where
  * the last drawing put the cursor as well as what to draw. That bookkeeping is
- * arithmetic over two numbers and a width, and it is here rather than beside
- * the writing so that a case can read the escape sequences back without a
- * terminal to send them to.
+ * a line, a cursor and a width laid out into rows, and it is here rather than
+ * beside the writing so that a case can read the escape sequences back without
+ * a terminal to send them to.
  *
  * The cursor is put back with the terminal's own save and restore
  * (`ESC 7`/`ESC 8`) rather than by counting where the text left it, because
@@ -15,8 +15,12 @@
  * screen: the saved position is the line's first row, and a line taller than
  * the terminal scrolls that row away.
  *
- * A code point is a column here, as it is in the buffer these numbers come
- * from, so a character a terminal draws double-wide is one column to both.
+ * A cursor arrives as a code-point index into the line, which is the unit the
+ * buffer it comes from moves in, and where that lands on the screen is worked
+ * out here at the columns a terminal gives each character. The two are not the
+ * same count: a character drawn double-wide is one code point and two columns,
+ * so a cursor moved by the index would sit left of where the typing appears,
+ * and by one column more for every such character in front of it.
  *
  * A line carries the width it was drawn at rather than taking the current one,
  * because a window resized between two drawings leaves the old line occupying
@@ -26,7 +30,10 @@
  * that put it there.
  */
 
+import { unicodeWidth } from "@std/cli/unicode-width";
+
 import { CSI, ESC } from "../view/ansi.ts";
+import { wrapped } from "./page.ts";
 import { escapeControlCharacters } from "./place.ts";
 
 /** A line as it was last drawn: what it said, where its cursor sat, how wide. */
@@ -34,7 +41,12 @@ export interface PaintedLine {
   /** The whole line, prompt included. */
   readonly text: string;
 
-  /** How many code points into it the cursor sat. */
+  /**
+   * How many code points into the text the cursor sat, which is an index into
+   * it rather than a place on the screen. What a terminal draws each of those
+   * code points as is what turns the one into the other, and this module is
+   * where that conversion happens.
+   */
   readonly column: number;
 
   /** How wide the terminal was when it was drawn. */
@@ -42,9 +54,9 @@ export interface PaintedLine {
 }
 
 /**
- * The empty line a terminal is on before anything is drawn on it. Its width is
- * the one width that divides nothing into no rows whatever it is, so which one
- * it carries decides nothing.
+ * The empty line a terminal is on before anything is drawn on it. No width
+ * lays nothing out over more than the row it starts on, so which one it
+ * carries decides nothing.
  */
 export const NOTHING_PAINTED: PaintedLine = { text: "", column: 0, columns: 1 };
 
@@ -57,15 +69,16 @@ export const NOTHING_PAINTED: PaintedLine = { text: "", column: 0, columns: 1 };
  * behind on the rows below.
  */
 export function repaint(from: PaintedLine, to: PaintedLine): string {
+  const cursor = cursorOf(to);
   return [
-    up(Math.floor(from.column / from.columns)),
+    up(cursorOf(from).row),
     "\r",
     `${ESC}7`,
     `${CSI}0J`,
     to.text,
     `${ESC}8`,
-    down(Math.floor(to.column / to.columns)),
-    right(to.column % to.columns),
+    down(cursor.row),
+    right(cursor.column),
   ].join("");
 }
 
@@ -76,13 +89,15 @@ export function repaint(from: PaintedLine, to: PaintedLine): string {
  * with whatever was written under it. Ending it is all this does: what a line
  * produced lands through {@link above}, because between the two the person may
  * have gone on typing and a terminal writes where its cursor is.
+ *
+ * The move is to the row the text ends on and not to the row the cursor is on,
+ * which are different rows for a line filling its last one exactly: ending
+ * where the cursor sits would leave a blank row above whatever is written next.
  */
 export function finish(painted: PaintedLine): string {
-  const cursorRow = Math.floor(painted.column / painted.columns);
-  const lastRow = Math.floor(
-    Math.max(width(painted.text) - 1, 0) / painted.columns,
-  );
-  return [down(lastRow - cursorRow), up(cursorRow - lastRow), "\r\n"].join("");
+  const cursor = cursorOf(painted).row;
+  const last = lastRowOf(painted);
+  return [down(last - cursor), up(cursor - last), "\r\n"].join("");
 }
 
 /**
@@ -111,7 +126,7 @@ export function finish(painted: PaintedLine): string {
  */
 export function above(painted: PaintedLine, text: string): string {
   return [
-    up(Math.floor(painted.column / painted.columns)),
+    up(cursorOf(painted).row),
     "\r",
     `${CSI}0J`,
     inert(text),
@@ -149,7 +164,52 @@ function right(count: number): string {
   return count > 0 ? `${CSI}${count}C` : "";
 }
 
-/** Helper for {@link finish}, which is how many columns `text` occupies. */
-function width(text: string): number {
-  return [...text].length;
+/** Where a drawn line left the cursor, counted from the line's own start. */
+interface Cursor {
+  /** How many rows below the line's first row it sat. */
+  readonly row: number;
+
+  /** How many columns across that row it sat. */
+  readonly column: number;
+}
+
+/**
+ * Helper for the writes above, which is where `painted` left the cursor.
+ *
+ * The count a line carries is an index and the answer is a place on the
+ * screen, so the text in front of the cursor is broken into rows the way the
+ * terminal breaks it — {@link wrapped} (`page.ts`), the one traversal this
+ * and a page both measure by. Two things follow from it being the terminal's
+ * traversal rather than a division. A character counts the columns it is drawn
+ * in, so a double-wide one moves the cursor two. And a row with one column
+ * left and a double-wide character to place is left that column blank, the
+ * character starting the row below, so the row a division names can be a row
+ * short and the column across it can be a column short of that.
+ *
+ * Text filling its last row exactly leaves the cursor at the start of the next
+ * row rather than at the end of the filled one. Every write here counts rows
+ * by this function, so whichever of those a terminal would have done, a
+ * drawing climbs back over exactly the rows the drawing before it came down.
+ * {@link finish} is the one caller wanting the other reading, and it asks for
+ * the row the text ends on separately.
+ */
+function cursorOf({ text, column, columns }: PaintedLine): Cursor {
+  const width = Math.max(columns, 1);
+  const rows = wrapped([[...text].slice(0, column).join("")], width);
+  const filled = unicodeWidth(rows[rows.length - 1]!);
+  return filled >= width
+    ? { row: rows.length, column: 0 }
+    : { row: rows.length - 1, column: filled };
+}
+
+/**
+ * Helper for {@link finish}, which is how many rows below its first row the
+ * last row of `painted` is.
+ *
+ * It measures the whole text where {@link cursorOf} measures what is in front
+ * of the cursor, and by the same traversal, so the two answers are rows of one
+ * layout and the difference between them is a distance to move.
+ */
+function lastRowOf({ text, columns }: PaintedLine): number {
+  return wrapped([text], columns).length - 1;
 }

--- a/packages/cli/lib/shuttle/prompt.ts
+++ b/packages/cli/lib/shuttle/prompt.ts
@@ -71,6 +71,10 @@ export interface PromptTerminal {
    * Shows `text` as the line being edited, with the cursor `column` code
    * points into it. Both are the whole line, prompt included, because where
    * the prompt ends and the typing begins is nothing a terminal needs to know.
+   *
+   * The count is an index into `text` rather than a place on the screen, so
+   * an implementation that draws on one works out where those code points put
+   * the cursor — `paint.ts` is where the one this package uses does it.
    */
   edit(text: string, column: number): void;
 
@@ -455,8 +459,9 @@ function apply(buffer: EditBuffer, key: Key): void {
 
 /**
  * Helper for {@link runPrompt}, which is the length of `text` in the unit the
- * cursor is measured in. The buffer counts a code point as a column, and this
- * counts the prompt in front of it the same way.
+ * cursor is measured in. The buffer moves its cursor a code point at a time,
+ * and this counts the prompt in front of it the same way, so the sum is an
+ * index into the line rather than a place on the screen.
  */
 function codePoints(text: string): number {
   return [...text].length;

--- a/packages/cli/test/shuttle-paint.test.ts
+++ b/packages/cli/test/shuttle-paint.test.ts
@@ -73,14 +73,68 @@ describe("paint", () => {
         .toBe(`\r\x1b7\x1b[0J${"a".repeat(25)}\x1b8\x1b[1B\x1b[5C`);
     });
 
-    it("counts a code point as a column, whatever a terminal draws it as", () => {
-      // The buffer the columns come from counts in code points, so this counts
-      // the same way rather than measuring what the glyphs occupy. A character
-      // a terminal draws double-wide therefore moves the cursor one column
-      // where it drew two.
+    describe("a double-width character", () => {
+      // The cursor arrives as an index into the line and leaves as a place on
+      // the screen, and a character a terminal draws double-wide is one of the
+      // first and two of the second. Every fixture here is written where
+      // counting the index and counting the columns give different answers.
 
-      expect(repaint(NOTHING_PAINTED, line("\u{1F9F5}", 1)))
-        .toBe("\r\x1b7\x1b[0J\u{1F9F5}\x1b8\x1b[1C");
+      it("moves the cursor across the columns the characters are drawn in", () => {
+        // Two wide characters are two code points and four columns.
+
+        expect(repaint(NOTHING_PAINTED, line("界界", 2)))
+          .toBe("\r\x1b7\x1b[0J界界\x1b8\x1b[4C");
+      });
+
+      it("moves the cursor onto the row a character orphaned by one column starts", () => {
+        // Three wide characters are six columns, which a width of five divides
+        // into one row and one column across it. The terminal puts the cursor
+        // a column further along: two characters fill four columns, the third
+        // wants two and one is left, so it starts the row below and leaves
+        // that column blank.
+
+        expect(repaint(NOTHING_PAINTED, line("界界界", 3, 5)))
+          .toBe("\r\x1b7\x1b[0J界界界\x1b8\x1b[1B\x1b[2C");
+      });
+
+      it("counts a blank column per row that a wrap left one on", () => {
+        // The case above at a width the columns divide evenly, which is where
+        // a measure that divides looks right and so is where the fixture has
+        // to be. Five wide characters are ten columns, and a width of five
+        // divides them into two rows and no columns across. The terminal
+        // agrees on the row and not on the column: each row fits two
+        // characters and leaves its fifth column blank, so the cursor sits two
+        // columns into the third row rather than at its start.
+
+        expect(repaint(NOTHING_PAINTED, line("界界界界界", 5, 5)))
+          .toBe("\r\x1b7\x1b[0J界界界界界\x1b8\x1b[2B\x1b[2C");
+      });
+
+      it("climbs back over the rows the old line's columns filled", () => {
+        expect(repaint(line("界界界", 3, 5), line("b", 1)))
+          .toBe("\x1b[1A\r\x1b7\x1b[0Jb\x1b8\x1b[1C");
+      });
+
+      it("counts a character outside the basic plane as one code point of the index", () => {
+        // The index the cursor arrives as counts code points, and one outside
+        // the basic plane is stored as two of the units a string is held in.
+        // A cursor two code points along here has passed a character drawn in
+        // two columns and one drawn in one.
+
+        expect(repaint(NOTHING_PAINTED, line("\u{1F9F5}a", 2)))
+          .toBe("\r\x1b7\x1b[0J\u{1F9F5}a\x1b8\x1b[3C");
+      });
+
+      it("moves the cursor onto the next row where the characters fill one exactly", () => {
+        // The other side of that boundary, and what stops the measure
+        // over-charging: two wide characters fill a width of four with nothing
+        // orphaned, which is the one row a division gives too. A row filled
+        // exactly leaves the cursor at the start of the next one and nowhere
+        // across it.
+
+        expect(repaint(NOTHING_PAINTED, line("界界", 2, 4)))
+          .toBe("\r\x1b7\x1b[0J界界\x1b8\x1b[1B");
+      });
     });
   });
 
@@ -103,6 +157,28 @@ describe("paint", () => {
 
     it("ends a wrapped line at the width it was drawn at", () => {
       expect(finish(line("a".repeat(25), 3, 20))).toBe("\x1b[1B\r\n");
+    });
+
+    describe("a double-width character", () => {
+      // Ending a line means reaching the last row it occupies, and that row is
+      // the terminal's own layout of it: neither a count of the characters nor
+      // a division of the columns they take lands on it.
+
+      it("moves down to the last row the drawn columns reach", () => {
+        // Four wide characters are eight columns. At a width of three each one
+        // starts a row of its own, since two columns do not fit in the one a
+        // character before it leaves, so the line is four rows. Counting the
+        // characters says two rows and dividing the columns says three.
+
+        expect(finish(line("界界界界", 0, 3))).toBe("\x1b[3B\r\n");
+      });
+
+      it("charges no extra row where the characters divide the width evenly", () => {
+        // Two wide characters fill a width of four with nothing orphaned, so
+        // the line is the one row it stands on and the ending goes where it is.
+
+        expect(finish(line("界界", 0, 4))).toBe("\r\n");
+      });
     });
   });
 
@@ -171,6 +247,17 @@ describe("paint", () => {
 
     it("leaves a text holding nothing of that class alone", () => {
       expect(above(NOTHING_PAINTED, "a b")).toContain("\r\x1b[0Ja b\r\n");
+    });
+
+    it("climbs the rows a line's drawn columns filled before it clears", () => {
+      // The climb is by the same measure the drawing came down by, so a line
+      // holding characters a terminal draws double-wide is climbed by the rows
+      // those columns filled rather than by the code points behind them.
+
+      expect(above(line("界界界", 3, 5), "gone"))
+        .toBe(
+          "\x1b[1A\r\x1b[0Jgone\r\n\r\x1b7\x1b[0J界界界\x1b8\x1b[1B\x1b[2C",
+        );
     });
 
     it("draws the line again at the width it was drawn at", () => {


### PR DESCRIPTION
## Why

Shuttle's prompt worked out where the cursor sits by counting **code points**:

```ts
function width(text: string): number {
  return [...text].length;
}
```

Terminals lay out in **columns**, and a CJK character or most emoji occupy
two. So every measurement after a wide character was short by one column per
character — the cursor drew left of where it typed, a repaint on a wrapped
line climbed to the wrong row, and clearing took the wrong region. A person
produces all of it by typing a name holding a wide character, which is
ordinary: piece names and data keys hold real text.

The identical defect existed in the paging arithmetic and was fixed there
first. This was found while fixing that one and deliberately left for its own
review, because changing cursor arithmetic under a live prompt is not
something to fold into an unrelated slice.

Closes #7051.

## What Changed

`width()` is gone. `cursorOf()` converts the code-point index a `PaintedLine`
carries into a screen place by laying the prefix out with **`wrapped` from
`page.ts`** — the same traversal a page measures its rows by, rather than a
second copy — and takes the last row's width with `unicodeWidth`.

**Dividing the display width is still wrong, which the fixtures pin.** At
width 5, `界界界` is 6 columns: the division says row 1 column 1, the terminal
says row 1 column 2, because the third character cannot fit the one remaining
column and starts the row below. At width 3, `界界界界` is 8 columns — the
division says three rows, the terminal needs four.

The module's existing reading that a row filled exactly puts the cursor at the
start of the next row is preserved, now stated in `cursorOf`'s doc and pinned
by both an ASCII and a wide-character case.

### A name flagged rather than changed

`PaintedLine.column` and `PromptTerminal.edit(text, column)` hold an **index**,
in the module that computes screen columns. That name is what invited the bug.
Renaming reaches roughly fifteen sites across five files and would bury a
defect fix in churn, so both doc comments now say plainly that the count is an
index and never a place on the screen. The rename is a reviewer's call.

### A ruling recorded, with no behaviour change

`announce.ts`'s `line()` doc now records that `console.group`'s depth is
unbounded **on purpose**: it is what a console does with the same calls, so a
pattern reads here what it would read anywhere else. What it costs is stated —
a pattern that never closes its groups indents every later line for the rest
of the run. No cap, no reset, no bound.

## Test plan

- `deno fmt --check` 0, `deno lint` 0 (462 files), `deno task check` 0,
  `check-docs` 0 (594 blocks), plus `check-control-characters`,
  `check-command-docs`, `check-skill-facts`, `check-package-cycles` — all 0.
- `packages/cli` both phases: **parallel 1810 / 0 failed, serial 216 / 0
  failed.**
- **`validated 12 / ran 12 / red 12 / survivors [] / did-not-run [] / faults
  []`.**
- **Every caller checked, not assumed** — `terminal.ts` (passes through, its
  one `.length` is on encoded bytes and correct), `prompt.ts` (produces the
  index, the unit the conversion expects), `editbuffer.ts` (code-point counts,
  correct as the editor's own motion unit). Other layout measurements in
  shuttle were checked and left with reasons: `help.ts` and `listing.ts` pad
  ASCII by construction, and `record.ts` **must** stay a character count
  because a caller slices the label back at a fixed width.
- **An astral fixture (`U+1F9F5`) is kept deliberately**: every `界` fixture is
  BMP, so a UTF-16 slice survives all of them and only an astral character
  reds the index-stepping clause.

### Instruments proved rather than trusted

- The harness was shown able to report a **survivor**, a **fault**, and a
  **did-not-run**, each under different words, by deliberately provoking all
  three.
- **`deno test --filter` cannot address a BDD `it()`** — it filters top-level
  names only, so a filtered run exits 0 having run nothing, which would read
  as a survivor. The harness reads per-case verdicts from `--reporter=junit`
  and calls it did-not-run unless the designated name matches exactly once.
- **`packages/cli`'s test task runs with `--no-check`**: a deliberate type
  error in a test file gave `deno test` exit 0 and `deno check` exit 1.
- `check-no-waitfor` covers none of these files — its scope is
  `packages/*/integration/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

