### PR TITLE
test(tasks): check-command-docs holds shuttle's verbs to a live document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,13 +344,16 @@ Each of these gates fails CI on its own, and none of them run as part of
   hand-maintained tables, and a slot missing from both is silent: it offers
   nothing, exactly as an unreachable fabric does. Give it candidates, or record
   in the task why it has none
-- `deno task check-command-docs` — a `cf` command no live document names. The
-  obligation to update a document when behavior changes cannot fire for a
-  command no document describes, so a command ships and its prose does not.
-  Describe it in a live document — the README of the package that implements it
-  is the usual home — or record in the task why it needs none. It fails the
-  other way round too, on a recorded reason naming a command the tree no longer
-  accepts: a command removed takes its entry with it
+- `deno task check-command-docs` — a `cf` command, or a shuttle verb, that no
+  live document describes. The obligation to update a document when behavior
+  changes cannot fire for a surface no document describes, so a command ships
+  and its prose does not. Describe it in a live document — the README of the
+  package that implements it is the usual home — or record in the task why it
+  needs none. What counts as described differs with the surface: a command is
+  named the way a caller types it, and a verb, whose name is a word a sentence
+  may hold for its own reasons, is given a row of its own in a table. It fails
+  the other way round too, on a recorded reason naming a command or a verb that
+  no longer exists: one removed takes its entry with it
 - `deno task check-local-program` — a program built from local files by hand
   rather than through `resolveLocalProgram`, which silently drops any data files
   the caller attached

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,11 +42,12 @@ is out of date when a command ships with no prose, because nothing claimed to
 cover it, and the absence is visible only to someone who already knows the
 command exists.
 
-For the `cf` command surface that half is mechanical: `deno task check-command-docs`
-fails when a command the CLI accepts is named in no live document, and takes a
-recorded reason instead where a command genuinely needs none. Prose belongs with
-the code it describes — the README of the package that implements the command,
-or the feature document that owns the surface — which is where the gate looks.
+For the surfaces a caller types that half is mechanical:
+`deno task check-command-docs` fails when a command the CLI accepts, or a verb
+shuttle accepts, is described in no live document, and takes a recorded reason
+instead where one genuinely needs none. Prose belongs with the code it
+describes — the README of the package that implements the command, or the
+feature document that owns the surface — which is where the gate looks.
 
 ## Historical documentation
 

--- a/packages/cli/lib/shuttle/verbs.ts
+++ b/packages/cli/lib/shuttle/verbs.ts
@@ -892,6 +892,18 @@ const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
 ]);
 
 /**
+ * Every verb, by the word that names one, read for what it says about itself
+ * rather than for what running it does.
+ *
+ * It is {@link VERBS} under the half of its type a reader outside the dispatch
+ * needs. `tasks/check-command-docs.ts` is that reader: it holds each verb to a
+ * live document naming it, and a gate that could reach `run` could call one.
+ * Every verb is here because it is the same map — a verb added to the table is
+ * a verb the gate asks about, with no second list to keep in step.
+ */
+export const VERB_HELP: ReadonlyMap<string, VerbHelp> = VERBS;
+
+/**
  * Helper for {@link cd}, which finishes `move`.
  *
  * A landing and a refusal are the answer already. The arms only a read can

--- a/tasks/check-command-docs.test.ts
+++ b/tasks/check-command-docs.test.ts
@@ -4,18 +4,28 @@ import { Command } from "@cliffy/command";
 import { dirname, fromFileUrl, join } from "@std/path";
 import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import {
+  COMMAND_SURFACE,
   commandPattern,
   declaredCommands,
-  describeCommandDocFailures,
-  documentedCommands,
+  declaredVerbs,
+  describeDocFailures,
+  documentedNames,
   isLiveDoc,
   main,
   NO_PROSE,
+  NO_VERB_PROSE,
   readPackageDocs,
-  reportCommandDocs,
+  reportDocs,
+  type Surface,
+  verbPattern,
+  verbSurface,
 } from "./check-command-docs.ts";
+import { VERB_HELP } from "../packages/cli/lib/shuttle/verbs.ts";
 
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+
+/** No verbs sought, for a case asking only what the commands are. */
+const NO_VERBS: ReadonlyMap<string, string> = new Map();
 
 /** Run the gate the way its task does, and return what the process reported. */
 async function runAsProgram(
@@ -161,6 +171,32 @@ describe("check-command-docs", () => {
     });
   });
 
+  describe("declaredVerbs()", () => {
+    it("holds every verb to the usage its own help writes it under", () => {
+      // The document is held to the verb's account of itself rather than to a
+      // spelling this file chose, so a verb whose operands change is a verb
+      // whose row stops satisfying the gate.
+
+      const verbs = declaredVerbs(
+        new Map([
+          ["cd", { usage: "cd <ref>" }],
+          ["ls", { usage: "ls" }],
+        ]),
+      );
+      expect([...verbs]).toEqual([["cd", "cd <ref>"], ["ls", "ls"]]);
+    });
+
+    it("asks about every verb the shuttle table holds", () => {
+      // The claim ranges over the table, so the case reads the table: a verb
+      // added to `verbs.ts` is one this gate asks about with nothing here to
+      // edit, and this reds if the projection ever drops one.
+
+      expect([...declaredVerbs(VERB_HELP).keys()]).toEqual([
+        ...VERB_HELP.keys(),
+      ]);
+    });
+  });
+
   describe("isLiveDoc()", () => {
     /** One package, the way the root config names its members. */
     const packageDocs = new Set(["packages/oven/README.md"]);
@@ -298,7 +334,59 @@ describe("check-command-docs", () => {
     });
   });
 
-  describe("documentedCommands()", () => {
+  describe("verbPattern()", () => {
+    it("reads a row whose first cell is the verb's usage as code", () => {
+      const row = "| `more`   | Writes the next page. |";
+      expect(verbPattern("more").test(row)).toBe(true);
+      expect(verbPattern("cd <ref>").test("| `cd <ref>` | Moves. |")).toBe(
+        true,
+      );
+      // The operand grammar is part of the cell, so a row written for an
+      // older signature does not answer for the current one.
+      expect(verbPattern("get [<ref>]").test("| `get` | Reads. |")).toBe(false);
+    });
+
+    it("does not read a mention in a sentence as a description", () => {
+      // This is the whole standard. `packages/cli/README.md` lost its row for
+      // `more` while its prose went on saying what `more` writes, and a rule
+      // that took the sentence would have passed that drift.
+
+      const prose = "held back; `more` writes the next one.";
+      expect(verbPattern("more").test(prose)).toBe(false);
+      // Nor a sentence that opens its own line, which is what a row does.
+      expect(verbPattern("more").test("\n`more` writes the next one.\n"))
+        .toBe(false);
+    });
+
+    it("does not read a cell that is not the row's first", () => {
+      // The row that describes a verb opens with it. A verb written into some
+      // other column is being mentioned by a row about something else — a
+      // second-cell mention, and a cell of its own further along alike.
+
+      expect(verbPattern("more").test("| `ls` | and `more` writes the rest |"))
+        .toBe(false);
+      expect(verbPattern("more").test("| Continues | `more` |")).toBe(false);
+    });
+
+    it("does not read a cell holding the verb and something besides", () => {
+      // A cell naming two verbs is a row about neither of them.
+
+      expect(verbPattern("ls").test("| `ls`, `more` | Two verbs. |")).toBe(
+        false,
+      );
+    });
+
+    it("reads a row wherever it sits in the document", () => {
+      // The table is somewhere in the middle of a document, so the row is
+      // found by opening a line rather than by opening the text.
+
+      const doc = "# Verbs\n\n| Verb | What it does |\n| ---- | ---- |\n" +
+        "| `pwd` | The complete address. |\n";
+      expect(verbPattern("pwd").test(doc)).toBe(true);
+    });
+  });
+
+  describe("documentedNames()", () => {
     /** A throwaway tree of documents, so the search runs against real files. */
     async function withDocs(
       files: Record<string, string>,
@@ -329,7 +417,9 @@ describe("check-command-docs", () => {
       await withDocs({ "docs/guide.md": "Run `cf glaze set` first." }, async (
         root,
       ) => {
-        expect([...await documentedCommands(root, ["glaze set"])])
+        expect([
+          ...(await documentedNames(root, ["glaze set"], NO_VERBS)).commands,
+        ])
           .toEqual(["glaze set"]);
       });
     });
@@ -341,7 +431,9 @@ describe("check-command-docs", () => {
       await withDocs({ "docs/guide.md": "Run `cf glaze setsrc`." }, async (
         root,
       ) => {
-        expect([...await documentedCommands(root, ["glaze set"])]).toEqual([]);
+        expect([
+          ...(await documentedNames(root, ["glaze set"], NO_VERBS)).commands,
+        ]).toEqual([]);
       });
     });
 
@@ -349,7 +441,9 @@ describe("check-command-docs", () => {
       await withDocs({ "docs/guide.md": "Run `cf glaze\nset` first." }, async (
         root,
       ) => {
-        expect([...await documentedCommands(root, ["glaze set"])])
+        expect([
+          ...(await documentedNames(root, ["glaze set"], NO_VERBS)).commands,
+        ])
           .toEqual(["glaze set"]);
       });
     });
@@ -362,7 +456,8 @@ describe("check-command-docs", () => {
         "docs/history/report.md": "We ran `cf brew` in July.",
         "docs/plans/later.md": "`cf brew` will gain a flag.",
       }, async (root) => {
-        expect([...await documentedCommands(root, ["brew"])]).toEqual([]);
+        expect([...(await documentedNames(root, ["brew"], NO_VERBS)).commands])
+          .toEqual([]);
       });
     });
 
@@ -374,7 +469,11 @@ describe("check-command-docs", () => {
         ".claude/agents/baker.md": "Run `cf brew` before you glaze.",
         "skills/baking/SKILL.md": "`cf glaze set` picks the flavor.",
       }, async (root) => {
-        const found = await documentedCommands(root, ["brew", "glaze set"]);
+        const { commands: found } = await documentedNames(
+          root,
+          ["brew", "glaze set"],
+          NO_VERBS,
+        );
         expect([...found]).toEqual(["glaze set"]);
       });
     });
@@ -384,7 +483,11 @@ describe("check-command-docs", () => {
         "packages/oven/README.md": "`cf brew` heats the glaze.",
         "packages/oven/brew.ts": "// `cf glaze set` in a comment",
       }, async (root) => {
-        const found = await documentedCommands(root, ["brew", "glaze set"]);
+        const { commands: found } = await documentedNames(
+          root,
+          ["brew", "glaze set"],
+          NO_VERBS,
+        );
         expect([...found]).toEqual(["brew"]);
       });
     });
@@ -399,7 +502,7 @@ describe("check-command-docs", () => {
       try {
         await Deno.writeTextFile(`${root}/deno.jsonc`, `{ "workspace": [] }`);
         await Deno.writeTextFile(`${root}/docs`, "a file where a tree goes");
-        await expect(documentedCommands(root, ["brew"])).rejects.toThrow(
+        await expect(documentedNames(root, ["brew"], NO_VERBS)).rejects.toThrow(
           /Not a directory/,
         );
       } finally {
@@ -414,30 +517,98 @@ describe("check-command-docs", () => {
         "packages/oven/README.md": "`cf brew` heats the glaze.",
         "packages/oven/test/fixtures/README.md": "`cf glaze set` here too.",
       }, async (root) => {
-        const found = await documentedCommands(root, ["brew", "glaze set"]);
+        const { commands: found } = await documentedNames(
+          root,
+          ["brew", "glaze set"],
+          NO_VERBS,
+        );
         expect([...found]).toEqual(["brew"]);
+      });
+    });
+
+    it("finds a verb a live document gives a row of its own", async () => {
+      await withDocs({
+        "docs/shell.md": "| Verb | What |\n| ---- | ---- |\n| `ls` | Lists. |",
+      }, async (root) => {
+        const { verbs } = await documentedNames(
+          root,
+          [],
+          new Map([["ls", "ls"]]),
+        );
+        expect([...verbs]).toEqual(["ls"]);
+      });
+    });
+
+    it("does not take a sentence naming the verb as its description", async () => {
+      // The drift this half exists for: the row went, the prose stayed, and
+      // the prose is not an account of the verb.
+
+      await withDocs({
+        "docs/shell.md": "One screenful is written and `more` writes the rest.",
+      }, async (root) => {
+        const { verbs } = await documentedNames(
+          root,
+          [],
+          new Map([["more", "more"]]),
+        );
+        expect([...verbs]).toEqual([]);
+      });
+    });
+
+    it("holds a verb to the same live-document rule a command is held to", async () => {
+      // A plan describes a surface that is intended. Shuttle's design lives
+      // under `docs/plans/`, so a verb table there would otherwise answer for
+      // every verb the shuttle grows.
+
+      await withDocs({
+        "docs/plans/shuttle.md": "| `wish <#name>` | Resolves one. |",
+        "docs/history/audit.md": "| `pwd` | The complete address. |",
+      }, async (root) => {
+        const { verbs } = await documentedNames(
+          root,
+          [],
+          new Map([["wish", "wish <#name>"], ["pwd", "pwd"]]),
+        );
+        expect([...verbs]).toEqual([]);
+      });
+    });
+
+    it("answers both surfaces from the one walk", async () => {
+      // One read of each document, both surfaces searched in it: a command
+      // and a verb described in the same document are both found.
+
+      await withDocs({
+        "packages/oven/README.md": "`cf brew` heats it.\n\n| `ls` | Lists. |",
+      }, async (root) => {
+        const found = await documentedNames(
+          root,
+          ["brew"],
+          new Map([["ls", "ls"]]),
+        );
+        expect([...found.commands]).toEqual(["brew"]);
+        expect([...found.verbs]).toEqual(["ls"]);
       });
     });
   });
 
-  describe("reportCommandDocs()", () => {
+  describe("reportDocs()", () => {
     const declared = ["brew", "glaze set"];
 
     it("names a command no document covers and no allowance excuses", () => {
-      const report = reportCommandDocs(declared, new Set(), new Map());
+      const report = reportDocs(declared, new Set(), new Map());
       expect(report.undocumented).toEqual(["brew", "glaze set"]);
     });
 
     it("returns no finding for a documented command", () => {
       expect(
-        reportCommandDocs(declared, new Set(declared), new Map()).undocumented,
+        reportDocs(declared, new Set(declared), new Map()).undocumented,
       ).toEqual([]);
     });
 
     it("returns no finding for a command the allowance records a reason for", () => {
       const allowed = new Map([["brew", "an internal entry point"]]);
       expect(
-        reportCommandDocs(declared, new Set(["glaze set"]), allowed)
+        reportDocs(declared, new Set(["glaze set"]), allowed)
           .undocumented,
       ).toEqual([]);
     });
@@ -447,27 +618,85 @@ describe("check-command-docs", () => {
 
       const allowed = new Map([["retired", "gone"]]);
       expect(
-        reportCommandDocs(declared, new Set(declared), allowed).staleAllowance,
+        reportDocs(declared, new Set(declared), allowed).staleAllowance,
       ).toEqual(["retired"]);
     });
   });
 
-  describe("describeCommandDocFailures()", () => {
+  describe("describeDocFailures()", () => {
     it("returns nothing when the report is empty", () => {
-      expect(describeCommandDocFailures({
+      expect(describeDocFailures({
         undocumented: [],
         staleAllowance: [],
-      })).toEqual([]);
+      }, COMMAND_SURFACE)).toEqual([]);
     });
 
     it("names the table to edit and the commands at fault", () => {
-      const text = describeCommandDocFailures({
+      const text = describeDocFailures({
         undocumented: ["brew"],
         staleAllowance: ["retired"],
-      }).join("\n");
+      }, COMMAND_SURFACE).join("\n");
       expect(text).toContain("NO_PROSE");
       expect(text).toContain("cf brew");
       expect(text).toContain("cf retired");
+    });
+  });
+
+  describe("verbSurface()", () => {
+    it("writes a verb as the row that would answer for it opens", () => {
+      // A reader who has just failed is shown the cell to paste, rather than
+      // the bare word, which is not what the check is looking for.
+
+      const surface = verbSurface(new Map([["get", "get [<ref>]"]]));
+      expect(surface.write("get")).toBe("`get [<ref>]`");
+    });
+
+    it("writes an allowance's own word where the verb has gone", () => {
+      // A stale entry has no usage left to write, so the word it recorded is
+      // what names it.
+
+      expect(verbSurface(new Map()).write("retired")).toBe("`retired`");
+    });
+
+    it("says what a row is, for a reader who has just been refused one", () => {
+      const text = describeDocFailures(
+        { undocumented: ["more"], staleAllowance: [] },
+        verbSurface(new Map([["more", "more"]])),
+      ).join("\n");
+      expect(text).toContain("NO_VERB_PROSE");
+      expect(text).toContain("a row of its own in a table");
+      expect(text).toContain("tasks/check-command-docs.ts");
+    });
+
+    it("tells a stale entry to go rather than to find a document", () => {
+      // The remedy that answers one direction does not answer the other: a
+      // verb the table no longer holds cannot be given a row.
+
+      const text = describeDocFailures(
+        { undocumented: [], staleAllowance: ["retired"] },
+        verbSurface(new Map()),
+      ).join("\n");
+      expect(text).toContain("Remove each entry");
+      expect(text).not.toContain("a row of its own in a table");
+    });
+
+    it("says the same two things about a command, in its own words", () => {
+      // Both surfaces are one reporting, so the shape holds for either: what
+      // is at fault, and what would answer that direction.
+
+      const surfaces: readonly Surface[] = [
+        COMMAND_SURFACE,
+        verbSurface(new Map([["brew", "brew"]])),
+      ];
+      for (const surface of surfaces) {
+        const text = describeDocFailures(
+          { undocumented: ["brew"], staleAllowance: ["retired"] },
+          surface,
+        ).join("\n");
+        expect(text, surface.noun).toContain(surface.table);
+        expect(text, surface.noun).toContain(surface.remedy);
+        expect(text, surface.noun).toContain("Remove each entry");
+      }
     });
   });
 
@@ -480,9 +709,39 @@ describe("check-command-docs", () => {
     });
 
     it("records a reason for every allowance, so none is a bare exemption", () => {
-      for (const [command, reason] of NO_PROSE) {
-        expect(reason.trim().length, `${command} has no reason`)
-          .toBeGreaterThan(0);
+      // Both tables, because an exemption without a reason is the same
+      // failure whichever surface recorded it.
+
+      for (const table of [NO_PROSE, NO_VERB_PROSE]) {
+        for (const [name, reason] of table) {
+          expect(reason.trim().length, `${name} has no reason`)
+            .toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("fails a verb no live document gives a row, naming the verb", async () => {
+      // Against a root with no documents, every verb is undescribed, which is
+      // the shape the real failure takes one verb at a time.
+
+      const { code, err } = await withFailure();
+      expect(code).toBe(1);
+      expect(err).toContain("shuttle verb(s) are described in no live");
+      expect(err).toContain("NO_VERB_PROSE");
+    });
+
+    it("asks about every verb the table holds, by the row that would answer", async () => {
+      // The claim ranges over the table, so the case reads the table rather
+      // than restating the verbs: a verb added to `verbs.ts` and described
+      // nowhere fails the gate without this file being touched.
+
+      let captured = { code: -1, out: "", err: "" };
+      await withEmptyRoot(async (root) => {
+        captured = await captureConsole(() => main(["--list"], root));
+      });
+      expect(VERB_HELP.size).toBeGreaterThan(0);
+      for (const [verb, help] of VERB_HELP) {
+        expect(captured.out, verb).toContain(`\`${help.usage}\``);
       }
     });
 
@@ -494,7 +753,7 @@ describe("check-command-docs", () => {
       const { code, err } = await withFailure();
       expect(code).toBe(1);
       expect(err).toContain("Command documentation check failed.");
-      expect(err).toContain("are named in no live document");
+      expect(err).toContain("are described in no live document");
       expect(err).toContain("NO_PROSE");
       // The offending commands by name, not a count an operator cannot act
       // on, and the remedy beside them.
@@ -537,6 +796,7 @@ describe("check-command-docs", () => {
       expect(code).toBe(0);
       expect(out).toContain("Command documentation OK");
       expect(out).toMatch(/\d+ command\(s\)/);
+      expect(out).toMatch(/\d+ shuttle verb\(s\)/);
       expect(out).toMatch(/\d+ deliberately without prose/);
     });
 

--- a/tasks/check-command-docs.ts
+++ b/tasks/check-command-docs.ts
@@ -1,30 +1,36 @@
 #!/usr/bin/env -S deno run --allow-read --allow-env --allow-sys --allow-ffi
 
 /**
- * Fails when a command the CLI accepts is described in no live document.
+ * Fails when something a caller can type is described in no live document.
  *
  * `docs/README.md` already obliges a change that alters documented behavior to
  * update the document in the same change. That obligation cannot fire for a
- * command no document describes: nothing is wrong, because nothing claimed to
+ * word no document describes: nothing is wrong, because nothing claimed to
  * cover it. So a command ships, the prose does not, and the absence is visible
  * only to someone who already knows the command exists.
  *
- * The command tree is walkable and the documents are greppable, so the question
- * is machine-answerable: is this command named anywhere a reader would find it?
+ * Two surfaces are held to that. `cf`'s command tree is walkable and shuttle's
+ * verbs are one table, the documents are greppable, and so for each the
+ * question is machine-answerable: is this word described anywhere a reader
+ * would find it? They are one check rather than two because the second half of
+ * a gate is where a gate divides — the same two directions, the same live-
+ * document rule and the same escape, said in the words of whichever surface is
+ * at fault.
  *
- * What this cannot decide is whether a command SHOULD have prose. Plenty should
+ * What this cannot decide is whether a word SHOULD have prose. Plenty should
  * not — an internal entry point exists for the packaged binary to call, and a
  * forensics subcommand may be `--help`-discoverable by design. What it requires
- * is that every command has been decided about, which is what {@link NO_PROSE}
- * records. That turns the next command's documentation from something
- * remembered into something the gate asks for.
+ * is that every one has been decided about, which is what {@link NO_PROSE} and
+ * {@link NO_VERB_PROSE} record. That turns the next command's documentation
+ * from something remembered into something the gate asks for.
  *
  * Usage: deno task check-command-docs
- *        deno task check-command-docs --list   # every undocumented command
+ *        deno task check-command-docs --list   # everything undocumented
  */
 
 import type { Command } from "@cliffy/command";
 import { main as cliRoot } from "../packages/cli/commands/main.ts";
+import { VERB_HELP } from "../packages/cli/lib/shuttle/verbs.ts";
 import { walk } from "@std/fs/walk";
 import { parse as parseJsonc } from "@std/jsonc";
 import { dirname, fromFileUrl, join, relative } from "@std/path";
@@ -47,6 +53,17 @@ export const NO_PROSE = new Map<string, string>([
     "the same, for the process that supervises the FUSE child",
   ],
 ]);
+
+/**
+ * Shuttle verbs deliberately left without prose, each with the reason.
+ *
+ * The escape {@link NO_PROSE} offers a command, in the shape it offers it, so
+ * that what excuses a verb is decided the way what excuses a command is. It
+ * answers the same question, against a higher bar: every verb here is a word a
+ * person types at a prompt, so none of them has the reason a command reached
+ * only by another program has.
+ */
+export const NO_VERB_PROSE = new Map<string, string>();
 
 /**
  * Where the gate looks for prose, relative to the repository root.
@@ -141,6 +158,23 @@ export function declaredCommands(
   return paths;
 }
 
+/**
+ * Every verb shuttle accepts, by the word that names one, against the usage a
+ * document has to write it under.
+ *
+ * The verb table is the domain rather than a copy of it, so a verb added to
+ * `packages/cli/lib/shuttle/verbs.ts` is a verb this gate asks about with
+ * nothing else to edit. It is that table's own account of itself that the
+ * document is held to: the usage string `help` opens a verb's page with is the
+ * one a row has to carry, so a verb whose operands change is a verb whose row
+ * has to be rewritten.
+ */
+export function declaredVerbs(
+  verbs: ReadonlyMap<string, { readonly usage: string }>,
+): Map<string, string> {
+  return new Map([...verbs].map(([verb, help]) => [verb, help.usage]));
+}
+
 /** Nothing in a pattern's own text may be read as regex syntax. */
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -178,17 +212,61 @@ export function commandPattern(
   );
 }
 
-/** The command paths some live document names. */
-export async function documentedCommands(
+/**
+ * The expression that decides whether a document describes one verb.
+ *
+ * A verb has no `cf` in front of it to make a mention unmistakable, and the
+ * words are `cd`, `get`, `help`, `more` and `where`: written into a sentence
+ * each is a word the sentence was going to hold anyway, and even in backticks
+ * it is as likely to be a sentence about something else — "`more` writes the
+ * next one" is a fact about paging, not the account of a verb. So the standard
+ * is the row that makes the verb its subject: a table cell that opens a line
+ * and holds the verb's usage, as code, and nothing besides.
+ *
+ * That is what a mention cannot satisfy, and the difference is the whole
+ * point. `packages/cli/README.md` lost its row for `more` while its prose went
+ * on saying what `more` writes, and no gate saw it.
+ */
+export function verbPattern(usage: string): RegExp {
+  return new RegExp(`^\\|[ \\t]*\`${escapeRegExp(usage)}\`[ \\t]*\\|`, "m");
+}
+
+/** What the live documents were found to describe, by surface. */
+export interface DocumentedNames {
+  /** The command paths some live document names. */
+  readonly commands: Set<string>;
+
+  /** The verbs some live document gives a row of their own. */
+  readonly verbs: Set<string>;
+}
+
+/**
+ * What some live document describes, of the commands and the verbs given.
+ *
+ * Both surfaces are answered from one walk, because the walk is the cost: each
+ * document is read once and every pattern tried against it, rather than the
+ * tree being read once per surface. `verbs` is {@link declaredVerbs}, the verb
+ * against the usage its row has to carry.
+ */
+export async function documentedNames(
   root: string,
   commands: readonly string[],
-): Promise<Set<string>> {
-  const found = new Set<string>();
+  verbs: ReadonlyMap<string, string>,
+): Promise<DocumentedNames> {
+  const found: DocumentedNames = { commands: new Set(), verbs: new Set() };
   const packageDocs = await readPackageDocs(root);
-  const patterns = commands.map((command) => ({
-    command,
-    pattern: commandPattern(command, commands),
-  }));
+  const patterns = [
+    ...commands.map((name) => ({
+      into: found.commands,
+      name,
+      pattern: commandPattern(name, commands),
+    })),
+    ...[...verbs].map(([name, usage]) => ({
+      into: found.verbs,
+      name,
+      pattern: verbPattern(usage),
+    })),
+  ];
   for (const dir of DOC_ROOTS) {
     // `walk` reports a missing directory when it is iterated rather than when
     // it is constructed, so the guard has to wrap the loop. A root a checkout
@@ -202,8 +280,8 @@ export async function documentedCommands(
         const path = relative(root, entry.path);
         if (!isLiveDoc(path, packageDocs)) continue;
         const text = await Deno.readTextFile(entry.path);
-        for (const { command, pattern } of patterns) {
-          if (!found.has(command) && pattern.test(text)) found.add(command);
+        for (const { into, name, pattern } of patterns) {
+          if (!into.has(name) && pattern.test(text)) into.add(name);
         }
       }
     } catch (error) {
@@ -213,49 +291,112 @@ export async function documentedCommands(
   return found;
 }
 
-/** What the check found, in the two directions it looks. */
-export interface CommandDocReport {
-  /** Commands no live document names and no allowance covers. */
+/** What the check found about one surface, in the two directions it looks. */
+export interface DocReport {
+  /** Names no live document describes and no allowance covers. */
   readonly undocumented: string[];
 
-  /** Allowances naming a command the tree no longer accepts. */
+  /** Allowances naming something the surface no longer holds. */
   readonly staleAllowance: string[];
 }
 
-/** Subtract what the documents cover from what the tree accepts. */
-export function reportCommandDocs(
+/** Subtract what the documents cover from what the surface declares. */
+export function reportDocs(
   declared: readonly string[],
   documented: ReadonlySet<string>,
   allowed: ReadonlyMap<string, string>,
-): CommandDocReport {
+): DocReport {
   const undocumented = declared
-    .filter((command) => !documented.has(command) && !allowed.has(command))
+    .filter((name) => !documented.has(name) && !allowed.has(name))
     .sort();
   const declaredSet = new Set(declared);
   const staleAllowance = [...allowed.keys()]
-    .filter((command) => !declaredSet.has(command))
+    .filter((name) => !declaredSet.has(name))
     .sort();
   return { undocumented, staleAllowance };
 }
 
-/** The failures a report describes, one paragraph each. */
-export function describeCommandDocFailures(
-  report: CommandDocReport,
+/**
+ * The words one surface's failures are written in.
+ *
+ * Every step but the vocabulary is shared, so the vocabulary is the parameter:
+ * the same report, the same two directions and the same paragraphs, said about
+ * whichever surface is at fault. A third surface is a value of this rather
+ * than a second copy of the reporting, which is where the two halves would
+ * otherwise part company.
+ */
+export interface Surface {
+  /** What one of its names is called, in the singular. */
+  readonly noun: string;
+
+  /** Writes one name the way a live document has to write it. */
+  readonly write: (name: string) => string;
+
+  /** The table in this file that records a deliberate silence about one. */
+  readonly table: string;
+
+  /** What would satisfy the check, for a reader who has just failed it. */
+  readonly remedy: string;
+}
+
+/** The `cf` commands, in the words their failures are written in. */
+export const COMMAND_SURFACE: Surface = {
+  noun: "command",
+  write: (command) => `cf ${command}`,
+  table: "NO_PROSE",
+  remedy: "Either describe the command in a live document, or record why it " +
+    "needs none in tasks/check-command-docs.ts.",
+};
+
+/**
+ * Shuttle's verbs, in the words their failures are written in.
+ *
+ * `verbs` is {@link declaredVerbs}, so a verb is written as the row that would
+ * satisfy the check opens — which is the answer to what a reader is being
+ * asked for. An allowance that outlived its verb has no usage left to write,
+ * and is named by the word it recorded.
+ */
+export function verbSurface(verbs: ReadonlyMap<string, string>): Surface {
+  return {
+    noun: "shuttle verb",
+    write: (verb) => `\`${verbs.get(verb) ?? verb}\``,
+    table: "NO_VERB_PROSE",
+    remedy: "A live document describes a verb by giving it a row of its own " +
+      "in a table, the row opening with the verb's usage in backticks as " +
+      "written above; the verb table in packages/cli/README.md is the shape. " +
+      "A mention in a sentence is not that. Either give the verb such a row, " +
+      "or record why it needs none in tasks/check-command-docs.ts.",
+  };
+}
+
+/**
+ * The failures a report describes, one paragraph each.
+ *
+ * Each paragraph closes with what would answer that paragraph, because the two
+ * directions are answered differently and a run can fail in both at once: what
+ * satisfies the check is no use to an entry whose subject has gone, and
+ * deleting the entry is no use to a verb that wants a row.
+ */
+export function describeDocFailures(
+  report: DocReport,
+  surface: Surface,
 ): string[] {
   const failures: string[] = [];
-  const block = (lines: readonly string[]) =>
-    lines.map((line) => `  cf ${line}`).join("\n");
+  const block = (names: readonly string[]) =>
+    names.map((name) => `  ${surface.write(name)}`).join("\n");
   if (report.undocumented.length > 0) {
     failures.push(
-      `${report.undocumented.length} command(s) are named in no live ` +
-        `document and have no entry in NO_PROSE:\n` +
-        block(report.undocumented),
+      `${report.undocumented.length} ${surface.noun}(s) are described in no ` +
+        `live document and have no entry in ${surface.table}:\n` +
+        `${block(report.undocumented)}\n\n${surface.remedy}`,
     );
   }
   if (report.staleAllowance.length > 0) {
     failures.push(
-      `${report.staleAllowance.length} NO_PROSE entr(ies) name a command the ` +
-        `tree no longer accepts:\n` + block(report.staleAllowance),
+      `${report.staleAllowance.length} ${surface.table} entr(ies) name a ` +
+        `${surface.noun} that no longer exists:\n` +
+        `${block(report.staleAllowance)}\n\nRemove each entry: what it ` +
+        `recorded a decision about is not there to decide about.`,
     );
   }
   return failures;
@@ -266,29 +407,37 @@ export async function main(
   args: readonly string[] = [],
   root = dirname(dirname(fromFileUrl(import.meta.url))),
 ): Promise<number> {
-  const declared = declaredCommands(cliRoot);
-  const documented = await documentedCommands(root, declared);
-  const report = reportCommandDocs(declared, documented, NO_PROSE);
+  const commands = declaredCommands(cliRoot);
+  const verbs = declaredVerbs(VERB_HELP);
+  const documented = await documentedNames(root, commands, verbs);
+  const surfaces: readonly (readonly [DocReport, Surface])[] = [
+    [reportDocs(commands, documented.commands, NO_PROSE), COMMAND_SURFACE],
+    [
+      reportDocs([...verbs.keys()], documented.verbs, NO_VERB_PROSE),
+      verbSurface(verbs),
+    ],
+  ];
 
   if (args.includes("--list")) {
-    for (const command of report.undocumented) console.log(`cf ${command}`);
+    for (const [report, surface] of surfaces) {
+      for (const name of report.undocumented) console.log(surface.write(name));
+    }
     return 0;
   }
 
-  const failures = describeCommandDocFailures(report);
+  const failures = surfaces.flatMap(([report, surface]) =>
+    describeDocFailures(report, surface)
+  );
   if (failures.length > 0) {
     console.error("Command documentation check failed.\n");
     console.error(failures.join("\n\n"));
-    console.error(
-      "\nEither describe the command in a live document, or record why it " +
-        "needs none in tasks/check-command-docs.ts.",
-    );
     return 1;
   }
 
   console.log(
-    `Command documentation OK (${declared.length} command(s), ` +
-      `${NO_PROSE.size} deliberately without prose).`,
+    `Command documentation OK (${commands.length} command(s) and ` +
+      `${verbs.size} shuttle verb(s), ` +
+      `${NO_PROSE.size + NO_VERB_PROSE.size} deliberately without prose).`,
   );
   return 0;
 }


### PR DESCRIPTION
## Why

`deno task check-command-docs` exists because the rule "update the document
when behaviour changes" cannot fire for a surface no document is required to
describe — so a command ships and its prose does not.

Shuttle's verbs are exactly such a surface. `cd`, `ls`, `pwd`, `get`, `wish`,
`where`, `help` and `more` are not `cf` commands, so none was in the gate's
scope, and `packages/cli/README.md` documents them anyway. A verb could be
added, or its row could go, with every gate green.

Closes #7043.

**One correction to that issue, established while building this.** It was
written as though the README had already drifted on main. It had not: of the
four commits where `more` is a verb, all four carry its README row, and the
drift it describes lived only in a working tree and was repaired before
landing. The gap is real; the claim that it had already bitten was wrong.

## What Changed

`check-command-docs` now takes shuttle's verb table as a second surface, held
to the same live-document rule `cf`'s commands are held to.

- **It reads the table, not a grep.** The task imports `VERB_HELP` from
  `lib/shuttle/verbs.ts`, so a verb added there is asked about without this
  check being touched. No new runtime: the task already imports the CLI for
  `cliRoot`, and it still runs under its declared permissions.
- **Described means a row, not a mention.** A verb has no `cf` prefix to
  disambiguate it, and `get`, `more`, `where` and `help` are words an ordinary
  sentence holds — a code-span rule would have passed the exact drift that
  motivated this. So: a Markdown row whose **first** cell is a code span
  holding **exactly** the verb's usage string. First-cell, whole-cell and
  usage-exactness each have a case and a red mutation.
- **The escape is the same shape** as the `cf` half — `NO_VERB_PROSE`, the same
  map type, the same reporting, and the same failure when an entry names a verb
  that no longer exists.
- **Generalized rather than duplicated.** One walk answers both surfaces;
  `describeCommandDocFailures` became `describeDocFailures(report, Surface)`.

### Considered and rejected

Requiring each declared option's flag to appear in the verb's row. It would
catch a second kind of drift, but the `cf` half checks *presence*, not
completeness — it never asks whether `cf cell get`'s flags are documented.
Holding one surface to a stricter standard than the other is precisely the
divergence the issue warns against. Recorded rather than silently skipped:
**this gate catches a missing row; it does not catch a row that predates the
verb's options, nor a stale module list.** Both are correct at HEAD and both
remain ungated.

## Test plan

- **The gate was proved to catch the thing it is for, not merely to pass.**
  Three demonstrations, each run against HEAD:
  1. **The failure reconstructed.** `more`'s row deleted → exit 1 naming
     `` `more` `` — and the README still mentioned `more` in prose at two other
     places, which the gate correctly refused to accept.
  2. **The current tree** → exit 0, "102 command(s) and 8 shuttle verb(s), 2
     deliberately without prose".
  3. **The escape, both directions.** A recorded reason for the missing row →
     exit 0. An entry naming a verb that does not exist → exit 1, telling it to
     go rather than to find a document.
- **`validated 14 / ran 14 / red 14 / survivors [] / did-not-run []`**, through
  a harness that validates its table before mutating anything and verifies each
  restore by SHA-256.
- **Universals derive from the table**: the "every verb" cases iterate
  `VERB_HELP` rather than restating the eight words, so a verb added and
  described nowhere fails without this test file being touched.
- **One survivor, measured and left open deliberately.** Replacing
  `NO_VERB_PROSE` with an empty map survives — nothing can red it while the
  table is empty, and the `cf` half is pinned only because its allowance has
  entries. Rather than invent an entry to close it, demonstration 3 exercises
  that wiring by hand. Reported rather than hidden.
- `deno task check` (46 groups), `deno fmt --check` (5,784 files), `deno lint`
  (5,616), the `tasks` suite (**804 passed / 0 failed**), the shuttle tests
  (17 files, 865 steps, 0 failed), and twenty `check-*` gates — all exit 0,
  with exit status captured separately from every pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

