### PR TITLE
test(shuttle): the shell against a fabric, and the loop against a clock

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -211,6 +211,14 @@ them, `announce.ts` what a connection and a pattern write onto that loop's
 out-of-band line, `record.ts` the form `where` and `pwd` share, and `paint.ts`
 and `terminal.ts` the escape sequences and the raw mode under it.
 
+Each of those is driven by a unit test with nothing behind it — no server, no
+piece, and no terminal — so what the shell does when all of them are real is a
+claim no case there makes.
+[`integration/shuttle-over-a-terminal.sh`](integration/shuttle-over-a-terminal.sh)
+is where that claim lives: it deploys a fixture into a fresh space, opens
+`cf sh` on a pseudo-terminal, and reads back the drawing a line at a time — what
+the shell said, and the prompt it then drew.
+
 ## Cell references
 
 `cf cell` holds the commands that act on a cell: `get` and `set` for its value,

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1241,6 +1241,24 @@ run_bulk_survey_drill() {
   echo "Successfully ran the bulk-survey drill for ${API_URL}."
 }
 
+# The interactive shell against a real fabric, on a real terminal. Same
+# delegation rationale as the walkthroughs above; it deploys its own fixture
+# and takes its own space.
+#
+# It is the only thing anywhere that runs `cf sh`. The shell's unit suite
+# drives every module with nothing behind it — no server, no piece, and no
+# terminal — so what no case there can see is the composition: whether a place
+# the fabric holds is the one a `cd` adopted, and whether the reference a
+# listing printed is the one the next line takes. It needs a pseudo-terminal
+# because the shell refuses to start without one, and python3 is what allocates
+# it, which this suite already depends on for its own timing helper.
+run_shuttle_walkthrough() {
+  echo "Running the shuttle walkthrough..."
+  API_URL="$API_URL" bash "$SCRIPT_DIR/shuttle-over-a-terminal.sh" ||
+    error "The shuttle walkthrough failed."
+  echo "Successfully ran the shuttle walkthrough for ${API_URL}."
+}
+
 run_wish() {
   setup_space
 
@@ -1388,6 +1406,8 @@ case "$SECTION" in
     run_topics_restore_drill
     cf_test_step_begin bulk-survey-drill
     run_bulk_survey_drill
+    cf_test_step_begin shuttle-walkthrough
+    run_shuttle_walkthrough
     cf_test_step_begin wish
     run_wish
     ;;
@@ -1438,6 +1458,8 @@ case "$SECTION" in
     run_topics_restore_drill
     cf_test_step_begin bulk-survey-drill
     run_bulk_survey_drill
+    cf_test_step_begin shuttle-walkthrough
+    run_shuttle_walkthrough
     ;;
   piece-call-only)
     cf_test_step_begin piece-call
@@ -1474,6 +1496,10 @@ case "$SECTION" in
   bulk-survey-drill)
     cf_test_step_begin bulk-survey-drill
     run_bulk_survey_drill
+    ;;
+  shuttle)
+    cf_test_step_begin shuttle-walkthrough
+    run_shuttle_walkthrough
     ;;
   *)
     error "Unknown CLI integration section: $SECTION"

--- a/packages/cli/integration/pattern/shuttle-place.tsx
+++ b/packages/cli/integration/pattern/shuttle-place.tsx
@@ -1,0 +1,99 @@
+/**
+ * Fixture for the shuttle walkthrough (`shuttle-over-a-terminal.sh`).
+ *
+ * It exists so the walkthrough owns its subject: the shipped patterns are used
+ * elsewhere, and a change to one of them should never break a demonstration of
+ * what a shell standing in a space can reach. Nothing else deploys this file.
+ *
+ * Every member is a place the walkthrough stands at or a value it reads, and
+ * each is here for one reason:
+ *
+ * - `label` is a stored scalar, which is the shortest thing `get` can return
+ *   and the shortest thing `cd` can land on.
+ * - `items` is a stored array, so a listing has numbered rows and a path has
+ *   a segment below the piece to walk to.
+ * - `settings` is a nested object, so a place can be two segments deep inside
+ *   one piece.
+ * - `summary` is computed from `items`, so what a read serves depends on
+ *   whether anything ran the pattern since the last write. That is the
+ *   difference between a warm read and a cold one, which the walkthrough
+ *   reads rather than assumes.
+ * - `addItem` writes, so the walkthrough has a way to change `items` from
+ *   outside the shell.
+ * - `[UI]` is a real node with a nested tree, so the walkthrough can ask
+ *   whether a read at the piece root serves it or holds it back.
+ */
+
+import {
+  action,
+  computed,
+  type Default,
+  NAME,
+  pattern,
+  type Stream,
+  UI,
+  type VNode,
+  type Writable,
+} from "commonfabric";
+
+/** What `addItem` is given: the one line to append. */
+interface AddEvent {
+  /** The text to append to `items`. */
+  text: string;
+}
+
+/** What the piece is started with, all of it optional and defaulted. */
+interface PlaceInput {
+  label?: Writable<string | Default<"a place">>;
+  items?: Writable<string[] | Default<[]>>;
+}
+
+/** What the piece offers a reader standing on it. */
+interface PlaceOutput {
+  [NAME]: string;
+  [UI]: VNode;
+
+  /** A stored scalar. */
+  label: string;
+
+  /** A stored array, whose rows a listing numbers. */
+  items: string[];
+
+  /** A nested object, so a place can stand two segments inside the piece. */
+  settings: { depth: number; note: string };
+
+  /** Computed from `items`, so a stale read of it differs from a warm one. */
+  summary: string;
+
+  /** Appends one line to `items`. */
+  addItem: Stream<AddEvent>;
+}
+
+/** The fixture the shuttle walkthrough deploys, twice, under two slugs. */
+export const ShuttlePlace = pattern<PlaceInput, PlaceOutput>(
+  ({ label, items }) => {
+    const addItem = action(({ text }: AddEvent) => {
+      const trimmed = text.trim();
+      if (trimmed !== "") items.push(trimmed);
+    });
+
+    const summary = computed(() => (items.get() ?? []).join(", "));
+
+    return {
+      [NAME]: "Shuttle place",
+      [UI]: (
+        <cf-vstack gap="2">
+          <cf-heading level={4}>Shuttle place</cf-heading>
+          <div id="shuttle-place-label">{label}</div>
+        </cf-vstack>
+      ),
+      label,
+      items,
+      settings: { depth: 2, note: "two segments in" },
+      summary,
+      addItem,
+    };
+  },
+);
+
+export default ShuttlePlace;

--- a/packages/cli/integration/shuttle-over-a-terminal.sh
+++ b/packages/cli/integration/shuttle-over-a-terminal.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# The shuttle walkthrough: open `cf sh` on a real space, on a real terminal,
+# and read back what it drew.
+#
+# Shuttle's unit suite drives every module with nothing behind it — no server,
+# no piece, and no terminal. `packages/cli/test/shuttle-terminal.test.ts` says
+# so of itself: "A handler that the runtime never runs, and a `setRaw` that the
+# driver never honours, would both pass here." What no case there can see is
+# the composition: whether a `cd` that a stub accepted lands on a cell the
+# fabric holds, whether the reference a listing printed is the one the next
+# line takes, and whether what a read serves is what storage holds. Each of
+# those is a property of the seams together and of no module, so this is where
+# they are asserted.
+#
+# The terminal is a real one. `cf sh` refuses to start unless both standard
+# streams are terminals, because it reads keys in raw mode and draws lines back
+# with escape sequences, so this drives it through a pseudo-terminal:
+# `shuttle-terminal.py` holds the master, types the lines, and takes the
+# drawing apart into one record per line — the line, what the shell wrote above
+# the next prompt, and the prompt it then drew. Its own header says how the
+# drawing is read apart and why no wait here is a poll.
+#
+# The prompt is half of every assertion below, because after a `cd` the prompt
+# is the whole of what the verb did: a `cd` that was refused and a `cd` that
+# moved differ in where the next line is typed, and nothing else.
+#
+# It deploys pattern/shuttle-place.tsx and nothing else. That fixture belongs
+# to this walkthrough alone, so a change to a pattern the product actually
+# ships can never break a demonstration of what a shell can reach.
+#
+# One step is a GAP rather than a capability, the way `verb-session-gaps.sh`
+# and `completion-over-the-cli.sh` carry theirs: reaching into a piece does not
+# warm it yet, so a computed value is served as storage holds it. That step
+# fails the day warming lands, which is how a walkthrough announces a decision
+# arriving instead of aging into a stale plan.
+#
+# Documented in packages/cli/README.md's "Interactive shell" section, which
+# explains the shell this exercises. Keep the two in step: the doc is the
+# explanation, this is the proof, and each names the other.
+#
+# Run standalone against any host:
+#   API_URL=http://localhost:8000 packages/cli/integration/shuttle-over-a-terminal.sh
+#
+# CI runs it through integration.sh's `piece-call` section (the
+# cli-integration matrix in .github/workflows/deno.yml); the `shuttle` section
+# is the standalone selector for running just this script by hand.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+API_URL="${API_URL:-http://localhost:8000}"
+FIXTURE="$SCRIPT_DIR/pattern/shuttle-place.tsx"
+DRIVER="$SCRIPT_DIR/shuttle-terminal.py"
+
+# Prefer a built binary when the harness supplies one; fall back to source.
+if [ -n "${CF_BINARY:-}" ]; then
+  CF="$CF_BINARY"
+else
+  CF="deno task --quiet --cwd $REPO_ROOT cf"
+fi
+
+PASS=0
+FAIL=0
+GAPS=0
+step() { printf '\n== %s\n' "$1"; }
+ok() { printf '  PASS %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '  FAIL %s\n' "$1"; FAIL=$((FAIL + 1)); }
+check() {
+  if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (expected [$1], got [$2])"; fi
+}
+contains() {
+  case "$2" in
+    *"$1"*) ok "$3" ;;
+    *) bad "$3 (nothing matching [$1] in [$2])" ;;
+  esac
+}
+lacks() {
+  case "$2" in
+    *"$1"*) bad "$3 (found [$1] in [$2])" ;;
+    *) ok "$3" ;;
+  esac
+}
+
+SPACE="${SPACE:-$(mktemp -u shuttleXXXXXXXX)}"
+if [ -z "${CF_IDENTITY:-}" ]; then
+  CF_IDENTITY=$(mktemp)
+  $CF id new >"$CF_IDENTITY" 2>/dev/null
+fi
+ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
+
+# The host's server-execution posture, which one step below turns on: with the
+# serving loop running, the server may recompute a piece nobody asked to run,
+# and a value read cold would then be warm through no doing of the shell's.
+#
+# It answers with three words and not two, because the third is a different
+# fact. A host that says nothing is not a host that says it does not execute,
+# and the step that reads this makes no claim at all on `unreadable` — where
+# folding the two together would let a quiet server decide which assertions the
+# walkthrough makes, and report as though it had established something it never
+# asked about.
+#
+# For the same reason the request carries no deadline of its own, where the
+# walkthroughs beside this one bound theirs. `docs/development/waiting-in-tests.md`
+# names the shape under "Browser-hosted unit tests have a harness backstop": a
+# bound at a call site caps what that call can observe, and here what it would
+# cap is a verdict — a health endpoint answering a second after the bound would
+# be read as a server that does not execute. By the time this runs the same host
+# has answered two deploys, a write and a whole session, so a request that never
+# comes back is a server that stopped, and the bound around the suite is what
+# says so.
+POSTURE=""
+read_posture() {
+  case "${EXPERIMENTAL_SERVER_EXECUTION:-}" in
+    true) POSTURE="on"; return ;;
+    false) POSTURE="off"; return ;;
+  esac
+  local stats status
+  stats=$(curl -fsS "$API_URL/api/health/stats" 2>/dev/null)
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    POSTURE="unreadable: the health endpoint exited $status"
+  elif ! printf '%s' "$stats" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    POSTURE="unreadable: the health endpoint answered no JSON object"
+  elif printf '%s' "$stats" | jq -e '.servingLoop != null' >/dev/null 2>&1; then
+    POSTURE="on"
+  else
+    POSTURE="off"
+  fi
+}
+
+echo "API_URL=$API_URL"
+echo "SPACE=$SPACE"
+START=$(date +%s)
+
+step "1. Deploy the fixture under two slugs"
+# --quiet makes the piece id stdout's only line; stderr is dropped and the
+# grep anchored so a compile warning carrying a fid1: token cannot be taken
+# for the deploy's id.
+FIRST=$($CF piece new --quiet --slug first "$FIXTURE" $ARGS 2>/dev/null |
+  grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
+SECOND=$($CF piece new --quiet --slug second "$FIXTURE" $ARGS 2>/dev/null |
+  grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
+if [ -n "$FIRST" ] && [ -n "$SECOND" ]; then
+  ok "deployed $FIRST and $SECOND"
+else
+  bad "deploy failed"
+  exit 1
+fi
+
+step "2. Write one item from outside, before any shell exists"
+# The write goes to the arguments cell, which changes what storage holds
+# without running the pattern. Doing it here rather than from inside a session
+# is what makes the reads below say something: the shell connects afterwards,
+# so what it serves is what it found, with no push to have raced.
+if echo '["bread"]' | $CF cell set --quiet --input --cell first items $ARGS \
+  >/dev/null 2>&1; then
+  ok "wrote items to the arguments cell of first"
+else
+  bad "the external write failed"
+fi
+
+step "3. Drive a session over a pseudo-terminal"
+SCRIPT=$(mktemp)
+TRANSCRIPT=$(mktemp)
+cat >"$SCRIPT" <<'LINES'
+where
+ls
+cd slugs
+ls
+cd nosuchslug
+cd first
+ls
+get label
+get items
+get summary
+cd nosuchkey
+cd settings
+ls
+cd ..
+cd /
+cd /slugs/first
+pwd
+get
+help
+get --help
+LINES
+python3 "$DRIVER" "$SCRIPT" "$TRANSCRIPT" -- \
+  $CF sh $ARGS >/dev/null
+DRIVE_STATUS=$?
+check "0" "$DRIVE_STATUS" "the session ran and ended on ctrl-d with a zero status"
+if [ "$DRIVE_STATUS" -ne 0 ]; then
+  echo "  the shell did not complete the session; nothing below can be read"
+  exit 1
+fi
+
+# What the shell said in answer to the Nth line, and the prompt it then drew.
+#
+# Each takes the line it expects as well as its number, because an edit to the
+# script above shifts every number after it and a walkthrough that silently
+# asserted against the neighbouring line would be worse than one that stopped.
+# A disagreement comes back as a sentence no assertion can match, so the check
+# that asked for it fails and says which record it wanted — the count cannot be
+# raised from here, every caller reading these through a command substitution
+# that runs them in a subshell of its own.
+misread() {
+  printf '<<transcript step %s is [%s], not [%s]>>\n' "$1" "$2" "$3"
+}
+said() {
+  local at="$1" want="$2" got
+  got=$(jq -r ".[$at].line // \"\"" "$TRANSCRIPT")
+  if [ "$got" != "$want" ]; then misread "$at" "$got" "$want"; return; fi
+  jq -r ".[$at].said" "$TRANSCRIPT"
+}
+prompt() {
+  local at="$1" want="$2" got
+  got=$(jq -r ".[$at].line // \"\"" "$TRANSCRIPT")
+  if [ "$got" != "$want" ]; then misread "$at" "$got" "$want"; return; fi
+  jq -r ".[$at].prompt" "$TRANSCRIPT"
+}
+
+step "4. The shell opens on the space root"
+check "shuttle / @space> " "$(jq -r '.[0].prompt' "$TRANSCRIPT")" \
+  "the first prompt stands at the space root"
+
+step "5. where names the connection the flags asked for"
+WHERE=$(said 1 "where")
+contains "api       $API_URL" "$WHERE" "where names the host it connected to"
+contains "space     $SPACE" "$WHERE" "where names the space it connected to"
+contains "identity  $CF_IDENTITY" "$WHERE" "where names the identity it opened"
+
+step "6. ls at the root lists the facets, and cd takes one of them"
+check "%1 slugs
+%2 pieces" "$(said 2 "ls")" "the root lists exactly the two facets"
+check "shuttle /slugs/ @space> " "$(prompt 3 "cd slugs")" \
+  "cd into the slug facet moves the prompt onto it"
+
+step "7. The slug index names both deployed slugs"
+SLUGS=$(said 4 "ls")
+contains "%1 first" "$SLUGS" "the listing numbers the first slug"
+contains "%2 second" "$SLUGS" "the listing numbers the second slug"
+
+step "8. A slug the index does not record is refused, and nothing moves"
+REFUSED_SLUG=$(said 5 "cd nosuchslug")
+contains "nosuchslug\` reaches no piece" "$REFUSED_SLUG" \
+  "cd names the slug it could not reach"
+check "shuttle /slugs/ @space> " "$(prompt 5 "cd nosuchslug")" \
+  "a refused cd leaves the prompt where it stood"
+
+step "9. A slug the index does record lands on the piece it names"
+check "shuttle first @space> " "$(prompt 6 "cd first")" \
+  "the prompt carries the name the index confirmed"
+check "%1 \$NAME
+%2 \$UI
+%3 addItem
+%4 items
+%5 label
+%6 settings
+%7 summary" "$(said 7 "ls")" "the piece lists every key the fixture declares"
+
+step "10. get reads a stored value, and reads it as storage holds it"
+check '"a place"' "$(said 8 "get label")" "get reads a stored scalar"
+check '[
+  "bread"
+]' "$(said 9 "get items")" "get serves the item the external write left"
+
+step "11. GAP: reaching into a piece does not warm it"
+# Decision 10 of docs/plans/shuttle/README.md rules that reaching in warms, so
+# that every read the shell serves is live. Until that lands, a computed value
+# is whatever the last thing to run the pattern left: `items` above changed and
+# `summary`, computed from it, did not. When warming arrives this step fails,
+# which is the announcement.
+#
+# The claim is only readable with the serving loop off. With it on, the server
+# may run the piece for reasons of its own, and a warm `summary` would then say
+# nothing about whether the shell warmed anything — and with the posture
+# unreadable, neither does anything else, so the step says that rather than
+# picking the arm that happens to pass.
+COLD=$(said 10 "get summary")
+read_posture
+case "$POSTURE" in
+  on)
+    ok "skipped: the server executes, so a warm value would not be the shell's doing"
+    ;;
+  off)
+    if [ "$COLD" = '""' ]; then
+      ok "gap still open: a computed value is served as storage holds it"
+      GAPS=$((GAPS + 1))
+    else
+      bad "GAP CLOSED — get summary read [$COLD]; warming has landed, so update this script"
+    fi
+    ;;
+  *)
+    bad "the server-execution posture is $POSTURE, so this step can read nothing"
+    ;;
+esac
+
+step "12. A path the cell does not hold is refused, with the keys that are"
+# The review this walkthrough answers found `cd` adopting a key that was not
+# there, and every later line failing with the runtime's own words one command
+# further on. Both halves are asserted: the refusal is shuttle's and names what
+# would have worked, and the place is where it was.
+REFUSED_KEY=$(said 11 "cd nosuchkey")
+contains "nosuchkey\` reaches no cell" "$REFUSED_KEY" \
+  "cd refuses a key the cell does not hold"
+contains "whose keys are \`\$NAME\`" "$REFUSED_KEY" \
+  "the refusal names the keys that would have worked"
+check "shuttle first @space> " "$(prompt 11 "cd nosuchkey")" \
+  "a refused cd leaves the place where it stood"
+
+step "13. cd walks into a nested value and back out of it"
+check "shuttle first/settings @space> " "$(prompt 12 "cd settings")" \
+  "cd stands two segments inside the piece"
+check "%1 depth
+%2 note" "$(said 13 "ls")" "the nested object lists its own keys"
+check "shuttle first @space> " "$(prompt 14 "cd ..")" \
+  "cd .. climbs back to the piece root"
+
+step "14. A rooted reference opening with a facet walks from the root"
+# The other half of the review's finding: `/slugs/first` read as a piece
+# slugged `slugs` would have been a trap one level down from the spelling the
+# root teaches. It reaches the same piece the relative spelling did, and `pwd`
+# names the handle the deploy printed.
+#
+# The `cd /` in front of it is what makes the claim about the reference rather
+# than about where the line before it left off: with the shell already standing
+# at the piece, a `/slugs/first` that was refused would leave the prompt
+# reading exactly what a `/slugs/first` that landed leaves it reading, and the
+# check could not tell the two apart. So the shell is sent to the root first,
+# and both halves are read — that the line said nothing, and that the prompt
+# moved.
+check "shuttle / @space> " "$(prompt 15 "cd /")" \
+  "the shell is standing at the root before the rooted reference is read"
+check "" "$(said 16 "cd /slugs/first")" \
+  "a rooted facet reference is not refused"
+check "shuttle first @space> " "$(prompt 16 "cd /slugs/first")" \
+  "a rooted facet reference reaches the piece the slug names"
+contains "$FIRST" "$(said 17 "pwd")" "pwd names the handle the deploy printed"
+
+step "15. get at a piece stands in for its picture of itself"
+WHOLE=$(said 18 "get")
+contains '"$UI": "<elided' "$WHOLE" "the UI node is stood in for"
+# `children` is the key every vnode carries and the first one the tree would
+# write, so it is the part of the node that reaches the page rather than a part
+# a bound would have cut off anyway.
+lacks '"children"' "$WHOLE" "no part of the vnode tree reaches the screen"
+contains '"label": "a place"' "$WHOLE" "the rest of the piece is written out"
+
+step "16. The shell has help, and a verb's --help is a page rather than a path"
+HELP=$(said 19 "help")
+contains "cd <ref>" "$HELP" "help lists the verb that moves"
+contains "get [<ref>]" "$HELP" "help lists the verb that reads"
+GET_HELP=$(said 20 "get --help")
+contains "Usage: get [<ref>]" "$GET_HELP" "--help writes the verb's page"
+lacks "names no facet" "$GET_HELP" "--help is not read as a path"
+
+# Where the stale-versus-warm read goes once warming lands. It needs two things
+# this script does not have: the warm set of decision 10, and a way to run a
+# command with the session standing at a prompt, so that the piece changes
+# under a shell that is already connected. The driver reads a settled prompt
+# already, so the second is a small addition to it — but adding it now would
+# mean asserting against the warming that is not there, and a check that passes
+# against a stub is the thing this walkthrough exists to escape. Step 11 holds
+# the place until then, and fails when it comes.
+
+rm -f "$SCRIPT" "$TRANSCRIPT"
+ELAPSED=$(($(date +%s) - START))
+printf '\n== %d passed, %d failed, %d gaps open — %ds wall clock\n' \
+  "$PASS" "$FAIL" "$GAPS" "$ELAPSED"
+[ "$FAIL" -eq 0 ]

--- a/packages/cli/integration/shuttle-terminal.py
+++ b/packages/cli/integration/shuttle-terminal.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Drive an interactive shell through a pseudo-terminal, and report what it drew.
+
+`cf sh` reads its keys off a terminal in raw mode and draws its lines back onto
+one, and refuses to start when either standard stream is redirected. So a test
+that runs it has to give it a terminal, and this is the terminal: a pty whose
+slave the shell is handed and whose master this holds, typing into one end and
+reading the drawing off the other.
+
+What it hands back is the drawing taken apart rather than the bytes. The shell
+paints through three writes (`lib/shuttle/paint.ts`), and two of them are told
+apart in the stream by construction:
+
+* a line being edited opens with `ESC 7` and then `CSI 0J`, and closes with
+  `ESC 8` — the cursor is saved before the line is drawn and restored after it;
+* a line written above it opens with a `CSI 0J` that no save precedes, and
+  closes with the CRLF ending it, ahead of the repaint of the line beneath.
+
+So what precedes the clear says which write this is, and what comes out is one
+record per line typed: the line, what the shell wrote above the next prompt in
+answer to it, and the prompt it then drew. That triple is the unit an assertion
+is written against, and the prompt is half of it — after a `cd`, where the
+prompt stands is the whole of what the verb did.
+
+Nothing here waits on a clock for progress. A line has settled when the shell
+draws a prompt with nothing typed at it, which it does once the line it was
+running answered and at no other time: every drawing made while a line is being
+typed carries what was typed after the `> `, and a line written above the prompt
+while one is in flight repaints an empty line rather than a prompt. Each read
+blocks until the terminal has bytes rather than asking again on an interval.
+
+The one deadline is a stuck-condition backstop, and it is the distinction
+`docs/development/waiting-in-tests.md` draws under "Browser-hosted unit tests
+have a harness backstop": a safety net at the harness level rather than a bound
+at the call site. No line is given a deadline of its own, because one per line
+would cap what each line can observe, which is the thing being avoided; this one
+only decides when to stop believing the shell will ever answer.
+
+That document is honest about what the shape costs and so is this: an early fire
+fails a session that would have finished. It is kept because the alternative —
+letting the continuous-integration step's own bound expire — takes the whole job
+down with nothing drawn to read, where this one fails with the transcript so far
+and says how long it waited.
+
+Usage:
+
+    shuttle-terminal.py <script> <transcript> -- <command> [args...]
+
+`<script>` is one line to type per line, with `#` comments and blank lines
+ignored. `<transcript>` is written as JSON: an array of
+`{"line", "said", "prompt"}` records in the order the shell answered them, after
+a leading record whose line is null carrying anything written before the first
+prompt. The exit status is the shell's own, and a shell that ended before the
+script did is an error here.
+"""
+
+import fcntl
+import json
+import os
+import pty
+import re
+import select
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+# What the shell sends around the line it is drawing, and around the line it
+# writes above that one. `paint.ts` composes both; these are the pieces that
+# tell one from the other.
+SAVE = "\x1b7"
+CLEAR = "\x1b[0J"
+RESTORE = "\x1b8"
+
+# The end of a line written above the prompt: its own CRLF, then the carriage
+# return and cursor save that open the repaint of the line beneath it.
+ABOVE_END = "\r\n\r" + SAVE
+
+# A prompt with nothing typed at it, which is the settle marker.
+SETTLED = re.compile(r"^shuttle .*> $")
+
+# How tall and wide the terminal is. Fixed rather than inherited, so that what
+# a page bounds and what a line wraps at is the same on every machine.
+ROWS = 24
+COLUMNS = 100
+
+# How long the whole session may take before the drawing so far is reported and
+# the run gives up. The backstop the module docstring describes: one bound over
+# the session, never one per line.
+DEADLINE_SECONDS = float(os.environ.get("SHUTTLE_PTY_DEADLINE_SECONDS", "600"))
+
+
+class Wedged(Exception):
+    """Raised when the session ran out of time with a line still unanswered."""
+
+    def __init__(self, drawn):
+        super().__init__("the shell drew nothing further")
+        self.drawn = drawn
+
+
+class Terminal:
+    """The pty, the process on the far end of it, and what has been drawn."""
+
+    def __init__(self, argv):
+        self.master, slave = pty.openpty()
+        fcntl.ioctl(
+            slave,
+            termios.TIOCSWINSZ,
+            struct.pack("HHHH", ROWS, COLUMNS, 0, 0),
+        )
+        # Output processing off, so that what arrives at the master is what the
+        # shell wrote. A terminal turns a line feed into a carriage return and
+        # a line feed on its way out by default, and the shell already sends
+        # both — the drawing would arrive with a return doubled in every place
+        # a line breaks, and the sequences below would be looked for in a
+        # stream that no writer composed.
+        mode = termios.tcgetattr(slave)
+        mode[1] &= ~termios.OPOST
+        termios.tcsetattr(slave, termios.TCSANOW, mode)
+        self.process = subprocess.Popen(
+            argv,
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            env=dict(os.environ, LINES=str(ROWS), COLUMNS=str(COLUMNS)),
+            start_new_session=True,
+        )
+        os.close(slave)
+        self.drawn = ""
+        self.read_from = 0
+        self.deadline = time.time() + DEADLINE_SECONDS
+
+    def pump(self):
+        """Blocks until the terminal has more bytes; false once it has none left."""
+        left = self.deadline - time.time()
+        if left <= 0 or not select.select([self.master], [], [], left)[0]:
+            raise Wedged(self.drawn)
+        try:
+            chunk = os.read(self.master, 65536)
+        except OSError:
+            # The far end closed the terminal, which the process ending does.
+            return False
+        if not chunk:
+            return False
+        self.drawn += chunk.decode("utf8", "replace")
+        return True
+
+    def next_write(self):
+        """The next thing drawn as an `("edit"|"above", text)` pair, None at the end."""
+        while True:
+            opened = self.drawn.find(CLEAR, self.read_from)
+            if opened >= 0:
+                body = opened + len(CLEAR)
+                edited = self.drawn[opened - len(SAVE):opened] == SAVE
+                ends = RESTORE if edited else ABOVE_END
+                closed = self.drawn.find(ends, body)
+                if closed >= 0:
+                    self.read_from = closed + len(ends)
+                    return ("edit" if edited else "above", self.drawn[body:closed])
+            if not self.pump():
+                return None
+
+    def type(self, text):
+        """Sends `text` to the terminal, as a person typing it would."""
+        os.write(self.master, text.encode("utf8"))
+
+
+def settle(terminal, said):
+    """Reads until an empty prompt is drawn, collecting what was written above it."""
+    while True:
+        write = terminal.next_write()
+        if write is None:
+            raise EOFError("the shell ended before the line it was given settled")
+        kind, text = write
+        if kind == "above":
+            said.append(text.replace("\r\n", "\n"))
+        elif SETTLED.match(text):
+            return text
+
+
+def run(script, argv):
+    """Drives `argv` through `script`, and is the records it made and the exit status."""
+    terminal = Terminal(argv)
+    banner = []
+    prompt = settle(terminal, banner)
+    records = [{"line": None, "said": "\n".join(banner), "prompt": prompt}]
+    for line in script:
+        said = []
+        terminal.type(line + "\r")
+        prompt = settle(terminal, said)
+        records.append({"line": line, "said": "\n".join(said), "prompt": prompt})
+    # `ctrl-d` on an empty line is how a session ends, and the terminal closes
+    # when the process on the far end of it does.
+    terminal.type("\x04")
+    while terminal.pump():
+        pass
+    return records, terminal.process.wait()
+
+
+def main():
+    if "--" not in sys.argv:
+        raise SystemExit(
+            "usage: shuttle-terminal.py <script> <transcript> -- <command> [args...]",
+        )
+    split = sys.argv.index("--")
+    script_path, transcript_path = sys.argv[1:split]
+    argv = sys.argv[split + 1:]
+    with open(script_path) as source:
+        script = [
+            line.strip() for line in source
+            if line.strip() != "" and not line.lstrip().startswith("#")
+        ]
+    try:
+        records, status = run(script, argv)
+    except Wedged as wedged:
+        sys.stderr.write(
+            "The shell answered nothing for %ds. What it drew:\n%s\n"
+            % (DEADLINE_SECONDS, wedged.drawn),
+        )
+        raise SystemExit(2)
+    except EOFError as ended:
+        sys.stderr.write("%s\n" % ended)
+        raise SystemExit(3)
+    with open(transcript_path, "w") as out:
+        json.dump(records, out, indent=2)
+    raise SystemExit(status)
+
+
+main()

--- a/packages/cli/test/shuttle-listing.test.ts
+++ b/packages/cli/test/shuttle-listing.test.ts
@@ -830,6 +830,7 @@ describe("listing", () => {
       let named = 0;
       let unnamed = 0;
       let reported = 0;
+      let reportedWithOperand = 0;
       let reportedWithoutOperand = 0;
 
       /**
@@ -877,6 +878,7 @@ describe("listing", () => {
         expect(moved(standing, tokens[0]).kind).toBe("moved");
         expect(standing.place).toEqual(childOf(from, row.name));
         named++;
+        if (row.error !== undefined) reportedWithOperand++;
       }
 
       const sources: {
@@ -946,11 +948,16 @@ describe("listing", () => {
       // counts add is that both arms are reached and that an error reaches
       // each — `named` and `unnamed` for the arms, `reported` for an error
       // anywhere, and one guard per arm for an error inside it, since the
-      // arms are where a row and its error are printed together and the
-      // marker arm is the one this case twice computed and did not read.
+      // arms are where a row and its error are printed together.
+      //
+      // Two arms means two guards, and neither stands for the other: an
+      // error counted in the marker arm leaves the strong clause free to hold
+      // over a set with no named row carrying an error in it, and a clause
+      // with nothing to hold over is the want these counts exist to refuse.
       expect(named).toBeGreaterThan(0);
       expect(unnamed).toBeGreaterThan(0);
       expect(reported).toBeGreaterThan(0);
+      expect(reportedWithOperand).toBeGreaterThan(0);
       expect(reportedWithoutOperand).toBeGreaterThan(0);
     });
   });

--- a/packages/cli/test/shuttle-prompt.test.ts
+++ b/packages/cli/test/shuttle-prompt.test.ts
@@ -455,6 +455,46 @@ describe("prompt", () => {
       ]);
     });
 
+    it("abandons the line while the read it was waiting on is still outstanding", async () => {
+      // The case above says what a cancel produces; this one says when. They
+      // are different claims, and only the second is the loop's: a prompt that
+      // waited for the read and cancelled afterwards would produce exactly the
+      // same words, one server round trip later, and every case that awaits
+      // the run before reading its writes would pass. So this one never
+      // answers the read while the run is going. What ends the run is the keys
+      // running out, and what settles the line is the cancel — so the run
+      // returning at all is the claim, and the writes say what it returned
+      // with.
+      //
+      // The read is answered below, after the assertions, because that is what
+      // makes them a statement about order rather than about outcome. It is
+      // answered rather than dropped for the same reason the case above
+      // answers it: the read a person stopped waiting for still comes back,
+      // and it comes back into nothing.
+
+      const read = gated();
+      let answered = false;
+      const writes = await running(
+        (async function* () {
+          yield* typed("get");
+          yield ENTER;
+          await read.started;
+          yield control("c");
+        })(),
+        atPiece(),
+        {
+          getCellValue: () =>
+            read.read().then((value) => {
+              answered = true;
+              return value;
+            }),
+        },
+      );
+      expect(produced(writes)).toEqual(["Interrupted."]);
+      expect(answered).toBe(false);
+      read.answer({ title: "a" });
+    });
+
     it("drops what was typed ahead when `ctrl-c` cancels the line", async () => {
       const read = gated();
       const writes = await running(


### PR DESCRIPTION
## Why

The shuttle unit suite is thorough — hundreds of cases, constructed round-trip
properties, every clause held by a mutation. It also stubs every read, which
means it structurally cannot see the defects that are properties of the
*composition* of real seams rather than of any module. The architecture review
named four it missed for exactly that reason.

And the prompt's cases stub the terminal but not the loop's *timing*. A test
that feeds keys and awaits the run cannot see a queued key executing late,
because the queued key does execute — later. Ordering is the property, and
awaiting the outcome destroys it.

Two tests, for the two gaps.

## What Changed

**The `ctrl-c` timing test** (`shuttle-prompt.test.ts`). The read is a deferred
the case **never answers during the run**, so the run can only return by way of
the cancel. It asserts the line was abandoned *and the read is still
outstanding*, then answers the deferred.

Under the mutation that makes cancellation await the read rather than race it,
the case does not fail with a wrong value — **it stalls**, and Deno reports
that itself: `Promise resolution is still pending but the event loop has
already resolved`. So the ordering is pinned with no clock, because within the
run "later" and "never" are the same thing. The pre-existing cancellation case
still passes under that mutation, which is the point: it could not see this.

**The integration test** — `shuttle-over-a-terminal.sh`, a pty driver, and its
own pattern fixture. It starts a toolshed, deploys the fixture under two slugs,
writes an item to the arguments cell **before any shell exists**, then drives
one session reading back a record per line: the line, what the shell wrote
above the next prompt, and the prompt it then drew.

**35 checks**, covering the four findings the unit suite cannot reach:
`cd nosuchkey` refused *naming the keys that would have worked* with the place
unmoved; `cd /` then `cd /slugs/first` reaching the piece; `get` eliding `$UI`;
and `get --help` being a page rather than a path refusal.

### What it deliberately does not assert

**The stale-versus-warm read**, which needs warming — unmerged. Rather than
stub it, there is a **GAP step** in the shape `verb-session-gaps.sh` already
uses: it records that `get summary` reads `""` while `items` reads
`["bread"]`, and **fails loudly the day warming lands**. A marked paragraph
says what the full check needs and why stubbing would defeat the purpose.

A subscription push mid-session is also not asserted: the shell's read does not
`step`, so observing an interleaved write is a race, and a flaky check is worse
than none.

## Test plan

- **The sandbox question was settled by experiment.** A toolshed is a Deno HTTP
  server and touches none of what Chrome needs, so rather than reason: a port
  was bound and fetched from inside the sandbox, then a real toolshed started
  from this tree with isolated `MEMORY_DIR`/`CACHE_DIR` answered `/_health`.
  Everything ran sandboxed; no unsandboxed execution was needed.
- **`validated 5 / ran 5 / red 5 / survivors [] / did-not-run []`**, per-case
  verdicts rather than `--filter`, which cannot address a BDD `it()`.
- **A mutation found a defect in the test itself.** The rooted-facet mutation
  initially *survived*, because `cd /slugs/first` came after a `cd ..` that had
  already left the prompt at the piece — so the assertion could not tell a
  landing from a refusal. It now sends `cd /` first and asserts both that the
  line said nothing and that the prompt moved.
- **The transcript-index guard was proved live** by shifting one index: it
  fails naming the mismatch rather than silently asserting against a neighbour.
- **One pre-existing suite failure**, `sqlite-link-seed.test.ts`, verified as
  unrelated rather than assumed: it passes alone in both trees and fails
  identically under the full suite on a clean `origin/main` worktree, with the
  step-count difference being exactly the one case added here.
- Two mechanical notes worth keeping: the driver clears `OPOST` on the slave
  (Deno's `setRaw` leaves output post-processing on, doubling every CR and
  making the paint sequences unfindable), and it fixes the window at 24×100
  with matching `LINES`/`COLUMNS` so a page bounds the same everywhere.

## Also: closes #6874

`shuttle-listing.test.ts` claimed one guard per arm and counted only one. The
second is added and **passes**, so the issue's alternative branch does not
apply — the construction does build named rows carrying errors. Measured
rather than inferred: `named 191, unnamed 179, reported 138, withOperand 51,
withoutOperand 87`, and 51 + 87 = 138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

