### PR TITLE
feat(shuttle): recall and completion, at the prompt B1c built

### DIFF
--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -318,6 +318,22 @@ invisible, the prompt renders the whole ambient record — place and scope
     lives in the event lines, never in mutated history. The pinned strip
     (a live region above the prompt) is designed and deferred
     ([`futures.md`](futures.md)).
+29. **Recall is in-session; completion offers a token the line takes.** `up`
+    and `down` walk the lines this run typed, which is the run's own memory
+    and nothing a later process reads — persistent, searchable history is a
+    separate feature and is deferred ([`futures.md`](futures.md)). The
+    traversal runs over those lines and the line being typed, one position
+    each, so an edit is held wherever it was made and everything that ends
+    the line returns the traversal to it. `tab` completes the token the line
+    ends in: a verb where the line names none, and otherwise whatever the
+    verb declares its next operand completes, which the two arms of the arity
+    that take an operand require and the arm that takes none cannot express.
+    What is offered under a place is the listing `ls` reads, under the
+    operands `operandForChild` offers for its rows, so a completion writes
+    what a listing prints and what `cd` takes back — the round trip decision
+    13's checked names rest on, held by reuse rather than by a second answer.
+    A completion is a read, so it is work in flight: it is cancelled by
+    `ctrl-c` and written onto the line it was computed for and onto no other.
 
 The line grammar itself — what a line may say, what its parts denote, and what
 shuttle does and shows in return — is drafted in [`grammar.md`](grammar.md). The
@@ -383,7 +399,7 @@ several) stay reachable later.
 | --- | --- | --- |
 | Canonical + alias reference grammar | `packages/cli/lib/llm-friendly-ref.ts` (doc comment), runner's `parseLLMFriendlyLink` | The address syntax; shuttle consumes it and must not fork it |
 | Target option surface | `targetOptions` in `packages/cli/commands/piece.ts` | The enumeration of exactly what a place must supply |
-| Live-state listing and completion | `keysOf` in `packages/cli/lib/cell-listing.ts` — exported, beside the `listCellKeys` that reads a cell through it, which path completion in `packages/cli/lib/completion/providers.ts` uses | The `ls` primitive and tab completion; shuttle reads the cell over the connection it holds and names its rows through `keysOf`, and a failed read raises rather than listing empty |
+| Live-state listing and completion | `keysOf` in `packages/cli/lib/cell-listing.ts` — exported, beside the `listCellKeys` that reads a cell through it, which path completion in `packages/cli/lib/completion/providers.ts` uses | The `ls` primitive and tab completion; shuttle reads the cell over the connection it holds and names its rows through `keysOf`, and a failed read raises rather than listing empty. Shuttle's own tab completion reads that listing rather than a second read, and swallows the failure at its own call site, as the providers do at theirs |
 | Pager/TUI substrate | `packages/cli/lib/view/` — `pager.ts` is the only module doing raw-mode full-screen TTY handling; `mod.ts` and `loadinput.ts` touch stdio for the one-shot path (capability probes, plain-output writes, piped input); `keys.ts`, `ansi.ts`, `render.ts`, `session.ts` hold state and decoding as pure logic | The full-screen half: raw mode, frames, key decoding, testable without a terminal; already follows references and edits buffers |
 | FUSE mount | `packages/fuse` | The same addressing as a POSIX filesystem; prior art for layout (arrays as numeric directories, handlers as executables, links as symlinks). Shuttle is its interactive, live sibling, not a replacement |
 | Offline inspector | `packages/state-inspector`, `cf inspect` | The forensic counterpart (snapshots, scopes, history); its HTML explorer is prior art for tree-plus-detail browsing |

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -481,6 +481,47 @@ Landed:
   reading of `%n` as a reference belongs with the verb that consumes it, and
   is B2's first slice rather than its last.
 
+- **B1h — recall and completion, at the prompt B1c built.** The two keys a
+  person's fingers reach for before they reach for a verb, and B1 owns them:
+  each rides the prompt loop and the line grammar rather than any verb, and
+  decision 29 rules what each is over.
+
+  `up` and `down` walk the lines this run typed
+  (`packages/cli/lib/shuttle/history.ts`), which is a value beside the
+  buffer and nothing outside the process reads. They are ordinary rows of
+  B1c's binding table, `ctrl-p` and `ctrl-n` beside them, since the buffer a
+  prompt holds is one row and a vertical motion over it has nowhere else to
+  go. The traversal runs over the recorded lines *and the line being typed*,
+  which is one mechanism rather than a mechanism plus a special case: an edit
+  is held at whichever position it was made at, the line being written when
+  the first `up` left it included, and everything that ends the line —
+  running it, and `ctrl-c` — drops the edits and returns the traversal to it.
+
+  `tab` completes the token the line ends in
+  (`packages/cli/lib/shuttle/completion.ts`): a verb where the line names
+  none, and where it names one, whatever that verb's arity declares its next
+  operand completes — a slot declared on the two arms that have an operand
+  and unspellable on the arm that has none, so a verb cannot be added without
+  the decision. The candidates under a place are the listing `ls` reads and
+  the operands `operandForChild` offers for its rows, so a completion writes
+  a token `cd` takes back to the row, a name needing quotes and a name the
+  reference has to carry included, and nothing gates a candidate on its shape.
+  Which token a half-typed line ends in is the split's own question, and it is
+  answered off the split's own scan (`tailOfLine`, `line.ts`): the token is
+  the last one the split reads rather than the run after the last separator,
+  which is what keeps an escaped or quoted separator a character of its token
+  instead of the edge of one.
+
+  A completion reads, so it is work in flight beside the keys exactly as a
+  line is: `enter` typed under one is held and runs the line it completed,
+  and `ctrl-c` cancels it — the read that has not gone out through the guard
+  every read here goes through, and the prompt back through the race, since a
+  read already sent may never answer. Two bounds are ruled rather than
+  inherited, and [`grammar.md`](grammar.md) carries them: a completion is
+  written onto the line it was computed for and onto no other, and a common
+  prefix shorter than a whole candidate is written only where it needs no
+  quoting.
+
 Still to come:
 
 - **Liveness, in two halves.** Recovery of an *established* connection needs

--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -172,8 +172,10 @@ decisions point here where they defer.
    refused with the reason.
 4. **History and records.** Persistent, searchable command history; a
    `record` verb writing the transcript to a `file:` target or into the
-   fabric. The event-line design already makes transcripts evidence;
-   this makes them saveable.
+   fabric. The recall `up` and `down` give is v1 and is over one run's own
+   lines (decision 29); what waits here is the half that outlives the
+   process. The event-line design already makes transcripts evidence; this
+   makes them saveable.
 5. **Time and diff.** `history <ref>` and `diff` across time or between
    references — the state inspector's reconstruction machinery is the
    offline prior art — plus a modest `undo` that writes back what the

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -817,6 +817,78 @@ short surface and is on screen continuously; what `pwd` is for is the thing
 you copy, so a form that cannot be pasted is the one output it should not
 produce.
 
+## Recall and completion
+
+`up` and `down` walk the lines this run typed. What they walk is those lines
+and the line being typed — one position each, the line being typed last — so
+an edit made at any of them is held there until the line is ended, and
+everything that ends a line ends the traversal with it: running the line, and
+`ctrl-c`. There is no wrap: `up` at the oldest line and `down` at the line
+being typed each leave the prompt as it is. A line with nothing on it is not
+recorded, nor is one identical to the line recorded last, and the comparison is
+against that one line alone — comparing against every line would drop a line
+from the middle of the run and leave the order no longer the order it was
+typed in. What is recorded is the line exactly as it was typed, at the moment
+it is taken rather than when it settles, so `up` reaches a line that is still
+running. The recall is the run's own memory; persistent history is a separate
+feature ([`futures.md`](futures.md)).
+
+`tab` completes the token the line ends in, and it completes that token only:
+with the cursor anywhere else on the line it does nothing, the token being
+finished being the one the line ends with. What may stand there is asked of
+the dispatch — the first token names a verb, and after a verb it is whatever
+that verb declares its next operand completes, which is a verb name for
+`help`, a reference for `cd` and `get`, and nothing for a verb whose operands
+are already given or which takes none. So a completion never offers a token
+the line would then refuse.
+
+**What a completion writes is a token that reaches what it names.** The
+candidates under a place are the operands `cd` takes to the rows `ls` lists,
+which is the same answer the listing prints in its name column: a name whose
+own characters are readings comes back as the reference that names it, and a
+name needing quotes comes back quoted. A row nothing names is not offered,
+which is the same shape as a listing printing a marker where a row has no
+operand.
+
+Three bounds, each of them a decision:
+
+- **A common prefix shorter than a whole candidate is written only where it is
+  bare.** Several candidates agreeing on `my ` agree on a partial that is not
+  a token — a quote around it closes where the person's next character has to
+  land, and no quote leaves the split refusing the line — so what is written
+  in that case is nothing, and typing on reaches the same candidates again.
+- **A completion is written onto the line it was computed for and onto no
+  other.** A read already sent cannot be called off, so its answer may come
+  back to a line a key has changed or a `ctrl-c` has emptied, and writing
+  there would take back a character the person typed after the `tab`.
+- **A read that failed offers nothing.** A `tab` is not a request for an
+  answer about the fabric, so where `ls` reports a failed read as the failure
+  it is, a completion writes nothing and says nothing. That is what
+  `packages/cli`'s own completion does, and the one thing shuttle's takes
+  from it.
+
+The token being completed is the last one the split reads, off the same scan
+the split itself runs. A separator inside quotes or behind a backslash is a
+character of its token, so the run of characters after the last separator is
+not the token: on `get --select a\ sl` it is `sl`, where the token is the
+option's value `a sl` — and a completion working from the run would offer an
+operand where the line has none and rewrite the value to reach it. The one
+line not completed is one the split refuses: both its refusals are a token
+with no end, and where the token being typed opens is exactly what such a
+line does not yet say.
+
+Nothing gates a candidate on its shape. What bounds a completion is which
+candidates there are — the operands reaching what stands where shuttle stands
+— so a prefix is completed exactly where it opens one of those. Two things
+follow, and the second is the first read the other way round. An operand
+carrying the separator is completed like any other, which is what reaches a
+row whose own operand is a reference: standing at a piece, `/@space/piece@…/.`
+completes to that reference's own `/..`, since the reference *is* the operand
+`operandForChild` offers for that row. And `cd slugs/bo` at a space root
+completes nothing — not because a rule turns it down, but because no row
+standing at the root is called that; the row it names stands inside `slugs/`,
+and reaching it is a read of a place the line has not moved to.
+
 ## Writes
 
 - `set <path> <value>` — the value parses as JSON; a bare word is a string

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -194,9 +194,35 @@ Emacs keys: `ctrl-a`/`ctrl-e` and `home`/`end` for the ends of the line,
 `ctrl-b`/`ctrl-f` and the arrows for a character, `alt-b`/`alt-f` for a word,
 `backspace` and `delete`/`ctrl-d` to delete, `ctrl-w`/`alt-backspace` and
 `alt-d` to kill a word, `ctrl-k` and `ctrl-u` to kill to the end of the line and
-to kill the line, `ctrl-y`/`alt-y` to yank and cycle, `ctrl-c` to abandon the
-line or cancel the one in flight, and `ctrl-d` on an empty line to end the
-session.
+to kill the line, `ctrl-y`/`alt-y` to yank and cycle, `up`/`ctrl-p` and
+`down`/`ctrl-n` to walk the lines you have typed, `ctrl-c` to abandon the line
+or cancel the work in flight, and `ctrl-d` on an empty line to end the session.
+
+`up` and `down` walk this run's own lines — nothing is written to disk and
+nothing survives the process. What they walk is those lines and the line you
+were typing, so `down` back past the newest returns it, and a half-typed change
+to a recalled line is still there when you come back to it. A line with nothing
+on it is not recorded, nor is one you just ran again, and neither end wraps
+round. Running a line or pressing `ctrl-c` returns you to the line being typed.
+
+`tab` completes the token the line ends in: a verb where you have typed none,
+and after a verb whatever that verb's operand takes — a verb name for `help`,
+and for `cd` and `get` the rows that stand where you stand. What it writes is
+what `ls` prints for the same row, so a name needing quotes arrives quoted and a
+name the reference has to carry arrives as the reference; where several rows
+agree only as far as a partial that would need quoting, nothing is written and
+you type on. Completing under a place is a read, so it runs beside the keys the
+way a line does: `enter` typed under it is held and runs the line it completed,
+`ctrl-c` cancels it, and a read that failed writes nothing rather than saying
+so. What it completes is the token at the end of the line, so a cursor elsewhere
+leaves the line alone — and the token is the one the split reads, so a space you
+quoted or escaped stays inside its token rather than starting a new one.
+
+Nothing turns a candidate down for its shape. What bounds a completion is which
+rows stand where you stand, so `cd slugs/bo` at a space root writes nothing —
+not because a rule forbids the `/`, but because no row standing at the root is
+called that. A row whose own operand carries a `/` completes exactly as any
+other does.
 
 The code is `lib/shuttle/`: `run.ts` composes a session, `place.ts` holds the
 place and what `cd` refuses, `connection.ts` the one `PiecesController` a
@@ -207,9 +233,11 @@ writes nothing — `help.ts` the form a verb's account of itself prints in,
 `page.ts` how much of a rendering one page holds, `value.ts` how a value the
 fabric holds is written, `session.ts` what the last listing numbered and what
 `more` writes next, `prompt.ts` the loop that reads keys and runs a line beside
-them, `announce.ts` what a connection and a pattern write onto that loop's
-out-of-band line, `record.ts` the form `where` and `pwd` share, and `paint.ts`
-and `terminal.ts` the escape sequences and the raw mode under it.
+them, `history.ts` the lines that loop has read and the traversal over them,
+`completion.ts` what `tab` finishes, `announce.ts` what a connection and a
+pattern write onto that loop's out-of-band line, `record.ts` the form `where`
+and `pwd` share, and `paint.ts` and `terminal.ts` the escape sequences and the
+raw mode under it.
 
 Each of those is driven by a unit test with nothing behind it — no server, no
 piece, and no terminal — so what the shell does when all of them are real is a

--- a/packages/cli/lib/shuttle/completion.ts
+++ b/packages/cli/lib/shuttle/completion.ts
@@ -1,0 +1,213 @@
+/**
+ * What `tab` finishes: the token a line ends in, completed against the verbs
+ * and against what stands where shuttle stands.
+ *
+ * Decision 3 (`docs/plans/shuttle/README.md`) names completion as part of what
+ * serves the audience it puts second, and this is that: a person who knows
+ * the fabric and not this shell's vocabulary finds both by pressing one key.
+ *
+ * `packages/cli` has a completion of its own under `lib/completion/`, and this
+ * is not a second copy of it. That one answers a shell asking what a
+ * half-typed `cf` line could become, so each provider resolves its own
+ * connection from the words on that line and fails silently and empty; this
+ * one runs inside a process that already holds a connection and already
+ * stands somewhere, so what it reads is the listing (`listing.ts`) rather
+ * than a resolution. The one thing it takes from the other is that posture
+ * toward failure: a read that failed offers nothing, where `ls` raises,
+ * because a tab is not a request for an answer about the fabric and a person
+ * pressing one has not asked to be told anything.
+ *
+ * Two properties bound what may be offered, and both are borrowed rather than
+ * restated.
+ *
+ * **A completion offers a token the line takes.** The candidates under a
+ * place are `operandForChild`'s answers (`place.ts`), which is what a listing
+ * prints for the same rows, so a name a completion writes is one `cd` takes
+ * back to the row — including a name whose own characters are readings, which
+ * comes back as the reference that names it. Where on the line the token may
+ * stand is `candidatesAfter`'s answer (`verbs.ts`), which reads the tokens
+ * before it through the dispatch's own option reading, so a completion never
+ * offers an operand the verb would refuse.
+ *
+ * Nothing else turns a candidate down, and in particular nothing reads its
+ * shape. An operand carrying the separator is offered like any other, which
+ * is how a row whose own operand is a reference is reached at all. So what
+ * bounds a completion is which candidates there are rather than which are
+ * allowed: `cd slugs/bo` at a space root writes nothing because no row
+ * standing at the root is called that, the row it names standing inside
+ * `slugs/` — and reaching a row there is a read of a place the line has not
+ * moved to, which is a completion of its own rather than a rule against this
+ * one.
+ *
+ * **A completion reads, so it cancels.** The read and the answer each go
+ * through `guarded`, so a `ctrl-c` stops the read that has not gone out and
+ * the answer that has not been given. What it cannot stop is a read already
+ * sent, and what stops that taking effect is the prompt: a completion is
+ * written onto the line it was computed for and onto no other, and a `ctrl-c`
+ * has emptied that line.
+ */
+
+import { quoteToken, tailOfLine } from "./line.ts";
+import { type Listing, listPlace } from "./listing.ts";
+import { operandForChild } from "./place.ts";
+import {
+  candidatesAfter,
+  guarded,
+  type Shuttle,
+  VERB_WORDS,
+  type VerbDeps,
+} from "./verbs.ts";
+
+/**
+ * The line `tab` leaves behind where it was pressed at the end of `line`, and
+ * nothing where the line is left as it was.
+ *
+ * Nothing is the answer to four different questions and they are not
+ * distinguished, because a person pressing `tab` gets the same thing from
+ * each: a line whose last token this cannot read, a position no token may
+ * stand at, no candidate matching what is typed, and a candidate that adds
+ * nothing to it. None of them is a mistake and none is worth a line above the
+ * prompt.
+ *
+ * @throws Nothing. A read that failed offers nothing, which is the one place
+ * this parts from `ls`.
+ */
+export async function completeLine(
+  shuttle: Shuttle,
+  line: string,
+  deps: VerbDeps = {},
+): Promise<string | undefined> {
+  const tail = tailOfLine(line);
+  if (tail === undefined) return undefined;
+  const wanted = candidatesAfter(tail.before);
+  if (wanted === "nothing") return undefined;
+  let offered: readonly string[] = VERB_WORDS;
+  if (wanted === "children") {
+    const listed = await guarded(deps, childOperands, shuttle, deps);
+    if (listed.kind !== "ran") return undefined;
+    offered = listed.answer;
+  }
+  // The composition is guarded as the read is, and for the same reason `ls`
+  // guards writing its numbering: what comes back from here is written onto
+  // the line, so a line the person stopped waiting for is one nothing is
+  // written onto. The arguments are built before `guarded` is entered, which
+  // is what leaves no await between its check and the call.
+  const written = await guarded(deps, chosen, offered, tail.prefix, tail.head);
+  return written.kind === "ran" ? written.answer : undefined;
+}
+
+/**
+ * Helper for {@link completeLine}, which is the operand `cd` takes to each
+ * row standing where shuttle stands, and none where the read failed.
+ *
+ * It is the listing `ls` composes, so a completion offers exactly the rows
+ * `ls` prints and offers them under the names `ls` prints — one read, and one
+ * answer about what a row is called. The operand is asked for again rather
+ * than taken off the row, because a row carries its operand written as a
+ * token and what a prefix is matched against is the value: a person typing
+ * `my` is completing a key called `my key`, whose token spelling opens with a
+ * quote and would match nothing they could have typed.
+ *
+ * A row `operandForChild` offers no operand for is left out. Neither its name
+ * nor the reference reaches it, so there is nothing to write that would take
+ * the line to that row.
+ */
+async function childOperands(
+  shuttle: Shuttle,
+  deps: VerbDeps,
+): Promise<readonly string[]> {
+  const place = shuttle.place.place;
+  let listing: Listing;
+  try {
+    listing = await listPlace(
+      shuttle.config,
+      place,
+      shuttle.connection,
+      deps.listing,
+    );
+  } catch {
+    return [];
+  }
+  return listing.rows.flatMap((row) => {
+    const operand = operandForChild(place, row.name);
+    return operand === undefined ? [] : [operand];
+  });
+}
+
+/**
+ * Helper for {@link completeLine}, which is the line `head` becomes once the
+ * token `prefix` opened is completed against `offered`, and nothing where it
+ * is left as it was.
+ *
+ * One matching candidate is written whole, as the token that names it, and a
+ * whole token is what the round trip covers: `quoteToken` writes it so that
+ * the split reads back the candidate, whatever the candidate holds.
+ *
+ * Several are written as far as they agree, and that far only where the
+ * agreement is a token in its own right. A partial that needs quoting is not
+ * one — `'my ` is a quote nothing closes and the split refuses the line —
+ * and a closed quote around a partial is worse, since the next character a
+ * person types lands outside it. So a common prefix is written where it is
+ * bare and withheld where it is not, and the person types on into a
+ * completion that will offer the same candidates again.
+ *
+ * Nothing where the line would be unchanged: `tab` at a token already
+ * complete leaves the buffer alone rather than writing what is already there.
+ */
+function chosen(
+  offered: readonly string[],
+  prefix: string,
+  head: string,
+): string | undefined {
+  const matched = offered.filter((candidate) => candidate.startsWith(prefix));
+  if (matched.length === 0) return undefined;
+  const written = matched.length === 1
+    ? quoteToken(matched[0])
+    : bare(agreed(matched));
+  return written === undefined || written === prefix
+    ? undefined
+    : `${head}${written}`;
+}
+
+/**
+ * Helper for {@link chosen}, which is `text` where it is already the token
+ * that names itself, and nothing where writing it as a token would change it.
+ */
+function bare(text: string): string | undefined {
+  return quoteToken(text) === text ? text : undefined;
+}
+
+/**
+ * Helper for {@link chosen}, which is the longest opening `candidates` all
+ * share.
+ *
+ * The comparison is by character rather than by code unit, and the difference
+ * is the whole of what this has to get right: two candidates that part inside
+ * a surrogate pair share its leading half, so a comparison counting code
+ * units would agree one unit past the last character they have in common and
+ * hand back a string ending in half of one. A terminal cannot draw that half,
+ * and the next character typed lands after it rather than completing it, so
+ * what the line then holds reaches no candidate at all.
+ *
+ * The prefix a caller matched against is a value the split read off the line,
+ * so it ends on a character boundary and every candidate that opens with it
+ * opens with whole characters. What is left to get wrong is where the
+ * agreement *ends*, which is here.
+ */
+function agreed(candidates: readonly string[]): string {
+  // Cut into characters once, at the one point, so that what a comparison
+  // below counts is settled here rather than at each side of it.
+  const written = candidates.map((candidate) => [...candidate]);
+  let shared = written[0];
+  for (const candidate of written.slice(1)) {
+    let length = 0;
+    while (
+      length < shared.length && length < candidate.length &&
+      shared[length] === candidate[length]
+    ) {
+      length++;
+    }
+    shared = shared.slice(0, length);
+  }
+  return shared.join("");
+}

--- a/packages/cli/lib/shuttle/history.ts
+++ b/packages/cli/lib/shuttle/history.ts
@@ -1,0 +1,139 @@
+/**
+ * The lines a run has typed, and the traversal `up` and `down` make over
+ * them.
+ *
+ * It is the run's own memory and nothing outside the process holds it: a
+ * shuttle that exits takes its lines with it. Persistent, searchable history
+ * is a separate feature with a design of its own
+ * (`docs/plans/shuttle/futures.md`), and nothing here is a step toward it —
+ * what this holds is the lines you can still see the results of.
+ *
+ * A pure value like {@link EditBuffer}: it holds strings and reports them, so
+ * it drives with no terminal, no keyboard and no clock behind it. What binds
+ * a key to it is the prompt's table (`prompt.ts`).
+ *
+ * The traversal runs over the recorded lines *and the line being typed*,
+ * which is one position past the last of them. That is one mechanism rather
+ * than a mechanism plus a special case: the line you were writing when you
+ * pressed `up` is held exactly as a recorded line you edit is held, so `down`
+ * back past the newest line returns it without the draft being a thing of its
+ * own.
+ */
+
+import type { EditBuffer } from "../view/editbuffer.ts";
+
+/**
+ * The lines one run typed, and where `up` and `down` currently stand among
+ * them.
+ *
+ * Per instance rather than per process, for the reason `CurrentPlace` is
+ * (`place.ts`): a run holding two prompts holds two sets of lines.
+ */
+export class LineHistory {
+  /** The lines recorded, oldest first. */
+  #lines: string[] = [];
+
+  /**
+   * The text left at a position the traversal moved off, by position.
+   *
+   * Position `#lines.length` is the line being typed, so the draft sits in
+   * this map like any other edit and needs no field of its own.
+   */
+  #edits = new Map<number, string>();
+
+  /** Where the traversal stands, `#lines.length` being the line being typed. */
+  #at = 0;
+
+  /**
+   * Records `line` as a line this run typed, and returns the traversal to the
+   * line being typed.
+   *
+   * Two lines are not recorded, and each is its own decision. A line that is
+   * empty or all whitespace ran nothing, so recording it would put a position
+   * with nothing on it between two lines that have something. And a line
+   * identical to the one recorded last is not recorded twice, so `ls` pressed
+   * three times is one position and `up` reaches the line before it in one
+   * press. The comparison is against the last line alone: comparing against
+   * every line would drop a line from the middle of the run and leave the
+   * order no longer the order it was typed in.
+   *
+   * It is called where the line is taken rather than where it settles, which
+   * is what makes `up` reach a line that is still running.
+   */
+  record(line: string): void {
+    if (line.trim() !== "" && line !== this.#lines.at(-1)) {
+      this.#lines.push(line);
+    }
+    this.abandon();
+  }
+
+  /**
+   * Returns the traversal to the line being typed, dropping every edit,
+   * without recording anything.
+   *
+   * This is what a line thrown away gets, and it is the same act recording
+   * one ends with: the traversal and its edits belong to the line being
+   * typed, so whatever ends that line ends them.
+   */
+  abandon(): void {
+    this.#edits.clear();
+    this.#at = this.#lines.length;
+  }
+
+  /**
+   * The line `up` puts on the prompt, holding `current` at the position it
+   * leaves, and nothing where there is no earlier line.
+   *
+   * Holding the current text is what lets a line be edited and come back
+   * edited: the edit is kept against the position it was made at until the
+   * line is ended, which is bash's default and the behavior a person who
+   * types half a change and goes looking for the rest expects. What it never
+   * does is change what was recorded — `up` twice and `down` twice reaches
+   * the recorded line again only where nothing was typed in between, and the
+   * recorded lines themselves are what a later run of the traversal walks.
+   *
+   * Nothing where there is nothing earlier, rather than the oldest line
+   * again: a traversal that wrapped would put the newest line under `up` at
+   * the oldest, which is a place a person arrives at by holding the key down.
+   */
+  earlier(current: string): string | undefined {
+    if (this.#at === 0) return undefined;
+    this.#edits.set(this.#at, current);
+    this.#at -= 1;
+    return this.#held(this.#at);
+  }
+
+  /**
+   * The line `down` puts on the prompt, holding `current` at the position it
+   * leaves, and nothing where the line being typed is already the position.
+   */
+  later(current: string): string | undefined {
+    if (this.#at === this.#lines.length) return undefined;
+    this.#edits.set(this.#at, current);
+    this.#at += 1;
+    return this.#held(this.#at);
+  }
+
+  /**
+   * Helper for the two motions, which is what stands at position `at`: the
+   * text left there where the traversal has been there, the recorded line
+   * otherwise, and the empty string at the line being typed.
+   */
+  #held(at: number): string {
+    return this.#edits.get(at) ?? this.#lines[at] ?? "";
+  }
+}
+
+/**
+ * Puts `line` on `buffer` with the cursor at its end, and leaves the buffer
+ * alone where there is no line.
+ *
+ * The cursor lands at the end because a recalled line is one you are about to
+ * add to or run: `ctrl-a` reaches its start in one key where a cursor left at
+ * the start would need one key per character to reach its end.
+ */
+export function recall(buffer: EditBuffer, line: string | undefined): void {
+  if (line === undefined) return;
+  buffer.setText(line);
+  buffer.moveLineEnd();
+}

--- a/packages/cli/lib/shuttle/line.ts
+++ b/packages/cli/lib/shuttle/line.ts
@@ -1,6 +1,6 @@
 /**
- * How a shuttle line splits into tokens, and how a value prints as one of
- * them.
+ * How a shuttle line splits into tokens, how a value prints as one of them,
+ * and where the token a half-typed line ends in begins.
  *
  * `cf` never does either: it is handed `Deno.args`, split for it already by
  * the operating system's shell. Shuttle reads its own line, so the split is
@@ -10,6 +10,11 @@
  * {@link quoteToken} writes, {@link splitLine} reads back as the one value it
  * was given. That is what lets a value print bare where nothing in it needs
  * more, which is the common case and the point.
+ *
+ * {@link tailOfLine} is the third, and it is here for the same reason: where
+ * a token ends is this module's question whether the line is whole or still
+ * being typed, and a completion that answered it for itself would be a
+ * second grammar to keep in step with this one.
  *
  * What a token then means is decided elsewhere — `place.ts` reads an operand
  * as a reference or as one of the navigation spellings, and a verb reads its
@@ -101,9 +106,115 @@ export type LineSplit =
  * the choice is safe, not that it was forced.
  */
 export function splitLine(line: string): LineSplit {
+  const scanned = scanLine(line);
+  return scanned.kind === "refused"
+    ? scanned
+    : { kind: "split", tokens: scanned.tokens };
+}
+
+/** What a completion at the end of a line is completing. */
+export interface LineTail {
+  /**
+   * The whole tokens written before the one being completed, which is what
+   * says where on the line that token stands.
+   */
+  readonly before: readonly string[];
+
+  /**
+   * The line up to where that token opens, which a completion keeps and
+   * writes the token it chose after.
+   */
+  readonly head: string;
+
+  /**
+   * The value of the token being completed — what the split reads it as,
+   * rather than how it is spelled. It is the empty string where the line ends
+   * in a separator, a completion there opening a token rather than continuing
+   * one.
+   */
+  readonly prefix: string;
+}
+
+/**
+ * What a completion at the end of `line` is completing, and nothing where the
+ * line is one the split refuses.
+ *
+ * The token is the last one {@link splitLine} reads, and `head` is the line up
+ * to where that token opened. Both come off the one scan the split itself
+ * runs, which is what makes this a projection of the grammar rather than a
+ * second reading of it — and the difference is not academic. A separator
+ * inside quotes or behind a backslash is a character of its token, so the run
+ * of characters after the last separator is not the token at all: on
+ * `get --select a\ sl` it is `sl`, where the token is the option's value
+ * `a sl`, and a completion working from the run would offer an operand where
+ * the line has none and rewrite the value to reach it.
+ *
+ * A line the split refuses is not completed. Both its refusals are a token
+ * with no end — an unclosed quote, a trailing backslash — so where the token
+ * being typed opens is exactly what such a line does not yet say.
+ *
+ * The prefix is a value rather than a spelling, so a caller matches candidates
+ * against it and writes its choice back as a token of its own
+ * ({@link quoteToken}); `head` ends where a token may open, so writing one
+ * after it puts it where this one was.
+ */
+export function tailOfLine(line: string): LineTail | undefined {
+  const scanned = scanLine(line);
+  if (scanned.kind === "refused") return undefined;
+  const { tokens, starts, unterminated } = scanned;
+  return unterminated
+    ? {
+      before: tokens.slice(0, -1),
+      head: line.slice(0, starts[starts.length - 1]),
+      prefix: tokens[tokens.length - 1],
+    }
+    : { before: tokens, head: line, prefix: "" };
+}
+
+/**
+ * Whether `character` separates two tokens, which is the one question the
+ * split asks of a character before any other.
+ *
+ * The class is exported as a predicate rather than as the expression, so a
+ * caller asks about a character and cannot come to depend on how the class is
+ * written. What it is for is a caller that has to enumerate the class rather
+ * than test one member of it.
+ */
+export function separatesTokens(character: string): boolean {
+  return SEPARATOR.test(character);
+}
+
+/** What one scan of a line found. */
+type LineScan =
+  | {
+    readonly kind: "scanned";
+    /** The tokens, in the order written. */
+    readonly tokens: readonly string[];
+    /** Where each of them opened on the line, in the same order. */
+    readonly starts: readonly number[];
+    /**
+     * Whether the last token was still open when the line ended — which is
+     * what tells a token being typed from one a separator finished.
+     */
+    readonly unterminated: boolean;
+  }
+  | { readonly kind: "refused"; readonly reason: string };
+
+/**
+ * Helper for {@link splitLine} and {@link tailOfLine}, which reads `line` as
+ * the grammar above describes and reports everything either of them needs.
+ *
+ * One scan rather than two, because there is one grammar: where a token ends
+ * is the same question whether the line is whole or still being typed, and a
+ * second traversal answering it would be a second grammar to keep in step.
+ * What the two projections differ in is which of the answers they carry.
+ */
+function scanLine(line: string): LineScan {
   const tokens: string[] = [];
+  const starts: number[] = [];
   let current = "";
   let started = false;
+  let openedTokenAt = 0;
   let quote: string | undefined;
   let openedAt = 0;
 
@@ -130,14 +241,20 @@ export function splitLine(line: string): LineSplit {
     if (SEPARATOR.test(character)) {
       if (started) {
         tokens.push(current);
+        starts.push(openedTokenAt);
         current = "";
         started = false;
       }
       continue;
     }
     // Set before the branches rather than in each of them, so that an empty
-    // pair of quotes opens a token the way a character does.
-    started = true;
+    // pair of quotes opens a token the way a character does. Where the token
+    // opened is recorded only as it opens, so that it names the token's first
+    // character rather than its last.
+    if (!started) {
+      started = true;
+      openedTokenAt = index;
+    }
     if (character === "'" || character === '"') {
       quote = character;
       openedAt = index;
@@ -159,8 +276,11 @@ export function splitLine(line: string): LineSplit {
         `never closed.`,
     );
   }
-  if (started) tokens.push(current);
-  return { kind: "split", tokens };
+  if (started) {
+    tokens.push(current);
+    starts.push(openedTokenAt);
+  }
+  return { kind: "scanned", tokens, starts, unterminated: started };
 }
 
 /**
@@ -194,8 +314,15 @@ function columnOf(line: string, index: number): number {
   return [...line.slice(0, index)].length + 1;
 }
 
-/** Helper for {@link splitLine}, which builds a refusal carrying `reason`. */
-function refuse(reason: string): LineSplit {
+/**
+ * Helper for {@link scanLine}, which builds the refusal carrying `reason`.
+ *
+ * The one shape serves both projections: a refused scan and a refused split
+ * are the same fact about the line, so the caller that splits hands it
+ * straight back and the caller that completes reads it as a line it cannot
+ * answer for.
+ */
+function refuse(reason: string): LineScan & { kind: "refused" } {
   return { kind: "refused", reason };
 }
 

--- a/packages/cli/lib/shuttle/prompt.ts
+++ b/packages/cli/lib/shuttle/prompt.ts
@@ -15,7 +15,9 @@
  * follow, and they are the whole reason for the shape. `ctrl-c` reaches a line
  * that is already running, which is the only way a shell whose server has gone
  * quiet is still a shell. And a key typed during that wait is drawn as it
- * arrives instead of being queued unseen and run blind afterwards.
+ * arrives instead of being queued unseen and run blind afterwards. A `tab`
+ * that reads is a second thing that runs beside the keys, and it runs beside
+ * them the same way and under the same cancel.
  *
  * The line editor is the view substrate's rather than `node:readline`'s.
  * `EditBuffer` (`lib/view/editbuffer.ts`) holds the motions and `decodeKeys`
@@ -36,6 +38,8 @@
 
 import { EditBuffer } from "../view/editbuffer.ts";
 import type { Key } from "../view/keys.ts";
+import { completeLine } from "./completion.ts";
+import { LineHistory, recall } from "./history.ts";
 import {
   escapeControlCharacters,
   holdsControlCharacter,
@@ -110,7 +114,7 @@ export interface PromptTerminal {
  * draws is that a shell whose server went away is still a shell, so this
  * reports it and reads the next line where a one-shot command would exit.
  *
- * One line runs at a time, and the keys keep arriving while it does. Three
+ * One line runs at a time, and the keys keep arriving while it does. Four
  * keys mean something other than editing:
  *
  * - `enter` runs the line. Pressed while a line is in flight it is held,
@@ -122,9 +126,19 @@ export interface PromptTerminal {
  *   shell spells that way, and on a line with anything on it deletes forward
  *   instead. On an empty line while a line is in flight it is held, as
  *   `enter` is.
- * - `ctrl-c` cancels: the line in flight, or the line being typed where none
+ * - `ctrl-c` cancels: the work in flight, or the line being typed where none
  *   is. It is never held, and it drops what was typed ahead of it, which is
  *   what a terminal does with type-ahead when the interrupt arrives.
+ * - `tab` completes the token the line ends in (`completion.ts`), which is a
+ *   read and therefore work in flight of its own: `enter` typed under one is
+ *   held as it is under a line, and `ctrl-c` cancels it. It acts only at a
+ *   prompt with no line in flight, since a line that is running is one that
+ *   may be about to move the place a completion reads against, and only with
+ *   the cursor at the end of the line.
+ *
+ * `up` and `down` are ordinary bindings rather than any of those: they walk
+ * the lines this run typed (`history.ts`), which is a value the prompt holds
+ * beside the line being edited and nothing reads.
  *
  * Cancelling is honest about what it can reach. The line is abandoned and the
  * prompt comes back, but a read already sent to the server is not something
@@ -138,6 +152,7 @@ export async function runPrompt(
   deps: VerbDeps = {},
 ): Promise<void> {
   const buffer = new EditBuffer("");
+  const history = new LineHistory();
   let prompt = promptFor(shuttle);
   const show = () =>
     terminal.edit(
@@ -161,6 +176,18 @@ export async function runPrompt(
     if (key.name === "ctrl-c") {
       terminal.finish();
       buffer.setText("");
+      history.abandon();
+    } else if (key.name === "tab") {
+      // Only at the end of the line, and nothing is drawn either way. The
+      // token a completion finishes is the one the line ends in, so a cursor
+      // standing anywhere else is standing in a token this would not be
+      // completing — and a line unchanged is a line already on the screen.
+      // Both sides of the test are the buffer's own count, which is where the
+      // cursor is in the line rather than where it lands on the screen.
+      if (buffer.col === buffer.currentLineLength()) {
+        running = startCompleting(buffer.text(), shuttle, deps);
+      }
+      return;
     } else if (endsLine(key, buffer)) {
       if (key.name === "ctrl-d") {
         ended = true;
@@ -170,6 +197,9 @@ export async function runPrompt(
       const line = buffer.text();
       terminal.finish();
       buffer.setText("");
+      // Recorded where the line is taken rather than where it settles, which
+      // is what puts a line still running under the first `up`.
+      history.record(line);
       running = start(line, shuttle, deps);
       // Nothing is drawn: the prompt for the next line appears when the line
       // settles, or when a key is typed before it does, so a line that
@@ -177,7 +207,7 @@ export async function runPrompt(
       // waited for it.
       return;
     } else {
-      apply(buffer, key);
+      apply({ buffer, history }, key);
     }
     show();
   };
@@ -204,6 +234,17 @@ export async function runPrompt(
       show();
       continue;
     }
+    if (arrival.kind === "completed") {
+      running = undefined;
+      // Onto the line it was computed for and onto no other. A read cannot be
+      // called off once sent, so what it answers may reach a line that has
+      // moved on — a key typed while it was out, or a `ctrl-c` that emptied
+      // it — and writing there would take back a character the person typed
+      // after the `tab`.
+      if (buffer.text() === arrival.from) recall(buffer, arrival.line);
+      show();
+      continue;
+    }
     typing = undefined;
     if (arrival.step.done) {
       ended = true;
@@ -213,33 +254,55 @@ export async function runPrompt(
     if (running === undefined) {
       act(key);
     } else if (key.name === "ctrl-c") {
+      // A completion runs beside the line it is completing, which is still
+      // being edited and so is still the line to end; a verb's line was ended
+      // where it was taken, and what is being edited under it is the next
+      // one.
+      if (running.kind === "completion") terminal.finish();
       running.stop();
       held = [];
       buffer.setText("");
+      history.abandon();
       show();
     } else if (held.length > 0 || endsLine(key, buffer)) {
       held.push(key);
     } else {
-      apply(buffer, key);
+      apply({ buffer, history }, key);
       show();
     }
   }
   terminal.finish();
 }
 
-/** What the loop is waiting on: the next key, or the line it is running. */
+/**
+ * What the loop is waiting on: the next key, or the work it started beside
+ * them.
+ */
 type Arrival =
   /** The key stream answered, with a key or with the end of the keys. */
   | { readonly kind: "typed"; readonly step: IteratorResult<Key> }
   /** The line in flight settled, and `text` is what it produced. */
-  | { readonly kind: "ran"; readonly text: string };
+  | { readonly kind: "ran"; readonly text: string }
+  /** A completion answered, for the line `from` and with `line` to write. */
+  | {
+    readonly kind: "completed";
+    readonly from: string;
+    readonly line: string | undefined;
+  };
 
-/** A line in flight: what it will produce, and how to cancel it. */
+/** Work in flight beside the keys: what it will produce, and how to stop it. */
 interface Running {
-  /** Settles with what the line produced, cancelled or not. */
+  /**
+   * Which of the two the prompt runs beside the keys, which is what says
+   * whether the line being edited is the one it came from: a verb's line was
+   * ended where it was taken, and a completion's is still being typed.
+   */
+  readonly kind: "line" | "completion";
+
+  /** Settles with what it produced, cancelled or not. */
   readonly settled: Promise<Arrival>;
 
-  /** Cancels the line, which settles it with what a cancelled line says. */
+  /** Cancels it, which settles it with what a cancelled one says. */
   stop(): void;
 }
 
@@ -265,9 +328,54 @@ function nextKey(keys: AsyncIterator<Key>): Promise<Arrival> {
 function start(line: string, shuttle: Shuttle, deps: VerbDeps): Running {
   const stopper = new AbortController();
   return {
+    kind: "line",
     stop: () => stopper.abort(),
     settled: report(line, shuttle, { ...deps, signal: stopper.signal })
       .then((text) => ({ kind: "ran", text }) as const),
+  };
+}
+
+/**
+ * Helper for {@link runPrompt}, which starts a completion of `line` and
+ * returns what running it is.
+ *
+ * The signal rides the deps bag as a verb's does, and for the same reason: a
+ * completion reads, so a `ctrl-c` reaches the read it has not sent and the
+ * answer it has not given (`completion.ts`).
+ *
+ * What the signal cannot reach is raced instead. A read already sent finishes
+ * into nothing and may never finish at all, and a completion awaited rather
+ * than raced would hold the prompt for the rest of the run against a server
+ * that has gone quiet — which is the one thing `ctrl-c` at such a server is
+ * for. The race delivers the prompt back and the read, whenever it lands, is
+ * answering a completion nothing is waiting on.
+ */
+function startCompleting(
+  line: string,
+  shuttle: Shuttle,
+  deps: VerbDeps,
+): Running {
+  const stopper = new AbortController();
+  const completed = completeLine(shuttle, line, {
+    ...deps,
+    signal: stopper.signal,
+  }).then((written) =>
+    ({ kind: "completed", from: line, line: written }) as const
+  );
+  return {
+    kind: "completion",
+    stop: () => stopper.abort(),
+    settled: Promise.race([
+      completed,
+      whenAborted(
+        stopper.signal,
+        {
+          kind: "completed",
+          from: line,
+          line: undefined,
+        } as const,
+      ),
+    ]),
   };
 }
 
@@ -286,6 +394,22 @@ function endsLine(key: Key, buffer: EditBuffer): boolean {
 }
 
 /**
+ * What a key acts on: the line being typed, and the lines typed before it.
+ *
+ * The two travel together because the recall keys act on both at once — a
+ * line put on the buffer is a position the traversal moved to — and a table
+ * of motions over one value is what lets the second table modal editing wants
+ * (`docs/plans/shuttle/futures.md`) bind the same acts.
+ */
+interface Editing {
+  /** The line being typed. */
+  readonly buffer: EditBuffer;
+
+  /** The lines this run typed, and where the traversal over them stands. */
+  readonly history: LineHistory;
+}
+
+/**
  * The motions a key runs, by the key that runs it. Emacs bindings, because
  * they are what the substrate's own editor binds and what a terminal's other
  * line editors offer.
@@ -299,28 +423,51 @@ function endsLine(key: Key, buffer: EditBuffer): boolean {
  * `ctrl-d` deletes forward here and ends the run in {@link runPrompt}, which
  * reads it first: what the two spellings have in common is that each removes
  * what is in front of the cursor, and on an empty line there is only the run.
+ *
+ * `up` and `down` walk the lines this run typed rather than the rows of the
+ * buffer, and nothing is lost by that: the prompt reads one line, `enter`
+ * being what ends it rather than what breaks it, so a buffer here has one row
+ * and a vertical motion over it has nowhere to go. `ctrl-p` and `ctrl-n` are
+ * bound beside them, those being what an Emacs binding spells the same two
+ * motions as.
  */
-const BINDINGS: ReadonlyMap<string, (buffer: EditBuffer) => void> = new Map([
-  ["left", (buffer) => buffer.moveLeft()],
-  ["ctrl-b", (buffer) => buffer.moveLeft()],
-  ["right", (buffer) => buffer.moveRight()],
-  ["ctrl-f", (buffer) => buffer.moveRight()],
-  ["home", (buffer) => buffer.moveLineStart()],
-  ["ctrl-a", (buffer) => buffer.moveLineStart()],
-  ["end", (buffer) => buffer.moveLineEnd()],
-  ["ctrl-e", (buffer) => buffer.moveLineEnd()],
-  ["alt-b", (buffer) => buffer.moveWordBackward()],
-  ["alt-f", (buffer) => buffer.moveWordForward()],
-  ["backspace", (buffer) => buffer.deleteBackward()],
-  ["delete", (buffer) => buffer.deleteForward()],
-  ["ctrl-d", (buffer) => buffer.deleteForward()],
-  ["ctrl-k", (buffer) => buffer.killLine()],
-  ["ctrl-u", (buffer) => buffer.killWholeLine()],
-  ["ctrl-w", (buffer) => buffer.killWordBackward()],
-  ["alt-backspace", (buffer) => buffer.killWordBackward()],
-  ["alt-d", (buffer) => buffer.killWordForward()],
-  ["ctrl-y", (buffer) => buffer.yank()],
-  ["alt-y", (buffer) => buffer.yankPop()],
+const BINDINGS: ReadonlyMap<string, (editing: Editing) => void> = new Map([
+  ["left", ({ buffer }) => buffer.moveLeft()],
+  ["ctrl-b", ({ buffer }) => buffer.moveLeft()],
+  ["right", ({ buffer }) => buffer.moveRight()],
+  ["ctrl-f", ({ buffer }) => buffer.moveRight()],
+  ["home", ({ buffer }) => buffer.moveLineStart()],
+  ["ctrl-a", ({ buffer }) => buffer.moveLineStart()],
+  ["end", ({ buffer }) => buffer.moveLineEnd()],
+  ["ctrl-e", ({ buffer }) => buffer.moveLineEnd()],
+  ["alt-b", ({ buffer }) => buffer.moveWordBackward()],
+  ["alt-f", ({ buffer }) => buffer.moveWordForward()],
+  ["backspace", ({ buffer }) => buffer.deleteBackward()],
+  ["delete", ({ buffer }) => buffer.deleteForward()],
+  ["ctrl-d", ({ buffer }) => buffer.deleteForward()],
+  ["ctrl-k", ({ buffer }) => buffer.killLine()],
+  ["ctrl-u", ({ buffer }) => buffer.killWholeLine()],
+  ["ctrl-w", ({ buffer }) => buffer.killWordBackward()],
+  ["alt-backspace", ({ buffer }) => buffer.killWordBackward()],
+  ["alt-d", ({ buffer }) => buffer.killWordForward()],
+  ["ctrl-y", ({ buffer }) => buffer.yank()],
+  ["alt-y", ({ buffer }) => buffer.yankPop()],
+  [
+    "up",
+    ({ buffer, history }) => recall(buffer, history.earlier(buffer.text())),
+  ],
+  [
+    "ctrl-p",
+    ({ buffer, history }) => recall(buffer, history.earlier(buffer.text())),
+  ],
+  [
+    "down",
+    ({ buffer, history }) => recall(buffer, history.later(buffer.text())),
+  ],
+  [
+    "ctrl-n",
+    ({ buffer, history }) => recall(buffer, history.later(buffer.text())),
+  ],
 ]);
 
 /**
@@ -392,9 +539,10 @@ async function report(
 ): Promise<string> {
   try {
     const running = runLine(line, shuttle, deps);
-    const outcome = await (deps.signal === undefined
-      ? running
-      : Promise.race([running, abandoned(deps.signal)]));
+    const outcome = await (deps.signal === undefined ? running : Promise.race([
+      running,
+      whenAborted<Outcome>(deps.signal, { kind: "interrupted" }),
+    ]));
     switch (outcome.kind) {
       case "nothing":
       case "moved":
@@ -414,19 +562,23 @@ async function report(
 }
 
 /**
- * Helper for {@link report}, which settles once `signal` is aborted and never
- * otherwise.
+ * Helper for {@link report} and {@link startCompleting}, which settles with
+ * `answer` once `signal` is aborted and never otherwise.
  *
- * A promise that never settles is exactly what is wanted for a line nobody
+ * A promise that never settles is exactly what is wanted for work nobody
  * cancels: it loses every race it is in and is collected with the controller
- * the line held. Nothing here waits on a clock, so a line that is slow is a
- * line that is still running.
+ * the work held. Nothing here waits on a clock, so work that is slow is work
+ * that is still running.
+ *
+ * The two callers race it for one reason. A read already sent cannot be
+ * called off, so this is what says the person has stopped waiting for it —
+ * the line answered as interrupted, the completion as one with nothing to
+ * write — and it is the answer either of them gets against a server that
+ * never replies at all.
  */
-function abandoned(signal: AbortSignal): Promise<Outcome> {
+function whenAborted<T>(signal: AbortSignal, answer: T): Promise<T> {
   return new Promise((resolve) => {
-    signal.addEventListener("abort", () => resolve({ kind: "interrupted" }), {
-      once: true,
-    });
+    signal.addEventListener("abort", () => resolve(answer), { once: true });
   });
 }
 
@@ -446,14 +598,14 @@ function abandoned(signal: AbortSignal): Promise<Outcome> {
  * (`place.ts`), so a line carrying one is a line already refused, and drawing
  * it would corrupt the screen on the way to that refusal.
  */
-function apply(buffer: EditBuffer, key: Key): void {
+function apply(editing: Editing, key: Key): void {
   const motion = BINDINGS.get(key.alt === true ? `alt-${key.name}` : key.name);
   if (motion !== undefined) {
-    motion(buffer);
+    motion(editing);
     return;
   }
   if (key.char !== undefined && !holdsControlCharacter(key.char)) {
-    buffer.insert(key.char);
+    editing.buffer.insert(key.char);
   }
 }
 

--- a/packages/cli/lib/shuttle/verbs.ts
+++ b/packages/cli/lib/shuttle/verbs.ts
@@ -249,15 +249,15 @@ function stopped(deps: VerbDeps): Interruption | undefined {
 }
 
 /** What an act guarded against a cancel did, where it was allowed to run. */
-type Ran<T> = { readonly kind: "ran"; readonly answer: T };
+export type Ran<T> = { readonly kind: "ran"; readonly answer: T };
 
 /**
  * Performs `act` over `args` unless the line has been cancelled, and is what
  * it answered where it was allowed to.
  *
- * Every read this module sends and every move it adopts goes through here,
- * and the reason is that the rule they are held to is not one discipline can
- * keep. The rule is that **nothing is awaited between the check and the act
+ * Every read a line sends and every move it adopts goes through here — this
+ * module's, and the completion's beside it (`completion.ts`) — and the reason
+ * is that the rule they are held to is not one discipline can keep. The rule is that **nothing is awaited between the check and the act
  * it guards** — an await there is a window the cancel lands in and the act
  * happens anyway — and a rule of that shape is invisible: the code reads
  * correctly whether or not the window is there, no case can see it, and the
@@ -284,7 +284,7 @@ type Ran<T> = { readonly kind: "ran"; readonly answer: T };
  * What is left to the caller is which arm it returns, and the arms are the
  * outcome's own, so a cancelled act is handed back rather than tested for.
  */
-async function guarded<A extends readonly unknown[], T>(
+export async function guarded<A extends readonly unknown[], T>(
   deps: VerbDeps,
   act: (...args: A) => T | Promise<T>,
   ...args: A
@@ -360,13 +360,33 @@ export async function runLine(
 }
 
 /**
- * How many operands a verb takes, and what one that needs an operand calls the
- * one it needs.
+ * What a completion offers where a token may stand.
+ *
+ * Three arms and no fourth, since what a v1 verb reads an operand as is a
+ * reference or a verb name, and everything else is a word only the fabric
+ * could supply: a `#name` entry point is resolved by a read of its own rather
+ * than listed, so `wish` declares `nothing` and says so where it declares it.
+ */
+export type Candidates =
+  /** The words that name a verb. */
+  | "verbs"
+  /** The children of the place, as the operands `cd` takes to reach them. */
+  | "children"
+  /** Nothing: no token this can name stands there. */
+  | "nothing";
+
+/**
+ * How many operands a verb takes, what one that needs an operand calls the
+ * one it needs, and what a completion offers for it.
  *
  * The noun phrase rides the arity because the refusal for a missing operand is
  * the verb's own sentence and the count is the dispatch's rule: declaring them
  * together is what lets one reader enforce every verb's arity without every
- * verb's refusal collapsing into one wording.
+ * verb's refusal collapsing into one wording. What a completion offers rides
+ * it for the tighter reason that it is the same slot: it is declared on the
+ * two arms that have an operand and unspellable on the arm that has none, so
+ * a verb taking an operand cannot be written without deciding what completes
+ * it, and one taking none cannot be given a decision that would never fire.
  *
  * Taking no operand and taking an optional one are told apart by what a verb
  * does with none, which is why `optional` is an arm rather than the absence of
@@ -377,9 +397,13 @@ type Arity =
   /** No operand at all, so any is too many. */
   | { readonly operands: "none" }
   /** One at most, and what no operand means is the verb's own. */
-  | { readonly operands: "optional" }
+  | { readonly operands: "optional"; readonly completes: Candidates }
   /** One, needed, `names` being what the refusal for none calls it. */
-  | { readonly operands: "required"; readonly names: string };
+  | {
+    readonly operands: "required";
+    readonly names: string;
+    readonly completes: Candidates;
+  };
 
 /**
  * What a line said past the verb that named it: the options it set, by the
@@ -784,7 +808,11 @@ const LIST_OPTIONS: readonly VerbOption[] = [
 const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
   ["cd", {
     run: cd,
-    arity: { operands: "required", names: "a place to move to" },
+    arity: {
+      operands: "required",
+      names: "a place to move to",
+      completes: "children",
+    },
     usage: "cd <ref>",
     summary: "Moves the place, which fills in what a reference omits.",
     detail:
@@ -804,7 +832,7 @@ const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
   }],
   ["get", {
     run: get,
-    arity: { operands: "optional" },
+    arity: { operands: "optional", completes: "children" },
     options: READ_OPTIONS,
     usage: "get [<ref>]",
     summary: "Reads the value at a cell, defaulting to where you stand.",
@@ -824,7 +852,7 @@ const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
   }],
   ["help", {
     run: help,
-    arity: { operands: "optional" },
+    arity: { operands: "optional", completes: "verbs" },
     usage: "help [<verb>]",
     summary: "Lists the verbs, or writes the page of the one named.",
     detail: "`<verb> --help` writes the same page, and every verb takes that " +
@@ -881,6 +909,10 @@ const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
     arity: {
       operands: "required",
       names: "the target to resolve, as in `wish #favorites`",
+      // A target is a name the fabric holds rather than a row of the place,
+      // and what would list them is a read of a different index; `wish`
+      // completes nothing until one exists to read.
+      completes: "nothing",
     },
     usage: "wish <#name>",
     summary: "Resolves a named entry point, as `cf wish` does.",
@@ -902,6 +934,66 @@ const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
  * a verb the gate asks about, with no second list to keep in step.
  */
 export const VERB_HELP: ReadonlyMap<string, VerbHelp> = VERBS;
+
+/**
+ * The words that name a verb, in the order the table declares them.
+ *
+ * Derived from the table rather than written beside it, so it is the same set
+ * the dispatch takes, `help` lists and a refusal names — a verb added is a
+ * verb a completion offers, with nothing to remember.
+ */
+export const VERB_WORDS: readonly string[] = [...VERBS.keys()];
+
+/**
+ * What a completion offers for the token standing after `tokens` on a line.
+ *
+ * The tokens are the whole ones written before it, so the question is the one
+ * the dispatch asks of a line and it is answered the same way: the first
+ * token names a verb, the rest go to that verb's own option reading, and what
+ * is left is the operands the line has already given it. A completion is
+ * offered where the verb takes another operand and nowhere else, which is
+ * what keeps a completion to a token the line takes — a second operand for a
+ * verb that takes one, or any for a verb that takes none, is a token the
+ * dispatch would refuse.
+ *
+ * Four lines answer `nothing` and each is a different fact: no verb by that
+ * word, so nothing is known about what follows it; a reading the parser
+ * refused, whose last token is an option's value rather than an operand; a
+ * verb with its operands already given; and a verb whose operand is a name
+ * only the fabric could supply.
+ *
+ * A line asking for a verb's page is among the refused readings rather than
+ * beside them: `--help` takes the whole reading and carries no operands, so
+ * there is no operand position for a completion to stand in.
+ */
+export function candidatesAfter(tokens: readonly string[]): Candidates {
+  const [word, ...rest] = tokens;
+  if (word === undefined) return "verbs";
+  const entry = VERBS.get(word);
+  if (entry === undefined) return "nothing";
+  const reading = readOptions(word, rest, entry.options);
+  if (reading.kind !== "read") return "nothing";
+  return afterOperands(entry.arity, reading.operands.length);
+}
+
+/**
+ * Helper for {@link candidatesAfter}, which is what `arity` offers where
+ * `given` operands have already been written.
+ *
+ * The arms are the arity's own, so a verb that takes no operand offers
+ * nothing without declaring it and the two that take one offer what they
+ * declared — until one has been given, since v1's every arity is one operand
+ * at most.
+ */
+function afterOperands(arity: Arity, given: number): Candidates {
+  switch (arity.operands) {
+    case "none":
+      return "nothing";
+    case "optional":
+    case "required":
+      return given === 0 ? arity.completes : "nothing";
+  }
+}
 
 /**
  * Helper for {@link cd}, which finishes `move`.
@@ -1725,7 +1817,7 @@ function tooMany(verb: string, takes: string, given: number): Outcome {
  */
 function notAVerb(word: string): string {
   return `\`${word}\` is not a verb. The verbs are ` +
-    `${listed([...VERBS.keys()])}.`;
+    `${listed(VERB_WORDS)}.`;
 }
 
 /**

--- a/packages/cli/test/shuttle-completion.test.ts
+++ b/packages/cli/test/shuttle-completion.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Unit tests for what `tab` finishes: the token a line ends in, completed
+ * against the verbs and against what stands where shuttle stands.
+ *
+ * Every read is stood in through the deps bag, so what is under test is which
+ * candidates a position offers and what is written back onto the line, with no
+ * socket and no server behind any of it. Where a completion lands on the
+ * screen is the prompt's (`shuttle-prompt.test.ts`).
+ *
+ * The verb words are read off the dispatch rather than written here, so a case
+ * about "the word that names a verb" stays a case about the table rather than
+ * a copy of it that would go quietly stale.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import type { PiecesController } from "@commonfabric/piece/ops";
+
+import type { SpaceConfig } from "../lib/piece.ts";
+import { completeLine } from "../lib/shuttle/completion.ts";
+import { HeldConnection } from "../lib/shuttle/connection.ts";
+import { CurrentPlace } from "../lib/shuttle/place.ts";
+import { ShuttleSession } from "../lib/shuttle/session.ts";
+import { moved } from "./shuttle-place-helpers.ts";
+import {
+  type Shuttle,
+  VERB_WORDS,
+  type VerbDeps,
+} from "../lib/shuttle/verbs.ts";
+
+const SPACE = "did:key:z6MkConnectedSpace" as MemorySpace;
+const HANDLE = "of:fid1:abcdefghijklmnop";
+
+const CONFIG: SpaceConfig = {
+  apiUrl: "https://toolshed.example/",
+  space: SPACE,
+  identity: "/keys/shuttle.pkcs8",
+};
+
+/** Helper for the cases below, which fails whichever read a case reaches. */
+const READS_NOTHING: VerbDeps = {
+  listing: {
+    listSpaceSlugs: () => {
+      throw new Error("The slug index was read.");
+    },
+    listPieces: () => {
+      throw new Error("The pieces were read.");
+    },
+    getCellValue: () => {
+      throw new Error("The cell was listed.");
+    },
+  },
+};
+
+/** Helper for the cases below, which is a shuttle at the space root. */
+function shuttleIn(): Shuttle {
+  return {
+    config: CONFIG,
+    place: new CurrentPlace(SPACE),
+    connection: new HeldConnection({
+      kind: "borrowed",
+      pieces: {
+        dispose: () => Promise.resolve(),
+        getSpace: () => SPACE,
+        getSpaceName: () => "board",
+      } as unknown as PiecesController,
+    }),
+    session: new ShuttleSession(),
+  };
+}
+
+/** Helper for the cases below, which stands a shuttle at a piece. */
+function atPiece(): Shuttle {
+  const shuttle = shuttleIn();
+  moved(shuttle.place, `/${HANDLE}`);
+  return shuttle;
+}
+
+/** Helper for the cases below, which stands `value` in for the cell read. */
+function holding(value: unknown): VerbDeps {
+  return {
+    ...READS_NOTHING,
+    listing: {
+      ...READS_NOTHING.listing,
+      getCellValue: () => Promise.resolve(value),
+    },
+  };
+}
+
+/** Helper for the cases below, which stands `slugs` in for the slug index. */
+function slugged(...slugs: readonly string[]): VerbDeps {
+  return {
+    ...READS_NOTHING,
+    listing: {
+      ...READS_NOTHING.listing,
+      listSpaceSlugs: () =>
+        Promise.resolve(slugs.map((slug) => ({ slug, piece: HANDLE }))),
+    },
+  };
+}
+
+/** Helper for the cases below, which is a signal already aborted. */
+function cancelled(): AbortSignal {
+  const stopper = new AbortController();
+  stopper.abort();
+  return stopper.signal;
+}
+
+describe("completion", () => {
+  describe("completeLine() over the verbs", () => {
+    it("writes the verb a prefix names, where it names one", async () => {
+      expect(await completeLine(shuttleIn(), "pw", READS_NOTHING))
+        .toBe("pwd");
+    });
+
+    it("reads nothing to answer, the verbs being a table rather than a read", async () => {
+      // `READS_NOTHING` raises on every read there is, so a case that answers
+      // under it is a case in which none was made.
+
+      expect(await completeLine(shuttleIn(), "wi", READS_NOTHING))
+        .toBe("wish");
+    });
+
+    it("writes every verb the table declares, under its own whole word", async () => {
+      // The claim ranges over the verbs, so the enumeration is written out
+      // and held to the table beside it. Ranging over `VERB_WORDS` alone
+      // would close nothing: the words offered and the words walked would be
+      // the same array, so a word missing from it would be a word this never
+      // asked about.
+
+      const words = [
+        "cd",
+        "get",
+        "help",
+        "ls",
+        "more",
+        "pwd",
+        "where",
+        "wish",
+      ];
+      expect([...VERB_WORDS]).toEqual(words);
+      for (const word of words) {
+        expect(
+          await completeLine(shuttleIn(), word.slice(0, -1), READS_NOTHING),
+        )
+          .toBe(word);
+      }
+    });
+
+    it("writes as far as several verbs agree, and no further", async () => {
+      // `where` and `wish` share `w`, so the shared opening is what a `tab` on
+      // it can write.
+
+      expect(await completeLine(shuttleIn(), "w", READS_NOTHING))
+        .toBeUndefined();
+      expect(await completeLine(shuttleIn(), "wh", READS_NOTHING))
+        .toBe("where");
+    });
+
+    it("writes nothing where the prefix names no verb", async () => {
+      expect(await completeLine(shuttleIn(), "zz", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("writes nothing where the word is already whole", async () => {
+      expect(await completeLine(shuttleIn(), "pwd", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("writes nothing for the empty line, every verb standing there", async () => {
+      expect(await completeLine(shuttleIn(), "", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("writes a verb for `help`, which is what its operand names", async () => {
+      expect(await completeLine(shuttleIn(), "help pw", READS_NOTHING))
+        .toBe("help pwd");
+    });
+  });
+
+  describe("completeLine() over what stands at the place", () => {
+    it("writes the facet a prefix names at a space root", async () => {
+      expect(await completeLine(shuttleIn(), "cd sl", READS_NOTHING))
+        .toBe("cd slugs");
+    });
+
+    it("writes a slug the index records, under the facet that lists them", async () => {
+      const shuttle = shuttleIn();
+      moved(shuttle.place, "slugs");
+      expect(await completeLine(shuttle, "cd bo", slugged("board", "topics")))
+        .toBe("cd board");
+    });
+
+    it("writes a key of the cell shuttle stands in", async () => {
+      // `entities` holds `ti` without opening with it, so the filter is a
+      // prefix test rather than a search.
+
+      expect(
+        await completeLine(
+          atPiece(),
+          "cd ti",
+          holding({ title: "a", entities: 1 }),
+        ),
+      ).toBe("cd title");
+    });
+
+    it("writes the key for `get`, whose operand takes what `cd` takes", async () => {
+      expect(
+        await completeLine(atPiece(), "get ti", holding({ title: "a" })),
+      ).toBe("get title");
+    });
+
+    it("writes every key where the token being completed is empty", async () => {
+      expect(await completeLine(atPiece(), "cd ", holding({ title: "a" })))
+        .toBe("cd title");
+    });
+
+    it("writes a key whose name needs quoting as the token that names it", async () => {
+      expect(
+        await completeLine(atPiece(), "cd my", holding({ "my key": 1 })),
+      ).toBe("cd 'my key'");
+    });
+
+    it("writes a key the name alone would not reach as the reference that does", async () => {
+      // A key called `..` is a reading rather than a name, so the operand
+      // `operandForChild` offers is the reference — which is what the listing
+      // prints for the same row, and what `cd` takes back to it. What is typed
+      // is the opening of that reference, since a completion extends the token
+      // on the line rather than swapping it for another spelling.
+
+      const written = await completeLine(
+        atPiece(),
+        "cd /",
+        holding({ "..": 1 }),
+      );
+      expect(written).toBe(`cd /@${SPACE}/${HANDLE}@space/..`);
+    });
+
+    it("offers no key that neither its name nor a reference reaches", async () => {
+      // A key opening with `#` has no operand at all — the reference grammar
+      // reserves the character — so there is nothing to write that would take
+      // the line to the row, and the row is left out rather than offered
+      // under a name that reaches nothing.
+
+      expect(await completeLine(atPiece(), "cd #", holding({ "#tag": 1 })))
+        .toBeUndefined();
+    });
+
+    it("offers no key under a name that is not the token reaching it", async () => {
+      // The bound the case above leaves: `..` is the row's name and not its
+      // operand, so typing it is not typing the beginning of what `cd` takes.
+
+      expect(await completeLine(atPiece(), "cd .", holding({ "..": 1 })))
+        .toBeUndefined();
+    });
+
+    it("writes nothing where several keys agree only on a partial that needs quoting", async () => {
+      // `'my ` is a quote nothing closes, so what agrees is not a token and is
+      // not written; the row is reached by typing on.
+
+      expect(
+        await completeLine(
+          atPiece(),
+          "cd my",
+          holding({ "my key": 1, "my other": 2 }),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("writes as far as several keys agree where the agreement is bare", async () => {
+      expect(
+        await completeLine(atPiece(), "cd t", holding({ title: 1, titles: 2 })),
+      ).toBe("cd title");
+    });
+
+    it("writes nothing where no key matches the prefix", async () => {
+      expect(await completeLine(atPiece(), "cd zz", holding({ title: 1 })))
+        .toBeUndefined();
+    });
+
+    it("writes nothing where the read failed, rather than raising", async () => {
+      // A tab is not a request for an answer about the fabric, so a read that
+      // failed offers nothing where `ls` reports the failure.
+
+      expect(await completeLine(atPiece(), "cd ti", READS_NOTHING))
+        .toBeUndefined();
+    });
+  });
+
+  describe("completeLine() over where a token may stand", () => {
+    it("writes nothing for a verb that takes no operand", async () => {
+      expect(await completeLine(shuttleIn(), "ls sl", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("writes nothing for a second operand where the verb takes one", async () => {
+      expect(await completeLine(shuttleIn(), "cd slugs sl", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("writes nothing after a word that names no verb", async () => {
+      expect(await completeLine(shuttleIn(), "lss sl", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("writes nothing for `wish`, whose operand is a name the fabric holds", async () => {
+      expect(await completeLine(shuttleIn(), "wish sl", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("writes nothing where the line asked for the verb's page", async () => {
+      expect(await completeLine(shuttleIn(), "cd --help sl", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("writes nothing where the token before it is an option's value", async () => {
+      // `--select` takes a value, so the token after it is that value and not
+      // the verb's operand — on a verb that does take one, which is what
+      // makes the position rather than the arity the reason.
+
+      expect(
+        await completeLine(atPiece(), "get --select ti", holding({ title: 1 })),
+      ).toBeUndefined();
+    });
+
+    it("writes the operand after a bare `--`, which ends the options", async () => {
+      expect(await completeLine(shuttleIn(), "cd -- sl", READS_NOTHING))
+        .toBe("cd -- slugs");
+    });
+
+    it("writes the operand after an option the verb declares", async () => {
+      expect(
+        await completeLine(atPiece(), "get --json ti", holding({ title: 1 })),
+      ).toBe("get --json title");
+    });
+  });
+
+  describe("completeLine() over the line's own reading", () => {
+    it("completes the token the split reads, not the run after the last separator", async () => {
+      // An escaped separator is a character of its token, so the token here is
+      // the value of `--select` and the position is an option's value rather
+      // than an operand.
+      //
+      // The place is the one that parts the two readings, and it has to be
+      // chosen rather than assumed. A reading taking the run after the last
+      // separator finds `sl`, and splitting the head it leaves behind reads
+      // `--select` as satisfied by `a ` — so it looks for a row opening with
+      // `sl`. At a piece there is no such row and the two readings agree on
+      // answering nothing, which is a case that would pass against the very
+      // fault it is written for. At a space root `slugs` opens with it, and
+      // the faulty reading writes `get --select a\\ slugs` — the option's own
+      // value rewritten to reach a row.
+
+      expect(
+        await completeLine(shuttleIn(), "get --select a\\ sl", READS_NOTHING),
+      ).toBeUndefined();
+    });
+
+    it("reads the tokens before that one as the whole ones, and not it among them", async () => {
+      // The same line at a place holding a row the token's *value* opens —
+      // `a slug` opens with `a sl`. So a reading that counted the token being
+      // typed among the tokens before it would read `--select` as satisfied,
+      // find an operand position, and write `get --select 'a slug'`.
+
+      expect(
+        await completeLine(
+          atPiece(),
+          "get --select a\\ sl",
+          holding({ "a slug": 1 }),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("completes a token whose separator was quoted, as the value it splits to", async () => {
+      // The same reading read the other way: the token is `my ke`, which opens
+      // where the quote does, so what is written replaces the whole of it.
+
+      expect(
+        await completeLine(atPiece(), "cd 'my ke'", holding({ "my key": 1 })),
+      ).toBe("cd 'my key'");
+    });
+
+    it("writes nothing where the line ends in a quote that never closes", async () => {
+      // Where the token being typed opens is exactly what such a line does
+      // not yet say, so there is nothing to complete rather than a guess to
+      // make.
+
+      expect(await completeLine(shuttleIn(), "cd 'unclosed sl", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("writes nothing where the line ends in a backslash escaping nothing", async () => {
+      expect(await completeLine(shuttleIn(), "cd sl\\", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("keeps the line before the token exactly as it was written", async () => {
+      expect(await completeLine(shuttleIn(), "  cd   sl", READS_NOTHING))
+        .toBe("  cd   slugs");
+    });
+
+    it("completes a prefix that opens a child's own multi-segment operand", async () => {
+      // Nothing gates a candidate on its shape, and this is the row that shows
+      // why nothing may: `..` is a reading rather than a name, so the operand
+      // reaching it is the reference — which carries the separator. A rule
+      // turning down a prefix holding one would put this row out of reach.
+
+      const reference = `/@${SPACE}/${HANDLE}@space/..`;
+      expect(
+        await completeLine(
+          atPiece(),
+          `cd ${reference.slice(0, -1)}`,
+          holding({ "..": 1 }),
+        ),
+      ).toBe(`cd ${reference}`);
+    });
+
+    it("writes nothing for a name that stands somewhere other than here", async () => {
+      // The bound on the case above, and it is a bound on the candidates
+      // rather than a rule about the prefix: no row standing at the root is
+      // called `slugs/bo`. The row it names stands inside `slugs/`, and
+      // reaching one there is a read of a place the line has not moved to.
+
+      expect(await completeLine(shuttleIn(), "cd slugs/bo", READS_NOTHING))
+        .toBeUndefined();
+    });
+
+    it("writes a common prefix in whole characters, so a pair is never cut in half", async () => {
+      // The two keys part inside a surrogate pair, so a common prefix counted
+      // in code units would agree one unit past the last character they share
+      // and hand back a string ending in half of one — which a terminal cannot
+      // draw and which the next character typed lands after rather than
+      // completing. They agree on `face` and no further, so nothing is
+      // written.
+
+      expect(
+        await completeLine(
+          atPiece(),
+          "cd face",
+          holding({ "face\u{1f600}": 1, "face\u{1f601}": 2 }),
+        ),
+      ).toBeUndefined();
+
+      // And the character itself is written where it is shared whole.
+      expect(
+        await completeLine(
+          atPiece(),
+          "cd x",
+          holding({ "x\u{1f600}a": 1, "x\u{1f600}b": 2 }),
+        ),
+      ).toBe("cd x\u{1f600}");
+    });
+  });
+
+  describe("completeLine() under a cancel", () => {
+    it("reads nothing where the line was cancelled before the read", async () => {
+      // The claim is about the read rather than about the answer, so the case
+      // watches the read: an answer of nothing is what a cancelled line gets
+      // either way, and would say nothing about whether the read went out.
+
+      let read = false;
+      const written = await completeLine(atPiece(), "cd ti", {
+        listing: {
+          getCellValue: () => {
+            read = true;
+            return Promise.resolve({ title: 1 });
+          },
+        },
+        signal: cancelled(),
+      });
+      expect(read).toBe(false);
+      expect(written).toBeUndefined();
+    });
+
+    it("writes nothing where the line was cancelled while the read was out", async () => {
+      // The read is answered and the cancel arrives with it, which is the one
+      // a check cannot stop from being sent — so what the guard after it
+      // stops is the answer being written.
+
+      const stopper = new AbortController();
+      const written = await completeLine(atPiece(), "cd ti", {
+        ...READS_NOTHING,
+        listing: {
+          ...READS_NOTHING.listing,
+          getCellValue: () => {
+            stopper.abort();
+            return Promise.resolve({ title: 1 });
+          },
+        },
+        signal: stopper.signal,
+      });
+      expect(written).toBeUndefined();
+    });
+
+    it("writes what it read where nothing cancelled the line", async () => {
+      // The control for the two above: the same read, the same signal, and
+      // nobody aborting it.
+
+      const stopper = new AbortController();
+      expect(
+        await completeLine(atPiece(), "cd ti", {
+          ...holding({ title: 1 }),
+          signal: stopper.signal,
+        }),
+      ).toBe("cd title");
+    });
+  });
+});

--- a/packages/cli/test/shuttle-history.test.ts
+++ b/packages/cli/test/shuttle-history.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for the lines a run typed, and the traversal `up` and `down`
+ * make over them.
+ *
+ * The traversal is a value with no I/O behind it, so every case here drives
+ * it directly: what the prompt does with what it returns is pinned where the
+ * prompt is (`shuttle-prompt.test.ts`).
+ *
+ * A case reads the traversal by walking it, there being no other surface: a
+ * position is what `earlier` and `later` hand back, and the text a case
+ * passes in is what the traversal is being told the line now holds.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { EditBuffer } from "../lib/view/editbuffer.ts";
+import { LineHistory, recall } from "../lib/shuttle/history.ts";
+
+/** Helper for the cases below, which is a traversal over `lines`. */
+function recorded(...lines: readonly string[]): LineHistory {
+  const history = new LineHistory();
+  for (const line of lines) history.record(line);
+  return history;
+}
+
+/**
+ * Helper for the cases below, which is what `up` reaches `presses` times over
+ * from the line being typed, with nothing typed in between.
+ */
+function up(history: LineHistory, presses: number): string | undefined {
+  let reached: string | undefined;
+  for (let press = 0; press < presses; press++) {
+    reached = history.earlier(reached ?? "");
+  }
+  return reached;
+}
+
+describe("history", () => {
+  describe("LineHistory.record()", () => {
+    it("records a line, which `up` then reaches", () => {
+      expect(recorded("ls").earlier("")).toBe("ls");
+    });
+
+    it("records the lines in the order they were typed, newest first under `up`", () => {
+      const history = recorded("pwd", "ls");
+      expect(history.earlier("")).toBe("ls");
+      expect(history.earlier("ls")).toBe("pwd");
+    });
+
+    it("records a line exactly as it was typed, its spacing included", () => {
+      expect(recorded("cd  slugs ").earlier("")).toBe("cd  slugs ");
+    });
+
+    it("records a line that named no verb, which is the line `up` is for", () => {
+      expect(recorded("lss").earlier("")).toBe("lss");
+    });
+
+    it("records nothing for an empty line", () => {
+      expect(recorded("").earlier("")).toBeUndefined();
+    });
+
+    it("records nothing for a line that is only whitespace", () => {
+      expect(recorded(" \t ").earlier("")).toBeUndefined();
+    });
+
+    it("records nothing for a line identical to the one recorded last", () => {
+      const history = recorded("ls", "ls");
+      expect(history.earlier("")).toBe("ls");
+      expect(history.earlier("ls")).toBeUndefined();
+    });
+
+    it("records a line identical to an earlier one that is not the last", () => {
+      // The comparison is against the last line alone. Comparing against every
+      // line would drop this `ls` and leave `up` twice reaching `pwd`, which
+      // is not the order the run typed.
+
+      const history = recorded("ls", "pwd", "ls");
+      expect(history.earlier("")).toBe("ls");
+      expect(history.earlier("ls")).toBe("pwd");
+      expect(history.earlier("pwd")).toBe("ls");
+    });
+
+    it("returns the traversal to the line being typed, wherever it stood", () => {
+      const history = recorded("pwd", "ls");
+      expect(history.earlier("")).toBe("ls");
+      history.record("cd slugs");
+      expect(history.later("")).toBeUndefined();
+    });
+
+    it("drops the edits the traversal was holding, so `up` walks the lines", () => {
+      // The `draft` was held against the line being typed. The line just
+      // recorded now stands at that position, and `up` reaches the line
+      // rather than the text that was held there.
+
+      const history = recorded("pwd", "ls");
+      history.earlier("draft");
+      history.record("cd slugs");
+      expect(history.earlier("")).toBe("cd slugs");
+    });
+  });
+
+  describe("LineHistory.abandon()", () => {
+    it("returns the traversal to the line being typed, which `down` leaves alone", () => {
+      const history = recorded("ls");
+      history.earlier("");
+      history.abandon();
+      expect(history.later("")).toBeUndefined();
+    });
+
+    it("records nothing, so what `up` reaches is what was recorded", () => {
+      const history = recorded("ls");
+      history.earlier("");
+      history.abandon();
+      expect(history.earlier("thrown away")).toBe("ls");
+    });
+
+    it("drops an edit held against a line the traversal had reached", () => {
+      // The edit has to be read at a position the traversal has not since
+      // moved off: `up` holds the current text as it leaves a position, so a
+      // case that walks back over the draft would overwrite the very edit it
+      // is asking about and pass whether or not anything was dropped.
+
+      const history = recorded("pwd", "ls");
+      history.earlier("draft");
+      history.earlier("ls --limit 2");
+      history.abandon();
+      expect(history.earlier("")).toBe("ls");
+      expect(history.later("ls")).toBe("");
+    });
+  });
+
+  describe("LineHistory.earlier()", () => {
+    it("returns nothing where nothing was recorded", () => {
+      expect(new LineHistory().earlier("half a line")).toBeUndefined();
+    });
+
+    it("returns nothing at the oldest line, rather than the newest again", () => {
+      const history = recorded("pwd", "ls");
+      expect(up(history, 3)).toBeUndefined();
+    });
+
+    it("holds the line being typed, which `down` then returns", () => {
+      const history = recorded("ls");
+      expect(history.earlier("cd sl")).toBe("ls");
+      expect(history.later("ls")).toBe("cd sl");
+    });
+
+    it("holds an edit made to a recorded line, which coming back returns", () => {
+      const history = recorded("pwd", "ls");
+      expect(history.earlier("")).toBe("ls");
+      expect(history.earlier("ls --limit 2")).toBe("pwd");
+      expect(history.later("pwd")).toBe("ls --limit 2");
+    });
+
+    it("leaves what was recorded alone, so a later traversal walks the lines", () => {
+      const history = recorded("pwd", "ls");
+      history.earlier("");
+      history.earlier("ls --limit 2");
+      history.abandon();
+      expect(up(history, 2)).toBe("pwd");
+    });
+  });
+
+  describe("LineHistory.later()", () => {
+    it("returns nothing at the line being typed, rather than the oldest", () => {
+      expect(recorded("ls").later("half a line")).toBeUndefined();
+    });
+
+    it("returns the empty line where nothing was typed before the first `up`", () => {
+      const history = recorded("ls");
+      expect(history.earlier("")).toBe("ls");
+      expect(history.later("ls")).toBe("");
+    });
+
+    it("holds an edit made to a recalled line, which coming back returns", () => {
+      const history = recorded("pwd", "ls");
+      expect(up(history, 2)).toBe("pwd");
+      expect(history.later("pwd --all")).toBe("ls");
+      expect(history.earlier("ls")).toBe("pwd --all");
+    });
+  });
+
+  describe("recall()", () => {
+    it("puts the line on the buffer", () => {
+      const buffer = new EditBuffer("");
+      recall(buffer, "cd slugs");
+      expect(buffer.text()).toBe("cd slugs");
+    });
+
+    it("leaves the cursor at the end of the line", () => {
+      const buffer = new EditBuffer("");
+      recall(buffer, "cd slugs");
+      expect(buffer.col).toBe(8);
+    });
+
+    it("counts the cursor in code points, so a line of pairs ends where it reads", () => {
+      const buffer = new EditBuffer("");
+      recall(buffer, "cd 𝄞𝄞");
+      expect(buffer.col).toBe(5);
+    });
+
+    it("leaves the buffer alone where there is no line", () => {
+      const buffer = new EditBuffer("cd sl");
+      buffer.moveLineStart();
+      recall(buffer, undefined);
+      expect([buffer.text(), buffer.col]).toEqual(["cd sl", 0]);
+    });
+  });
+});

--- a/packages/cli/test/shuttle-line.test.ts
+++ b/packages/cli/test/shuttle-line.test.ts
@@ -24,8 +24,34 @@ import { describe, it } from "@std/testing/bdd";
 import {
   quoteToken,
   RESERVED_CHARACTERS,
+  separatesTokens,
   splitLine,
+  tailOfLine,
 } from "../lib/shuttle/line.ts";
+
+/**
+ * Helper for the cases below, which divides every code point into the ones
+ * the split separates on and the ones it does not.
+ *
+ * The division is the split's own predicate rather than a list written here,
+ * which is what lets a case over either side close the class: a character the
+ * expression starts or stops matching moves between the two sides, and the
+ * case that then fails is the one whose claim stopped holding.
+ *
+ * The lone surrogates are left out because neither side is a claim about
+ * them: they are not characters, and a line carrying one is not a line
+ * anything typed.
+ */
+function classified(): { separators: string[]; others: string[] } {
+  const separators: string[] = [];
+  const others: string[] = [];
+  for (let code = 0; code <= 0x10ffff; code++) {
+    if (code >= 0xd800 && code <= 0xdfff) continue;
+    const character = String.fromCodePoint(code);
+    (separatesTokens(character) ? separators : others).push(character);
+  }
+  return { separators, others };
+}
 
 describe("line", () => {
   describe("RESERVED_CHARACTERS", () => {
@@ -332,6 +358,108 @@ describe("line", () => {
           tokens: [value],
         });
       }
+    });
+  });
+
+  describe("tailOfLine()", () => {
+    it("returns the token the line ends in, and the head up to where it opens", () => {
+      expect(tailOfLine("cd a b"))
+        .toEqual({ before: ["cd", "a"], head: "cd a ", prefix: "b" });
+    });
+
+    it("returns the whole line as the token where it holds no separator", () => {
+      expect(tailOfLine("cd"))
+        .toEqual({ before: [], head: "", prefix: "cd" });
+    });
+
+    it("returns an empty prefix where the line ends in a separator", () => {
+      expect(tailOfLine("cd "))
+        .toEqual({ before: ["cd"], head: "cd ", prefix: "" });
+    });
+
+    it("returns an empty pair for the empty line", () => {
+      expect(tailOfLine("")).toEqual({ before: [], head: "", prefix: "" });
+    });
+
+    it("returns a head carrying the separators exactly as they were written", () => {
+      expect(tailOfLine("  cd   sl"))
+        .toEqual({ before: ["cd"], head: "  cd   ", prefix: "sl" });
+    });
+
+    it("returns the token the split reads, not the run after the last separator", () => {
+      // The finding this exists for. A backslash before a separator makes it a
+      // character of its token, and the backslash then sits in the head rather
+      // than in the run after it — so a reading that looked at that run alone
+      // would find `sl`, call it an operand, and hand a completion the option's
+      // value to rewrite.
+
+      expect(tailOfLine("get --select a\\ sl")).toEqual({
+        before: ["get", "--select"],
+        head: "get --select ",
+        prefix: "a sl",
+      });
+    });
+
+    it("returns a quoted token as its value, opening where the quote does", () => {
+      expect(tailOfLine("cd 'a b" + "'")).toEqual({
+        before: ["cd"],
+        head: "cd ",
+        prefix: "a b",
+      });
+    });
+
+    it("returns the tokens before it whole, and without it among them", () => {
+      expect(tailOfLine("cd 'a b' c"))
+        .toEqual({ before: ["cd", "a b"], head: "cd 'a b' ", prefix: "c" });
+    });
+
+    it("returns nothing where the line ends in a quote that never closes", () => {
+      expect(tailOfLine("cd 'a b")).toBeUndefined();
+    });
+
+    it("returns nothing where the line ends in a backslash escaping nothing", () => {
+      expect(tailOfLine("cd a\\")).toBeUndefined();
+    });
+
+    it("opens a token at every separator the split separates on", () => {
+      // The claim ranges over a class, so the enumeration is derived from the
+      // expression that defines it rather than sampled: `separatesTokens` is
+      // the split's own test, and every code point is asked. A case listing
+      // the separators it happened to think of would have said nothing about
+      // the ones it did not — U+2028, U+2029 and U+FEFF among them.
+
+      const separators = classified().separators;
+      expect(separators.length).toBeGreaterThan(7);
+      for (const separator of separators) {
+        expect(tailOfLine(`cd${separator}sl`)).toEqual({
+          before: ["cd"],
+          head: `cd${separator}`,
+          prefix: "sl",
+        });
+      }
+    });
+
+    it("opens a token at no character the split does not separate on", () => {
+      // The other direction, and the one the case above does not reach: that
+      // separators separate says nothing about whether anything else does.
+      // It is the same scan with the predicate flipped, over the complement
+      // the same pass already collected — so the pair closes the class in
+      // both directions rather than in the one that is easy to ask.
+      //
+      // Two characters answer differently and are named rather than allowed
+      // for: a quote opens a token nothing closes, so the line has no reading
+      // at all. Every other character is data — the ones the grammar reserves
+      // among them, and the backslash, which escapes the character after it
+      // and still leaves one token.
+
+      const { others } = classified();
+      const refused: string[] = [];
+      for (const character of others) {
+        const tail = tailOfLine(`cd${character}sl`);
+        if (tail === undefined) refused.push(character);
+        else expect(tail.before).toEqual([]);
+      }
+      expect(refused.sort()).toEqual(['"', "'"]);
     });
   });
 });

--- a/packages/cli/test/shuttle-prompt.test.ts
+++ b/packages/cli/test/shuttle-prompt.test.ts
@@ -90,6 +90,15 @@ function typed(text: string): Key[] {
 /** Helper for the cases below, which is the key that runs a line. */
 const ENTER: Key = { name: "enter" };
 
+/** Helper for the cases below, which is the key that completes a token. */
+const TAB: Key = { name: "tab" };
+
+/** Helper for the cases below, which is the key that recalls an earlier line. */
+const UP: Key = { name: "up" };
+
+/** Helper for the cases below, which is the key that recalls a later one. */
+const DOWN: Key = { name: "down" };
+
 /** Helper for the cases below, which is `letter` typed with control held. */
 function control(letter: string): Key {
   return { name: `ctrl-${letter}`, ctrl: true };
@@ -747,6 +756,251 @@ describe("prompt", () => {
         text: `${AT_ROOT}ab`,
         column: 20,
       });
+    });
+  });
+
+  describe("recalling a line", () => {
+    // What the prompt does with the traversal, which is where the two meet:
+    // what the traversal itself holds is pinned in `shuttle-history.test.ts`.
+
+    it("draws the line before it on `up`, with the cursor at its end", async () => {
+      const writes = await running([...typed("pwd"), ENTER, UP]);
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: `${AT_ROOT}pwd`,
+        column: 21,
+      });
+    });
+
+    it("draws the line that was being typed on `down` back past the newest", async () => {
+      const writes = await running([
+        ...typed("pwd"),
+        ENTER,
+        ...typed("ab"),
+        UP,
+        DOWN,
+      ]);
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: `${AT_ROOT}ab`,
+        column: 20,
+      });
+    });
+
+    it("recalls on `ctrl-p` and `ctrl-n`, which are the same two motions", async () => {
+      const back = await running([...typed("pwd"), ENTER, control("p")]);
+      expect(drawn(back))
+        .toEqual({ kind: "edit", text: `${AT_ROOT}pwd`, column: 21 });
+      const forward = await running(
+        [...typed("pwd"), ENTER, ...typed("ab"), control("p"), control("n")],
+      );
+      expect(drawn(forward))
+        .toEqual({ kind: "edit", text: `${AT_ROOT}ab`, column: 20 });
+    });
+
+    it("records the line where it is taken, so `up` reaches one still running", async () => {
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get");
+          yield ENTER;
+          await read.started;
+          yield UP;
+          read.answer({ title: "a" });
+        })(),
+        atPiece(),
+        { getCellValue: read.read },
+      );
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: `${AT_PIECE}get`,
+        column: [...AT_PIECE].length + 3,
+      });
+    });
+
+    it("records nothing for a line with nothing on it", async () => {
+      // The blank line runs nothing, so `up` past it reaches the line that
+      // did rather than a position with nothing on it.
+
+      const writes = await running([...typed("pwd"), ENTER, ENTER, UP]);
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: `${AT_ROOT}pwd`,
+        column: 21,
+      });
+    });
+
+    it("returns the traversal to an empty line on `ctrl-c`", async () => {
+      // The `ab` was held against the line being typed when the first `up`
+      // left it. `ctrl-c` throws that line away, so the position it was held
+      // at holds nothing, and `down` back to it draws an empty prompt.
+
+      const writes = await running([
+        ...typed("pwd"),
+        ENTER,
+        ...typed("ab"),
+        UP,
+        control("c"),
+        UP,
+        DOWN,
+      ]);
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: AT_ROOT,
+        column: 18,
+      });
+    });
+  });
+
+  describe("completing a token", () => {
+    // What `tab` does at the prompt. Which candidates a position offers is
+    // pinned in `shuttle-completion.test.ts`; these are about the loop the
+    // read runs inside.
+
+    /** Helper for the cases below, which is the read a listing makes. */
+    function listing(read: Gated): VerbDeps {
+      return { listing: { getCellValue: read.read } };
+    }
+
+    it("draws the completed line, with the cursor at its end", async () => {
+      const writes = await running([...typed("pw"), TAB]);
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: `${AT_ROOT}pwd`,
+        column: 21,
+      });
+    });
+
+    it("leaves the line alone where the cursor is not at its end", async () => {
+      // The token a completion finishes is the one the line ends in, so a
+      // cursor standing anywhere else is standing in a token this is not
+      // completing.
+
+      const writes = await running([...typed("pw"), control("a"), TAB]);
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: `${AT_ROOT}pw`,
+        column: 18,
+      });
+    });
+
+    it("writes onto the line it was computed for and onto no other", async () => {
+      // A read cannot be called off once sent, so its answer may reach a line
+      // that has moved on. Writing `cd title` here would take back the `m`
+      // the person typed while the read was out.
+
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("cd ti");
+          yield TAB;
+          await read.started;
+          yield* typed("m");
+          read.answer({ title: 1 });
+        })(),
+        atPiece(),
+        listing(read),
+      );
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: `${AT_PIECE}cd tim`,
+        column: [...AT_PIECE].length + 6,
+      });
+    });
+
+    it("holds `enter` typed under a completion, and runs the line it completed", async () => {
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get ti");
+          yield TAB;
+          await read.started;
+          yield ENTER;
+          read.answer({ title: 1, tail: 2 });
+        })(),
+        atPiece(),
+        {
+          ...listing(read),
+          // Answering by path is what makes the line that ran readable: the
+          // held `enter` runs whatever is on the buffer, and only the
+          // completed line reads `title`.
+          getCellValue: (_config, path) =>
+            Promise.resolve(path[0] === "title" ? "the title" : "the tail"),
+        },
+      );
+      expect(produced(writes)[0]).toContain("the title");
+    });
+
+    it("leaves `tab` alone while a line is in flight, and is not held either", async () => {
+      // A line that is running is one that may be about to move the place a
+      // completion reads against, so `tab` is not a completion there — and it
+      // is not held for later either, since the token it would finish is on a
+      // line the person is still typing.
+
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get");
+          yield ENTER;
+          await read.started;
+          yield* typed("pw");
+          yield TAB;
+          read.answer({ title: "a" });
+        })(),
+        atPiece(),
+        { getCellValue: read.read },
+      );
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: `${AT_PIECE}pw`,
+        column: [...AT_PIECE].length + 2,
+      });
+    });
+
+    it("frees the prompt on `ctrl-c` where the read never answers", async () => {
+      // The one thing `ctrl-c` at a server that has gone quiet is for. A read
+      // already sent cannot be called off, so what the prompt does is stop
+      // waiting on it — and the `pwd` behind it is the evidence that it did.
+
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get ti");
+          yield TAB;
+          await read.started;
+          yield control("c");
+          yield* typed("pwd");
+          yield ENTER;
+        })(),
+        atPiece(),
+        listing(read),
+      );
+      expect(produced(writes)).toEqual([
+        `position  /@${SPACE}/${HANDLE}@space\nscope     @space`,
+      ]);
+    });
+
+    it("ends the line being completed on `ctrl-c`, which is still the line being typed", async () => {
+      // A verb's line was ended where it was taken and what is under it is
+      // the next one; a completion's line is the one on the screen, so
+      // throwing it away leaves it there and draws a fresh prompt below.
+
+      const read = gated();
+      const writes = await running(
+        (async function* () {
+          yield* typed("get ti");
+          yield TAB;
+          await read.started;
+          yield control("c");
+        })(),
+        atPiece(),
+        listing(read),
+      );
+      const typing = writes.findLastIndex((write) =>
+        write.kind === "edit" && write.text === `${AT_PIECE}get ti`
+      );
+      expect(typing).toBeGreaterThan(-1);
+      expect(writes[typing + 1]).toEqual({ kind: "finish" });
     });
   });
 });


### PR DESCRIPTION
## Why

Two things a shell has that shuttle did not, and that the architecture review
found unscheduled rather than deferred: the bindings table had no `up`/`down`,
`EditBuffer` had no history surface, and no stage mentioned completion at all —
though decision 3 names completion as what serves the second audience.

`futures.md` candidate 4 defers *persistent* history, which is a different
thing from recalling what this run typed.

Architecture-review finding 10.

## What Changed

**Recall.** `up`/`down` (and `ctrl-p`/`ctrl-n`) over the lines this run typed.

**Completion.** `tab` over verbs, facet names, slugs and the keys under the
place, filtered by the prefix on the line.

Both are scheduled rather than merely built: `build-sequence.md` gains **B1h**,
`README.md` **decision 29**, `grammar.md` a **Recall and completion** section,
and `futures.md`'s candidate 4 now says the in-session half is v1.

### Design calls

**Recall** — recorded at `enter` rather than at settle, so `up` reaches a line
still running. Blank lines are not recorded. **Adjacent dedup only**: comparing
against every line would drop one from the middle of the run and stop the order
being the order it was typed. The traversal runs over the recorded lines *plus
the line being typed*, one position each, so the draft is not a special case;
an edit is held at the position it was made at, and anything that ends the line
drops every edit and returns to the draft. No wrap at either end.

**Completion** — the slot **rides the arity**, declared on the arms that take an
operand and unspellable on the arm that takes none, so a verb cannot be added
without deciding what it completes. Candidates are `operandForChild`'s answers
over the listing's rows — **called, not re-derived**, with the prefix matched
against its unquoted answer, since a row carries its operand already quoted and
a bare typed prefix could never match that.

A unique candidate is written quoted; a common prefix shorter than a whole
candidate is written **only where it needs no quoting**, because a partial
quoted token is one the split would not read back. The tail is the run after
the last separator and only where it holds no quote or backslash — the one
class where the split's reading and "characters after the last separator"
agree, via a new `tailOfLine` seam in `line.ts` **so there is no second
grammar**.

**A completion is work in flight beside the keys**: read and answer both go
through `guarded`, `enter` under it is held, `ctrl-c` cancels it, and the
prompt **races** the signal so a read that never answers cannot wedge the
prompt. It is written onto the line it was computed for and onto no other — a
key typed after the `tab` is not taken back.

### Ruled and recorded rather than coded around

A multi-segment operand (`cd slugs/bo`) is not completed: its head names a
place the line has not moved to. Options are not completed. Neither is a
`#name` target — that needs an index nothing reads yet.

## Test plan

- `deno task check` 0, `deno fmt --check` 0, `deno lint` 0, `packages/cli`
  216 passed / 0 failed, and sixteen `check-*` gates 0 — all re-run after the
  rebase across #7054 and #7055.
- **`validated 58 / ran 58 / red 58 / survivors [] / did-not-run []`** across
  five modules, through a harness that locates each anchor **inside a named
  region** and verifies every restore by SHA-256.
- **The verdict parser was wrong, and reported 58 of 58 as survivors.** It
  required the reporter line to end with `FAILED`; Deno appends `(1ms)`. Caught
  because "everything survived" is not a possible reading — and closed
  generally by a **baseline pass**: every designated case is read `ok` off an
  unmutated run before anything is mutated, so a parser that can see nothing
  fails loudly rather than reading as a pass.
- **Two vacuous cases found and replaced, both masked rather than wrong**: one
  walked back over the very edit it asked about, overwriting it; the other put
  its quote in the head rather than the token, so it exercised `splitLine`
  instead of `tailOfLine`. A third iterated `VERB_WORDS` — the array under test
  — so no mutation of it could red the case; it now pins the eight words and
  asserts the array equals them.
- **One clause is red by deadlock**: removing the `Promise.race` in
  `startCompleting` ends the run on "Promise resolution is still pending", with
  the case printed and unsettled. That clause's only failure mode is that the
  prompt never returns, so no assertion can carry it.
- `check-no-waitfor` covers none of these files (its scope is
  `packages/*/integration/`); the absence of timers, sleeps and polls was
  verified by hand.

## The rebase

Main moved twice underneath: #7054 and #7055. One conflict in `verbs.ts` —
both sides added an export immediately after the `VERBS` table — kept both.
`prompt.ts` auto-merged and **its content was checked rather than trusted**:
#7054 changed only doc comments there plus a signature already widened here,
and its ruling that the count `edit()` takes is a code-point index rather than
a screen place is consistent with the `tab` guard, which compares two of the
buffer's own counts. Full mutation table re-run after the rebase: 58/58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

