### PR TITLE
refactor(runner): `Runner` takes a deferred-start committer through `accessForTestingOnly` and marks each piece install; `#startCore`, `#startWithTx`, `#catchUpAndStartOnStaleRead`

### DIFF
--- a/docs/specs/pattern-construction/graph-snapshot.md
+++ b/docs/specs/pattern-construction/graph-snapshot.md
@@ -127,7 +127,7 @@ type NodeFactoryDescriptor =
 > **Note:** This describes future implementation work after Phase 1 type
 > unification is complete.
 
-1. When `Runner.startWithTx` iterates nodes during lift/handler execution,
+1. When `Runner.#startWithTx()` iterates nodes during lift/handler execution,
    instrument each instantiation to record:
    - The resolved module descriptor, including implementation reference
    - Normalized input links (already resolved since cells have concrete causes

--- a/docs/specs/pattern-construction/overview.md
+++ b/docs/specs/pattern-construction/overview.md
@@ -64,8 +64,8 @@ metadata, and lifts and handlers gain cause-based identifier stability.
 - Setup merges defaults into the argument cell, materializes
   `derivedInternalCells` into result-relative internal cells, and binds the
   serialized pattern graph via `unwrapOneLevelAndBindToDoc`.
-- `startWithTx` iterates serialized nodes, resolves modules, and calls
-  `instantiateNode`, turning aliases into real `Cell` instances through
+- `Runner.#startWithTx()` iterates serialized nodes, resolves modules, and
+  calls `instantiateNode`, turning aliases into real `Cell` instances through
   `sendValueToBinding`. The scheduler maintains reactivity.
 - Handlers can emit new patterns; lifts that return patterns spawn fresh graphs
   and register teardown hooks.

--- a/docs/specs/server-side-execution/runtime-mapping.md
+++ b/docs/specs/server-side-execution/runtime-mapping.md
@@ -75,7 +75,7 @@ Status legend:
 
 | # | behavior | today (anchor) | v2 doc § | status |
 | --- | --- | --- | --- | --- |
-| 30 | `setup` / `start` / `run` / `runSynced`: argument staging, setup state, node instantiation | `runner.ts:1077`, `1941`, `2950`, `3052`, `Runner.startCore()` | serving-loop §3 (hosted runtime) | COVERED |
+| 30 | `setup` / `start` / `run` / `runSynced`: argument staging, setup state, node instantiation | `runner.ts:1077`, `1941`, `2950`, `3052`, `Runner.#startCore()` | serving-loop §3 (hosted runtime) | COVERED |
 | 31 | Who starts pieces: shell navigation, `ensurePieceRunning` on event, CLI, roots at bootstrap | `ensure-piece-running.ts:97`, `runner.ts:2343-2530` | serving-loop §1 (no piece-start policy; demand-driven pull) | RULED |
 | 32 | `stop` / `stopAll`: cancel groups, start-generation tombstones, lifecycle epochs | `runner.ts:3807-3852`, `3926-3956`, `2056-2077` | serving-loop §1 (park = dispose) | COVERED |
 | 33 | Child pieces from list coordinators (map/filter/flatMap): per-element `runner.run`, identity reuse, release-on-removal, `resumeMode: "always-run"` | `builtins/map.ts:344-412`, release `builtins/list-element-keys.ts:38-59`, registration `scheduler/facade.ts:316-322` | builtins §1 (listed as pure) | CHANGED |

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -850,7 +850,7 @@ at the stamping choke points the scheduler and runner own: the
 reactive-action run, the event dispatch, the pattern swap, and — the
 PIECE-START site (RULED 2026-08-13, the F1 fold-in) — the
 demanded-piece startup path's setup/instantiation writes
-(`ensurePieceRunning` → start → `startCore`: the self-minted
+(`ensurePieceRunning` → start → `Runner.#startCore()`: the self-minted
 instantiation tx, the missing-stream-marker setup REPAIR, the
 deferred piece-start/run transactions, and the runtime-internal
 pattern-update/rollforward writes — the same `applySetupState`

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6104,8 +6104,8 @@ supply; OW29/OW32/OW34 closed):
     that registration, still current, is handed off — because a
     COMPETING start can install into the registry the recovery's
     entry emptied with no stop and so no generation bump
-    (`Runner.#startCore()`'s
-    unconditional install; the only bump sites live in stopResult),
+    (`Runner.#startCore()`'s unconditional install; the only bump
+    sites live in stopResult),
     and the walk's already-started returns report it as success; on
     a foreign registration the recovery YIELDS exactly as
     `Runner.#startWithTx()` yields on an owned key (the piece runs under the

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6051,7 +6051,7 @@ supply; OW29/OW32/OW34 closed):
     > servers fills in, it converges, done)."
 
     — owner (Berni), 2026-08-24. As built (`runner.ts`
-    `catchUpAndStartOnStaleRead` + `startFromServedState`; the
+    `Runner.#catchUpAndStartOnStaleRead()` + `startFromServedState`; the
     readiness `awaitCommitRetryReadiness` cherry-picked from closed
     #6208 along with its discriminator — the retry itself
     deliberately NOT brought): both deferred-start arms' stale-read
@@ -6100,21 +6100,22 @@ supply; OW29/OW32/OW34 closed):
     foreign registration into (the delta review's D2, closed by
     construction) — and the hand-off is IDENTITY-EXACT (Cubic P1,
     post-mini-delta, confirmed and fixed red-first): the attempt
-    records the registration its OWN startCore created, and only
+    records the registration its OWN `Runner.#startCore()` created, and only
     that registration, still current, is handed off — because a
     COMPETING start can install into the registry the recovery's
-    entry emptied with no stop and so no generation bump (startCore's
+    entry emptied with no stop and so no generation bump
+    (`Runner.#startCore()`'s
     unconditional install; the only bump sites live in stopResult),
     and the walk's already-started returns report it as success; on
     a foreign registration the recovery YIELDS exactly as
-    `startWithTx` yields on an owned key (the piece runs under the
+    `Runner.#startWithTx()` yields on an owned key (the piece runs under the
     competitor's authority — an independent navigate keeps its
     life). After the hand-off the parent's one Cancel handle stops
     the recovered run, and a cancel that landed during the wait or
     the walk is finished by that markInstalled against the real
     registration: stopped in the same breath, the walk reporting
     not-running. If another start took the key during the wait, the
-    recovery yields exactly as `startWithTx` yields on an owned
+    recovery yields exactly as `Runner.#startWithTx()` yields on an owned
     key. The recovery arm commits nothing (store-door pin: zero
     `commitNative` calls post-refusal), mints no transaction, and
     re-issues the one-shot pull the refused commit's success arm

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -1791,8 +1791,8 @@ describe("opening a space root", () => {
     // fails to load), so there is no patternIdentity watcher when the swap
     // lands. ensureDefaultPattern reconciles BEFORE start
     // (startEnsuredDefaultPattern -> checkAndUpdateDefaultPattern), then
-    // cold-starts the piece — and Runner.startCore's initial instantiation
-    // does not run the setup phase, so the incoming pattern's
+    // cold-starts the piece — and `Runner.#startCore()`'s initial
+    // instantiation does not run the setup phase, so the incoming pattern's
     // { "$stream": true } markers were never materialized on the reused doc.
 
     await setupHome();

--- a/packages/runner/src/builtins/navigate-to.ts
+++ b/packages/runner/src/builtins/navigate-to.ts
@@ -43,8 +43,8 @@ export function navigateTo(
     // A SERVED run never consults the `navigated` closure state
     // (independent review M2, 2026-08-11): the running builtin instance
     // and its closure are REUSED across a wave requeue (runner.ts's
-    // startWithTx cancels-guard), so closure state would suppress the
-    // re-issue a requeued event's wave-2 re-run owes — the handler's
+    // `Runner.#startWithTx()` cancels-guard), so closure state would suppress
+    // the re-issue a requeued event's wave-2 re-run owes — the handler's
     // consequences re-landed while the intent stayed lost forever.
     // Store-derived state governs the served arm instead: the
     // result-cell read below returns a LANDED navigation early (and a

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1324,7 +1324,7 @@ export type DependencySyncer = (
 export type DeferredStartCommit = () => Promise<Result<Unit, CommitError>>;
 
 /**
- * The commit a test supplies in place of `Runner`'s own step for a
+ * The committer a test supplies around `Runner`'s own commit of a
  * commit-gated start's transaction. It receives that step as `commit`, so
  * it can refuse the transaction in its stead, mark it before the store sees
  * it, or observe its verdict; `resultCell` is the piece the start is for.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -131,12 +131,15 @@ import { rendererVDOMSchema } from "./schemas.ts";
 import { flattenBuilderArtifacts } from "./storage-preflight.ts";
 import { TransactionWrapper } from "./storage/extended-storage-transaction.ts";
 import {
+  type CommitError,
   type DID,
   type IExtendedStorageTransaction,
   type IReadOptions,
   type IStorageSubscription,
   type MemorySpace,
+  type Result,
   toThrowable,
+  type Unit,
   type URI,
 } from "./storage/interface.ts";
 import {
@@ -256,7 +259,7 @@ type StartAttempt = {
   // The result this attempt resolved to, which a link start only learns by
   // following the link.
   targetKey?: `${MemorySpace}/${ScopeKey}/${URI}`;
-  // The exact registration THIS attempt's startCore created, when it
+  // The exact registration THIS attempt's `#startCore()` created, when it
   // created one. A walk can also report success for a registration it did
   // NOT create (doStart's already-started returns, including the
   // mid-resume re-check) — a COMPETING start can install into a registry
@@ -1049,7 +1052,7 @@ const markPieceOwnedStores = (
  * from its stored identity — a cold replica loading one — enrolls too, and so
  * that a setup attempt that never commits enrolls nothing. It runs again on
  * every re-instantiation, which is idempotent; the enrollment goes out once,
- * with the piece, at the release `startCore` registers.
+ * with the piece, at the release `Runner.#startCore()` registers.
  */
 const enrollPieceOwnedStores = (
   tx: IExtendedStorageTransaction,
@@ -1314,6 +1317,24 @@ export type DependencySyncer = (
   sync: DependencySync,
 ) => Promise<boolean>;
 
+/**
+ * Commits a commit-gated start's transaction and resolves to its verdict:
+ * the shape of `Runner`'s own step.
+ */
+export type DeferredStartCommit = () => Promise<Result<Unit, CommitError>>;
+
+/**
+ * The commit a test supplies in place of `Runner`'s own step for a
+ * commit-gated start's transaction. It receives that step as `commit`, so
+ * it can refuse the transaction in its stead, mark it before the store sees
+ * it, or observe its verdict; `resultCell` is the piece the start is for.
+ */
+export type DeferredStartCommitter = (
+  tx: IExtendedStorageTransaction,
+  resultCell: Cell<any>,
+  commit: DeferredStartCommit,
+) => Promise<Result<Unit, CommitError>>;
+
 type RunResult<R> = {
   resultCell: Cell<R>;
 
@@ -1402,7 +1423,8 @@ const LIST_OP_INPUT_SCHEMAS = {
   flatMap: FLATMAP_INPUT_SCHEMA,
 } as const;
 
-// Options shared by run()/startWithTx()/startAfterSuccessfulCommit().
+// Options shared by `run()`, `#startWithTx()`, and
+// `#startAfterSuccessfulCommit()`.
 type RunnerRunOptions = {
   doNotUpdateOnPatternChange?: boolean;
   // Resumed-from-synced-state: hold each action's initial rehydration/run until
@@ -1918,11 +1940,11 @@ export class Runner {
   /**
    * In-flight catch-up recoveries of commit-gated starts whose transaction lost
    * its basis to the serving side's own first-hydration materialization (see
-   * `catchUpAndStartOnStaleRead()`). _Never_ awaited by `dispose()`, for the
-   * same reason as the watcher loads above: the readiness gate they await is a
-   * session catch-up, which a closing runtime may never reach, and a cancelled
-   * ownership already tombstones the work. Tracked solely so tests can
-   * synchronize deterministically.
+   * `#catchUpAndStartOnStaleRead()`). _Never_ awaited by `dispose()`, for
+   * the same reason as the watcher loads above: the readiness gate they await
+   * is a session catch-up, which a closing runtime may never reach, and a
+   * cancelled ownership already tombstones the work. Tracked solely so tests
+   * can synchronize deterministically.
    */
   #pendingDeferredStartCatchUps = new Set<Promise<unknown>>();
 
@@ -2123,6 +2145,12 @@ export class Runner {
    */
   #dependencySyncer: DependencySyncer | undefined = undefined;
 
+  /**
+   * The committer a test supplies around a commit-gated start's commit;
+   * `undefined` means the runner's own.
+   */
+  #deferredStartCommitter: DeferredStartCommitter | undefined = undefined;
+
   #crossSpaceChildSpaces = new WeakMap<
     IExtendedStorageTransaction,
     MemorySpace[]
@@ -2142,10 +2170,10 @@ export class Runner {
 
   /**
    * The result and pointer tables, the deferred-start and start-attempt
-   * sets, the dependency syncer a test may supply, the setup,
-   * storage-subscription, commit-gated run, ownership, key, sync, walk, and
-   * retry steps, and the implementation invoker, which a test drives
-   * directly.
+   * sets, the dependency syncer and deferred-start committer a test may
+   * supply, the setup, storage-subscription, commit-gated run, ownership,
+   * key, sync, walk, and retry steps, and the implementation invoker, which
+   * a test drives directly.
    */
   get accessForTestingOnly(): {
     readonly locallyPreparedResults: BoundedKeyMap<
@@ -2170,6 +2198,7 @@ export class Runner {
     >;
     readonly activeStartAttempts: Set<StartAttempt>;
     dependencySyncer: DependencySyncer | undefined;
+    deferredStartCommitter: DeferredStartCommitter | undefined;
     createStorageSubscription(): IStorageSubscription;
     setupInternal<T, R>(
       providedTx: IExtendedStorageTransaction | undefined,
@@ -2237,6 +2266,12 @@ export class Runner {
       },
       set dependencySyncer(value) {
         outerThis.#dependencySyncer = value;
+      },
+      get deferredStartCommitter() {
+        return outerThis.#deferredStartCommitter;
+      },
+      set deferredStartCommitter(value) {
+        outerThis.#deferredStartCommitter = value;
       },
       createStorageSubscription: () => this.#createStorageSubscription(),
       // Forwards to the TypeScript-private member so that a test which
@@ -3689,7 +3724,7 @@ export class Runner {
       // an entity id with the space-scoped root, so omitting scope would
       // misclassify it as the root and silently suppress its heal. `path` is
       // intentionally not compared: doStart normalizes a subpath input to its
-      // root before startCore, so resultCell is always a root cell here.
+      // root before `#startCore()`, so resultCell is always a root cell here.
       return a.space === b.space &&
         (a.scope ?? "space") === (b.scope ?? "space") &&
         a.id === b.id;
@@ -3734,12 +3769,8 @@ export class Runner {
    * @param options.tx - Transaction to use for initial setup (optional)
    * @param options.givenPattern - Pattern to use instead of looking up by ID
    * @returns The exact cancel registration installed for this start
-   *
-   * TypeScript-private rather than a `#` name, because
-   * `test/deferred-start-catchup-start.test.ts` replaces this member by
-   * assignment, which a `#` method does not allow.
    */
-  private startCore<T = any>(
+  #startCore<T = any>(
     resultCell: Cell<T>,
     options: {
       tx?: IExtendedStorageTransaction;
@@ -3759,6 +3790,9 @@ export class Runner {
       doNotUpdateOnPatternChange,
     } = options;
     const key = this.#getDocKey(resultCell);
+    // Before the registration below is set, so that a listener reads the
+    // registry as it stood when this install began.
+    this.#runtime.telemetry.submit({ type: "runner.piece.install", key });
     this.#locallyStoppedResults.delete(key);
 
     // Create cancel group early, before wiring pattern/node sinks.
@@ -4455,7 +4489,7 @@ export class Runner {
         // precondition read or prepare throwing) aborts the tx and rethrows the
         // ORIGINAL instantiate error, so the piece is left exactly as it was.
         const repairTx = this.#runtime.edit();
-        // Self-minted repair tx inside startCore — piece machinery with
+        // Self-minted repair tx inside `#startCore()` — piece machinery with
         // no scheduler run around it; bookkeeping per serving-loop.md
         // §3d (reachable server-side via the demand loader's start).
         this.#runtime.stampServerRun(repairTx, {
@@ -4808,7 +4842,7 @@ export class Runner {
     if (wasPreparedLocally || wasStoppedLocally) {
       if (!this.#isStartAttemptCurrent(attempt)) return Promise.resolve(false);
       try {
-        attempt.installedRegistration = this.startCore(rootCell, {
+        attempt.installedRegistration = this.#startCore(rootCell, {
           givenPattern: resolvedPattern,
         });
       } catch (err) {
@@ -4854,7 +4888,7 @@ export class Runner {
 
       const startCoreStart = performance.now();
       try {
-        attempt.installedRegistration = this.startCore(rootCell, {
+        attempt.installedRegistration = this.#startCore(rootCell, {
           givenPattern: resolvedPattern,
           schedulerRehydration: this.#schedulerRehydrationOptions(
             rootCell,
@@ -4879,12 +4913,8 @@ export class Runner {
   /**
    * Starts the pattern behind `resultCell` inside `tx`, returning the
    * registration's cancel, or nothing when there was nothing to start.
-   *
-   * TypeScript-private rather than a `#` name, because
-   * `test/deferred-start-catchup-start.test.ts` replaces this member by
-   * assignment, which a `#` method does not allow.
    */
-  private startWithTx<T = any>(
+  #startWithTx<T = any>(
     tx: IExtendedStorageTransaction,
     resultCell: Cell<T>,
     givenPattern?: Pattern,
@@ -4893,13 +4923,28 @@ export class Runner {
     const key = this.#getDocKey(resultCell);
     if (this.#cancels.has(key)) return undefined;
 
-    return this.startCore(resultCell, {
+    return this.#startCore(resultCell, {
       tx,
       givenPattern,
       doNotUpdateOnPatternChange: options.doNotUpdateOnPatternChange,
       awaitSyncBeforeInitialRun: options.awaitSyncBeforeInitialRun,
       parentPieceRootId: options.parentPieceRootId,
     });
+  }
+
+  /**
+   * Commits `tx`, a commit-gated start's transaction for `resultCell`, and
+   * resolves to its verdict. A committer a test supplied wraps the commit.
+   */
+  #commitDeferredStart(
+    tx: IExtendedStorageTransaction,
+    resultCell: Cell<any>,
+  ): Promise<Result<Unit, CommitError>> {
+    const committer = this.#deferredStartCommitter;
+    const commit: DeferredStartCommit = () => tx.commit();
+    return committer === undefined
+      ? commit()
+      : committer(tx, resultCell, commit);
   }
 
   #createDeferredStartOwnership<T>(
@@ -5015,7 +5060,7 @@ export class Runner {
         startTx,
       );
       try {
-        const installedRegistration = this.startWithTx(
+        const installedRegistration = this.#startWithTx(
           startTx,
           committedResultCell,
           givenPattern,
@@ -5026,10 +5071,10 @@ export class Runner {
           return;
         }
         this.#runtime.prepareTxForCommit(startTx);
-        startTx.commit().then(({ error }) => {
+        this.#commitDeferredStart(startTx, resultCell).then(({ error }) => {
           if (error) {
             if (
-              this.catchUpAndStartOnStaleRead(
+              this.#catchUpAndStartOnStaleRead(
                 error,
                 resultCell,
                 "start",
@@ -5086,7 +5131,7 @@ export class Runner {
    * the client reads their targets as absent, so the client's basis is
    * stale whenever the interleaving is tight — the EXPECTED outcome of
    * losing the race, not an exceptional one. Terminating there is what
-   * made the race fatal: `startWithTx` has already installed the
+   * made the race fatal: `#startWithTx()` has already installed the
    * client-side piece inside the transaction when the refusal lands, the
    * error arm's cancel tears that install down, and nothing re-runs it —
    * the piece has no client context for the rest of the session and every
@@ -5146,7 +5191,7 @@ export class Runner {
    * mapping — the same synchronous block as the claim checks, no
    * promise hop for a stop+restart to slip a foreign registration into
    * (delta review D2) — and the hand-off is EXACT: only the
-   * registration this attempt's own startCore created, still current
+   * registration this attempt's own `#startCore()` created, still current
    * (Cubic P1 — a COMPETING start can install into the registry the
    * recovery's entry emptied with no stop and so no generation bump,
    * and the walk's already-started returns report it as success; an
@@ -5158,17 +5203,13 @@ export class Runner {
    * real registration: the run is stopped in the same breath and the
    * walk reports not-running.
    * If another start took the key while the recovery waited, the
-   * recovery yields exactly as `startWithTx` yields on an owned key:
+   * recovery yields exactly as `#startWithTx()` yields on an owned key:
    * the piece has a context under someone else's authority, and the
    * token settles without touching it. The lifecycle epoch still covers
    * the one window no token can: a teardown that ran before the
    * refusal's continuation, whose sweep could not see this scheduling.
-   *
-   * TypeScript-private rather than a `#` name, because
-   * `test/deferred-start-catchup-start.test.ts` replaces this member by
-   * assignment, which a `#` method does not allow.
    */
-  private catchUpAndStartOnStaleRead<T>(
+  #catchUpAndStartOnStaleRead<T>(
     error: { name?: string; message?: string },
     resultCell: Cell<T>,
     label: string,
@@ -5243,8 +5284,8 @@ export class Runner {
         }
         if (this.#cancels.has(key)) {
           // Another start took the key while the recovery waited — the
-          // same yield startWithTx makes on an owned key. The piece HAS a
-          // context under someone else's authority; the recovery's purpose
+          // same yield `#startWithTx()` makes on an owned key. The piece HAS
+          // a context under someone else's authority; the recovery's purpose
           // is met and its claim dissolves. Settling the token touches no
           // live registration (its stale install no longer matches).
           ownership.cancel();
@@ -5363,7 +5404,7 @@ export class Runner {
               // success. The piece runs under the competitor's
               // authority; binding it to the caller's token would let a
               // parent cancel tear down a run whose lifecycle the
-              // parent does not own. Yield exactly as startWithTx
+              // parent does not own. Yield exactly as `#startWithTx()`
               // yields on an owned key: settle the token without
               // touching the registration.
               ownership.cancel();
@@ -5456,10 +5497,10 @@ export class Runner {
           );
         }
         this.#runtime.prepareTxForCommit(startTx);
-        startTx.commit().then(({ error }) => {
+        this.#commitDeferredStart(startTx, resultCell).then(({ error }) => {
           if (error) {
             if (
-              this.catchUpAndStartOnStaleRead(
+              this.#catchUpAndStartOnStaleRead(
                 error,
                 resultCell,
                 "cross-space pattern",
@@ -5628,7 +5669,7 @@ export class Runner {
           pullOnceAfterStart,
         );
       } else {
-        installedCancel = this.startWithTx(
+        installedCancel = this.#startWithTx(
           tx,
           resultCell,
           pattern,
@@ -5932,7 +5973,7 @@ export class Runner {
 
       if (setupRes?.needsStart) {
         if (givenTx) {
-          this.startWithTx(
+          this.#startWithTx(
             givenTx,
             resultCell.withTx(givenTx),
             setupRes.pattern,
@@ -7208,11 +7249,11 @@ export class Runner {
 
   /**
    * TESTS ONLY: settle in-flight catch-up recoveries of commit-gated starts
-   * (see `catchUpAndStartOnStaleRead`). Loops in case a settled recovery's
-   * continuation schedules another. Never called from dispose(): the
-   * readiness gate a recovery awaits is a session catch-up, which a closing
-   * runtime need never reach — a cancelled ownership is what stops the work
-   * there.
+   * (see `#catchUpAndStartOnStaleRead()`). Loops in case a settled
+   * recovery's continuation schedules another. Never called from dispose():
+   * the readiness gate a recovery awaits is a session catch-up, which a
+   * closing runtime need never reach — a cancelled ownership is what stops
+   * the work there.
    */
   async idleDeferredStartCatchUps(): Promise<void> {
     while (this.#pendingDeferredStartCatchUps.size > 0) {
@@ -7239,7 +7280,7 @@ export class Runner {
     // Invalidate every asynchronous start continuation before canceling live
     // registrations. In-flight snapshot listings may still resolve after
     // storage teardown, but they can neither publish a cache nor call
-    // startCore under the new epoch.
+    // `#startCore()` under the new epoch.
     this.#lifecycleEpoch++;
     // The epoch change already makes every held attempt non-current, so no
     // later start can join one; dropping the index releases the attempts too.

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -163,6 +163,12 @@ export type RuntimeTelemetryMarker = {
   durationMs: number;
   error?: string;
 } | {
+  // Emitted as the runner begins installing a piece's registration under
+  // `key`, BEFORE the registration is set: a listener reads the registry as
+  // it stood when the install began.
+  type: "runner.piece.install";
+  key: string;
+} | {
   // Emitted once per settle pass, unconditionally (unlike SettleStats, which
   // is opt-in): the user-facing "event → stable graph" number.
   type: "scheduler.settle";

--- a/packages/runner/test/cfc-runtime-owned-store-wiring.test.ts
+++ b/packages/runner/test/cfc-runtime-owned-store-wiring.test.ts
@@ -26,7 +26,8 @@ const elsewhere =
  * `cfc-writer-fit.test.ts` states the RULE against a hand-recorded marker.
  * These run a real piece, so they cover the wiring the rule rests on: which
  * transaction names the stores, and when the enrollment ends. A hand-recorded
- * marker cannot tell whether `startCore` registered anything at all.
+ * marker cannot tell whether `Runner.#startCore()` registered anything at
+ * all.
  */
 describe("runtime-owned-store enrollment wiring", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/deferred-start-catchup-start.test.ts
+++ b/packages/runner/test/deferred-start-catchup-start.test.ts
@@ -10,6 +10,8 @@ import {
 } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
 import { entityKey } from "../src/scheduler/keys.ts";
+import type { CommitError } from "../src/storage/interface.ts";
+import type { RuntimeTelemetryEvent } from "../src/telemetry.ts";
 
 // A commit-gated piece start whose transaction is REFUSED for a stale
 // confirmed read. Under server-side execution that refusal is the expected
@@ -34,27 +36,27 @@ import { entityKey } from "../src/scheduler/keys.ts";
 // today's terminal behavior, pinned below.
 //
 // These tests drive the runner through its public surface and refuse the
-// START transaction at the transaction seam — the idiom this package already
-// uses to isolate a commit-classification decision from every other moving
-// part (edit-with-retry-classification.test.ts,
-// compile-cache-writeback-conflict.test.ts). Refusing at the memory server
-// instead cannot reach this path: a start whose setup already committed with
-// its handler's transaction carries no operations of its own, so its commit
-// never makes a server round trip at all, while the real first-hydration
-// start (whose setup rides the start) does. The refusal object is the shape
-// `toRejectedError` (storage/v2.ts) produces from the wire — the engine's own
-// message text, plus the conflict descriptor it parses out of it — so the
-// discriminator under test sees exactly what a real refusal presents.
+// START transaction at the runner's own commit seam: the deferred-start
+// committer it takes through `accessForTestingOnly`, which is handed exactly
+// the transaction under test and no other commit of the run. Refusing at the
+// memory server instead cannot reach this path: a start whose setup already
+// committed with its handler's transaction carries no operations of its own,
+// so its commit never makes a server round trip at all, while the real
+// first-hydration start (whose setup rides the start) does. The refusal
+// object is the shape `toRejectedError` (storage/v2.ts) produces from the
+// wire — the engine's own message text, plus the conflict descriptor it
+// parses out of it — so the discriminator under test sees exactly what a
+// real refusal presents.
 
 const signer = await Identity.fromPassphrase("deferred start catch up");
 const space = signer.did();
 
 /**
  * Refuse the first `count` START transactions with `error`, and nothing
- * else. A start transaction is recognized by the runner handing it to
- * `startWithTx` — which happens before the commit — so this refuses exactly
- * the transaction under test and leaves every other commit of the run
- * (the setup, the scheduler's runs, the readiness pull) untouched.
+ * else. A start transaction is the one the runner hands its deferred-start
+ * committer, so this refuses exactly the transaction under test and leaves
+ * every other commit of the run (the setup, the scheduler's runs, the
+ * readiness pull) untouched.
  *
  * With `count` at MAX_SAFE_INTEGER the injector doubles as the NO-RECOMMIT
  * witness: any second commit of a start-marked transaction would be refused
@@ -82,40 +84,24 @@ function refuseDeferredStartCommits(
   refusals(): number;
   restore(): void;
 } {
-  const originalEdit = runtime.edit.bind(runtime);
-  const runner = runtime.runner as unknown as {
-    startWithTx: (...args: unknown[]) => () => void;
-  };
-  const originalStartWithTx = runner.startWithTx;
-  const startTransactions = new WeakSet<object>();
+  const harness = runtime.runner.accessForTestingOnly;
   const waiters = new Map<number, ReturnType<typeof Promise.withResolvers>>();
   let refusals = 0;
 
-  runner.startWithTx = (...args: unknown[]) => {
-    startTransactions.add(args[0] as object);
-    return Reflect.apply(originalStartWithTx, runtime.runner, args) as () =>
-      void;
+  expect(harness.deferredStartCommitter).toBeUndefined();
+  harness.deferredStartCommitter = (tx, _resultCell, commit) => {
+    if (refusals >= count) return commit();
+    refusals++;
+    onRefusal?.();
+    for (const [at, waiter] of waiters) {
+      if (at <= refusals) waiter.resolve(undefined);
+    }
+    // A refused commit applies nothing, so discard this attempt's writes
+    // the way the rollback behind a server refusal does. The refusal is the
+    // wire's shape, declared here as the commit error it stands in for.
+    tx.abort(error.message);
+    return Promise.resolve({ error: error as CommitError });
   };
-
-  (runtime as unknown as { edit: typeof runtime.edit }).edit = ((
-    ...args: Parameters<typeof runtime.edit>
-  ) => {
-    const tx = originalEdit(...args);
-    const commit = tx.commit.bind(tx);
-    (tx as unknown as { commit: typeof tx.commit }).commit = (() => {
-      if (refusals >= count || !startTransactions.has(tx)) return commit();
-      refusals++;
-      onRefusal?.();
-      for (const [at, waiter] of waiters) {
-        if (at <= refusals) waiter.resolve(undefined);
-      }
-      // A refused commit applies nothing, so discard this attempt's writes
-      // the way the rollback behind a server refusal does.
-      tx.abort(error.message);
-      return Promise.resolve({ error });
-    }) as typeof tx.commit;
-    return tx;
-  }) as typeof runtime.edit;
 
   return {
     refusalsReach: (n: number) => {
@@ -129,8 +115,7 @@ function refuseDeferredStartCommits(
     },
     refusals: () => refusals,
     restore: () => {
-      (runtime as unknown as { edit: typeof runtime.edit }).edit = originalEdit;
-      runner.startWithTx = originalStartWithTx;
+      harness.deferredStartCommitter = undefined;
     },
   };
 }
@@ -149,52 +134,41 @@ async function waitForSignal(
 }
 
 /**
- * Watch the runner assemble the client-side piece context for one result:
- * how many context installs ran, and whether one ever ran while a previous
- * one was still registered — the double-install question a recovery raises.
+ * Watch the runner assemble the client-side piece context for the result
+ * registered under `key`: how many context installs ran, and whether one
+ * ever ran while a previous one was still registered — the double-install
+ * question a recovery raises.
  *
- * Hooked at `startCore` rather than `startWithTx`, because the two context
- * paths meet there: the deferred first attempt reaches it through
- * `startWithTx`, and the catch-up recovery reaches it through the ordinary
- * load walk (`doStart`), which never passes `startWithTx` at all.
- *
- * Deliberately passes `startCore`'s return value through UNCHANGED. The
- * runner compares that exact cancel against its registry to decide whether
- * an ownership still owns the registration, so a harness that wraps it
- * silently suppresses every teardown and would manufacture the very
- * concurrency it claims to measure. Liveness is read from the runner's own
- * registry instead.
+ * Read from the `runner.piece.install` marker, which the runner emits as an
+ * install begins and before it registers, on both context paths: the
+ * deferred first attempt's and the catch-up recovery's ordinary load walk.
+ * Liveness is read from the runner's own registry.
  */
 function observeContextInstalls(
   runtime: Runtime,
-  matches: (cell: Cell<unknown>) => boolean,
-  registered: () => boolean,
+  key: ReturnType<typeof entityKey>,
 ): {
   installs(): number;
   everConcurrent(): boolean;
   nth(n: number): Promise<void>;
   restore(): void;
 } {
-  const runner = runtime.runner as unknown as {
-    startCore: (...args: unknown[]) => () => void;
-  };
-  const original = runner.startCore;
   const waiters = new Map<number, ReturnType<typeof Promise.withResolvers>>();
   let installs = 0;
   let everConcurrent = false;
 
-  runner.startCore = (...args: unknown[]) => {
-    if (matches(args[0] as Cell<unknown>)) {
-      // Read BEFORE this install registers: a registration still standing
-      // here belongs to a previous attempt that was never torn down.
-      if (registered()) everConcurrent = true;
-      installs++;
-      for (const [at, waiter] of waiters) {
-        if (at <= installs) waiter.resolve(undefined);
-      }
+  const listener = (event: Event) => {
+    const { marker } = (event as RuntimeTelemetryEvent).detail;
+    if (marker.type !== "runner.piece.install" || marker.key !== key) return;
+    // Read BEFORE this install registers: a registration still standing
+    // here belongs to a previous attempt that was never torn down.
+    if (runtime.runner.cancels.has(key)) everConcurrent = true;
+    installs++;
+    for (const [at, waiter] of waiters) {
+      if (at <= installs) waiter.resolve(undefined);
     }
-    return Reflect.apply(original, runtime.runner, args) as () => void;
   };
+  runtime.telemetry.addEventListener("telemetry", listener);
 
   return {
     installs: () => installs,
@@ -209,7 +183,7 @@ function observeContextInstalls(
       return waiter.promise as Promise<void>;
     },
     restore: () => {
-      runner.startCore = original;
+      runtime.telemetry.removeEventListener("telemetry", listener);
     },
   };
 }
@@ -281,6 +255,24 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     );
   }
 
+  // A stale-confirmed-read refusal whose readiness gate forces the recovery's
+  // walk onto the RESUME path. The gate runs AFTER the recovery's entry (whose
+  // teardown re-arms the local-assembly shortcuts) and BEFORE the walk;
+  // clearing the shortcuts there sends the walk through its dependency
+  // pre-sync, whose await is the real-world interleaving window (a cold
+  // resume looks exactly like this) and the seam a test can act inside.
+  function resumingRefusalOf(cell: Cell<unknown>) {
+    const harness = runtime.runner.accessForTestingOnly;
+    return {
+      ...staleConfirmedReadOf(cell),
+      readyToRetry: () => {
+        harness.locallyStoppedResults.delete(key(cell));
+        harness.locallyPreparedResults.delete(key(cell));
+        return Promise.resolve();
+      },
+    };
+  }
+
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
     // EXPLICITLY flag-ON, with no serving posture: a flag-ON CLIENT — the
@@ -318,11 +310,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       Number.MAX_SAFE_INTEGER,
     );
     const storeCommits = countStoreCommits(storageManager);
-    const installed = observeContextInstalls(
-      runtime,
-      (cell) => key(cell) === key(result),
-      () => runtime.runner.cancels.has(key(result)),
-    );
+    const installed = observeContextInstalls(runtime, key(result));
     try {
       runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
       expect((await tx.commit()).error).toBeUndefined();
@@ -383,11 +371,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       runtime,
       staleConfirmedReadOf(result),
     );
-    const installed = observeContextInstalls(
-      runtime,
-      (cell) => key(cell) === key(result),
-      () => runtime.runner.cancels.has(key(result)),
-    );
+    const installed = observeContextInstalls(runtime, key(result));
     try {
       runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
       expect((await tx.commit()).error).toBeUndefined();
@@ -443,11 +427,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       // the install-still-current check can cover.
       () => runtime.runner.stop(result),
     );
-    const installed = observeContextInstalls(
-      runtime,
-      (cell) => key(cell) === key(result),
-      () => runtime.runner.cancels.has(key(result)),
-    );
+    const installed = observeContextInstalls(runtime, key(result));
     try {
       runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
       expect((await tx.commit()).error).toBeUndefined();
@@ -496,11 +476,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       runtime,
       staleConfirmedReadOf(result),
     );
-    const installed = observeContextInstalls(
-      runtime,
-      (cell) => key(cell) === key(result),
-      () => runtime.runner.cancels.has(key(result)),
-    );
+    const installed = observeContextInstalls(runtime, key(result));
     try {
       const { cancelDeferredStart } = harness.runWithStartOwnership(
         tx,
@@ -556,20 +532,10 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       undefined,
       tx,
     );
-    // The refusal carries a readiness gate that runs AFTER the recovery's
-    // entry (whose teardown re-arms the local-assembly shortcuts) and
-    // BEFORE the walk: clearing the shortcuts there forces the walk onto
-    // the RESUME path, whose dependency-sync await is the real-world
-    // interleaving window (a cold resume looks exactly like this).
-    const refusal = {
-      ...staleConfirmedReadOf(result),
-      readyToRetry: () => {
-        harness.locallyStoppedResults.delete(key(result));
-        harness.locallyPreparedResults.delete(key(result));
-        return Promise.resolve();
-      },
-    };
-    const injector = refuseDeferredStartCommits(runtime, refusal);
+    const injector = refuseDeferredStartCommits(
+      runtime,
+      resumingRefusalOf(result),
+    );
     // The competitor: a second, independent public start of the same
     // result (the navigate landing flow), fired inside the recovery
     // walk's dependency-sync await.
@@ -635,11 +601,6 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       doubled: lift((input: number) => input * 2)(value),
     }));
     const harness = runtime.runner.accessForTestingOnly;
-    // Replaced by assignment below, which only a TypeScript-private member
-    // allows, so it is reached the old way.
-    const stubbed = runtime.runner as unknown as {
-      startCore: (...args: unknown[]) => () => void;
-    };
     const tx = gatedTxOn(runtime);
     const result = runtime.getCell<{ doubled?: number }>(
       space,
@@ -649,20 +610,17 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     );
     const injector = refuseDeferredStartCommits(
       runtime,
-      staleConfirmedReadOf(result),
+      resumingRefusalOf(result),
     );
-    // Fire the parent's handle synchronously INSIDE the recovery's context
-    // assembly — the widest point of the walk window.
+    const installed = observeContextInstalls(runtime, key(result));
+    // Fire the parent's handle INSIDE the recovery's walk: at its dependency
+    // pre-sync, after the readiness wait resolved and before the walk's
+    // install lands. Only the recovery's walk pre-syncs this result; the
+    // refused attempt's install never passed this step.
     let parentCancel: (() => void) | undefined;
-    let assemblies = 0;
-    const originalStartCore = stubbed.startCore;
-    stubbed.startCore = (...args: unknown[]) => {
-      if (key(args[0] as Cell<unknown>) === key(result)) {
-        assemblies++;
-        if (assemblies === 2) parentCancel?.();
-      }
-      return Reflect.apply(originalStartCore, runtime.runner, args) as () =>
-        void;
+    harness.dependencySyncer = (cell, executable, inputs, sync) => {
+      if (key(cell) === key(result)) parentCancel?.();
+      return sync(cell, executable, inputs);
     };
     try {
       const { cancelDeferredStart } = harness.runWithStartOwnership(
@@ -686,10 +644,11 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       // Both assemblies ran (the refused attempt's and the recovery's),
       // the mid-walk cancel landed, and NOTHING stays registered: the
       // recovered run was stopped, not leaked.
-      expect(assemblies).toBe(2);
+      expect(installed.installs()).toBe(2);
       expect(runtime.runner.cancels.has(key(result))).toBe(false);
     } finally {
-      stubbed.startCore = originalStartCore;
+      harness.dependencySyncer = undefined;
+      installed.restore();
       injector.restore();
     }
   });
@@ -715,11 +674,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       runtime,
       staleConfirmedReadOf(result),
     );
-    const installed = observeContextInstalls(
-      runtime,
-      (cell) => key(cell) === key(result),
-      () => runtime.runner.cancels.has(key(result)),
-    );
+    const installed = observeContextInstalls(runtime, key(result));
     try {
       runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
       expect((await tx.commit()).error).toBeUndefined();
@@ -772,11 +727,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       // flight, so the teardown cannot see a token that does not exist yet.
       () => runtime.runner.stopAll(),
     );
-    const installed = observeContextInstalls(
-      runtime,
-      (cell) => key(cell) === key(result),
-      () => runtime.runner.cancels.has(key(result)),
-    );
+    const installed = observeContextInstalls(runtime, key(result));
     try {
       runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
       expect((await tx.commit()).error).toBeUndefined();
@@ -823,11 +774,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       },
     };
     const injector = refuseDeferredStartCommits(runtime, refusal);
-    const installed = observeContextInstalls(
-      runtime,
-      (cell) => key(cell) === key(result),
-      () => runtime.runner.cancels.has(key(result)),
-    );
+    const installed = observeContextInstalls(runtime, key(result));
     try {
       runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
       expect((await tx.commit()).error).toBeUndefined();
@@ -891,11 +838,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       },
       Number.MAX_SAFE_INTEGER,
     );
-    const installed = observeContextInstalls(
-      runtime,
-      (cell) => key(cell) === key(result),
-      () => runtime.runner.cancels.has(key(result)),
-    );
+    const installed = observeContextInstalls(runtime, key(result));
     try {
       runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
       expect((await tx.commit()).error).toBeUndefined();
@@ -972,11 +915,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
         refusal,
         Number.MAX_SAFE_INTEGER,
       );
-      const installed = observeContextInstalls(
-        runtime,
-        (cell) => key(cell) === key(result),
-        () => runtime.runner.cancels.has(key(result)),
-      );
+      const installed = observeContextInstalls(runtime, key(result));
       try {
         runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
         expect((await tx.commit()).error).toBeUndefined();
@@ -1016,28 +955,22 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       undefined,
       tx,
     );
+    const harness = runtime.runner.accessForTestingOnly;
     const injector = refuseDeferredStartCommits(
       runtime,
-      staleConfirmedReadOf(result),
+      resumingRefusalOf(result),
     );
-    // Fail the SECOND context assembly (the recovery's) at the same seam the
-    // install observer hooks: the first attempt wires normally and is torn
-    // down by the refusal; the recovery's walk then dies synchronously.
-    const runner = runtime.runner as unknown as {
-      startCore: (...args: unknown[]) => () => void;
-    };
-    const originalStartCore = runner.startCore;
-    let assemblies = 0;
-    runner.startCore = (...args: unknown[]) => {
-      const cell = args[0] as Cell<unknown>;
-      if (key(cell) === key(result)) {
-        assemblies++;
-        if (assemblies >= 2) {
-          throw new Error("injected: the recovery walk's assembly failed");
-        }
-      }
-      return Reflect.apply(originalStartCore, runtime.runner, args) as () =>
-        void;
+    const installed = observeContextInstalls(runtime, key(result));
+    // Fail the recovery's walk at its dependency pre-sync: the first attempt
+    // wires normally, never passing that step, and is torn down by the
+    // refusal; the recovery's walk then dies at the step only it reaches.
+    let syncFailures = 0;
+    harness.dependencySyncer = (cell, executable, inputs, sync) => {
+      if (key(cell) !== key(result)) return sync(cell, executable, inputs);
+      syncFailures++;
+      return Promise.reject(
+        new Error("injected: the recovery walk's dependency sync failed"),
+      );
     };
     try {
       runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
@@ -1050,13 +983,17 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       await runtime.runner.idleDeferredStartCatchUps();
       await runtime.idle();
 
-      // Both assemblies were attempted, the failure was contained, and the
-      // runner holds neither a registration nor a pending recovery.
-      expect(assemblies).toBe(2);
+      // The refused attempt installed once, the recovery's walk failed once
+      // and was contained, and the runner holds neither a registration nor
+      // a pending recovery.
+      expect(installed.installs()).toBe(1);
+      expect(syncFailures).toBe(1);
       expect(injector.refusals()).toBe(1);
       expect(runtime.runner.cancels.has(key(result))).toBe(false);
+      expect(harness.pendingDeferredStarts.has(key(result))).toBe(false);
     } finally {
-      runner.startCore = originalStartCore;
+      harness.dependencySyncer = undefined;
+      installed.restore();
       injector.restore();
     }
   });
@@ -1079,11 +1016,6 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       doubled: lift((input: number) => input * 2)(value),
     }));
     const harness = runtime.runner.accessForTestingOnly;
-    // Replaced by assignment below, which only a TypeScript-private member
-    // allows, so it is reached the old way.
-    const stubbed = runtime.runner as unknown as {
-      catchUpAndStartOnStaleRead(...args: unknown[]): boolean;
-    };
     const tx = runtime.edit();
     const receipt = runtime.getCell<Record<string, unknown>>(
       space,
@@ -1094,7 +1026,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     // THIS pin refuses at the STORE DOOR (replica.commitNative), not at
     // the tx seam: the cross-space arm's startTx carries the SETUP (this
     // arm's defining difference), so runWithStartOwnership attached a
-    // failure-compensation commit callback to it — and the tx-seam
+    // failure-compensation commit callback to it — and the committer
     // injector's abort() settles that callback with an ABORT-shaped
     // error, which releases the install BEFORE the error arm (an injector
     // artifact: a real wire refusal settles the callbacks with the
@@ -1102,19 +1034,30 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     // install). Because this startTx carries operations, it genuinely
     // reaches the store door — the primary arm's op-less startTx cannot —
     // so here the refusal can ride the REAL commit machinery end to end.
-    const error = staleConfirmedReadOf(receipt);
-    const runnerForMark = runtime.runner as unknown as {
-      startWithTx: (...args: unknown[]) => (() => void) | undefined;
+    // The ROUTING witness (review F13 / Cubic P2): the old terminal path
+    // also produces one refusal, no registration, and a settled idle, so
+    // those observables alone cannot tell recovery from terminal death. Only
+    // a SCHEDULED recovery awaits the refusal's readiness gate, so counting
+    // that call is the pin: deleting the recovery's call site from
+    // runPatternAfterSuccessfulCommit leaves it at zero. Holding the gate
+    // also exposes the scheduled recovery's token in the pending index.
+    const gate = Promise.withResolvers<void>();
+    const gateReached = Promise.withResolvers<void>();
+    let scheduled = 0;
+    const error = {
+      ...staleConfirmedReadOf(receipt),
+      readyToRetry: () => {
+        scheduled++;
+        gateReached.resolve();
+        return gate.promise;
+      },
     };
-    const originalStartWithTx = runnerForMark.startWithTx;
+    // The committer marks the start transaction, whose inner transaction is
+    // what the store door sees, and commits it through the real machinery.
     const startTransactions = new WeakSet<object>();
-    runnerForMark.startWithTx = (...args: unknown[]) => {
-      startTransactions.add(
-        (args[0] as { tx?: object }).tx ?? (args[0] as object),
-      );
-      return Reflect.apply(originalStartWithTx, runtime.runner, args) as
-        | (() => void)
-        | undefined;
+    harness.deferredStartCommitter = (startTx, _resultCell, commit) => {
+      startTransactions.add(startTx.tx);
+      return commit();
     };
     const replica = storageManager.open(space).replica as unknown as {
       commitNative: (...args: unknown[]) => unknown;
@@ -1135,28 +1078,6 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       }
       return Reflect.apply(originalCommitNative, this, args);
     };
-    // The ROUTING witness (review F13 / Cubic P2): the old terminal path
-    // also produces one refusal, no registration, and a settled idle, so
-    // those observables alone cannot tell recovery from terminal death.
-    // Instrument the recovery entry point for this receipt: the pin
-    // demands the error arm actually ROUTED here and the recovery was
-    // SCHEDULED — deleting the call site from
-    // runPatternAfterSuccessfulCommit reds this, where it used to pass.
-    const originalEntry = stubbed.catchUpAndStartOnStaleRead;
-    let routed = 0;
-    let scheduled = 0;
-    stubbed.catchUpAndStartOnStaleRead = function (...args: unknown[]) {
-      const took = Reflect.apply(
-        originalEntry,
-        runtime.runner,
-        args,
-      ) as boolean;
-      if (key(args[1] as Cell<unknown>) === key(receipt)) {
-        routed++;
-        if (took) scheduled++;
-      }
-      return took;
-    };
     try {
       harness.runPatternAfterSuccessfulCommit(
         tx,
@@ -1172,22 +1093,29 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
         refusalWaiter.promise,
         "the cross-space start's transaction being refused at the store",
       );
+      // The refusal ROUTED into the recovery and the recovery was
+      // scheduled — the discriminating assertions: it awaits the readiness
+      // gate, and its token sits in the pending index while it does.
+      await waitForSignal(
+        gateReached.promise,
+        "the recovery awaiting the refusal's readiness gate",
+      );
+      expect(scheduled).toBe(1);
+      expect(harness.pendingDeferredStarts.get(key(receipt))?.size).toBe(1);
+      gate.resolve();
       await runtime.runner.idleDeferredStartCatchUps();
       await runtime.idle();
 
-      // The refusal ROUTED into the recovery and the recovery was
-      // scheduled — the discriminating assertions…
-      expect(routed).toBe(1);
-      expect(scheduled).toBe(1);
-      // …and exactly one refusal (the recovery never re-committed a start
+      // Exactly one refusal (the recovery never re-committed a start
       // transaction — its walk failed before any second commit), the
       // failed recovery leaving nothing behind.
+      expect(scheduled).toBe(1);
       expect(refusals).toBe(1);
       expect(runtime.runner.cancels.has(key(receipt))).toBe(false);
     } finally {
-      stubbed.catchUpAndStartOnStaleRead = originalEntry;
+      gate.resolve();
       replica.commitNative = originalCommitNative;
-      runnerForMark.startWithTx = originalStartWithTx;
+      harness.deferredStartCommitter = undefined;
     }
   });
 
@@ -1214,11 +1142,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       runtime,
       staleConfirmedReadOf(result),
     );
-    const installed = observeContextInstalls(
-      runtime,
-      (cell) => key(cell) === key(result),
-      () => runtime.runner.cancels.has(key(result)),
-    );
+    const installed = observeContextInstalls(runtime, key(result));
     try {
       runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
       expect((await tx.commit()).error).toBeUndefined();
@@ -1287,11 +1211,7 @@ describe("a deferred start refused for a stale confirmed read, flag-OFF", () => 
       staleConfirmedReadOf(result),
       Number.MAX_SAFE_INTEGER,
     );
-    const installed = observeContextInstalls(
-      runtime,
-      (cell) => key(cell) === key(result),
-      () => runtime.runner.cancels.has(key(result)),
-    );
+    const installed = observeContextInstalls(runtime, key(result));
     try {
       runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
       expect((await tx.commit()).error).toBeUndefined();

--- a/packages/runner/test/executor-effect-channel.test.ts
+++ b/packages/runner/test/executor-effect-channel.test.ts
@@ -691,7 +691,7 @@ describe("Phase 4 client-effect channel", () => {
     // takes the intent tx with it), release, and require the wave-2
     // re-run to re-issue the intent. Store-derived state must govern
     // the served arm: the builtin instance and its closure are REUSED
-    // across the re-run (runner.ts's startWithTx cancels-guard), so a
+    // across the re-run (the `Runner.#startWithTx()` cancels-guard), so a
     // closure `navigated` guard would suppress the re-issue forever —
     // the defect this test pins red-first.
     ({ manager: clientManager, runtime: clientRuntime } = openClient(

--- a/packages/runner/test/executor-run-supply.test.ts
+++ b/packages/runner/test/executor-run-supply.test.ts
@@ -759,7 +759,7 @@ describe("stage P2-F piece-start commit failure surfacing (F1)", () => {
   // handler-bearing V3 whose stream marker the V1 doc never
   // materialized — the exact durable state whose demanded start mints
   // a setup-REPAIR write on the serving runtime (`ensurePieceRunning`
-  // → start → startCore → applySetupState).
+  // → start → `Runner.#startCore()` → applySetupState).
   const brickedPiece = async () => {
     const tx = runtime.edit();
     const pm = runtime.patternManager;
@@ -847,7 +847,7 @@ describe("stage P2-F piece-start commit failure surfacing (F1)", () => {
 
   it("surfaces a refused fire-and-forget piece-INSTANTIATE commit through the observer (the start path's own arm, not only the repair's)", async () => {
     // A HEALTHY piece — no repair involved: run V1, stop, restart. The
-    // restart's startCore mints the self-minted fire-and-forget
+    // restart's `Runner.#startCore()` mints the self-minted fire-and-forget
     // instantiation tx (`piece-instantiate/<root>`) — the arm the F1
     // hazard was actually filed about (start() resolves before the
     // commit settles, so a swallowed refusal leaves the piece silently

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -175,9 +175,10 @@ describe("stage D seal-into-wave", () => {
             if (instantiations === options.throwOnInstantiation) {
               throw new Error(`witness instantiation ${instantiations} failed`);
             }
-            // `parentCell` is bound to startCore's actual transaction. A
-            // changing value makes every instantiation contribute a real
-            // bookkeeping write instead of being optimized to a no-op.
+            // `parentCell` is bound to `Runner.#startCore()`'s actual
+            // transaction. A changing value makes every instantiation
+            // contribute a real bookkeeping write instead of being optimized
+            // to a no-op.
             parentCell.key("witness").set(instantiations);
             const thisInstantiation = instantiations;
             const action = () => {

--- a/packages/runner/test/nested-piece-setup-repair.test.ts
+++ b/packages/runner/test/nested-piece-setup-repair.test.ts
@@ -14,10 +14,11 @@ import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 // pattern watcher armed to self-heal. If its stored doc predates the pattern's
 // setup (here: set up for V1, then re-pointed at the handler-bearing V3 whose
 // `bump` stream marker the V1 doc never materialized), instantiation throws
-// "Handler used as lift … marker was never written". Runner.startCore's initial
-// instantiation re-runs the pinned pattern's OWN setup on that failure and
-// retries — the same repair the home ROOT gets in startEnsuredDefaultPattern,
-// here for the nested pieces that never pass through the PieceController.
+// "Handler used as lift … marker was never written". `Runner.#startCore()`'s
+// initial instantiation re-runs the pinned pattern's OWN setup on that
+// failure and retries — the same repair the home ROOT gets in
+// startEnsuredDefaultPattern, here for the nested pieces that never pass
+// through the PieceController.
 // The repair moves no durable identity pointer; it replays the pattern the
 // pointer already names. The root itself is excluded because its controller
 // owns the repair; a nested piece is never a space's `.defaultPattern`, so it

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -1694,8 +1694,8 @@ describe("setup/start", () => {
 
   it("run() with a given pattern leaves no running registration when instantiation throws", () => {
     // Same regression as above, via the fresh-run entry (the path a live
-    // `cf piece new` takes): startCore's givenPattern branch must also clean
-    // up when node instantiation throws.
+    // `cf piece new` takes): `Runner.#startCore()`'s givenPattern branch must
+    // also clean up when node instantiation throws.
     const pattern: Pattern = {
       argumentSchema: { type: "object", properties: {} },
       resultSchema: {},


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

The last three TypeScript-`private` members of `Runner` become `#` members. All three were `private` for one reason: `test/deferred-start-catchup-start.test.ts` replaced them by assignment to observe, gate, or fail the deferred-start path around them. This PR gives that file the seams it was taking by force, built as one design (BL-093 items 8, 9, 10).

## The six stubbing sites and what serves each

* **The refusal injector** (`refuseDeferredStartCommits`, used by every flag-ON test and the flag-OFF test) stubbed `startWithTx` to mark the start transaction, and reassigned `runtime.edit` and each transaction's `commit` to refuse it. It now sets `Runner.accessForTestingOnly.deferredStartCommitter`, a collaborator in the shape #7030 set: it receives the start transaction, the result cell, and the runner's own commit step, and decides whether to refuse in its stead or call through. A new `#commitDeferredStart()` step is what both deferred arms (the primary start and the cross-space `runPatternAfterSuccessfulCommit` arm) commit through. Three reassignments of internals become one accessor write.
* **The cross-space start-transaction marking** stubbed `startWithTx` to mark the inner transaction for the store-door refusal. The same committer marks it and calls through.
* **The install observer** (`observeContextInstalls`, ten tests) stubbed `startCore` to count installs and to read, before each install registered, whether a registration already stood. It now listens for a new telemetry marker, `runner.piece.install { key }`, which `#startCore()` emits before it sets the registration. The listener's synchronous read of `runner.cancels` is the same read as before, and the marker's ordering contract is what the one-live-context test pins: moving the emit below the registration reds it.
* **The mid-walk parent cancel** and **the walk that throws** stubbed `startCore` to act at the recovery's second install. Both now act inside the recovery walk's dependency pre-sync through the existing `dependencySyncer`, the seam #7030 added, forcing the resume path the way the competing-start test already does (a shared `resumingRefusalOf` helper). Only the recovery's walk pre-syncs the result, so neither needs a call count.
* **The routing witness** stubbed `catchUpAndStartOnStaleRead` to learn that the cross-space refusal was routed to the recovery and the recovery was scheduled. No seam: the recovery returns true at exactly one point, and the only path there awaits the refusal's `readyToRetry`, so the test counts that call. Holding the gate also exposes the scheduled recovery's token in `pendingDeferredStarts`.

## Production changes

* `Runner.#startCore()`, `#startWithTx()`, `#catchUpAndStartOnStaleRead()`; their "TypeScript-private because" notes go.
* `#commitDeferredStart(tx, resultCell)` replaces the two `startTx.commit()` calls. `DeferredStartCommit` and `DeferredStartCommitter` name the shapes.
* `deferredStartCommitter` on the accessor, `undefined` by default, beside `dependencySyncer`.
* `runner.piece.install` on `RuntimeTelemetryMarker`. No consumer switches over marker types exhaustively, so none needs a case.
* Comments in `runner.ts`, eight comments in other test and source files, and five live spec documents name the three members with their class (`Runner.#startCore()`), as #7030 did for its two.

## What does not change

Behavior with no collaborator set: the same commit, under a named step. The timing label `startCoreResume` and the local `startCoreStart` stay, since the label is a timing-stats identity. Every `it()` description is unchanged; each remains true of what its test now does. `runner.test.ts`'s `setupInternal` stub (BL-093 item 7) is out of scope and keeps its note.

## Mutation checks

Each rewritten pin was run against a deliberate break of what it guards, then the break reverted:

1. Drop the `#catchUpAndStartOnStaleRead()` call in the cross-space arm: the routing witness reds (its gate is never reached, and the file's no-deadline signal idiom fails the wait).
2. Make `#commitDeferredStart()` ignore the committer: every injector-driven test reds.
3. Move the install marker below the registration: the one-live-context test reds on `everConcurrent`.
4. Drop the recovery's `markInstalled(undefined)` at entry: the mid-walk cancel test reds with a registration left standing.
5. Drop the recovery's catch-side `ownership.cancel()`: the walk-throws test reds on the pending index, an assertion this PR adds to it (its own comment already said no pending recovery may linger).

## Gates

`deno fmt --check`, `deno lint`, full `deno task check`, `deno task check-docs`; the file itself 15/0; runner suite 1390/0; piece suite 56/0 (one comment changed there).

Both classes are mostly @seefeldb's, for visibility: this adds one settable collaborator and one telemetry marker to `Runner`, the collaborator reachable only through `accessForTestingOnly`.

## Review

Reviewed by a `cf-review` subagent (report only; approve, no blockers). They re-ran mutation checks 1 and 3 and confirmed both, traced the mid-walk cancel and walk-throws rewrites through the recovery's catch arms and the hand-off, confirmed the `readyToRetry` count is reachable only through a scheduled recovery in this flow, and checked every consumer of `RuntimeTelemetryMarker` (the OTel bridge's switch has no default or exhaustiveness check, the shell debugger filters by prefix, cf-harness filters on one type). Two nits taken: the `DeferredStartCommitter` doc comment opens "The committer ..." as its field's does, and a hand wrap in `verification-coverage.md` is rejoined. Pre-existing debts they noticed (two pattern-construction specs attributing node iteration to `#startWithTx()` when it lives in `#startCore()`, stale line anchors in `runtime-mapping.md`, the test file's two top-level `describe()`s and `//` preamble) are recorded for the tidy-up and left alone here.
