### PR TITLE
refactor(fuse): `CellBridge`'s last four `private` members are `#` members; their tests drive seams the bridge already offers

### DIFF
--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -195,7 +195,11 @@ function getFileContent(tree: FsTree, parentIno: bigint, name: string): string {
   return decoder.decode(node.content);
 }
 
-/** A source write path for a piece, as the flush path would hand one over. */
+/**
+ * A source write path for a piece, as the flush path would hand one over;
+ * `piece` is what a finalize consults, and the default serves callers whose
+ * finalize never does.
+ */
 function sourceWritePath(
   spaceName: string,
   pieceName: string,
@@ -297,23 +301,17 @@ async function openDirectorySnapshot(
 
 /**
  * An `FsTree` that refuses to add one named entry, throwing `failure`; every
- * other add goes through. `refuse()` arms it, so a test can build its setup
- * on the tree first and then have the bridge's own next write of that name
- * fail.
+ * other add goes through.
  */
 class RefusingTree extends FsTree {
+  #refusedName: string;
   #failure: Error;
-  #refusedName: string | undefined;
 
-  /** Constructs an instance which throws `failure` at the refused name. */
-  constructor(failure: Error) {
+  /** Constructs an instance which throws `failure` at every add of `name`. */
+  constructor(name: string, failure: Error) {
     super();
-    this.#failure = failure;
-  }
-
-  /** Refuses every later add of `name`. */
-  refuse(name: string): void {
     this.#refusedName = name;
+    this.#failure = failure;
   }
 
   override addDir(
@@ -543,12 +541,12 @@ Deno.test("CellBridge rejects invalid entity projection cache limits", () => {
 
 Deno.test("CellBridge removes partial state after a late connection failure", async () => {
   // The failure lands at the connect's index write, after the space's tree
-  // and state exist: the tree refuses `.index.json`. Everything the connect
-  // had recorded for the space by then must be gone afterward, and the
-  // failing dispose of the space's runtime is warned about, not thrown.
+  // and state exist: the tree refuses `.index.json`. The space's tree and
+  // state, and the per-space table entries seeded here as a connect could
+  // have left them, must be gone afterward, and the failing dispose of the
+  // space's runtime is warned about, not thrown.
   const connectionFailure = new Error("manifest generation failed");
-  const tree = new RefusingTree(connectionFailure);
-  tree.refuse(".index.json");
+  const tree = new RefusingTree(".index.json", connectionFailure);
   let disposeCalls = 0;
   const spacePieces = {
     getSpace: () => "did:key:zFailedSpace",
@@ -597,7 +595,7 @@ Deno.test("CellBridge removes partial state after a late connection failure", as
   assertEquals(internals.syncAgain.has("home"), false);
 });
 
-Deno.test("CellBridge.removeFailedSpaceTree cancels every subscription and forgets every table entry of the space", async () => {
+Deno.test("CellBridge.#removeFailedSpaceTree cancels every subscription and forgets every table entry of the space", () => {
   // The cleanup a late connection failure runs, driven on a space seeded
   // with every kind of state a partially built space can hold: cancels in
   // both subscription tables, a partial piece and entity directory, and an
@@ -626,6 +624,7 @@ Deno.test("CellBridge.removeFailedSpaceTree cancels every subscription and forge
     {} as UnhydratedEntityRootInfo,
   );
   internals.entityProjectionUseOrder.set(entityIno, 1);
+  internals.entityProjectionLookupRefs.set(entityIno, entityIno);
   internals.pendingEntityRemovals.set(
     entityIno,
     {} as UnhydratedEntityRootInfo,
@@ -635,7 +634,6 @@ Deno.test("CellBridge.removeFailedSpaceTree cancels every subscription and forge
   internals.syncAgain.add("home");
 
   internals.removeFailedSpaceTree("home", state);
-  await Promise.resolve();
 
   assertEquals(cancellations, 3);
   assertEquals(
@@ -651,6 +649,7 @@ Deno.test("CellBridge.removeFailedSpaceTree cancels every subscription and forge
     false,
   );
   assertEquals(internals.entityProjectionUseOrder.has(entityIno), false);
+  assertEquals(internals.entityProjectionLookupRefs.has(entityIno), false);
   assertEquals(internals.pendingEntityRemovals.has(entityIno), false);
   assertEquals(internals.pendingPieceHydrations.has("home"), false);
   assertEquals(internals.pieceSyncs.has("home"), false);
@@ -3100,9 +3099,15 @@ Deno.test("CellBridge queues piece prop rebuilds for the same prop", async () =>
     const state = buildTestSpace(bridge, "home", []);
     const pieceIno = tree.addDir(state.piecesIno, "queued");
     const enqueue = bridge.accessForTestingOnly.enqueuePiecePropRebuild;
+    // More entries than one tree-builder batch (`BUILD_BATCH_SIZE` in
+    // `tree-builder.ts`), so the build yields once mid-way.
+    const entriesPerValue = 250;
     const wide = (label: string) =>
       Object.fromEntries(
-        Array.from({ length: 250 }, (_, i) => [`k${i}`, `${label}-${i}`]),
+        Array.from(
+          { length: entriesPerValue },
+          (_, i) => [`k${i}`, `${label}-${i}`],
+        ),
       );
     const job = (label: string) => {
       const value = wide(label);
@@ -3140,8 +3145,9 @@ Deno.test("CellBridge queues piece prop rebuilds for the same prop", async () =>
     await time.runMicrotasks();
     assertEquals(events, ["start-first"]);
 
-    // Fire each yield the rebuilds schedule, one at a time: a bulk run would
-    // look for the next timer before the microtasks that schedule it.
+    // Each yield is scheduled by microtasks that run only after the previous
+    // one fires, so the timers are fired one at a time with a microtask drain
+    // between.
     while (await time.nextAsync()) {
       // The loop body is the firing.
     }

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -5480,11 +5480,12 @@ Deno.test("CellBridge.reportSourceRefreshWarning reports nothing for a refreshed
 });
 
 Deno.test("CellBridge.reportSourceRefreshWarning leaves an authored error.log alone", () => {
-  // `buildSourceTree` mints the synthetic `error.log` only when no authored
-  // source file claims that name, so a piece that ships one of its own has no
-  // synthetic file and no entry in `srcErrorLogInos`. Resolving the file by
-  // name here would find the authored one and overwrite committed source with
-  // this report; the console line is the whole report such a piece gets.
+  // `CellBridge.#buildSourceTree()` mints the synthetic `error.log` only when
+  // no authored source file claims that name, so a piece that ships one of
+  // its own has no synthetic file and no entry in `srcErrorLogInos`.
+  // Resolving the file by name here would find the authored one and
+  // overwrite committed source with this report; the console line is the
+  // whole report such a piece gets.
   const bridge = new CellBridge(new FsTree(), "/tmp/cf-exec");
   const state = buildTestSpace(bridge, "space", []);
   const tree = bridge.tree;

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -200,12 +200,13 @@ function sourceWritePath(
   spaceName: string,
   pieceName: string,
   srcIno: bigint,
+  piece: unknown = {},
 ): SourceWritePath {
   return {
     spaceName,
     pieceName,
     relPath: "main.tsx",
-    piece: {} as never,
+    piece: piece as never,
     srcIno,
   };
 }
@@ -294,24 +295,46 @@ async function openDirectorySnapshot(
   );
 }
 
-type UpdateIndexJson = (state: SpaceState) => void;
+/**
+ * An `FsTree` that refuses to add one named entry, throwing `failure`; every
+ * other add goes through. `refuse()` arms it, so a test can build its setup
+ * on the tree first and then have the bridge's own next write of that name
+ * fail.
+ */
+class RefusingTree extends FsTree {
+  #failure: Error;
+  #refusedName: string | undefined;
 
-type RebuildPieceProp = (args: {
-  cell: FakeCell;
-  newValue: unknown;
-  pieceId: string;
-  pieceIno: bigint;
-  pieceName: string;
-  propName: "input" | "result";
-  resolveLink: (value: unknown, depth: number) => string | null;
-  spaceName: string;
-}) => Promise<void>;
+  /** Constructs an instance which throws `failure` at the refused name. */
+  constructor(failure: Error) {
+    super();
+    this.#failure = failure;
+  }
 
-type RefreshPiecePatternMetadata = (
-  state: SpaceState,
-  piece: unknown,
-  pieceIno: bigint,
-) => Promise<void>;
+  /** Refuses every later add of `name`. */
+  refuse(name: string): void {
+    this.#refusedName = name;
+  }
+
+  override addDir(
+    parentIno: bigint,
+    name: string,
+    jsonType?: "object" | "array",
+  ): bigint {
+    if (name === this.#refusedName) throw this.#failure;
+    return super.addDir(parentIno, name, jsonType);
+  }
+
+  override addFile(
+    parentIno: bigint,
+    name: string,
+    content: Uint8Array | string,
+    jsonType: "string" | "number" | "boolean" | "null" | "object" | "array",
+  ): bigint {
+    if (name === this.#refusedName) throw this.#failure;
+    return super.addFile(parentIno, name, content, jsonType);
+  }
+}
 
 Deno.test("CellBridge reconnect validates the existing piece registry", async () => {
   const tree = new FsTree();
@@ -519,8 +542,13 @@ Deno.test("CellBridge rejects invalid entity projection cache limits", () => {
 });
 
 Deno.test("CellBridge removes partial state after a late connection failure", async () => {
-  const tree = new FsTree();
-  let cancellations = 0;
+  // The failure lands at the connect's index write, after the space's tree
+  // and state exist: the tree refuses `.index.json`. Everything the connect
+  // had recorded for the space by then must be gone afterward, and the
+  // failing dispose of the space's runtime is warned about, not thrown.
+  const connectionFailure = new Error("manifest generation failed");
+  const tree = new RefusingTree(connectionFailure);
+  tree.refuse(".index.json");
   let disposeCalls = 0;
   const spacePieces = {
     getSpace: () => "did:key:zFailedSpace",
@@ -537,45 +565,9 @@ Deno.test("CellBridge removes partial state after a late connection failure", as
   bridge.init({ apiUrl: "https://example.invalid", identity: "test" });
 
   const internals = bridge.accessForTestingOnly;
-  const connectionFailure = new Error("manifest generation failed");
-  let partialEntityIno = 0n;
-  (bridge as unknown as { updateIndexJson: UpdateIndexJson })
-    .updateIndexJson = (state) => {
-      const cancel = () => {
-        cancellations++;
-      };
-      state.unsubscribes.push(cancel);
-      state.pieceSubs.set("partial-piece", [cancel]);
-      tree.addDir(state.piecesIno, "partial-piece");
-      const entityIno = tree.addDir(state.entitiesIno, "partial-entity");
-      partialEntityIno = entityIno;
-      internals.entitySubscriptions.set(entityIno, [cancel]);
-      internals.unhydratedEntityRoots.set(
-        entityIno,
-        {} as UnhydratedEntityRootInfo,
-      );
-      internals.pendingEntityHydrations.set(
-        entityIno,
-        Promise.resolve(false),
-      );
-      internals.entityProjectionLru.set(
-        entityIno,
-        {} as UnhydratedEntityRootInfo,
-      );
-      internals.entityProjectionEvictionCandidates.set(
-        entityIno,
-        {} as UnhydratedEntityRootInfo,
-      );
-      internals.entityProjectionUseOrder.set(entityIno, 1);
-      internals.pendingEntityRemovals.set(
-        entityIno,
-        {} as UnhydratedEntityRootInfo,
-      );
-      internals.pendingPieceHydrations.set("home", Promise.resolve());
-      internals.pieceSyncs.set("home", Promise.resolve());
-      internals.syncAgain.add("home");
-      throw connectionFailure;
-    };
+  internals.pendingPieceHydrations.set("home", Promise.resolve());
+  internals.pieceSyncs.set("home", Promise.resolve());
+  internals.syncAgain.add("home");
 
   const warnings: unknown[][] = [];
   const originalWarn = console.warn;
@@ -590,7 +582,6 @@ Deno.test("CellBridge removes partial state after a late connection failure", as
     console.warn = originalWarn;
   }
 
-  assertEquals(cancellations, 3);
   assertEquals(disposeCalls, 1);
   assertEquals(warnings.length, 1);
   assertEquals(String(warnings[0][0]).includes("dispose failed"), true);
@@ -601,17 +592,66 @@ Deno.test("CellBridge removes partial state after a late connection failure", as
   assertEquals(bridge.spaces.has("home"), false);
   assertEquals(bridge.knownSpaces.has("home"), false);
   assertEquals(bridge.isConnecting("home"), false);
-  assertNotEquals(partialEntityIno, 0n);
-  assertEquals(internals.entitySubscriptions.has(partialEntityIno), false);
-  assertEquals(internals.unhydratedEntityRoots.has(partialEntityIno), false);
-  assertEquals(internals.pendingEntityHydrations.has(partialEntityIno), false);
-  assertEquals(internals.entityProjectionLru.has(partialEntityIno), false);
+  assertEquals(internals.pendingPieceHydrations.has("home"), false);
+  assertEquals(internals.pieceSyncs.has("home"), false);
+  assertEquals(internals.syncAgain.has("home"), false);
+});
+
+Deno.test("CellBridge.removeFailedSpaceTree cancels every subscription and forgets every table entry of the space", async () => {
+  // The cleanup a late connection failure runs, driven on a space seeded
+  // with every kind of state a partially built space can hold: cancels in
+  // both subscription tables, a partial piece and entity directory, and an
+  // entry in each per-entity and per-space table.
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+  const internals = bridge.accessForTestingOnly;
+  let cancellations = 0;
+  const cancel = () => {
+    cancellations++;
+  };
+  state.unsubscribes.push(cancel);
+  state.pieceSubs.set("partial-piece", [cancel]);
+  tree.addDir(state.piecesIno, "partial-piece");
+  const entityIno = tree.addDir(state.entitiesIno, "partial-entity");
+  internals.entitySubscriptions.set(entityIno, [cancel]);
+  internals.unhydratedEntityRoots.set(
+    entityIno,
+    {} as UnhydratedEntityRootInfo,
+  );
+  internals.pendingEntityHydrations.set(entityIno, Promise.resolve(false));
+  internals.entityProjectionLru.set(entityIno, {} as UnhydratedEntityRootInfo);
+  internals.entityProjectionEvictionCandidates.set(
+    entityIno,
+    {} as UnhydratedEntityRootInfo,
+  );
+  internals.entityProjectionUseOrder.set(entityIno, 1);
+  internals.pendingEntityRemovals.set(
+    entityIno,
+    {} as UnhydratedEntityRootInfo,
+  );
+  internals.pendingPieceHydrations.set("home", Promise.resolve());
+  internals.pieceSyncs.set("home", Promise.resolve());
+  internals.syncAgain.add("home");
+
+  internals.removeFailedSpaceTree("home", state);
+  await Promise.resolve();
+
+  assertEquals(cancellations, 3);
   assertEquals(
-    internals.entityProjectionEvictionCandidates.has(partialEntityIno),
+    tree.lookup(tree.rootIno, encodeFuseComponent("home")),
+    undefined,
+  );
+  assertEquals(internals.entitySubscriptions.has(entityIno), false);
+  assertEquals(internals.unhydratedEntityRoots.has(entityIno), false);
+  assertEquals(internals.pendingEntityHydrations.has(entityIno), false);
+  assertEquals(internals.entityProjectionLru.has(entityIno), false);
+  assertEquals(
+    internals.entityProjectionEvictionCandidates.has(entityIno),
     false,
   );
-  assertEquals(internals.entityProjectionUseOrder.has(partialEntityIno), false);
-  assertEquals(internals.pendingEntityRemovals.has(partialEntityIno), false);
+  assertEquals(internals.entityProjectionUseOrder.has(entityIno), false);
+  assertEquals(internals.pendingEntityRemovals.has(entityIno), false);
   assertEquals(internals.pendingPieceHydrations.has("home"), false);
   assertEquals(internals.pieceSyncs.has("home"), false);
   assertEquals(internals.syncAgain.has("home"), false);
@@ -3040,58 +3080,82 @@ Deno.test("CellBridge.rebuildPieceProp keeps inodes stable and invalidates only 
 });
 
 Deno.test("CellBridge queues piece prop rebuilds for the same prop", async () => {
-  const tree = new FsTree();
-  const bridge = new CellBridge(tree, "/tmp/cf-exec");
-  const cell = makeCell({}, undefined);
-
-  let releaseFirst: (() => void) | undefined;
-  const firstCanFinish = new Promise<void>((resolve) => {
-    releaseFirst = resolve;
-  });
-  let active = 0;
-  let maxActive = 0;
-  const events: string[] = [];
-
-  (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
-    .rebuildPieceProp = async (args) => {
-      active++;
-      maxActive = Math.max(maxActive, active);
-      events.push(`start-${String(args.newValue)}`);
-      if (args.newValue === "first") {
-        await firstCanFinish;
-      }
-      events.push(`end-${String(args.newValue)}`);
-      active--;
+  // Two real rebuilds of one prop. Each value is wider than one build batch,
+  // so the first rebuild yields to a timer mid-way, and that yield is where
+  // an unqueued second rebuild would start. A rebuild's start is witnessed
+  // at the first thing it asks of the job's cell, its schema, and its end
+  // at the projection-rebuilt hook.
+  const time = new FakeTime();
+  try {
+    const tree = new FsTree();
+    const events: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+    const bridge = new CellBridge(tree, "/tmp/cf-exec", {
+      onCfcProjectionRebuilt: () => {
+        active--;
+        events.push("end");
+      },
+    });
+    const state = buildTestSpace(bridge, "home", []);
+    const pieceIno = tree.addDir(state.piecesIno, "queued");
+    const enqueue = bridge.accessForTestingOnly.enqueuePiecePropRebuild;
+    const wide = (label: string) =>
+      Object.fromEntries(
+        Array.from({ length: 250 }, (_, i) => [`k${i}`, `${label}-${i}`]),
+      );
+    const job = (label: string) => {
+      const value = wide(label);
+      const cell = makeCell(value, undefined);
+      let started = false;
+      const inner = cell.asSchemaFromLinks.bind(cell);
+      cell.asSchemaFromLinks = () => {
+        if (!started) {
+          started = true;
+          active++;
+          maxActive = Math.max(maxActive, active);
+          events.push(`start-${label}`);
+        }
+        return inner();
+      };
+      return {
+        cell: cell as never,
+        newValue: value,
+        pieceId: "of:queued-prop",
+        pieceIno,
+        pieceName: "Queued Prop",
+        propName: "input" as const,
+        resolveLink: () => null,
+        spaceName: "home",
+      };
     };
 
-  const enqueue = bridge.accessForTestingOnly.enqueuePiecePropRebuild;
+    const first = enqueue(job("first"));
+    await time.runMicrotasks();
+    assertEquals(events, ["start-first"]);
 
-  const baseJob = {
-    cell: cell as never,
-    pieceId: "of:queued-prop",
-    pieceIno: 42n,
-    pieceName: "Queued Prop",
-    propName: "result" as const,
-    resolveLink: () => null,
-    spaceName: "home",
-  };
+    // The first rebuild is parked on its mid-build yield; the second must
+    // not start while it is.
+    const second = enqueue(job("second"));
+    await time.runMicrotasks();
+    assertEquals(events, ["start-first"]);
 
-  const first = enqueue({ ...baseJob, newValue: "first" });
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  const second = enqueue({ ...baseJob, newValue: "second" });
-  await new Promise((resolve) => setTimeout(resolve, 0));
+    // Fire each yield the rebuilds schedule, one at a time: a bulk run would
+    // look for the next timer before the microtasks that schedule it.
+    while (await time.nextAsync()) {
+      // The loop body is the firing.
+    }
+    await Promise.all([first, second]);
 
-  assertEquals(events, ["start-first"]);
-  releaseFirst?.();
-  await Promise.all([first, second]);
-
-  assertEquals(maxActive, 1);
-  assertEquals(events, [
-    "start-first",
-    "end-first",
-    "start-second",
-    "end-second",
-  ]);
+    assertEquals(maxActive, 1);
+    assertEquals(events, ["start-first", "end", "start-second", "end"]);
+    assertEquals(
+      getFileContent(tree, tree.lookup(pieceIno, "input")!, "k249"),
+      "second-249",
+    );
+  } finally {
+    time.restore();
+  }
 });
 
 Deno.test("CellBridge.rebuildPieceProp clears stale result mounts when value becomes null", async () => {
@@ -4036,12 +4100,21 @@ Deno.test("CellBridge pattern reference refresh fails closed", async () => {
 });
 
 Deno.test("CellBridge reports pattern metadata subscription failures", async () => {
+  // The piece's root cell fires its meta sink at once, so the subscription
+  // refreshes the pattern metadata immediately; the refresh fails at the
+  // kernel invalidation of the piece's `meta.json`, and the failure must be
+  // reported rather than swallowed.
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const state = buildTestSpace(bridge, "home", []);
   const errors: string[] = [];
+  const reported = defer<void>();
   const originalError = console.error;
-  console.error = (...args: unknown[]) => errors.push(args.join(" "));
+  console.error = (...args: unknown[]) => {
+    const line = args.join(" ");
+    errors.push(line);
+    if (line.includes("refresh failed")) reported.resolve();
+  };
 
   const immediateRootCell = {
     asSchema: () => ({ sync: () => Promise.resolve() }),
@@ -4050,11 +4123,20 @@ Deno.test("CellBridge reports pattern metadata subscription failures", async () 
       return () => {};
     },
   };
+  const patternRef = {
+    identity: "B".repeat(43),
+    symbol: "default",
+    source: {
+      ref: `cf:pattern:${"B".repeat(43)}`,
+      repository: "https://example.invalid/patterns",
+      entry: "/main.tsx",
+    },
+  };
   const piece = {
     id: "of:pattern-subscription-failure",
     name: () => "Pattern Subscription Failure",
     getCell: () => immediateRootCell,
-    getPatternRef: () => Promise.resolve(undefined),
+    getPatternRef: () => Promise.resolve(patternRef),
     getPatternMeta: () => Promise.resolve({}),
     getPatternSourceProgram: () =>
       Promise.resolve({ main: "/main.tsx", files: [] }),
@@ -4067,10 +4149,9 @@ Deno.test("CellBridge reports pattern metadata subscription failures", async () 
       get: () => Promise.resolve({}),
     },
   };
-  (bridge as unknown as {
-    refreshPiecePatternMetadata: RefreshPiecePatternMetadata;
-  }).refreshPiecePatternMetadata = () =>
-    Promise.reject(new Error("refresh failed"));
+  bridge.onInvalidate = (_parentIno, names) => {
+    if (names.includes("meta.json")) throw new Error("refresh failed");
+  };
 
   try {
     await bridge.accessForTestingOnly.addPieceToSpace(
@@ -4078,12 +4159,19 @@ Deno.test("CellBridge reports pattern metadata subscription failures", async () 
       piece as never,
       "home",
     );
-    await Promise.resolve();
+    await reported.promise;
   } finally {
     console.error = originalError;
   }
 
-  assertEquals(errors.some((line) => line.includes("refresh failed")), true);
+  assertEquals(
+    errors.some((line) =>
+      line.includes("Could not refresh") && line.includes("refresh failed")
+    ),
+    true,
+  );
+  const subs = state.pieceSubs.get("Pattern Subscription Failure");
+  if (subs) { for (const cancel of subs) cancel(); }
 });
 
 Deno.test("CellBridge reports pattern metadata setup failures", async () => {
@@ -5542,7 +5630,11 @@ Deno.test("CellBridge.finalizeSourceWritePath preserves both warnings when the r
   // not eat the first's message — "the source saved and the piece is not
   // running it" is the receipt's fact, not the rebuild's — so it is reported
   // even as the rebuild's own failure propagates to become the caller's
-  // projection warning.
+  // projection warning. The rebuild fails in its metadata-refresh step, at
+  // the kernel invalidation of the piece's `meta.json`, after the source
+  // tree has been rebuilt and a fresh synthetic log tracked; a failure in
+  // the source-tree step itself drops the tracked log before it can fail,
+  // and its receipt warning reaches the console alone.
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const state = buildTestSpace(bridge, "space", []);
@@ -5552,9 +5644,30 @@ Deno.test("CellBridge.finalizeSourceWritePath preserves both warnings when the r
   state.pieceInos.set("notes", pieceIno);
   state.srcInos.set("notes", srcIno);
   state.srcErrorLogInos.set("notes", errorLogIno);
-  (bridge as unknown as { buildSourceTree: () => Promise<void> })
-    .buildSourceTree = () => Promise.reject(new Error("rebuild failed"));
-  const writePath = sourceWritePath("space", "notes", srcIno);
+  const piece = {
+    id: "of:notes",
+    getPatternSourceProgram: () =>
+      Promise.resolve({
+        main: "/main.tsx",
+        files: [{ name: "/main.tsx", contents: "export default 2;" }],
+      }),
+    getPatternRef: () =>
+      Promise.resolve({
+        identity: "A".repeat(43),
+        symbol: "default",
+        source: {
+          ref: `cf:pattern:${"A".repeat(43)}`,
+          repository: "https://example.invalid/patterns",
+          entry: "/main.tsx",
+        },
+      }),
+  };
+  bridge.onInvalidate = (parentIno, names) => {
+    if (parentIno === pieceIno && names.includes("meta.json")) {
+      throw new Error("rebuild failed");
+    }
+  };
+  const writePath = sourceWritePath("space", "notes", srcIno, piece);
   const receipt = {
     status: "committed" as const,
     ref: { identity: "A".repeat(43), symbol: "default" },
@@ -5590,8 +5703,9 @@ Deno.test("CellBridge.finalizeSourceWritePath preserves both warnings when the r
     ).length,
     1,
   );
+  // The rebuild replaced `.src`, so the log is in the directory it minted.
   assertEquals(
-    getFileContent(tree, srcIno, "error.log"),
+    getFileContent(tree, tree.lookup(pieceIno, ".src")!, "error.log"),
     `Source revision revision-2 committed as cf:module/${
       "A".repeat(43)
     }#default, but refreshing the running piece failed: dependency unavailable\n` +

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -377,13 +377,6 @@ interface PropRebuildJob {
 }
 
 export class CellBridge {
-  // Four methods below stay TypeScript-`private` rather than `#`, which is
-  // the convention elsewhere in this class: `cell-bridge.test.ts` replaces
-  // each by assignment, which a `#` method does not allow. They are
-  // `refreshPiecePatternMetadata()`, `rebuildPieceProp()`,
-  // `updateIndexJson()`, and `buildSourceTree()`, and each carries a note
-  // naming the test that replaces it.
-
   #tree: FsTree;
   #spaces: Map<string, SpaceState> = new Map();
   #knownSpaces: Map<string, string> = new Map();
@@ -658,14 +651,12 @@ export class CellBridge {
           existingIno,
           rootKind,
         ),
-      // The next four forward to TypeScript-private members so that a test
-      // which replaces one by assignment is honored here too.
       refreshPiecePatternMetadata: (state, piece, pieceIno) =>
-        this.refreshPiecePatternMetadata(state, piece, pieceIno),
-      rebuildPieceProp: (args) => this.rebuildPieceProp(args),
-      updateIndexJson: (state) => this.updateIndexJson(state),
+        this.#refreshPiecePatternMetadata(state, piece, pieceIno),
+      rebuildPieceProp: (args) => this.#rebuildPieceProp(args),
+      updateIndexJson: (state) => this.#updateIndexJson(state),
       buildSourceTree: (pieceIno, piece, state, pieceName) =>
-        this.buildSourceTree(pieceIno, piece, state, pieceName),
+        this.#buildSourceTree(pieceIno, piece, state, pieceName),
     };
   }
 
@@ -1011,12 +1002,8 @@ export class CellBridge {
 
   /**
    * Refreshes synthetic pattern metadata after an in-place pattern swap.
-   *
-   * TypeScript-private rather than a `#` name, because
-   * `cell-bridge.test.ts` replaces this member by assignment, which a `#`
-   * method does not allow.
    */
-  private async refreshPiecePatternMetadata(
+  async #refreshPiecePatternMetadata(
     state: SpaceState,
     piece: PieceController,
     pieceIno: bigint,
@@ -1134,7 +1121,7 @@ export class CellBridge {
       await this.#verifyPiecesConnection(pieces);
       state = this.#buildSpaceTree(spaceName, pieces);
 
-      this.updateIndexJson(state);
+      this.#updateIndexJson(state);
       this.#updatePiecesJson(state);
       this.#spaces.set(spaceName, state);
       this.#knownSpaces.set(spaceName, state.did);
@@ -2032,12 +2019,8 @@ export class CellBridge {
   /**
    * Rebuilds the mounted subtree of one piece prop from a new cell value, in
    * place.
-   *
-   * TypeScript-private rather than a `#` name, because
-   * `cell-bridge.test.ts` replaces this member by assignment, which a `#`
-   * method does not allow.
    */
-  private async rebuildPieceProp(args: {
+  async #rebuildPieceProp(args: {
     cell: Cell<unknown>;
     newValue: unknown;
     pieceId: string;
@@ -2313,7 +2296,7 @@ export class CellBridge {
     const previous = this.#pendingPropRebuildQueues.get(key) ??
       Promise.resolve();
     const current = previous.catch(() => {}).then(() =>
-      this.rebuildPieceProp(args)
+      this.#rebuildPieceProp(args)
     );
     this.#pendingPropRebuildQueues.set(key, current);
     try {
@@ -2530,13 +2513,13 @@ export class CellBridge {
       const state = this.#spaces.get(writePath.spaceName);
       const pieceIno = state?.pieceInos.get(writePath.pieceName);
       if (state && pieceIno !== undefined) {
-        await this.buildSourceTree(
+        await this.#buildSourceTree(
           pieceIno,
           writePath.piece,
           state,
           writePath.pieceName,
         );
-        await this.refreshPiecePatternMetadata(
+        await this.#refreshPiecePatternMetadata(
           state,
           writePath.piece,
           pieceIno,
@@ -2563,7 +2546,7 @@ export class CellBridge {
    * `undefined` is the refresh having succeeded, and reports nothing.
    *
    * The directory a caller was handed is not the one to write into after a
-   * finalize: `buildSourceTree` replaces `.src` wholesale and mints a fresh
+   * finalize: `#buildSourceTree()` replaces `.src` wholesale and mints a fresh
    * empty `error.log` inside it, so both the text written before that and the
    * inode it was written to are gone. Resolving the directory here, from the
    * state the rebuild updated, is what lets a report outlive the rebuild that
@@ -2592,7 +2575,7 @@ export class CellBridge {
    *
    * Every mutation of the log goes through here — the clear a clean write
    * performs, the diagnostic a failed one leaves, and the refresh warning
-   * above — because the file is identified by the inode `buildSourceTree`
+   * above — because the file is identified by the inode `#buildSourceTree()`
    * recorded when it minted it, never by name. A pattern is free to author a
    * source file called `error.log`, and resolving by name would find that
    * file and overwrite the mounted copy of committed source with a
@@ -3413,7 +3396,7 @@ export class CellBridge {
       "pieces",
     );
     state.pieceInos.set(name, pieceIno);
-    await this.buildSourceTree(pieceIno, piece, state, name);
+    await this.#buildSourceTree(pieceIno, piece, state, name);
     await this.#refreshPieceManifest(state, piece);
 
     const subs = await this.#subscribePiece(
@@ -3542,7 +3525,7 @@ export class CellBridge {
     }
 
     // Update index and invalidate
-    this.updateIndexJson(state);
+    this.#updateIndexJson(state);
     this.#updatePiecesJson(state);
     if (this.#onInvalidate) {
       // Invalidate child entries under pieces/
@@ -3597,12 +3580,8 @@ export class CellBridge {
 
   /**
    * Updates the `pieces/.index.json` file for a space.
-   *
-   * TypeScript-private rather than a `#` name, because
-   * `cell-bridge.test.ts` replaces this member by assignment, which a `#`
-   * method does not allow.
    */
-  private updateIndexJson(state: SpaceState): void {
+  #updateIndexJson(state: SpaceState): void {
     const existingIno = this.#tree.lookup(state.piecesIno, ".index.json");
     if (existingIno !== undefined) {
       this.#tree.clear(existingIno);
@@ -4310,7 +4289,7 @@ export class CellBridge {
             const cancelPatternRef = rootCell.sinkMeta(
               key,
               () => {
-                void this.refreshPiecePatternMetadata(
+                void this.#refreshPiecePatternMetadata(
                   state,
                   piece,
                   pieceIno,
@@ -4458,7 +4437,7 @@ export class CellBridge {
             }
 
             // Rebuild .index.json and pieces.json.
-            this.updateIndexJson(state);
+            this.#updateIndexJson(state);
             this.#updatePiecesJson(state);
 
             // Invalidate kernel cache.
@@ -4666,12 +4645,8 @@ export class CellBridge {
    * authored source files (recovered from the content-addressed
    * `pattern:<identity>` source-doc closure). Skips system pieces that have no
    * recoverable source.
-   *
-   * TypeScript-private rather than a `#` name, because
-   * `cell-bridge.test.ts` replaces this member by assignment, which a `#`
-   * method does not allow.
    */
-  private async buildSourceTree(
+  async #buildSourceTree(
     pieceIno: bigint,
     piece: PieceController,
     state: SpaceState,

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -520,8 +520,8 @@ export class CellBridge {
 
   /**
    * The synchronization and hydration tables, the entity-projection tables,
-   * the disconnection state, and the tree-building steps this bridge keeps to
-   * itself, which a test drives directly.
+   * the disconnection state, and the tree-building and failed-connection
+   * cleanup steps this bridge keeps to itself, which a test drives directly.
    */
   get accessForTestingOnly(): {
     readonly pieceSyncs: Map<string, Promise<void>>;
@@ -539,6 +539,7 @@ export class CellBridge {
     disconnected: boolean;
     reconnectTimer: ReturnType<typeof setTimeout> | null;
     attemptReconnect(): Promise<void>;
+    removeFailedSpaceTree(spaceName: string, state: SpaceState): void;
     enqueuePiecePropRebuild(args: PropRebuildJob): Promise<void>;
     hydratePieceProp(
       pieceIno: bigint,
@@ -626,6 +627,8 @@ export class CellBridge {
         outerThis.#reconnectTimer = value;
       },
       attemptReconnect: () => this.#attemptReconnect(),
+      removeFailedSpaceTree: (spaceName, state) =>
+        this.#removeFailedSpaceTree(spaceName, state),
       enqueuePiecePropRebuild: (args) => this.#enqueuePiecePropRebuild(args),
       hydratePieceProp: (pieceIno, propName, retries) =>
         this.#hydratePieceProp(pieceIno, propName, retries),


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

The last four TypeScript-`private` members of `CellBridge` (`packages/fuse/cell-bridge.ts`) become `#` members. Each was `private` for one reason: one test in `cell-bridge.test.ts` replaced it by assignment with a canned result. This PR gives those four tests real routes, built from a written plan whose rewrites were run against the real methods before any edit (BL-093 items 12 through 15). No new production hook and no settable collaborator: one accessor entry, one test-local `FsTree` subclass, two hooks the bridge already offers, and `FakeTime`.

## The four stubbing tests and what serves each

* **`updateIndexJson`, the late-connection-failure test.** Its fake did two jobs: routing a failure into the connect after the space's state existed, and seeding a dozen tables with partial state that a real connect cannot produce. The test splits. A test-local `RefusingTree` (an `FsTree` that throws on `.index.json`) routes the failure, and the test keeps its name and its routing assertions. A new test, `CellBridge.removeFailedSpaceTree cancels every subscription and forgets every table entry of the space`, drives the cleanup step directly on a seeded space through a new accessor entry, and keeps every table-thoroughness assertion.
* **`rebuildPieceProp`, the queue test.** Two real rebuilds of one prop, each wider than one build batch, so the first rebuild parks on the tree builder's own `setTimeout(0)` yield between batches under `FakeTime`. That yield is where an unqueued second rebuild would start. A rebuild's start is witnessed at the first thing it asks of the job's cell, its schema, and its end at the existing `onCfcProjectionRebuilt` hook. The test's two timer sleeps go: it waits with `runMicrotasks` and fires each scheduled yield with `nextAsync` (not `runAllAsync`, which looks for the next timer before the microtasks that schedule it and hangs). A final assertion checks the second value won.
* **`refreshPiecePatternMetadata`, the refresh-failure test.** The real step calls the public `onInvalidate` callback unconditionally once the piece's pattern ref resolves, so a piece whose ref resolves plus an `onInvalidate` that throws makes the real step reject with the test's own message, and the subscription path logs it. The bare `await Promise.resolve()` becomes a deferred resolved by the captured console line.
* **`buildSourceTree`, the finalize test.** The one finding. The stub stood in for a source-tree failure that leaves the tracked `error.log` in place, and the real step cannot produce that: it drops the tracked log before its first fallible call, so a receipt warning could only reach the console. The test's claim, that neither warning is eaten when the finalize's rebuild fails, is reachable through the finalize's second step, the metadata refresh, which the same throwing `onInvalidate` fails after a real rebuild has tracked a fresh log. The log is then read from the rebuilt `.src`, and the expected contents are unchanged byte for byte. The test's comment says which step fails and why the other cannot be the one.

## Production changes

* `#refreshPiecePatternMetadata()`, `#rebuildPieceProp()`, `#updateIndexJson()`, `#buildSourceTree()`; the four notes and the class-head note go; the accessor's forwarders point at the `#` names; two doc comments name `#buildSourceTree()`.
* `accessForTestingOnly.removeFailedSpaceTree(spaceName, state)`, forwarding to the existing cleanup step.
* The test file drops the three cast-only type aliases with the casts, and `sourceWritePath()` takes an optional piece.

Nothing else in the tree names these members. Behavior is unchanged.

## Mutation checks

Each rewritten pin was run against a deliberate break of what it guards, then the break reverted:

1. The connect's catch removes the space directory but skips the cleanup step: the late-connection-failure test reds on the per-space tables.
2. The cleanup forgets one table: the new cleanup test reds on that table, and so does the late-connection-failure test, which checks the per-space tables too.
3. The queue runs each rebuild at once: the queue test reds on the mid-test no-overlap assertion.
4. The subscription swallows a refresh failure: the refresh-failure test's deferred never resolves and Deno reports the pending wait.
5. The receipt warning is reported only when the rebuild survives: the finalize test reds on the console line count.

## Gates

`deno fmt --check`, `deno lint`, full `deno task check`; `cell-bridge.test.ts` 97/0; fuse suite 383/0 (1 ignored, as on `main`).

For visibility: `CellBridge` is the fuse package's core class; this adds one accessor entry and no other surface.

## Review

Reviewed by a `cf-review` subagent (report only; approve, no blockers). They walked every production path the rewritten tests now drive, confirmed the finalize test's moved claim against the source-tree step's early drop of the tracked log, and re-ran the `runAllAsync` hang the queue test's comment warns about. Taken, in a third commit: the queue test's value width is a named constant whose comment points at the tree builder's batch size; the new cleanup test also seeds and asserts the entity-projection lookup refs, which the step clears, so its "every table" is true; `RefusingTree` takes the refused name at construction, since no caller built anything between constructing and arming; the late-failure test's comment says the per-space table entries are seeded, not recorded by the connect; the cleanup test drops a vestigial `await` and its `async`; the timer-drain comment describes what the code does rather than the alternative; the new test's title names the member as `CellBridge.#removeFailedSpaceTree`; and `sourceWritePath()`'s doc names its new parameter. Left: `using time = new FakeTime()` over `try/finally`, to match the file's two other uses. Pre-existing debts they noticed (no class doc comment on `CellBridge`, six undocumented `#` helpers, the test file's header and `Deno.test` shape, about twenty titles naming members without `#`) are recorded for the tidy-up and left alone here.
