### PR TITLE
refactor(runner): telemetry markers stand in for four `accessForTestingOnly` reads, and `errorHandlers` goes onto `onError()`

### DIFF
--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -1417,7 +1417,7 @@ Deno.test("CellBridge reconnect does not require entity listing support", async 
   reconnectable.disconnected = true;
   await reconnectable.attemptReconnect();
 
-  assertEquals(reconnectable.disconnected, false);
+  assertEquals(bridge.disconnected, false);
   assertEquals(sessionProbes, 1);
   assertEquals(pieceListRequests, 0);
   assertEquals(disposedManagers, 1);
@@ -1479,7 +1479,7 @@ Deno.test("CellBridge reconnect checks every space before resuming writes", asyn
     reconnectable.reconnectTimer = null;
   }
 
-  assertEquals(reconnectable.disconnected, true);
+  assertEquals(bridge.disconnected, true);
   assertEquals(sessionProbes, ["authorized", "revoked"]);
   assertEquals(piecesSyncs, ["authorized", "revoked"]);
   assertEquals(disposedManagers, ["authorized", "revoked"]);

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -753,7 +753,6 @@ export class PatternManager {
     readonly inProgressCompilations: Map<string, Promise<Pattern>>;
     maxEvaluatedModuleCacheSize: number;
     readonly modulesByIdentity: Map<string, { exports: Exports }>;
-    readonly pendingCacheWriteBacks: Set<Promise<unknown>>;
     readonly persistedCompileCacheClosures: Map<string, string>;
     hasStoredCompileCacheClosure(
       space: MemorySpace,
@@ -795,7 +794,6 @@ export class PatternManager {
         outerThis.#maxEvaluatedModuleCacheSize = value;
       },
       modulesByIdentity: this.#modulesByIdentity,
-      pendingCacheWriteBacks: this.#pendingCacheWriteBacks,
       persistedCompileCacheClosures: this.#persistedCompileCacheClosures,
       hasStoredCompileCacheClosure: (
         space,
@@ -2728,8 +2726,7 @@ export class PatternManager {
       closureSignature,
       persistence,
     });
-    this.#compileCacheWrites.add(persistence);
-    this.#pendingCacheWriteBacks.add(persistence);
+    this.#trackCacheWriteBack(space, entryIdentity, persistence);
     try {
       await persistence;
     } finally {
@@ -2739,9 +2736,45 @@ export class PatternManager {
       if (current?.persistence === persistence) {
         this.#inProgressCompileCacheWrites.delete(persistenceSlotKey);
       }
-      this.#compileCacheWrites.delete(persistence);
-      this.#pendingCacheWriteBacks.delete(persistence);
+      this.#untrackCacheWriteBack(space, entryIdentity, persistence);
     }
+  }
+
+  /**
+   * Helper for the write-back steps, which enters `write` into both in-flight
+   * sets and emits the `pattern.cache-write-back.start` marker for it.
+   */
+  #trackCacheWriteBack(
+    space: MemorySpace,
+    entryIdentity: string,
+    write: Promise<unknown>,
+  ): void {
+    this.#compileCacheWrites.add(write);
+    this.#pendingCacheWriteBacks.add(write);
+    this.#runtime.telemetry.submit({
+      type: "pattern.cache-write-back.start",
+      space,
+      entryIdentity,
+    });
+  }
+
+  /**
+   * Helper for the write-back steps, which removes `write` from both
+   * in-flight sets once it has settled and emits the
+   * `pattern.cache-write-back.complete` marker for it.
+   */
+  #untrackCacheWriteBack(
+    space: MemorySpace,
+    entryIdentity: string,
+    write: Promise<unknown>,
+  ): void {
+    this.#compileCacheWrites.delete(write);
+    this.#pendingCacheWriteBacks.delete(write);
+    this.#runtime.telemetry.submit({
+      type: "pattern.cache-write-back.complete",
+      space,
+      entryIdentity,
+    });
   }
 
   async #hasStoredCompileCacheClosure(
@@ -2808,8 +2841,7 @@ export class PatternManager {
       moduleDelegations,
       delegated,
     );
-    this.#compileCacheWrites.add(writeBack);
-    this.#pendingCacheWriteBacks.add(writeBack);
+    this.#trackCacheWriteBack(space, entryIdentity, writeBack);
     try {
       await writeBack;
       this.#recordPersistedClosureSpaces(
@@ -2817,8 +2849,7 @@ export class PatternManager {
         space,
       );
     } finally {
-      this.#compileCacheWrites.delete(writeBack);
-      this.#pendingCacheWriteBacks.delete(writeBack);
+      this.#untrackCacheWriteBack(space, entryIdentity, writeBack);
     }
   }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2169,11 +2169,11 @@ export class Runner {
   }
 
   /**
-   * The result and pointer tables, the deferred-start and start-attempt
-   * sets, the dependency syncer and deferred-start committer a test may
-   * supply, the setup, storage-subscription, commit-gated run, ownership,
-   * key, sync, walk, and retry steps, and the implementation invoker, which
-   * a test drives directly.
+   * The result and pointer tables, the start-attempt set, the dependency
+   * syncer and deferred-start committer a test may supply, the setup,
+   * storage-subscription, commit-gated run, ownership, key, sync, walk, and
+   * retry steps, and the implementation invoker, which a test drives
+   * directly.
    */
   get accessForTestingOnly(): {
     readonly locallyPreparedResults: BoundedKeyMap<
@@ -2187,10 +2187,6 @@ export class Runner {
     readonly sessionPatternPointers: BoundedKeyMap<
       `${MemorySpace}/${ScopeKey}/${URI}`,
       { identity: string; symbol: string }
-    >;
-    readonly pendingDeferredStarts: Map<
-      `${MemorySpace}/${ScopeKey}/${URI}`,
-      Set<DeferredCancelOwnership>
     >;
     readonly resultPatternCache: Map<
       `${MemorySpace}/${URI}`,
@@ -2258,7 +2254,6 @@ export class Runner {
       locallyPreparedResults: this.#locallyPreparedResults,
       locallyStoppedResults: this.#locallyStoppedResults,
       sessionPatternPointers: this.#sessionPatternPointers,
-      pendingDeferredStarts: this.#pendingDeferredStarts,
       resultPatternCache: this.#resultPatternCache,
       activeStartAttempts: this.#activeStartAttempts,
       get dependencySyncer() {
@@ -4965,28 +4960,59 @@ export class Runner {
     // from then on, or it was cancelled.
     const ownership: DeferredCancelOwnership = {
       cancel: () => {
-        unregister();
+        this.#unregisterPendingDeferredStart(key, ownership, "cancelled");
         base.cancel();
       },
       isCancelled: base.isCancelled,
       markInstalled: (registration) => {
-        unregister();
+        this.#unregisterPendingDeferredStart(key, ownership, "installed");
         return base.markInstalled(registration);
       },
     };
-    const unregister = () => {
-      const pending = this.#pendingDeferredStarts.get(key);
-      if (pending === undefined) return;
-      pending.delete(ownership);
-      if (pending.size === 0) this.#pendingDeferredStarts.delete(key);
-    };
+    this.#registerPendingDeferredStart(key, ownership);
+    return ownership;
+  }
+
+  /**
+   * Helper for the deferred-start paths, which enters `ownership` into the
+   * pending index under `key` and emits the `runner.deferred-start.pending`
+   * marker for it.
+   */
+  #registerPendingDeferredStart(
+    key: `${MemorySpace}/${ScopeKey}/${URI}`,
+    ownership: DeferredCancelOwnership,
+  ): void {
     let pending = this.#pendingDeferredStarts.get(key);
     if (pending === undefined) {
       pending = new Set();
       this.#pendingDeferredStarts.set(key, pending);
     }
     pending.add(ownership);
-    return ownership;
+    this.#runtime.telemetry.submit({
+      type: "runner.deferred-start.pending",
+      key,
+    });
+  }
+
+  /**
+   * Helper for the deferred-start paths, which removes `ownership` from the
+   * pending index under `key` and emits the `runner.deferred-start.settled`
+   * marker for it. Does nothing for an ownership the index does not hold, so
+   * the marker pairs with the one `#registerPendingDeferredStart()` emitted.
+   */
+  #unregisterPendingDeferredStart(
+    key: `${MemorySpace}/${ScopeKey}/${URI}`,
+    ownership: DeferredCancelOwnership,
+    outcome: "installed" | "cancelled",
+  ): void {
+    const pending = this.#pendingDeferredStarts.get(key);
+    if (pending === undefined || !pending.delete(ownership)) return;
+    if (pending.size === 0) this.#pendingDeferredStarts.delete(key);
+    this.#runtime.telemetry.submit({
+      type: "runner.deferred-start.settled",
+      key,
+      outcome,
+    });
   }
 
   #cancelPendingDeferredStarts(
@@ -4994,8 +5020,13 @@ export class Runner {
   ): void {
     const pending = this.#pendingDeferredStarts.get(key);
     if (pending === undefined) return;
-    this.#pendingDeferredStarts.delete(key);
-    for (const ownership of pending) ownership.cancel();
+    // Every entry leaves the index before any of them is cancelled, so the
+    // index never holds an attempt whose cancel is under way.
+    const owners = [...pending];
+    for (const ownership of owners) {
+      this.#unregisterPendingDeferredStart(key, ownership, "cancelled");
+    }
+    for (const ownership of owners) ownership.cancel();
   }
 
   #startAfterSuccessfulCommit<T = any>(
@@ -5262,12 +5293,7 @@ export class Runner {
     // the same path that tombstones a pending first attempt. (The
     // markInstalled above also unregistered the token — a no-op, it was
     // not registered — so this add is the token's one live entry.)
-    let pending = this.#pendingDeferredStarts.get(key);
-    if (pending === undefined) {
-      pending = new Set();
-      this.#pendingDeferredStarts.set(key, pending);
-    }
-    pending.add(ownership);
+    this.#registerPendingDeferredStart(key, ownership);
     const recovery = this.#runtime.awaitCommitRetryReadiness(error)
       .then(async () => {
         // Paired guards, each the other's backstop (the mutation pins kill

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -18,6 +18,7 @@ import { normalizeCellScope } from "../scope.ts";
 import type {
   CycleReport,
   NonIdempotentReport,
+  RuntimeTelemetry,
   SchedulerActionInfo,
   SchedulerDiagnosisResult,
 } from "../telemetry.ts";
@@ -39,6 +40,9 @@ export type CausalEdge = {
 };
 
 export interface SchedulerDiagnosisControlState {
+  /** The channel the `scheduler.diagnosis.start` marker is emitted on. */
+  readonly telemetry: RuntimeTelemetry;
+
   readonly getDiagnosisEnabled: () => boolean;
   readonly setDiagnosisEnabled: (enabled: boolean) => void;
   readonly getDiagnosisTimeout: () => ReturnType<typeof setTimeout> | null;
@@ -431,6 +435,7 @@ export function startSchedulerDiagnosis(
       stopSchedulerDiagnosis(state);
     }, durationMs),
   );
+  state.telemetry.submit({ type: "scheduler.diagnosis.start", durationMs });
 }
 
 export function stopSchedulerDiagnosis(

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -541,13 +541,10 @@ export class Scheduler {
   get accessForTestingOnly(): {
     readonly actionStats: BoundedKeyMap<string, ActionStats>;
     readonly dependencyUpdateState: DependencyUpdateState;
-    readonly diagnosisEnabled: boolean;
-    readonly errorHandlers: Set<ErrorHandler>;
     readonly eventExecutionState: SchedulerEventExecutionState;
     readonly eventQueue: QueuedEvent[];
     readonly eventQueueState: SchedulerEventQueueState;
     readonly gates: SchedulerGates;
-    readonly materializers: SchedulerMaterializers;
     readonly nodes: NodeRegistry;
     readonly pending: Set<Action>;
     pendingQueueTaskTimer: ReturnType<typeof setTimeout> | null;
@@ -573,10 +570,6 @@ export class Scheduler {
       get dependencyUpdateState() {
         return outerThis.#dependencyUpdateState;
       },
-      get diagnosisEnabled() {
-        return outerThis.#diagnosisEnabled;
-      },
-      errorHandlers: this.#errorHandlers,
       get eventExecutionState() {
         return outerThis.#eventExecutionState;
       },
@@ -585,7 +578,6 @@ export class Scheduler {
         return outerThis.#eventQueueState;
       },
       gates: this.#gates,
-      materializers: this.#materializers,
       nodes: this.#nodes,
       pending: this.#pending,
       get pendingQueueTaskTimer() {
@@ -2321,6 +2313,7 @@ export class Scheduler {
 
   #createDiagnosisControlState(): SchedulerDiagnosisControlState {
     return {
+      telemetry: this.runtime.telemetry,
       getDiagnosisEnabled: () => this.#diagnosisEnabled,
       setDiagnosisEnabled: (enabled) => {
         this.#diagnosisEnabled = enabled;
@@ -3252,6 +3245,12 @@ export class Scheduler {
       action,
       (action as Partial<TelemetryAnnotations>).materializerWriteEnvelopes,
     );
+    this.runtime.telemetry.submit({
+      type: "scheduler.materializer.register",
+      actionId: this.#getActionId(action),
+      writes: (this.#materializers.getMaterializerWriteEnvelopes(action) ?? [])
+        .map((w) => `${w.space}/${w.id}/${w.path.join("/")}`),
+    });
     notifyNodeLivenessChange(this.#dependencyGraphState, action, wasLive);
   }
 

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -171,14 +171,16 @@ export type RuntimeTelemetryMarker = {
 } | {
   // Emitted as a commit-gated start for the result under `key` enters the
   // runner's pending index, where a stop arriving before the commit finds it.
-  // One marker per pending attempt; a key can hold several at once.
+  // One marker per entry into the index: a key can hold several attempts at
+  // once, and an attempt that recovers from a refused commit re-enters.
   type: "runner.deferred-start.pending";
   key: string;
 } | {
   // Emitted as a pending commit-gated start leaves the index: `installed`
-  // when its commit landed and the registration now owns itself, `cancelled`
-  // when a stop or a failed commit ended it first. Pairs one-to-one with
-  // `runner.deferred-start.pending` for the same attempt.
+  // once the attempt has installed its registration, which happens before
+  // its own transaction commits, and `cancelled` when the attempt ended
+  // before installing one. Pairs one-to-one with
+  // `runner.deferred-start.pending` for the same entry.
   type: "runner.deferred-start.settled";
   key: string;
   outcome: "installed" | "cancelled";

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -169,6 +169,47 @@ export type RuntimeTelemetryMarker = {
   type: "runner.piece.install";
   key: string;
 } | {
+  // Emitted as a commit-gated start for the result under `key` enters the
+  // runner's pending index, where a stop arriving before the commit finds it.
+  // One marker per pending attempt; a key can hold several at once.
+  type: "runner.deferred-start.pending";
+  key: string;
+} | {
+  // Emitted as a pending commit-gated start leaves the index: `installed`
+  // when its commit landed and the registration now owns itself, `cancelled`
+  // when a stop or a failed commit ended it first. Pairs one-to-one with
+  // `runner.deferred-start.pending` for the same attempt.
+  type: "runner.deferred-start.settled";
+  key: string;
+  outcome: "installed" | "cancelled";
+} | {
+  // Emitted as the pattern manager begins a tracked compile-cache write-back
+  // into `space` for the closure rooted at `entryIdentity`: a closure
+  // persistence or a source write-back, the writes replication waits on
+  // before reading its origin space.
+  type: "pattern.cache-write-back.start";
+  space: string;
+  entryIdentity: string;
+} | {
+  // Emitted as a tracked compile-cache write-back settles, whichever way it
+  // settled. Pairs one-to-one with `pattern.cache-write-back.start`.
+  type: "pattern.cache-write-back.complete";
+  space: string;
+  entryIdentity: string;
+} | {
+  // Emitted each time the scheduler decides an action's materializer
+  // registration, on subscribe and on resubscribe. `writes` are the compacted
+  // write envelopes the action is registered under, as `space/id/path`
+  // strings; an action registered under none is not a materializer.
+  type: "scheduler.materializer.register";
+  actionId: string;
+  writes: string[];
+} | {
+  // Emitted as diagnosis mode switches on, whether by an explicit run or by
+  // the non-settling auto-trigger, with the window it will capture for.
+  type: "scheduler.diagnosis.start";
+  durationMs: number;
+} | {
   // Emitted once per settle pass, unconditionally (unlike SettleStats, which
   // is opt-in): the user-facing "event → stable graph" number.
   type: "scheduler.settle";

--- a/packages/runner/test/artifact-index-pinning.test.ts
+++ b/packages/runner/test/artifact-index-pinning.test.ts
@@ -5,6 +5,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { observeCacheWriteBacks } from "./support/telemetry-observers.ts";
 
 /**
  * Open question 2 (docs/specs/content-addressed-action-identity.md) resolved:
@@ -90,9 +91,11 @@ describe("artifact index pinning (session-lifetime)", () => {
     // persisted ref has a durable closure behind it.
     const pm = runtime.patternManager;
     const tx = runtime.edit();
+    const writeBacks = observeCacheWriteBacks(runtime);
     await pm.compilePattern(program(7), { space: signer.did(), tx });
+    expect(writeBacks.started()).toBeGreaterThan(0);
+    expect(writeBacks.inFlight()).toBe(0);
+    writeBacks.restore();
     await tx.commit();
-    const pending = pm.accessForTestingOnly.pendingCacheWriteBacks;
-    expect(pending.size).toBe(0);
   });
 });

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -29,6 +29,7 @@ import {
   writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { observeCacheWriteBacks } from "./support/telemetry-observers.ts";
 
 import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
 import { buildCfcPolicyArtifactManifest } from "../src/cfc/policy.ts";
@@ -2145,6 +2146,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
       ],
     });
     const manager = runtime.patternManager.accessForTestingOnly;
+    const writeBacks = observeCacheWriteBacks(runtime);
     const firstStarted = Promise.withResolvers<void>();
     const releaseFirst = Promise.withResolvers<void>();
     const secondStarted = Promise.withResolvers<void>();
@@ -2178,7 +2180,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
         { runtimeVersion },
       );
 
-      expect(manager.pendingCacheWriteBacks.size).toBe(2);
+      expect(writeBacks.inFlight()).toBe(2);
       releaseFirst.resolve();
       await secondStarted.promise;
       releaseSecond.resolve();
@@ -2192,6 +2194,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
           (write): write is Promise<void> => write !== undefined,
         ),
       );
+      writeBacks.restore();
       manager.compileCacheWriter = undefined;
     }
   });

--- a/packages/runner/test/child-run-ownership.test.ts
+++ b/packages/runner/test/child-run-ownership.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
 import { entityKey } from "../src/scheduler/keys.ts";
+import { observePendingDeferredStarts } from "./support/telemetry-observers.ts";
 
 // The four guarantees a child run carries beyond "whoever created it stops it".
 // Each drives the public API only: a parent pattern, a child reached through
@@ -357,10 +358,10 @@ describe("child run ownership", () => {
       undefined,
       tx,
     );
+    const pending = observePendingDeferredStarts(runtime);
     runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
 
-    const pending = runtime.runner.accessForTestingOnly.pendingDeferredStarts;
-    expect(pending.size).toBe(1);
+    expect(pending.keys()).toBe(1);
 
     expect((await tx.commit()).error).toBeUndefined();
     await runtime.idle();
@@ -368,7 +369,8 @@ describe("child run ownership", () => {
     // The installed registration owns itself from here, so nothing is left
     // waiting to be tombstoned.
     expect(runtime.runner.cancels.has(key(result))).toBe(true);
-    expect(pending.size).toBe(0);
+    expect(pending.keys()).toBe(0);
+    pending.restore();
     runtime.runner.stop(result);
   });
 
@@ -387,10 +389,10 @@ describe("child run ownership", () => {
       undefined,
       tx,
     );
+    const pending = observePendingDeferredStarts(runtime);
     runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
 
-    const pending = runtime.runner.accessForTestingOnly.pendingDeferredStarts;
-    expect(pending.size).toBe(1);
+    expect(pending.keys()).toBe(1);
 
     expect(tx.abort("setup rejected").error).toBeUndefined();
     await runtime.idle();
@@ -398,7 +400,8 @@ describe("child run ownership", () => {
     // The start will never install, so it settles as cancelled and leaves
     // nothing behind for the result's key.
     expect(runtime.runner.cancels.has(key(result))).toBe(false);
-    expect(pending.size).toBe(0);
+    expect(pending.keys()).toBe(0);
+    pending.restore();
   });
 
   it("stops tracking a commit-gated pattern run when its transaction fails", async () => {
@@ -418,6 +421,7 @@ describe("child run ownership", () => {
       undefined,
       tx,
     );
+    const pending = observePendingDeferredStarts(runtime);
     harness.runPatternAfterSuccessfulCommit(
       tx,
       receipt,
@@ -426,13 +430,14 @@ describe("child run ownership", () => {
       true,
       true,
     );
-    expect(harness.pendingDeferredStarts.size).toBe(1);
+    expect(pending.keys()).toBe(1);
 
     expect(tx.abort("handler rejected").error).toBeUndefined();
     await runtime.idle();
 
-    expect(harness.pendingDeferredStarts.size).toBe(0);
+    expect(pending.keys()).toBe(0);
     expect(runtime.runner.cancels.has(key(receipt))).toBe(false);
+    pending.restore();
   });
 
   it("declines to release a result that has no registration", () => {

--- a/packages/runner/test/child-run-ownership.test.ts
+++ b/packages/runner/test/child-run-ownership.test.ts
@@ -370,6 +370,8 @@ describe("child run ownership", () => {
     // waiting to be tombstoned.
     expect(runtime.runner.cancels.has(key(result))).toBe(true);
     expect(pending.keys()).toBe(0);
+    expect(pending.settled("installed")).toBe(1);
+    expect(pending.settled("cancelled")).toBe(0);
     pending.restore();
     runtime.runner.stop(result);
   });
@@ -401,6 +403,8 @@ describe("child run ownership", () => {
     // nothing behind for the result's key.
     expect(runtime.runner.cancels.has(key(result))).toBe(false);
     expect(pending.keys()).toBe(0);
+    expect(pending.settled("cancelled")).toBe(1);
+    expect(pending.settled("installed")).toBe(0);
     pending.restore();
   });
 
@@ -436,6 +440,8 @@ describe("child run ownership", () => {
     await runtime.idle();
 
     expect(pending.keys()).toBe(0);
+    expect(pending.settled("cancelled")).toBe(1);
+    expect(pending.settled("installed")).toBe(0);
     expect(runtime.runner.cancels.has(key(receipt))).toBe(false);
     pending.restore();
   });

--- a/packages/runner/test/computed-error.test.ts
+++ b/packages/runner/test/computed-error.test.ts
@@ -48,8 +48,7 @@ Deno.test("computed throws error", async () => {
 
   let errorCaught = false;
 
-  const errorHandlers = runtime.scheduler.accessForTestingOnly.errorHandlers;
-  errorHandlers.add((_err: Error) => {
+  runtime.scheduler.onError((_err: Error) => {
     errorCaught = true;
   });
 

--- a/packages/runner/test/deferred-start-catchup-start.test.ts
+++ b/packages/runner/test/deferred-start-catchup-start.test.ts
@@ -12,6 +12,7 @@ import { Runtime } from "../src/runtime.ts";
 import { entityKey } from "../src/scheduler/keys.ts";
 import type { CommitError } from "../src/storage/interface.ts";
 import type { RuntimeTelemetryEvent } from "../src/telemetry.ts";
+import { observePendingDeferredStarts } from "./support/telemetry-observers.ts";
 
 // A commit-gated piece start whose transaction is REFUSED for a stale
 // confirmed read. Under server-side execution that refusal is the expected
@@ -961,6 +962,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       resumingRefusalOf(result),
     );
     const installed = observeContextInstalls(runtime, key(result));
+    const pending = observePendingDeferredStarts(runtime);
     // Fail the recovery's walk at its dependency pre-sync: the first attempt
     // wires normally, never passing that step, and is torn down by the
     // refusal; the recovery's walk then dies at the step only it reaches.
@@ -990,9 +992,10 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       expect(syncFailures).toBe(1);
       expect(injector.refusals()).toBe(1);
       expect(runtime.runner.cancels.has(key(result))).toBe(false);
-      expect(harness.pendingDeferredStarts.has(key(result))).toBe(false);
+      expect(pending.count(key(result))).toBe(0);
     } finally {
       harness.dependencySyncer = undefined;
+      pending.restore();
       installed.restore();
       injector.restore();
     }
@@ -1065,6 +1068,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
     const originalCommitNative = replica.commitNative;
     const refusalWaiter = Promise.withResolvers<void>();
     let refusals = 0;
+    const pending = observePendingDeferredStarts(runtime);
     replica.commitNative = function (...args: unknown[]) {
       const candidate = args[1] as { tx?: object } | object;
       const inner = (candidate as { tx?: object }).tx ?? candidate;
@@ -1101,7 +1105,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
         "the recovery awaiting the refusal's readiness gate",
       );
       expect(scheduled).toBe(1);
-      expect(harness.pendingDeferredStarts.get(key(receipt))?.size).toBe(1);
+      expect(pending.count(key(receipt))).toBe(1);
       gate.resolve();
       await runtime.runner.idleDeferredStartCatchUps();
       await runtime.idle();
@@ -1114,6 +1118,7 @@ describe("a deferred start refused for a stale confirmed read, flag-ON", () => {
       expect(runtime.runner.cancels.has(key(receipt))).toBe(false);
     } finally {
       gate.resolve();
+      pending.restore();
       replica.commitNative = originalCommitNative;
       harness.deferredStartCommitter = undefined;
     }

--- a/packages/runner/test/materializer-envelope-collection.test.ts
+++ b/packages/runner/test/materializer-envelope-collection.test.ts
@@ -19,6 +19,7 @@ import type { NormalizedFullLink } from "../src/link-utils.ts";
 import { trustExecutable } from "./support/trusted-builder.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import type { Cell } from "../src/cell.ts";
+import type { RuntimeTelemetryEvent } from "../src/telemetry.ts";
 
 const signer = await Identity.fromPassphrase(
   "materializer envelope collection",
@@ -301,40 +302,61 @@ describe("materializer envelope branch selection", () => {
     ],
   });
 
-  const materializerIndex = () =>
-    runtime.scheduler.accessForTestingOnly.materializers;
-
-  const runPattern = async (withWriteMetadata: boolean) => {
-    const resultCell = runtime.getCell(
-      space,
-      `branch-selection-${withWriteMetadata}`,
-    );
-    const result = runtime.run(
-      undefined,
-      trustExecutable(
-        runtime,
-        triConditionPattern(withWriteMetadata) as never,
-      ),
-      { notifyArg: {}, targetArg: 1 } as never,
-      resultCell as never,
-    );
-    await result.pull();
-    await runtime.idle();
+  // Runs the pattern to idle, and returns the write envelopes each action
+  // ended up registered under, read from the scheduler's
+  // `scheduler.materializer.register` markers: an action's latest marker
+  // says whether it is a materializer, and under which writes.
+  const runPattern = async (
+    withWriteMetadata: boolean,
+  ): Promise<Map<string, string[]>> => {
+    const writesByAction = new Map<string, string[]>();
+    const listener = (event: Event) => {
+      const { marker } = (event as RuntimeTelemetryEvent).detail;
+      if (marker.type !== "scheduler.materializer.register") return;
+      writesByAction.set(marker.actionId, marker.writes);
+    };
+    runtime.telemetry.addEventListener("telemetry", listener);
+    try {
+      const resultCell = runtime.getCell(
+        space,
+        `branch-selection-${withWriteMetadata}`,
+      );
+      const result = runtime.run(
+        undefined,
+        trustExecutable(
+          runtime,
+          triConditionPattern(withWriteMetadata) as never,
+        ),
+        { notifyArg: {}, targetArg: 1 } as never,
+        resultCell as never,
+      );
+      await result.pull();
+      await runtime.idle();
+    } finally {
+      runtime.telemetry.removeEventListener("telemetry", listener);
+    }
+    return writesByAction;
   };
 
+  const materializers = (writesByAction: Map<string, string[]>) =>
+    [...writesByAction.values()].filter((writes) => writes.length > 0);
+
   it("send-only write metadata suppresses the opaque-result fallback", async () => {
-    await runPattern(true);
+    const registered = materializers(await runPattern(true));
     // The stream path does not brand-match and the writable arg does not
     // path-match: no envelopes, so the action never registers as a
     // materializer.
-    expect(materializerIndex().materializers.size).toBe(0);
+    expect(registered).toHaveLength(0);
   });
 
   it("without write metadata the opaque-result fallback collects writable args", async () => {
-    await runPattern(false);
-    const index = materializerIndex();
-    expect(index.materializers.size).toBe(1);
-    // The registered envelope addresses the writable arg's backing entity.
-    expect(index.materializersByEntity.size).toBeGreaterThan(0);
+    const registered = materializers(await runPattern(false));
+    expect(registered).toHaveLength(1);
+    // The registered envelope addresses the writable arg's backing entity,
+    // which lives in the test's space.
+    expect(registered[0].length).toBeGreaterThan(0);
+    for (const write of registered[0]) {
+      expect(write.startsWith(`${space}/`)).toBe(true);
+    }
   });
 });

--- a/packages/runner/test/scheduler-settling-telemetry.test.ts
+++ b/packages/runner/test/scheduler-settling-telemetry.test.ts
@@ -60,9 +60,11 @@ describe("scheduler non-settling telemetry", () => {
     try {
       const scheduler = runtime.scheduler.accessForTestingOnly;
       const markers: { busyTime: number; windowDuration: number }[] = [];
+      let diagnosisStarts = 0;
       const listener = (event: Event) => {
         const { marker } = (event as RuntimeTelemetryEvent).detail;
         if (marker.type === "scheduler.non-settling") markers.push(marker);
+        if (marker.type === "scheduler.diagnosis.start") diagnosisStarts++;
       };
       runtime.telemetry.addEventListener("telemetry", listener);
       try {
@@ -84,12 +86,13 @@ describe("scheduler non-settling telemetry", () => {
         expect(markers[0].windowDuration).toBeGreaterThanOrEqual(8_000);
         expect(runtime.scheduler.isNonSettling()).toBe(true);
         // Auto-trigger switched diagnosis on.
-        expect(scheduler.diagnosisEnabled).toBe(true);
+        expect(diagnosisStarts).toBe(1);
 
         // A later execute end in the same episode stays quiet (and takes the
         // diagnosis busy-time accounting branch instead).
         scheduler.recordExecuteEndTelemetry();
         expect(markers.length).toBe(1);
+        expect(diagnosisStarts).toBe(1);
       } finally {
         runtime.telemetry.removeEventListener("telemetry", listener);
       }

--- a/packages/runner/test/stack-trace-patterns.test.ts
+++ b/packages/runner/test/stack-trace-patterns.test.ts
@@ -53,8 +53,7 @@ Deno.test("lift error through CTS pipeline has correct source line", async () =>
   const patternFn = main!["default"];
 
   let capturedError: Error | null = null;
-  const errorHandlers = runtime.scheduler.accessForTestingOnly.errorHandlers;
-  errorHandlers.add((err: Error) => {
+  runtime.scheduler.onError((err: Error) => {
     capturedError = err;
   });
 
@@ -131,8 +130,7 @@ Deno.test("handler error through CTS pipeline has correct source line", async ()
   const patternFn = main!["default"];
 
   let capturedError: Error | null = null;
-  const errorHandlers = runtime.scheduler.accessForTestingOnly.errorHandlers;
-  errorHandlers.add((err: Error) => {
+  runtime.scheduler.onError((err: Error) => {
     capturedError = err;
   });
 
@@ -211,8 +209,7 @@ Deno.test("lift error stack has multiple frames with correct source line", async
   const patternFn = main!["default"];
 
   let capturedError: Error | null = null;
-  const errorHandlers = runtime.scheduler.accessForTestingOnly.errorHandlers;
-  errorHandlers.add((err: Error) => {
+  runtime.scheduler.onError((err: Error) => {
     capturedError = err;
   });
 

--- a/packages/runner/test/support/telemetry-observers.ts
+++ b/packages/runner/test/support/telemetry-observers.ts
@@ -36,11 +36,18 @@ function listen(
 export function observePendingDeferredStarts(runtime: Runtime): {
   /** How many keys hold at least one pending attempt. */
   keys(): number;
+
   /** How many attempts are pending under `key`. */
   count(key: string): number;
+
+  /** How many attempts have settled with the given outcome. */
+  settled(outcome: "installed" | "cancelled"): number;
+
+  /** Stops listening. */
   restore(): void;
 } {
   const pending = new Map<string, number>();
+  const settled = { installed: 0, cancelled: 0 };
   const restore = listen(runtime, (marker) => {
     if (marker.type === "runner.deferred-start.pending") {
       pending.set(marker.key, (pending.get(marker.key) ?? 0) + 1);
@@ -48,11 +55,13 @@ export function observePendingDeferredStarts(runtime: Runtime): {
       const left = (pending.get(marker.key) ?? 0) - 1;
       if (left > 0) pending.set(marker.key, left);
       else pending.delete(marker.key);
+      settled[marker.outcome]++;
     }
   });
   return {
     keys: () => pending.size,
     count: (key) => pending.get(key) ?? 0,
+    settled: (outcome) => settled[outcome],
     restore,
   };
 }
@@ -66,8 +75,11 @@ export function observePendingDeferredStarts(runtime: Runtime): {
 export function observeCacheWriteBacks(runtime: Runtime): {
   /** How many write-backs have started. */
   started(): number;
+
   /** How many write-backs have started and not yet settled. */
   inFlight(): number;
+
+  /** Stops listening. */
   restore(): void;
 } {
   let started = 0;

--- a/packages/runner/test/support/telemetry-observers.ts
+++ b/packages/runner/test/support/telemetry-observers.ts
@@ -1,0 +1,84 @@
+/**
+ * Listeners on a runtime's telemetry that shadow two indexes a test would
+ * otherwise have to read from inside the class: the runner's pending
+ * commit-gated starts, and the pattern manager's in-flight cache write-backs.
+ * Each rebuilds its index from the marker pair the class emits as an entry
+ * comes and goes. Dispatch is synchronous, so a read here sees the change the
+ * moment the class made it.
+ */
+
+import type { Runtime } from "../../src/runtime.ts";
+import type {
+  RuntimeTelemetryEvent,
+  RuntimeTelemetryMarker,
+} from "../../src/telemetry.ts";
+
+/**
+ * Helper for the observers, which runs `onMarker` for every marker `runtime`
+ * emits until the returned function is called.
+ */
+function listen(
+  runtime: Runtime,
+  onMarker: (marker: RuntimeTelemetryMarker) => void,
+): () => void {
+  const listener = (event: Event) => {
+    onMarker((event as RuntimeTelemetryEvent).detail.marker);
+  };
+  runtime.telemetry.addEventListener("telemetry", listener);
+  return () => runtime.telemetry.removeEventListener("telemetry", listener);
+}
+
+/**
+ * Watches the runner's index of pending commit-gated starts through its
+ * `runner.deferred-start.pending` and `runner.deferred-start.settled` markers.
+ * Install it before the start whose attempts are to be counted.
+ */
+export function observePendingDeferredStarts(runtime: Runtime): {
+  /** How many keys hold at least one pending attempt. */
+  keys(): number;
+  /** How many attempts are pending under `key`. */
+  count(key: string): number;
+  restore(): void;
+} {
+  const pending = new Map<string, number>();
+  const restore = listen(runtime, (marker) => {
+    if (marker.type === "runner.deferred-start.pending") {
+      pending.set(marker.key, (pending.get(marker.key) ?? 0) + 1);
+    } else if (marker.type === "runner.deferred-start.settled") {
+      const left = (pending.get(marker.key) ?? 0) - 1;
+      if (left > 0) pending.set(marker.key, left);
+      else pending.delete(marker.key);
+    }
+  });
+  return {
+    keys: () => pending.size,
+    count: (key) => pending.get(key) ?? 0,
+    restore,
+  };
+}
+
+/**
+ * Watches the pattern manager's in-flight compile-cache write-backs through
+ * its `pattern.cache-write-back.start` and `pattern.cache-write-back.complete`
+ * markers. Install it before the compile or persist whose writes are to be
+ * counted.
+ */
+export function observeCacheWriteBacks(runtime: Runtime): {
+  /** How many write-backs have started. */
+  started(): number;
+  /** How many write-backs have started and not yet settled. */
+  inFlight(): number;
+  restore(): void;
+} {
+  let started = 0;
+  let completed = 0;
+  const restore = listen(runtime, (marker) => {
+    if (marker.type === "pattern.cache-write-back.start") started++;
+    else if (marker.type === "pattern.cache-write-back.complete") completed++;
+  });
+  return {
+    started: () => started,
+    inFlight: () => started - completed,
+    restore,
+  };
+}

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -652,24 +652,17 @@ export class XHeaderView extends BaseView {
   #resizeTimer?: ReturnType<typeof setTimeout>;
 
   /**
-   * The favorites subscription step, the favorite-toggle guard, the
-   * favorited-piece test, and the three click handlers, which a test drives
-   * directly.
+   * The favorites subscription step, the favorited-piece test, and the three
+   * click handlers, which a test drives directly.
    */
   get accessForTestingOnly(): {
-    readonly isFavoriteLoading: boolean;
     ensureFavoritesSubscription(): void;
     isFavorite(): boolean;
     handleLogoClick(e: Event): void;
     handleToggleFavorite(e: Event): Promise<void>;
     copyReference(e: Event): Promise<void>;
   } {
-    // deno-lint-ignore no-this-alias
-    const outerThis = this;
     return {
-      get isFavoriteLoading() {
-        return outerThis.#isFavoriteLoading;
-      },
       ensureFavoritesSubscription: () => this.#ensureFavoritesSubscription(),
       isFavorite: () => this.#isFavorite(),
       handleLogoClick: (e) => this.#handleLogoClick(e),

--- a/packages/shell/test/header-view-favorites.test.ts
+++ b/packages/shell/test/header-view-favorites.test.ts
@@ -214,7 +214,8 @@ Deno.test("toggling a favorite requests the subscription and swallows a disposal
   try {
     const { XHeaderView } = await import("../src/views/HeaderView.ts");
 
-    // A successful toggle subscribes and clears the in-flight flag.
+    // A successful toggle subscribes and releases the in-flight guard: a
+    // second toggle writes again.
     const ok = new XHeaderView() as unknown as HeaderViewLike;
     const okRt = makeRuntime();
     ok.rt = okRt;
@@ -226,9 +227,11 @@ Deno.test("toggling a favorite requests the subscription and swallows a disposal
     await ok.accessForTestingOnly.handleToggleFavorite(fakeEvent());
     assertEquals(okRt.subscribeCount, 1);
     assertEquals(okRt.writeCount, 1);
-    assertFalse(ok.accessForTestingOnly.isFavoriteLoading);
+    await ok.accessForTestingOnly.handleToggleFavorite(fakeEvent());
+    assertEquals(okRt.writeCount, 2);
 
-    // A write cancelled by a disposed runtime is swallowed, not surfaced.
+    // A write cancelled by a disposed runtime is swallowed, not surfaced,
+    // and releases the guard the same way.
     const racing = new XHeaderView() as unknown as HeaderViewLike;
     const racingRt = makeRuntime({ failWrite: true, aborted: true });
     racing.rt = racingRt;
@@ -238,7 +241,9 @@ Deno.test("toggling a favorite requests the subscription and swallows a disposal
       scope: "space",
     };
     await racing.accessForTestingOnly.handleToggleFavorite(fakeEvent());
-    assertFalse(racing.accessForTestingOnly.isFavoriteLoading);
+    assertEquals(racingRt.writeCount, 1);
+    await racing.accessForTestingOnly.handleToggleFavorite(fakeEvent());
+    assertEquals(racingRt.writeCount, 2);
 
     // A piece whose scope the view does not yet know has no address to be
     // favorited at, and the toggle writes nothing rather than favoriting


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

Four `accessForTestingOnly` members whose every test site only observed them are retired in favor of telemetry markers the class emits as the observed thing happens, the tactic `runner.piece.install` introduced. The tests listen on `runtime.telemetry` and rebuild what they used to read. Three bycatch items from the same census ride along.

## The four members and their markers

* **`Runner.pendingDeferredStarts`** (six sites in `child-run-ownership` and `deferred-start-catchup-start`) becomes `runner.deferred-start.pending { key }` and `runner.deferred-start.settled { key, outcome }`. Two new `#` helpers own every per-entry mutation of the index and emit as they mutate (the wholesale `clear()` in `stopAll()` runs after the per-key cancel loop has emptied it), so a listener keeping pending-minus-settled per key holds exactly what the index holds; `EventTarget` dispatch is synchronous, so the pre-commit `size === 1` read stays a synchronous read. `#cancelPendingDeferredStarts()` unregisters every entry before cancelling any, as the wholesale delete it replaces did.
* **`PatternManager.pendingCacheWriteBacks`** (two sites) becomes `pattern.cache-write-back.start` and `.complete { space, entryIdentity }`. Two new helpers own the add and delete on both in-flight sets and emit alongside. The cold-compile test now also pins that at least one write-back ran, which the size read could not say.
* **`Scheduler.materializers`** (three sites) becomes `scheduler.materializer.register { actionId, writes }`, emitted from `#updateMaterializerRegistration()` with the compacted envelopes in the `space/id/path` form `scheduler.dependencies.update` uses. The envelope-collection tests read each action's latest marker; the by-entity assertion becomes "every write is in the test's space".
* **`Scheduler.diagnosisEnabled`** (one site) becomes `scheduler.diagnosis.start { durationMs }`, emitted from `startSchedulerDiagnosis()` so both the auto-trigger and an explicit run report. `SchedulerDiagnosisControlState` carries the telemetry channel for it.

The observers the runner tests share are in `test/support/telemetry-observers.ts`.

## Bycatch

* `Scheduler.errorHandlers` leaves the accessor. Its four sites only called `.add()`, which the public `onError()` does.
* Two `CellBridge.disconnected` reads in `cell-bridge.test.ts` use the public getter. The setter stays for the three sites that arm the disconnected state by hand.
* `HeaderView.isFavoriteLoading` leaves the accessor. The test shows the guard's release by toggling a second time and counting a second write, in both the successful and the disposal-race arms.

## Mutation checks

Each rewritten pin was run against a deliberate break, then the break reverted:

1. Drop the `settled` emit: both deferred-start files red (five steps). Report `cancelled` from the install arm: the ownership test whose start installs reds on `outcome`.
2. Drop the write-back `complete` emit: the cold-compile pin reds. Drop the `start` emit: the two-in-flight pin reds too.
3. Report `writes: []` from the materializer marker: the writable-args test reds.
4. Drop the `diagnosis.start` emit: the auto-trigger test reds.
5. Never release the favorite-toggle guard: two header-view tests red.

## Gates

`deno fmt --check`, `deno lint`, full `deno task check`; runner suite 1390/0; piece suite 56/0; shell 62/0; html 26/0; fuse 382/0.

Coverage: the Coverage Check names `packages/fuse/cell-bridge.ts` 616-618, the accessor's `disconnected` getter, which the two reads that moved to the public getter no longer reach. The getter stays, since an accessor entry for a reassigned field is a getter first and gains its setter for the tests that assign it; the debt is accepted below, as the unread collaborator getters were.

ACCEPT_COVERAGE_DEBT: packages/fuse +3 lines

## Not in this change

The runner members whose tests both observe and inject or invoke them (`resultPatternCache`, `locallyPreparedResults`, `activeStartAttempts`, `compileCacheWrites`, `gates`, `Engine.executableRegistry`) keep their accessor entries; a marker there would retire a read but not the member. Markers for classes outside the runner would put their packages' concepts into the runner's marker union, and are not added.

## Review

Reviewed by a `cf-review` subagent (report only; approve with nits, no blockers). They confirmed the `#cancelPendingDeferredStarts()` rewrite behavior-identical under re-entrancy, traced every emit site against its marker comment, checked the one constructor of `SchedulerDiagnosisControlState`, and re-ran the focused files. Taken: the `runner.deferred-start.settled` comment said `installed` meant the commit had landed, when `markInstalled()` runs at the install, before the start transaction commits, so the comment now says that and the `pending` comment says one marker per entry into the index; `outcome` was unpinned (flipping the install arm to `cancelled` passed), so the observer counts settles by outcome and the three ownership tests assert theirs; the observers' return types document `restore()` and space their documented members; and the body's "every mutation" claim is bounded by the `clear()` in `stopAll()`. Noted and left: the materializer marker builds its `writes` array on every subscribe and resubscribe whether or not anything listens, as `scheduler.dependencies.update` already does per dependency update.
