### PR TITLE
fix(shuttle): refusals written in the vocabulary the prompt has

### DIFF
--- a/packages/cli/integration/shuttle-over-a-terminal.sh
+++ b/packages/cli/integration/shuttle-over-a-terminal.sh
@@ -257,6 +257,7 @@ link /slugs/first/label#argument /slugs/second/label
 set label '"pointed at"'
 set settings/note '"written once and never again"'
 link /slugs/first/label /slugs/second/label#argument
+edit
 LINES
 EDITOR="$EDITOR_SCRIPT" python3 "$DRIVER" "$SCRIPT" "$TRANSCRIPT" -- \
   $CF sh $ARGS >/dev/null
@@ -560,7 +561,7 @@ check '"jam"' "$(said 37 "get summary")" \
 contains "\`verbs\` lists what this piece can be asked to do" \
   "$(said 38 "call . --help")" "an option in the name position names verbs"
 
-step "24. edit writes back what the editor saved, and stops three ways"
+step "24. edit writes back what the editor saved, stopping three ways after the editor and one before it"
 check "Wrote \`label\` on \`$FIRST\`." "$(said 39 "edit label")" \
   "edit writes back what came out of the editor"
 check '"edited in the editor"' "$(said 40 "get label")" \
@@ -583,6 +584,16 @@ else
 fi
 check '"garble me"' "$(said 44 "get label")" \
   "the refused edit left the cell holding what it held"
+# The stop that comes before the editor rather than after it. The operand
+# names the whole piece — here by naming nothing, shuttle standing on one —
+# and no write onto a whole piece can land, so the line is turned down while
+# there is nothing typed to lose. The editor never runs: had it run, this
+# fixture would have saved `"edited in the editor"` over the piece and the
+# line would have come back as a receipt or as the seam's refusal, neither of
+# which is this sentence. It is typed last, after everything that moves, which
+# is what leaves shuttle standing on the piece for it.
+check 'A write onto a whole piece is refused. `link` is what writes a reference.' \
+  "$(said 50 "edit")" "edit turns down a whole piece in the sentence set gives it"
 
 step "25. link writes a reference, so the second cell reads the first"
 check "Wrote a reference at \`/slugs/second/label\` naming \`/slugs/first/label\`." \

--- a/packages/cli/integration/shuttle-over-a-terminal.sh
+++ b/packages/cli/integration/shuttle-over-a-terminal.sh
@@ -43,14 +43,13 @@
 # to this walkthrough alone, so a change to a pattern the product actually
 # ships can never break a demonstration of what a shell can reach.
 #
-# Three gaps are asserted, as `verb-session-gaps.sh` and
-# `completion-over-the-cli.sh` assert theirs, and all three are about wording
-# rather than about capability: a refusal that names no spelling the prompt
-# accepts (step 19), and a write onto a whole piece refused in a vocabulary
-# the prompt does not have, whose one suggested spelling answers in another
-# verb's name (step 20). Each is written so that it fails the day the sentence
-# improves — which is the signal wanted, where pinning the wording would hold
-# the wart in place. Nothing else here is a gap.
+# No gap is open here, and the two steps that would carry one read a refusal's
+# words back instead: a value opening with `-` is told about the bare `--` that
+# writes it (step 19), and a write onto a whole piece is refused in the sentence
+# `set`'s own page carries (step 20). Both are wording a prompt can act on, so
+# both are pinned. The counter and the summary line stay as
+# `verb-session-gaps.sh` and `completion-over-the-cli.sh` carry theirs, for
+# whatever the next reading of this shell turns up.
 #
 # Documented in packages/cli/README.md's "Interactive shell" section, which
 # explains the shell this exercises. Keep the two in step: the doc is the
@@ -477,84 +476,47 @@ contains "is read as JSON; anything else is the string it spells" \
 check '"a written place"' "$(said 25 "get label")" \
   "the refused write left the cell holding what it held"
 
-step "19. GAP: a value opening with a dash is refused without naming the escape"
-# The grammar itself is ruled and is not in question: a token opening with `-`
-# is an option wherever one may be written, which is why the line above spells
-# its value after a bare `--`. That spelling is exercised there rather than
-# described here.
-#
-# What is a gap is the sentence. A person writing a negative number is told
-# they wrote an unknown option and pointed at `-h`, and the one thing that
-# would help — the bare `--` that makes the token a value — goes unmentioned.
-# Issue #7065 carries it. Pinning the wording would make this step fail the
-# day somebody improves the sentence, which is backwards, so the gap is
-# written the other way round: it holds while the refusal says nothing about
-# `--`, and fails when it starts to.
-#
-# Which makes what counts as "says something about `--`" the judgement this
-# step turns on, and it is deliberately loose. A refusal names the escape when
-# it writes `--` as a token of its own — anywhere, in any wording, quoted or
-# bare, alone or inside a worked example. What it must not count is the `--`
-# that opens a long flag, `--help` among them, which the sentence already
-# carries and which teaches nobody how to write a value; hence the character
-# after it deciding, rather than the two characters alone.
-#
-# The bound is that the escape has to be written rather than described: a
-# refusal saying "put it after the option terminator" and never spelling `--`
-# would not be recognised. And the bias runs the other way from the usual one
-# — an ASCII double hyphen used as a dash in prose would read as the escape
-# and close the gap early. That is the direction to err in. A gap that fires
-# when it might have closed costs somebody a look; one that stays quiet after
-# it has closed is a marker that has silently stopped being true, which is the
-# failure this step exists to avoid.
+step "19. A value opening with a dash is refused, and the refusal names the escape"
+# The grammar is ruled and both halves of it are read back here: a token
+# opening with `-` is an option wherever one may be written, so `-5` is refused
+# as an option nobody declared, and the bare `--` the line above spells its
+# value after is what writes one as an operand. A negative number has no
+# spelling that does not open with `-`, so the escape is the whole of what the
+# refusal owes the person, and the parser's own sentence — which points at
+# `-h` — cannot know to offer it.
 DASH_VALUE=$(said 26 "set label -5")
-names_the_escape() {
-  printf '%s' "$1" | grep -qE -- '--([^A-Za-z0-9]|$)'
-}
-if printf '%s' "$DASH_VALUE" | grep -q "Unknown option" &&
-  ! names_the_escape "$DASH_VALUE"; then
-  ok "gap still open: the refusal does not name the \`--\` that writes the value"
-  GAPS=$((GAPS + 1))
-else
-  bad "GAP CLOSED — set label -5 reads [$DASH_VALUE]; update this step"
-fi
+contains 'Unknown option "-5"' "$DASH_VALUE" \
+  "a token opening with a dash is read as an option, which is the ruled grammar"
+contains 'a bare `--` writes every token after it as an operand' "$DASH_VALUE" \
+  'the refusal names the `--` that writes the value'
 
-step "20. A write onto a whole piece is refused, in words the prompt cannot use"
-# The safety property first, because it is the one that matters and it holds:
-# `set` passes `refuseRootWrite`, so a line naming the piece rather than a path
-# inside it writes nothing.
+step "20. A write onto a whole piece is refused, in the words the page uses"
+# The safety property first, because it is the one that matters and it holds: a
+# line naming the piece rather than a path inside it writes nothing, shuttle
+# refusing it and `refuseRootWrite` behind that for the paths only resolution
+# can judge.
 ROOT_WRITE=$(said 27 "set . '{\"label\":\"x\"}'")
 # Read after both of this step's lines rather than between them, so it says
-# neither of them wrote. Two things stop the first: `refuseRootWrite`, and the
+# neither of them wrote. Two things stop the first: the refusal below, and the
 # pattern's own schema, which turns down a result cell missing members the
 # fixture declares. Removing either leaves the other, which is what a safety
 # check should be able to say.
 check '"a written place"' "$(said 29 "get label")" \
   "the refused root write left the piece as it was"
-# What it says, though, is `pathRequiredRefusal()` (`lib/piece.ts`), written
-# for `cf`'s command line: it offers an address to embed a path in and a
-# positional argument to pass one as, and a shuttle line has neither — the
-# path IS the operand the person wrote. `set --help` carries the sentence that
-# would help ("A write onto a whole piece is refused. `link` is what writes a
-# reference"), and the runtime refusal does not.
-if printf '%s' "$ROOT_WRITE" | grep -q '/of:'; then
-  ok "gap still open: the root-write refusal speaks in cf's address vocabulary"
-  GAPS=$((GAPS + 1))
-else
-  bad "GAP CLOSED — the root-write refusal reads [$ROOT_WRITE]; update this step"
-fi
-# And the one spelling it does name is refused in another verb's name.
-# `movePlace` (`lib/shuttle/place.ts`) is the operand reading every verb aims
-# through, and its empty-operand refusal says `cd` whatever verb asked — so a
-# person following the advice above lands on a sentence about a verb they did
-# not write.
+# And what it says is the sentence `set --help` carries, word for word, which
+# is the whole of what a person reads whether they take the page first or the
+# refusal after: the address to embed a path in and the positional to pass one
+# as are `cf`'s command line, and a shuttle line has neither — the path IS the
+# operand the person wrote.
+check 'A write onto a whole piece is refused. `link` is what writes a reference.' \
+  "$ROOT_WRITE" "the root-write refusal is the sentence the verb's page carries"
+# The empty operand is a line of its own, and it is refused in the name of the
+# verb that wrote it. `movePlace` (`lib/shuttle/place.ts`) is the operand
+# reading every verb aims through, so a sentence of its own about `cd` would
+# reach a person who wrote no `cd`.
 EMPTY_OPERAND=$(said 28 "set '' '\"x\"'")
-if [ "$EMPTY_OPERAND" = '`cd` takes a place to move to.' ]; then
-  ok "gap still open: the empty operand a set line writes is refused in cd's name"
-  GAPS=$((GAPS + 1))
-else
-  bad "GAP CLOSED — the empty operand reads [$EMPTY_OPERAND]; update this step"
-fi
+check '`set` was given an empty operand, which names no place.' \
+  "$EMPTY_OPERAND" "the empty operand a set line writes is refused in set's name"
 
 step "21. verbs lists what the piece can be asked to do, and numbers each row"
 check "%1 addItem <handler on result> <Appends one line to \`items\`.>

--- a/packages/cli/lib/shuttle/options.ts
+++ b/packages/cli/lib/shuttle/options.ts
@@ -147,6 +147,13 @@ export type OptionReading =
  * as no option can be, a value missing from an option that takes one, and a
  * value given to one that does not.
  *
+ * That sentence names the bare `--` as well, for a verb that opens no section.
+ * A person writing a value that opens with `-` — a negative number has no
+ * other spelling — is told they wrote an option, and the escape that makes it
+ * an operand is the one thing the parser's own sentence cannot know to
+ * mention. Under `opens` it is left out rather than reworded, the `--` there
+ * closing the callable's section instead of quoting an operand.
+ *
  * @throws Whatever the parser throws that is not a refusal of the line — a
  * table naming a type nothing registered, which is a fault in the verb rather
  * than in what was typed.
@@ -168,7 +175,12 @@ export function readOptions(
     return {
       kind: "refused",
       reason: `${thrown.message} \`${verb} --help\` says what \`${verb}\` ` +
-        `takes.`,
+        `takes${
+          opens
+            ? ""
+            : ", and a bare `--` writes every token after it as an operand, " +
+              "whatever it opens with"
+        }.`,
     };
   }
   if (parsed.flags.help === true) return { kind: "help" };

--- a/packages/cli/lib/shuttle/place.ts
+++ b/packages/cli/lib/shuttle/place.ts
@@ -484,7 +484,7 @@ export function operandForChild(
   const from: Standing = { place, trail: [] };
   for (const candidate of [child, renderPosition(goal)]) {
     if (readsAsOption(candidate)) continue;
-    const reach = reached(movePlace(from, candidate));
+    const reach = reached(movePlace(from, candidate, "cd"));
     if (reach !== undefined && samePlace(reach.place, goal)) return candidate;
   }
   return undefined;
@@ -584,12 +584,12 @@ export class CurrentPlace {
    * `..`, `-`, and `/` — nothing about either being a read's to decide.
    */
   cd(operand: string): Move {
-    return this.#commit(movePlace(this.#here, operand, this.#previous));
+    return this.#commit(movePlace(this.#here, operand, "cd", this.#previous));
   }
 
   /**
    * Where `operand` points and which of a piece's two cells it selects,
-   * without going there.
+   * without going there, `verb` naming the verb whose line it was read from.
    *
    * It differs from {@link CurrentPlace.cd} in the two ways a read differs
    * from a move. Nothing moves, so shuttle stays where it stood whatever
@@ -610,7 +610,7 @@ export class CurrentPlace {
    * aimed at such a cell fails on its own account, in the read's own words,
    * and there is nothing left for a check in front of it to add.
    */
-  aim(operand: string): Aim {
+  aim(operand: string, verb: string): Aim {
     if (operand === ARGUMENT_SUFFIX) {
       return { input: false, move: pointing(refuse(SUFFIX_NAMES_NO_TARGET)) };
     }
@@ -618,7 +618,7 @@ export class CurrentPlace {
     return {
       input: stripped !== undefined,
       move: pointing(
-        movePlace(this.#here, stripped ?? operand, this.#previous),
+        movePlace(this.#here, stripped ?? operand, verb, this.#previous),
       ),
     };
   }
@@ -665,7 +665,8 @@ export class CurrentPlace {
 
   /**
    * Moves as a {@link HandleMove} says, `at` being the place the listing that
-   * minted the handle was read at and `toward` the operand its row prints.
+   * minted the handle was read at, `toward` the operand its row prints, and
+   * `verb` the verb whose line the handle was written on.
    *
    * The row's operand is walked from the listing's place, and the walk written
    * after the handle from wherever that reached. Both are the walk a person
@@ -679,8 +680,8 @@ export class CurrentPlace {
    * a view rather than a path shuttle took, so a `..` written after one backs
    * out of the level the row stands in.
    */
-  reach(move: HandleMove, at: Place, toward: string): Move {
-    return this.#commit(this.#reached(move, at, toward));
+  reach(move: HandleMove, at: Place, toward: string, verb: string): Move {
+    return this.#commit(this.#reached(move, at, toward, verb));
   }
 
   /**
@@ -690,8 +691,13 @@ export class CurrentPlace {
    *
    * Nothing comes back pending, for {@link CurrentPlace.aim}'s reason.
    */
-  resolveHandle(move: HandleMove, at: Place, toward: string): Aimed {
-    return pointing(this.#reached(move, at, toward));
+  resolveHandle(
+    move: HandleMove,
+    at: Place,
+    toward: string,
+    verb: string,
+  ): Aimed {
+    return pointing(this.#reached(move, at, toward, verb));
   }
 
   /**
@@ -783,8 +789,13 @@ export class CurrentPlace {
    * keeps that a property of this walk rather than of what a listing happens
    * to offer.
    */
-  #reached(move: HandleMove, at: Place, toward: string): Step {
-    const step = movePlace({ place: at, trail: [] }, toward);
+  #reached(
+    move: HandleMove,
+    at: Place,
+    toward: string,
+    verb: string,
+  ): Step {
+    const step = movePlace({ place: at, trail: [] }, toward, verb);
     const from = reached(step);
     if (from === undefined) return step;
     return move.rest === ""
@@ -868,8 +879,12 @@ type Step =
   | Unlanded;
 
 /**
- * Where `operand` moves `from` to, `previous` being the standing `-` returns
- * to.
+ * Where `operand` moves `from` to, `verb` naming the verb whose line it was
+ * read from and `previous` being the standing `-` returns to.
+ *
+ * The verb is carried for one sentence: an empty operand names no place, and
+ * every verb aims through this reading, so the refusal for one names the verb
+ * whose line it is reading rather than a verb of its own.
  *
  * The operand is read in the order the spellings can be told apart: `-`, a
  * `.` and its `./` and `.@` heads, and `/` are shuttle's own, a rooted
@@ -890,10 +905,15 @@ type Step =
 function movePlace(
   from: Standing,
   operand: string,
+  verb: string,
   previous?: Standing,
 ): Step {
   const place = from.place;
-  if (operand === "") return refuse("`cd` takes a place to move to.");
+  if (operand === "") {
+    return refuse(
+      `\`${verb}\` was given an empty operand, which names no place.`,
+    );
+  }
   if (operand === "-") {
     return previous === undefined
       ? refuse("There is no previous place to return to.")

--- a/packages/cli/lib/shuttle/place.ts
+++ b/packages/cli/lib/shuttle/place.ts
@@ -484,7 +484,7 @@ export function operandForChild(
   const from: Standing = { place, trail: [] };
   for (const candidate of [child, renderPosition(goal)]) {
     if (readsAsOption(candidate)) continue;
-    const reach = reached(movePlace(from, candidate, "cd"));
+    const reach = reached(movePlace(from, candidate, MOVING_VERB));
     if (reach !== undefined && samePlace(reach.place, goal)) return candidate;
   }
   return undefined;
@@ -584,7 +584,9 @@ export class CurrentPlace {
    * `..`, `-`, and `/` — nothing about either being a read's to decide.
    */
   cd(operand: string): Move {
-    return this.#commit(movePlace(this.#here, operand, "cd", this.#previous));
+    return this.#commit(
+      movePlace(this.#here, operand, MOVING_VERB, this.#previous),
+    );
   }
 
   /**
@@ -800,7 +802,7 @@ export class CurrentPlace {
     if (from === undefined) return step;
     return move.rest === ""
       ? step
-      : moveBySegments(from, move.rest, move.operand);
+      : moveBySegments(from, move.rest, move.operand, verb);
   }
 
   /**
@@ -929,7 +931,12 @@ function movePlace(
   if (operand === RELATIVE_HEAD) return land(place, from.trail);
   if (operand.startsWith(SCOPE_HEAD)) return moveScope(from, operand);
   if (operand.startsWith(MEMBER_HEAD)) {
-    return moveBySegments(from, operand.slice(MEMBER_HEAD.length), operand);
+    return moveBySegments(
+      from,
+      operand.slice(MEMBER_HEAD.length),
+      operand,
+      verb,
+    );
   }
 
   // A leading `/` roots a reference, and `/` alone roots one and names
@@ -949,7 +956,7 @@ function movePlace(
   // the root split on the same separator here, so `/slugs/board` is what `cd
   // /` and `cd slugs/board` are together, down to the trail it leaves.
   const walk = rootedFacetWalk(operand);
-  if (walk !== undefined) return moveBySegments(root, walk, operand);
+  if (walk !== undefined) return moveBySegments(root, walk, operand, verb);
 
   const edged = rootedOnlyByTrim(operand);
   if (edged !== undefined) return edged;
@@ -963,7 +970,7 @@ function movePlace(
     return refuse(messageOf(error));
   }
   if (reference !== undefined) {
-    return moveByReference(place, reference, operand);
+    return moveByReference(place, reference, operand, verb);
   }
 
   if (operand.startsWith("#")) return { kind: "wish", target: operand };
@@ -981,7 +988,7 @@ function movePlace(
       operand,
     };
   }
-  return moveBySegments(from, operand, operand);
+  return moveBySegments(from, operand, operand, verb);
 }
 
 /**
@@ -1103,8 +1110,9 @@ function moveByReference(
   place: Place,
   reference: NormalizedLLMFriendlyRef,
   operand: string,
+  verb: string,
 ): Step {
-  if (reference.input === true) return refuseArgumentSuffix();
+  if (reference.input === true) return refuseArgumentSuffix(verb);
   const badPiece = unnameablePiece(reference.pieceId);
   if (badPiece !== undefined) return refuseUnnameable(operand, badPiece);
   const badSegment = firstUnnameableSegment(reference.path);
@@ -1169,6 +1177,7 @@ function moveBySegments(
   from: Standing,
   walk: string,
   operand: string,
+  verb: string,
 ): Step {
   const segments = walk.split("/");
   if (segments[segments.length - 1] === "") segments.pop();
@@ -1182,7 +1191,7 @@ function moveBySegments(
     // not the reason a data key gets.
     const step = segment === ".."
       ? moveUp(moved)
-      : moveDown(moved, segment, operand);
+      : moveDown(moved, segment, operand, verb);
     const reach = reached(step);
     if (reach === undefined) return step;
     moved = reach;
@@ -1227,7 +1236,12 @@ function enclosing(position: Position): Position {
  * back pending, a piece having still to resolve and a key having still to be
  * found.
  */
-function moveDown(from: Standing, segment: string, operand: string): Step {
+function moveDown(
+  from: Standing,
+  segment: string,
+  operand: string,
+  verb: string,
+): Step {
   const place = from.place;
   const position = place.position;
   const trail = [...from.trail, position];
@@ -1244,7 +1258,7 @@ function moveDown(from: Standing, segment: string, operand: string): Step {
             scopeMoveHint(operand),
         );
     case "facet":
-      return moveIntoPiece(place, position, segment, trail, operand);
+      return moveIntoPiece(place, position, segment, trail, operand, verb);
     case "piece": {
       const fault = unnameableSegment(segment);
       if (fault !== undefined) return refuseUnnameable(operand, fault);
@@ -1282,11 +1296,12 @@ function moveIntoPiece(
   segment: string,
   trail: Trail,
   operand: string,
+  verb: string,
 ): Step {
   const hash = segment.indexOf("#");
   if (hash !== -1) {
     const suffix = segment.slice(hash);
-    return suffix === "#argument" ? refuseArgumentSuffix() : refuse(
+    return suffix === "#argument" ? refuseArgumentSuffix(verb) : refuse(
       `Unknown suffix "${suffix}". The one supported suffix is ` +
         `"#argument", which selects the piece's arguments cell the way ` +
         `"--input" does.`,
@@ -1514,6 +1529,14 @@ export function scopeMoveHint(operand: string): string {
 const ARGUMENT_SUFFIX = "#argument";
 
 /**
+ * The verb whose operand this module reads to stand somewhere rather than to
+ * point at something, which is what tells {@link refuseArgumentSuffix} which
+ * of its two sentences a line is owed: only a move can be wrong about what a
+ * place may be.
+ */
+const MOVING_VERB = "cd";
+
+/**
  * The reason {@link ARGUMENT_SUFFIX} written with nothing in front of it is
  * refused. It selects a piece's arguments cell, so what it wants in front of
  * it is a target.
@@ -1552,18 +1575,41 @@ function argumentSuffixOff(operand: string): string | undefined {
 }
 
 /**
- * Helper for the movers, which refuses the `#argument` suffix on a `cd`
- * operand. A place is result-rooted, so no spelling of the suffix moves one
- * and the reason never turns on which spelling carried it.
+ * Helper for the movers, which refuses an operand carrying the `#argument`
+ * suffix, `verb` naming the verb whose line it was read from.
+ *
+ * Two sentences, because the two callers are wrong about different things and
+ * one sentence for both would be false of one of them.
+ *
+ * A move is refused in every spelling the suffix is written in: a place is
+ * result-rooted, and one rooted at the arguments cell would leave every later
+ * relative read ambiguous about which side of the piece it addressed
+ * (`docs/plans/shuttle/grammar.md`). That reason is about what a place may be,
+ * so it holds wherever the suffix sits in the operand.
+ *
+ * A read never reaches here with the suffix at the end of its operand:
+ * {@link CurrentPlace.aim} takes that one off and reads the arguments cell
+ * with it, which is the spelling the same document names as the way to reach
+ * arguments. So what reaches this from a read is a suffix with a walk written
+ * after it, where what is wrong is the position of the suffix rather than
+ * anything about a place — and a sentence about places would be telling a
+ * `get` line that a spelling it has works only for `cd`.
  */
-function refuseArgumentSuffix(): Step {
-  return refuse(
-    "A place is result-rooted, so `cd` takes no `#argument` suffix. A " +
-      "place rooted at the arguments cell would leave every later " +
-      "relative read ambiguous about which side of the piece it " +
-      "addressed. Reach arguments per operand instead, as in " +
-      "`get topics/3#argument`.",
-  );
+function refuseArgumentSuffix(verb: string): Step {
+  return verb === MOVING_VERB
+    ? refuse(
+      "A place is result-rooted, so `cd` takes no `#argument` suffix. A " +
+        "place rooted at the arguments cell would leave every later " +
+        "relative read ambiguous about which side of the piece it " +
+        "addressed. Reach arguments per operand instead, as in " +
+        "`get topics/3#argument`.",
+    )
+    : refuse(
+      `\`${verb}\` takes \`${ARGUMENT_SUFFIX}\` at the end of an operand ` +
+        `and nowhere else: it selects a piece's arguments cell, and a path ` +
+        `inside that cell is written in front of it, as in ` +
+        `\`topics/3/title${ARGUMENT_SUFFIX}\`.`,
+    );
 }
 
 /**

--- a/packages/cli/lib/shuttle/verbs.ts
+++ b/packages/cli/lib/shuttle/verbs.ts
@@ -338,9 +338,9 @@ async function cd(
   deps: VerbDeps,
 ): Promise<Outcome> {
   // `cd ''` is one operand, so the dispatch passes it on and the place is what
-  // answers it — in the sentence the dispatch composes for no operand at all,
-  // so the two spellings read alike. That guard is `movePlace`'s own and
-  // stands for the callers this one is not.
+  // answers it, in this verb's name. That guard is `movePlace`'s own and
+  // answers for every verb that aims an operand through it, which is why it
+  // is given the name to say.
   const moved = await landing(
     shuttle,
     shuttle.place.cd(line.operands[0]),
@@ -393,7 +393,7 @@ async function get(
   const operand = line.operands[0];
   const at = operand === undefined
     ? { kind: "place" as const, place: shuttle.place.place, input: false }
-    : await aimed(shuttle, operand, deps);
+    : await aimed(shuttle, operand, "get", deps);
   if (at.kind === "refused") return at;
   // Before the read and not after it, which is the whole point of warming: the
   // value a read serves is what a running pattern holds, so the pattern runs
@@ -603,6 +603,17 @@ function where(shuttle: Shuttle): Outcome {
 }
 
 /**
+ * What a write onto a whole piece is refused with, and what `set`'s page says
+ * about one.
+ *
+ * Both read it from here because a person reads one of the two: the page
+ * before they write the line, and the refusal after. Two copies of a sentence
+ * are two sentences the moment one of them is improved.
+ */
+const WHOLE_PIECE_REFUSAL =
+  "A write onto a whole piece is refused. `link` is what writes a reference.";
+
+/**
  * Writes the value the line's second operand spells at the cell its first
  * names, and says where it landed.
  *
@@ -610,10 +621,13 @@ function where(shuttle: Shuttle): Outcome {
  * suffix included, so `set title#argument x` writes the arguments cell exactly
  * as `--input` does for `cf cell set`.
  *
- * The write refuses to land on a whole cell. Only resolution can decide that —
- * an address naming a collection spends its leading segments reaching the
- * member, so a path can still resolve to a piece's root — so the refusal is
- * the seam's, in the seam's own words.
+ * The write refuses to land on a whole cell, and the refusal is written twice
+ * because the question is asked twice. An operand that reached a piece and
+ * named no path inside it is refused here, in {@link WHOLE_PIECE_REFUSAL},
+ * which is the sentence this verb's page carries. The rest only resolution can
+ * decide — an address naming a collection spends its leading segments reaching
+ * the member, so a path can still resolve to a piece's root — and that one is
+ * the seam's under `refuseRootWrite`, in the seam's own words.
  */
 async function set(
   shuttle: Shuttle,
@@ -630,6 +644,10 @@ async function set(
   if (value.kind === "refused") return value;
   const at = await writable(shuttle, path, "set", deps);
   if (at.kind !== "aimed") return at;
+  // The operand reached a piece and named no path inside it, which is the
+  // half of the refusal the line settles. Ahead of the warm, a line that
+  // cannot write being no reason to start a pattern.
+  if (at.place.position.path.length === 0) return refuse(WHOLE_PIECE_REFUSAL);
   const warmed = await warm(shuttle, at.place, deps);
   if (warmed !== undefined) return warmed;
   const position = at.place.position;
@@ -1265,8 +1283,7 @@ const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
       '`"milk"`. A value opening the way JSON opens one and then ' +
       "failing to\nparse is refused with the parser's reason rather than " +
       "written as a string.\n`-` is refused, standard input being the " +
-      "keyboard the prompt reads.\n\nA write onto a whole piece is " +
-      "refused. `link` is what writes a reference.",
+      `keyboard the prompt reads.\n\n${WHOLE_PIECE_REFUSAL}`,
   }],
   ["verbs", {
     run: listVerbs,
@@ -1465,6 +1482,7 @@ async function landing(
         move,
         row.at,
         row.toward,
+        "cd",
       );
       return reached.kind !== "ran"
         ? reached
@@ -2189,7 +2207,7 @@ async function writable(
 ): Promise<Writable> {
   const at = operand === undefined
     ? { kind: "place" as const, place: shuttle.place.place, input: false }
-    : await aimed(shuttle, operand, deps);
+    : await aimed(shuttle, operand, verb, deps);
   if (at.kind === "refused") return at;
   const position = at.place.position;
   if (position.kind !== "piece") {
@@ -2470,7 +2488,7 @@ async function receiver(
 ): Promise<Receiving> {
   const at = operand === undefined
     ? { kind: "place" as const, place: shuttle.place.place, input: false }
-    : await aimed(shuttle, operand, deps);
+    : await aimed(shuttle, operand, verb, deps);
   if (at.kind === "refused") return at;
   if (at.input) {
     return refuse(
@@ -2607,7 +2625,7 @@ async function dispatched(
   // everywhere else. Only a bare handle can carry a name: a walk written after
   // one ends at a cell inside the row, and a cell is a receiver rather than a
   // verb, so it takes the name in the next operand like any other reference.
-  const aim = shuttle.place.aim(first).move;
+  const aim = shuttle.place.aim(first, "call").move;
   const carried = aim.kind === "handle" && aim.rest === ""
     ? carriedName(shuttle, aim.handle)
     : undefined;

--- a/packages/cli/lib/shuttle/verbs.ts
+++ b/packages/cli/lib/shuttle/verbs.ts
@@ -701,11 +701,16 @@ async function set(
  * holds the tag, which is the question issue #6944 carries for `get` and is
  * not this verb's to settle.
  *
- * Four things stop the write, and each leaves the cell as it was. A value JSON
- * cannot carry is refused above. An editor that did not finish is the editor's
- * own refusal, carried through. Text that came back unchanged is nothing to
- * write, and says so. Text that will not parse is refused with the parse error
- * and the file it is still in.
+ * Five things stop the write, and each leaves the cell as it was. A whole
+ * piece is refused in {@link WHOLE_PIECE_REFUSAL}, which is the sentence
+ * {@link set} gives that write, and the refusal comes before the editor opens
+ * rather than after a save: what a person typed into an editor is work, and a
+ * line that could never have written it should say so while there is nothing
+ * to lose. A value JSON cannot carry is refused above, before the editor opens
+ * too. An editor that did not finish is the editor's own refusal, carried
+ * through. Text that came back unchanged is nothing to write, and says so.
+ * Text that will not parse is refused with the parse error and the file it is
+ * still in.
  *
  * What decides the file's fate is not which of those happened but whether the
  * cell took the text: the file is removed exactly where it holds nothing the
@@ -729,6 +734,10 @@ async function edit(
   }
   const at = await writable(shuttle, line.operands[0], "edit", deps);
   if (at.kind !== "aimed") return at;
+  // The operand reached a piece and named no path inside it, which is
+  // {@link set}'s guard on the write both verbs make. Ahead of the read and
+  // the editor, so nothing is typed into a file for a write that cannot land.
+  if (at.place.position.path.length === 0) return refuse(WHOLE_PIECE_REFUSAL);
   const warmed = await warm(shuttle, at.place, deps);
   if (warmed !== undefined) return warmed;
   const position = at.place.position;
@@ -1170,11 +1179,12 @@ const VERBS: ReadonlyMap<string, VerbEntry> = new Map<string, VerbEntry>([
     summary: "Opens a cell's value in `$EDITOR` and writes back what you save.",
     detail: "The value goes out as JSON and comes back as JSON, so what is " +
       "edited is\nwhat a write takes rather than what `get` prints.\n\n" +
-      "Four things stop the write, and each leaves the cell as it was: a " +
-      "value\nJSON cannot carry, which is refused before the editor opens; " +
-      "an editor that\ndid not finish; text that came back unchanged; and " +
-      "text that will not\nparse, which is refused with the file it is " +
-      "still in.\n\nIt is the one write with no `cf` equivalent behind it.",
+      "Five things stop the write, and each leaves the cell as it was: a " +
+      "whole\npiece, and a value JSON cannot carry, both refused before the " +
+      "editor opens;\nan editor that did not finish; text that came back " +
+      "unchanged; and text that\nwill not parse, which is refused with the " +
+      "file it is still in.\n\nIt is the one write with no `cf` equivalent " +
+      "behind it.",
   }],
   ["get", {
     run: get,

--- a/packages/cli/lib/shuttle/vocabulary.ts
+++ b/packages/cli/lib/shuttle/vocabulary.ts
@@ -375,15 +375,21 @@ export type Verb = (
 
 /**
  * Helper for {@link get}, which is where `operand` points, read from where
- * shuttle stands and settling nothing.
+ * shuttle stands and settling nothing, `verb` naming the verb whose line the
+ * operand was written on.
+ *
+ * The verb reaches the place's reading rather than anything here: an operand
+ * every verb aims through is refused in the name of the one that wrote it
+ * ({@link CurrentPlace.aim}).
  */
 export async function aimed(
   shuttle: Shuttle,
   operand: string,
+  verb: string,
   deps: VerbDeps,
 ): Promise<Aiming> {
-  const aim = shuttle.place.aim(operand);
-  const at = await reading(shuttle, aim.move, deps);
+  const aim = shuttle.place.aim(operand, verb);
+  const at = await reading(shuttle, aim.move, verb, deps);
   return at.kind === "refused" ? at : { ...at, input: aim.input };
 }
 
@@ -453,7 +459,8 @@ export type Aiming =
   | Refusal;
 
 /**
- * Helper for {@link get}, which finishes `move` without moving.
+ * Helper for {@link get}, which finishes `move` without moving, `verb` naming
+ * the verb whose line it came off.
  *
  * A space written as a name is settled the way {@link landing} settles one. A
  * `#name` target is not: `cf cell get` takes no such target and `cf wish`
@@ -473,6 +480,7 @@ export type Aiming =
 async function reading(
   shuttle: Shuttle,
   move: Aimed,
+  verb: string,
   deps: VerbDeps,
 ): Promise<Reading> {
   switch (move.kind) {
@@ -492,6 +500,7 @@ async function reading(
       return named.kind === "refused" ? named : await reading(
         shuttle,
         shuttle.place.resolveNamedSpace(move, named.space),
+        verb,
         deps,
       );
     }
@@ -499,7 +508,8 @@ async function reading(
       const row = rowFor(shuttle, move);
       return row.kind === "refused" ? row : await reading(
         shuttle,
-        shuttle.place.resolveHandle(move, row.at, row.toward),
+        shuttle.place.resolveHandle(move, row.at, row.toward, verb),
+        verb,
         deps,
       );
     }

--- a/packages/cli/test/shuttle-options.test.ts
+++ b/packages/cli/test/shuttle-options.test.ts
@@ -150,13 +150,28 @@ describe("options", () => {
       expect(reasonOf(readOptions("get", ["-x"])))
         .toBe(
           'Unknown option "-x". Did you mean option "-h"? `get --help` says ' +
-            "what `get` takes.",
+            "what `get` takes, and a bare `--` writes every token after it " +
+            "as an operand, whatever it opens with.",
+        );
+    });
+
+    it("returns a refusal naming the bare `--` for a value that opens with `-`", () => {
+      // The line the escape exists for. A negative number has no spelling
+      // that does not open with `-`, so the person is told they wrote an
+      // option, and what the parser's own sentence cannot know to offer is
+      // the token that makes theirs an operand.
+
+      expect(reasonOf(readOptions("set", ["label", "-5"])))
+        .toBe(
+          'Unknown option "-5". Did you mean option "-h"? `set --help` says ' +
+            "what `set` takes, and a bare `--` writes every token after it " +
+            "as an operand, whatever it opens with.",
         );
     });
 
     it("returns a refusal naming the verb's page, for the verb the line named", () => {
       expect(reasonOf(readOptions("ls", ["-x"])))
-        .toContain("`ls --help` says what `ls` takes.");
+        .toContain("`ls --help` says what `ls` takes,");
     });
 
     it("returns a refusal where a declared option that takes a value is given none", () => {
@@ -288,7 +303,8 @@ describe("options", () => {
           ),
         ).toBe(
           'Unknown option "--query". Did you mean option "--help"? `call ' +
-            "--help` says what `call` takes.",
+            "--help` says what `call` takes, and a bare `--` writes every " +
+            "token after it as an operand, whatever it opens with.",
         );
       });
 

--- a/packages/cli/test/shuttle-place.test.ts
+++ b/packages/cli/test/shuttle-place.test.ts
@@ -2346,6 +2346,32 @@ describe("place", () => {
           });
         });
 
+        it("refuses a suffix with a walk after it, where `cd` is refused for its place", () => {
+          // One operand, two doors, two sentences. A read never reaches the
+          // place's suffix refusal with the suffix at the end of its operand
+          // — this door takes that one off and reads the arguments cell with
+          // it — so what a read is refused for is where the suffix sits,
+          // which is not what a move is refused for. Both are asserted here
+          // because a sentence that moved to the other door would pass
+          // whichever of the two was pinned alone.
+
+          expect(inSlugs().aim("board#argument/title", "get").move).toEqual({
+            kind: "refused",
+            reason: "`get` takes `#argument` at the end of an operand and " +
+              "nowhere else: it selects a piece's arguments cell, and a " +
+              "path inside that cell is written in front of it, as in " +
+              "`topics/3/title#argument`.",
+          });
+          expect(moved(inSlugs(), "board#argument/title")).toEqual({
+            kind: "refused",
+            reason: "A place is result-rooted, so `cd` takes no `#argument` " +
+              "suffix. A place rooted at the arguments cell would leave " +
+              "every later relative read ambiguous about which side of the " +
+              "piece it addressed. Reach arguments per operand instead, as " +
+              "in `get topics/3#argument`.",
+          });
+        });
+
         it("names the verb it was given in the refusal for an empty operand", () => {
           // Every verb aims an operand through this door, so the name in that
           // refusal is the caller's rather than the door's own.

--- a/packages/cli/test/shuttle-place.test.ts
+++ b/packages/cli/test/shuttle-place.test.ts
@@ -694,7 +694,7 @@ describe("place", () => {
         it("refuses an empty operand", () => {
           expect(moved(atSpaceRoot(), "")).toEqual({
             kind: "refused",
-            reason: "`cd` takes a place to move to.",
+            reason: "`cd` was given an empty operand, which names no place.",
           });
         });
 
@@ -2189,7 +2189,7 @@ describe("place", () => {
 
         /** Helper for the cases below, which is where `operand` points. */
         function pointsAt(place: CurrentPlace, operand: string): Move {
-          return place.aim(operand).move;
+          return place.aim(operand, "get").move;
         }
 
         it("returns where a relative operand points", () => {
@@ -2210,20 +2210,20 @@ describe("place", () => {
         it("leaves shuttle where it stood", () => {
           const place = atPiece();
           const before = place.place;
-          place.aim("topics/3");
+          place.aim("topics/3", "get");
           expect(place.place).toBe(before);
         });
 
         it("returns no selection of the arguments cell for an operand carrying no suffix", () => {
-          expect(atPiece().aim("topics").input).toBe(false);
+          expect(atPiece().aim("topics", "get").input).toBe(false);
         });
 
         it("returns the arguments cell selected for an operand ending in `#argument`", () => {
-          expect(atPiece().aim("topics#argument").input).toBe(true);
+          expect(atPiece().aim("topics#argument", "get").input).toBe(true);
         });
 
         it("returns the position the operand names with the suffix off it", () => {
-          expect(atPiece().aim("topics/3#argument").move).toEqual(
+          expect(atPiece().aim("topics/3#argument", "get").move).toEqual(
             pointsAt(atPiece(), "topics/3"),
           );
         });
@@ -2233,7 +2233,7 @@ describe("place", () => {
           // two doors visibly disagree: `cd` turns the suffix down because a
           // place is result-rooted, and a read is not standing anywhere.
           const place = inSlugs();
-          expect(place.aim("board#argument")).toEqual({
+          expect(place.aim("board#argument", "get")).toEqual({
             input: true,
             move: pointsAt(inSlugs(), "board"),
           });
@@ -2241,14 +2241,16 @@ describe("place", () => {
         });
 
         it("reads the suffix off a rooted reference", () => {
-          expect(atSpaceRoot().aim(`/${HANDLE}/title#argument`)).toEqual({
-            input: true,
-            move: pointsAt(atSpaceRoot(), `/${HANDLE}/title`),
-          });
+          expect(atSpaceRoot().aim(`/${HANDLE}/title#argument`, "get")).toEqual(
+            {
+              input: true,
+              move: pointsAt(atSpaceRoot(), `/${HANDLE}/title`),
+            },
+          );
         });
 
         it("refuses the suffix written with nothing in front of it", () => {
-          expect(atPiece().aim("#argument")).toEqual({
+          expect(atPiece().aim("#argument", "get")).toEqual({
             input: false,
             move: {
               kind: "refused",
@@ -2263,14 +2265,14 @@ describe("place", () => {
           // leaves the head reading to decide, and the head reading is the
           // wish target.
 
-          expect(atPiece().aim("#argument ")).toEqual({
+          expect(atPiece().aim("#argument ", "get")).toEqual({
             input: false,
             move: { kind: "wish", target: "#argument " },
           });
         });
 
         it("hands a `#name` target on whole, the head reading being another one", () => {
-          expect(atPiece().aim("#favorites")).toEqual({
+          expect(atPiece().aim("#favorites", "get")).toEqual({
             input: false,
             move: { kind: "wish", target: "#favorites" },
           });
@@ -2280,7 +2282,7 @@ describe("place", () => {
           // The suffix reading is the one spelling it accepts and nothing
           // wider, so every other `#` reaches the door that decides it — here
           // the walk, where `#` is data.
-          expect(atPiece().aim("a#b")).toEqual({
+          expect(atPiece().aim("a#b", "get")).toEqual({
             input: false,
             move: pointsAt(atPiece(), "a#b"),
           });
@@ -2288,7 +2290,7 @@ describe("place", () => {
         });
 
         it("refuses a key ending in whitespace inside a piece", () => {
-          expect(atPiece().aim("topics ")).toEqual({
+          expect(atPiece().aim("topics ", "get")).toEqual({
             input: false,
             move: {
               kind: "refused",
@@ -2299,7 +2301,7 @@ describe("place", () => {
         });
 
         it("returns the key a leading space names inside a piece", () => {
-          expect(atPiece().aim(" topics")).toEqual({
+          expect(atPiece().aim(" topics", "get")).toEqual({
             input: false,
             move: {
               kind: "moved",
@@ -2317,7 +2319,7 @@ describe("place", () => {
         });
 
         it("refuses a piece ending in whitespace inside a facet", () => {
-          expect(inSlugs().aim("board ")).toEqual({
+          expect(inSlugs().aim("board ", "get")).toEqual({
             input: false,
             move: {
               kind: "refused",
@@ -2333,19 +2335,29 @@ describe("place", () => {
           // The read door keeps the two apart the way the move door does: one
           // named nothing, and one named a key that is only a space.
 
-          expect(atPiece().aim("").move).toEqual({
+          expect(atPiece().aim("", "get").move).toEqual({
             kind: "refused",
-            reason: "`cd` takes a place to move to.",
+            reason: "`get` was given an empty operand, which names no place.",
           });
-          expect(atPiece().aim(" ").move).toEqual({
+          expect(atPiece().aim(" ", "get").move).toEqual({
             kind: "refused",
             reason: "` ` has a segment ending in whitespace, so a rendering " +
               "of the place would name a different cell.",
           });
         });
 
+        it("names the verb it was given in the refusal for an empty operand", () => {
+          // Every verb aims an operand through this door, so the name in that
+          // refusal is the caller's rather than the door's own.
+
+          expect(atPiece().aim("", "set").move).toEqual({
+            kind: "refused",
+            reason: "`set` was given an empty operand, which names no place.",
+          });
+        });
+
         it("carries the reason a reference gave a fragment that is no suffix", () => {
-          expect(atSpaceRoot().aim(`/${HANDLE}/a#b`)).toEqual({
+          expect(atSpaceRoot().aim(`/${HANDLE}/a#b`, "get")).toEqual({
             input: false,
             move: {
               kind: "refused",
@@ -2909,7 +2921,12 @@ describe("place", () => {
             rest: "deeper",
             operand: "%1/deeper",
           };
-          const reached = place.reach(move, place.place, "nowhere-at-all");
+          const reached = place.reach(
+            move,
+            place.place,
+            "nowhere-at-all",
+            "cd",
+          );
           expect(reached.kind).toBe("refused");
           // And it moved nothing, a refusal leaving the place where it stood.
           expect(place.place).toEqual(new CurrentPlace(SPACE).place);

--- a/packages/cli/test/shuttle-verbs.test.ts
+++ b/packages/cli/test/shuttle-verbs.test.ts
@@ -799,8 +799,12 @@ describe("verbs", () => {
         // The half a maximum alone cannot express. `get` reads where it stands
         // and `help` lists the verbs, so neither is a line the dispatch may
         // answer for, and a count refusing none would take both readings away.
+        //
+        // Standing inside the piece rather than on it, so that the count is
+        // the only thing that could refuse: a whole piece is no cell to write
+        // onto, which `edit` says of a line naming none from a piece's root.
 
-        const outcome = await runLine(word, atPiece(), answering());
+        const outcome = await runLine(word, atPiece("title"), answering());
         expect(outcome.kind).not.toBe("refused");
       });
     }
@@ -3318,6 +3322,50 @@ describe("verbs", () => {
         "No editor is reachable from here, so there is nothing to open the " +
           "value in.",
       );
+    });
+
+    it("refuses a whole piece before the editor opens", async () => {
+      // The sentence `set` gives the same write, said while there is nothing
+      // to lose: a person who has typed a document into an editor and saved
+      // it is owed the write, and this line could never have made one. It is
+      // said in front of the warm as well, for the reason `set` says it
+      // there.
+
+      let warmed = false;
+      let read = false;
+      let opened = false;
+      expect(
+        reasonOf(
+          await runLine(
+            "edit .",
+            atPiece(),
+            answering({
+              warmPiece: (config) => {
+                warmed = true;
+                return Promise.resolve({ piece: config.piece });
+              },
+              getCellValue: () => {
+                read = true;
+                return Promise.resolve({ a: 1 });
+              },
+              editText: (text) => {
+                opened = true;
+                return Promise.resolve({
+                  kind: "edited" as const,
+                  text: `${text} `,
+                  file: "/tmp/edited",
+                  discard: () => Promise.resolve(),
+                });
+              },
+            }),
+          ),
+        ),
+      ).toBe(
+        "A write onto a whole piece is refused. `link` is what writes a " +
+          "reference.",
+      );
+      expect({ warmed, read, opened })
+        .toEqual({ warmed: false, read: false, opened: false });
     });
 
     it("opens the value as JSON a person can read", async () => {

--- a/packages/cli/test/shuttle-verbs.test.ts
+++ b/packages/cli/test/shuttle-verbs.test.ts
@@ -634,7 +634,8 @@ describe("verbs", () => {
       expect(reasonOf(await runLine("ls -x", shuttleIn(), READS_NOTHING)))
         .toBe(
           'Unknown option "-x". Did you mean option "-h"? `ls --help` says ' +
-            "what `ls` takes.",
+            "what `ls` takes, and a bare `--` writes every token after it " +
+            "as an operand, whatever it opens with.",
         );
     });
 
@@ -855,11 +856,11 @@ describe("verbs", () => {
 
     it("returns the place's own refusal for an operand that is the empty string", async () => {
       // One operand, so the dispatch hands it on and `movePlace`'s guard is
-      // what answers — in the sentence the dispatch composes for a line naming
-      // no operand at all, so the two spellings read alike.
+      // what answers, in this verb's name — the guard being the one every
+      // verb aims an operand through.
 
       expect(reasonOf(await runLine("cd ''", shuttleIn(), READS_NOTHING)))
-        .toBe("`cd` takes a place to move to.");
+        .toBe("`cd` was given an empty operand, which names no place.");
     });
 
     it("refuses an operand ending in `#argument`, a place being result-rooted", async () => {
@@ -2965,10 +2966,52 @@ describe("verbs", () => {
       expect(options?.input).toBe(true);
     });
 
+    it("refuses a write onto a whole piece before the seam is asked", async () => {
+      // The operand reached a piece and named no path inside it, which the
+      // line settles: refusing it here is what keeps the sentence the one
+      // this verb's page carries, `cf`'s address and positional being no
+      // spelling a prompt has. Nothing is warmed for it either, a line that
+      // cannot write being no reason to start a pattern.
+
+      let warmed = false;
+      let wrote = false;
+      expect(
+        reasonOf(
+          await runLine(
+            `set . '{"label":"x"}'`,
+            atPiece(),
+            answering({
+              warmPiece: (config) => {
+                warmed = true;
+                return Promise.resolve({ piece: config.piece });
+              },
+              setCellValue: () => {
+                wrote = true;
+                return Promise.resolve({ piece: HANDLE, path: [] });
+              },
+            }),
+          ),
+        ),
+      ).toBe(
+        "A write onto a whole piece is refused. `link` is what writes a " +
+          "reference.",
+      );
+      expect({ warmed, wrote }).toEqual({ warmed: false, wrote: false });
+    });
+
+    it("refuses an empty operand in its own name", async () => {
+      // The reading every verb aims an operand through is `movePlace`'s, so
+      // the name in its refusal is the line's rather than one verb's.
+
+      expect(reasonOf(await runLine(`set '' '"x"'`, atPiece(), answering())))
+        .toBe("`set` was given an empty operand, which names no place.");
+    });
+
     it("asks the seam to refuse a write onto a whole piece", async () => {
-      // Only resolution can decide it — an address naming a collection spends
-      // its leading segments reaching the member, so a path can still resolve
-      // to a piece's root — so the refusal is the seam's, in its own words.
+      // The half of the refusal only resolution can decide: an address naming
+      // a collection spends its leading segments reaching the member, so a
+      // path the line carried can still resolve to a piece's root, and the
+      // seam is what sees that.
 
       let options: { refuseRootWrite?: boolean } | undefined;
       await runLine(

--- a/packages/cli/test/shuttle-verbs.test.ts
+++ b/packages/cli/test/shuttle-verbs.test.ts
@@ -2970,6 +2970,25 @@ describe("verbs", () => {
       expect(options?.input).toBe(true);
     });
 
+    it("refuses a suffix with a walk after it, in the name of the verb that wrote it", async () => {
+      // The name reaches the place's reading through this verb's own aim, so
+      // a line that never says `get` is not answered in `get`'s name.
+
+      expect(
+        reasonOf(
+          await runLine(
+            `set slugs/board#argument/title '"x"'`,
+            shuttleIn(),
+            answering(),
+          ),
+        ),
+      ).toBe(
+        "`set` takes `#argument` at the end of an operand and nowhere else: " +
+          "it selects a piece's arguments cell, and a path inside that cell " +
+          "is written in front of it, as in `topics/3/title#argument`.",
+      );
+    });
+
     it("refuses a write onto a whole piece before the seam is asked", async () => {
       // The operand reached a piece and named no path inside it, which the
       // line settles: refusing it here is what keeps the sentence the one


### PR DESCRIPTION
## Why

Closes #7065.

A refusal is the shell talking to a person, and these ones were talking to
`cf`. Standing at a piece root and typing `set . '{"label":"x"}'`, you were
told to embed the path in a `--cell` address or pass it as a separate
positional — at a prompt that has neither, where the path **is** the operand
you just wrote. Both remedies named things that are not there. Following the
one spelling it did offer landed you on a sentence about `cd`, on a `set` line.

`edit` was worse than a wording problem. Standing at a piece root it opened
`$EDITOR`, let you write a document, took your save — and only then refused,
because a write onto a whole piece was never possible. The work was gone. The
refusal existed the whole time and was reachable before the editor opened.

None of this is visible to the unit suite: every one is a property of the
composition rather than of any module, which is why they were found by driving
the shell against a real fabric and were recorded as GAP steps that fail the
day they are fixed. This change is that day, and the three gaps are now three
assertions.

## What Changed

**Three refusals rewritten in the vocabulary the prompt has.**

- A write onto a whole piece is refused **in front of** the seam, sharing one
  `WHOLE_PIECE_REFUSAL` constant with the verb's own `--help` detail, so the
  page and the refusal cannot drift apart. `pathRequiredRefusal()` is untouched
  — `cf` still needs it, and its remedies are correct there — and nothing
  string-matches its text.
- `movePlace` is the operand reader **every** verb aims through, so it now
  takes the verb's name and says it. `get`, `set`, `edit`, `link`, `verbs`,
  `describe` and `call` each refuse an empty operand in their own name instead
  of in `cd`'s.
- A value that opens with `-` still refuses — the grammar is ruled and
  unchanged — but the refusal now names the bare `--` that writes it, which is
  the only spelling a negative number has. Omitted for a verb opening a
  section, where `--` closes the section instead and saying it would be false.

**Two more found while fixing those.**

- `edit` gets the same guard, ahead of the warm, the read and the editor.
- `refuseArgumentSuffix()` was the third instance of one shape:

  > a refusal constructed in a shared reader must either take the caller's
  > identity, or say something true of every caller.

  Two is a coincidence; three is a mechanism, so the general form is stated
  here rather than a third point fix being filed. A sweep of
  `packages/cli/lib/shuttle/` found no fourth — the only other refusals naming
  a verb name the verb they sit in.

**Measured, not assumed.** Before touching the suffix, the terminal spelling
was driven against a real fabric: `get <piece>#argument` **is served**, and
`get settings#argument` answers `Available keys: items, label` — which only the
arguments cell can say. So no ruled property was being denied, and only the
non-terminal walk's sentence was wrong. `grammar.md`'s two rulings (that `cd`
refuses the suffix, and that arguments are reached per operand) are unchanged,
and which operands are accepted is unchanged.

## Test plan

- `deno fmt --check`, `deno lint` (packages/cli), `deno task check` (root),
  `deno task test` (packages/cli) — all green, reported per commit.
  `packages/cli`'s test task runs `--no-check`, so `deno task check` is the only
  gate that sees a type error in a test file; both were run.
- The walkthrough against a real fabric over a pty: **3 gaps open → 0**, with
  the assertion count rising as each gap became a check.
- Cross-check that the gaps were live rather than decorative: the **pre-change**
  script run against the fixed code fails on exactly those three steps with
  `GAP CLOSED —`, and nowhere else.
- Every new unit case names the mutation it kills, including the guard being
  deleted, moved after the warm, moved after the read, and the shared sentence
  losing its `link` clause. A case that cannot fail is worse than no case.

One thing deliberately not tested: nothing pins the `edit` page's *count* of
stoppers against the code's. Nothing can check that mechanically, and a
`toContain` proxy would be near-vacuous — it is prose, held by review.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

