### PR TITLE
docs(shuttle): decision 25's premise, corrected against a measurement

### DIFF
--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -279,12 +279,12 @@ invisible, the prompt renders the whole ambient record — place and scope
     so a run's handles stay valid until a new listing resets them.
 25. **List views watch membership raw, elements deep, window only.**
     Reader schemas cannot express a membership-only subscription (verified
-    — shapes that look shallow to a reader do not bound what the server
-    syncs), so membership comes from a raw-document subscription on the
-    collection doc and only visible rows sink deeply — cost bounded by
-    the visible page in element documents; membership is one document whose
-    size grows with the collection's link array — linear in links, not in
-    element closures. The seam and solution lanes are
+    — an opaque item schema bounds the element closure but still delivers
+    every element's root document), so membership comes from a raw-document
+    subscription on the collection doc and only visible rows sink deeply —
+    cost bounded by the visible page in element documents; membership is
+    one document whose size grows with the collection's link array — linear
+    in links, not in element closures. The seam and solution lanes are
     issue [#6534](https://github.com/commontoolsinc/labs/issues/6534); B3
     opens by proving the seam, and falls back to a capped deep sink with
     an honest label if it disappoints. The raw subscription serves the

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -106,9 +106,10 @@ first work item, made in `packages/cli` where the substrate lives.
   raw value — and sinks deeply only the rows on screen. Element cost is
   bounded by the visible page; membership is one document whose size
   grows with the collection's link array — the linear-in-links frame
-  that replaces the element-closure shape behind the 89MB sync. Schema shapes that look
-  shallow to a reader do not bound what the server syncs, so this is the
-  one place shuttle reads below `Cell.sink`; the seam
+  that replaces the element-closure shape behind the 89MB sync. A schema
+  that looks shallow to a reader bounds the element closure but still
+  delivers every element's root document, so this is the one place shuttle
+  reads below `Cell.sink`; the seam
   (`SpaceReplica.sinkDocument`) exists but is unexercised. Issue
   [#6534](https://github.com/commontoolsinc/labs/issues/6534) carries the
   problem and the solution lanes. B3 opens by proving that seam on the


### PR DESCRIPTION
## Why

Decision 25 justifies shuttle's raw-document subscription with a parenthetical:
*"shapes that look shallow to a reader do not bound what the server syncs."*
Measured against a real fabric while proving the B3 seam, that sentence is too
strong — and the error is not cosmetic, because the fallback lane hangs off it.

An `asCell: ["opaque"]` item schema, and `items: false` which is byte-identical
to it, delivers **33 documents / 15,466 bytes** for a 32-element collection at
both 64-byte and 8,192-byte element bodies — flat across a 128× swing in
element size. Such a schema *does* bound what the server syncs. What it cannot
do is stop the element **roots** arriving, which is the real reason it cannot
express membership-only.

Read as written, the capped-deep-sink fallback sounds like an element-closure
read. It is not: on the same fixture it costs **57,056 bytes** where the full
deep read costs **281,664** — about five times cheaper. That is the difference
between a fallback that is embarrassing and one that is merely second choice,
and it is the sort of thing someone would decide against on the strength of a
sentence that happens to be wrong.

The ruled conclusion does not change. Membership still comes from the raw
subscription; B3 still opens by proving that seam; the base-scope-only rule and
the fallback both stand. Only the justification moves.

## What Changed

The claim was restated in two places and both are corrected — nothing
mechanical holds prose in step across files, so a sweep rather than a point fix:

- `docs/plans/shuttle/README.md`, decision 25
- `docs/plans/shuttle/views.md`, the list-view section

Text only. No decision, no behaviour, and no code changes.

## Test plan

- `deno fmt --check` — `Checked 5801 files`, clean.
- `deno task check-docs` — `All 595 checked code block(s) passed.`
- Line wrapping verified not to regress: the set of over-79-column lines in
  `README.md` is identical to `origin/main`'s, and `views.md` goes from two to
  one.

The numbers above are measured, with a positive control (deep and capped arms
on the same fixture grow with element payload while the raw and opaque arms do
not, so the instrument demonstrably sees closure traffic when it exists). Full
method and per-arm figures are on
[#6534](https://github.com/commontoolsinc/labs/issues/6534), together with the
proving test the issue asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

