### PR TITLE
test(runtime-client): cover delegated render admission

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -50,7 +50,7 @@ was last checked against the code.
 | [`messageCompressionV1`](#messagecompressionv1)                             | `setMessageCompressionConfig()` (negotiated per connection)                                                                                     | on                                                                                   | PR #6474                                             | retire the rollback switch after the binary WebSocket envelope has field-soaked                                                                                                                                                   | implemented, on by default                                                      |
 | [`ownWriteEcho`](#ownwriteecho)                                             | `setOwnWriteEchoConfig()` (server-side only, not negotiated)                                                                                    | on                                                                                   | Robin McCollum (CT-1965)                              | remove the switch once the echo has field-soaked                                                                                                                                                                                  | implemented, on by default                                                      |
 | [`experimentalConcurrentWatchRefresh`](#experimentalconcurrentwatchrefresh) | `IRemoteStorageProviderSettings`; in the shell, the `commonfabric.concurrentWatchRefresh()` console command (localStorage, per browser profile) | off                                                                                  | Ben Follington (#4937; shell toggle #4974)            | graduate to always-on after live measurement, or remove if superseded                                                                                                                                                             | implemented behind the flag, off by default, not yet measured over real latency |
-| [`cfcRenderCeiling`](#cfcrenderceiling)                                     | `commonfabric.cfcRenderCeiling()` in the browser (localStorage)                                                                                 | off                                                                                  | Bernhard Seefeld (#4550)                              | graduate once exchange resolution lands                                                                                                                                                                                           | implemented, off by default, dogfood only                                       |
+| [`cfcRenderCeiling`](#cfcrenderceiling)                                     | `commonfabric.cfcRenderCeiling()` in the browser (localStorage)                                                                                 | off                                                                                  | Bernhard Seefeld (#4550)                              | graduate to an unconditional ceiling                                                                                                                                                                                           | implemented, off by default, dogfood only                                       |
 | [`INGEST_SELF_SERVE_ENABLED`](#ingest_self_serve_enabled) | `INGEST_SELF_SERVE_ENABLED` env on toolshed | off | Alex Komoroske (self-serve ingest channels) | graduate on once named-space keys stop deriving from a public passphrase | implemented, off by default |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning)                                 | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache`                                                             | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts                          | Ian Hickson                                           | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked                                                                                                                                      | implemented, on by default for FUSE-T, soak-validated                           |
 
@@ -1183,19 +1183,20 @@ the per-epic implementation notes).
 - **Added by.** Bernhard Seefeld, in "populate the render confidentiality
   ceiling behind a shell dogfood flag (Epic H3a)" (#4550, 2026-07-07).
 - **Purpose.** Populates the CFC render confidentiality ceiling in the shell's
-  runtime. When on, display sinks admit only the acting user's own identity atom
-  plus allow-listed influence-class caveat kinds; everything else fails closed
-  and renders as a blocked placeholder, and author-supplied render-boundary
-  declassification is denied.
-- **Current default and planned end state.** Off by default. It changes what the
-  shell renders and is expected to over-block until exchange resolution (a later
-  CFC stage, Epic H3b) lands, so it is enabled deliberately per browser profile
-  for dogfooding. The end state is to graduate the ceiling on once exchange
-  resolution makes the blocking precise.
-- **Status on 2026-07-08.** Implemented, off by default, dogfood only.
-- **Path to removal.** Land exchange resolution so the ceiling stops
-  over-blocking, turn it on by default, and then remove the localStorage toggle
-  and make the ceiling unconditional.
+  runtime. Display sinks admit the acting user's identity and personal-space
+  atoms plus allow-listed influence-class caveat kinds. Before the fit check,
+  the worker resolves shared `Space` labels through verified reader membership;
+  a delegate's access to the session workspace requires its own membership
+  evidence. Confidentiality the ceiling does not satisfy stays blocked, and
+  author-supplied render-boundary declassification is denied.
+- **Current default and planned end state.** Off by default and enabled per
+  browser profile for dogfooding. The end state is to enable the ceiling by
+  default and make it unconditional.
+- **Status on 2026-09-08.** Exchange resolution is implemented. Where reader
+  membership is required, missing or unsynced ACL evidence keeps the content
+  blocked; a reader grant admits it and a revocation blocks it again.
+- **Path to removal.** Finish dogfood validation, turn the ceiling on by default,
+  then remove the localStorage toggle and make the ceiling unconditional.
 
 ## Category 5: Fuse mount cache tuning
 

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -161,7 +161,9 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
    * the runtime acts as, which is also the audience the render ceiling admits
    * when `cfcRenderCeiling` is on. Omit it to send one naming the session
    * identity; pass `null` to send none, which leaves the worker to build its
-   * own, naming the session identity as well.
+   * own, naming the session identity as well. A supplied snapshot without an
+   * `actingPrincipal` leaves transaction trust unnamed; rendering falls back
+   * to the session identity as its audience.
    */
   trustSnapshot?: RuntimeTrustSnapshot | null;
 
@@ -325,15 +327,11 @@ export function createRuntimeClientOptions({
   // (§8.12.8) keeps the derived component tracking the current value rather
   // than ratcheting forever. H1 shipped "observe" as the measurement stage.
   cfcFlowLabels = "persist",
-  // Epic H3a: populate the render confidentiality ceiling. Off by default —
-  // a deployment-posture change to what the shell renders, enabled
-  // deliberately per host (shell dogfood flag). When on, display sinks
-  // admit only the §8.10.6 profile (the acting user's own identity atom
-  // plus display-dischargeable influence-class caveat kinds) and
-  // author-supplied render declassification is denied (audit S15); the
-  // reconciler's fail-closed narrowing does the enforcement. Exact-match
-  // forms only until H3b adds exchange resolution, so over-blocking is
-  // expected — that is the point of the dogfood stage.
+  // Hosts opt into the §8.10.6 display ceiling. The worker resolves shared
+  // `Space` labels through verified reader membership before the reconciler
+  // fits them against the acting user's identity atoms and the admitted
+  // influence-class caveat kinds. Author-supplied render declassification is
+  // denied, and labels that still do not fit the ceiling stay blocked.
   cfcRenderCeiling = false,
   trustSnapshot,
   forwardWorkerConsole,

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -897,9 +897,9 @@ describe("RuntimeInternals", () => {
       session.as.did(),
     );
 
-    // `null` asks for no trust snapshot at all, which is a different case
-    // from a snapshot that carries no acting principal. Neither names an
-    // audience, so the session identity is acting in both.
+    // `null` leaves the worker to build its default session-principal snapshot.
+    // A supplied snapshot with no principal stays unnamed for transactions.
+    // Both use the session identity as the render audience.
     const withoutSnapshot = createRuntimeClientOptions({
       session,
       apiUrl: new URL("http://shell.test/"),

--- a/packages/runtime-client/test/backends/render-audience.test.ts
+++ b/packages/runtime-client/test/backends/render-audience.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Checks host trust options through worker construction and display admission.
+ * Real cells and ACL changes drive an in-process renderer over emulated storage.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { cfcAtom } from "@commonfabric/api/cfc";
+import type { VDomOp } from "@commonfabric/html/vdom-ops";
+import {
+  WorkerReconciler,
+  type WorkerRenderNode,
+} from "@commonfabric/html/worker";
+import { createSession, Identity } from "@commonfabric/identity";
+import { createRuntimeClientOptions } from "@commonfabric/lib-shell/runtime";
+import {
+  Runtime,
+  runtimePresets,
+  RuntimeTelemetry,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "../../../runner/test/cfc-seed-envelope.ts";
+
+import {
+  browserWorkerParamsFromInitializationData,
+  renderConfidentialityResolverFor,
+  renderMembershipProviderFor,
+} from "@/backends/runtime-processor.ts";
+
+/** Builds the worker's effective runtime from host options over local storage. */
+function createWorkerRuntime(
+  options: ReturnType<typeof createRuntimeClientOptions>,
+): Runtime {
+  const storageManager = StorageManager.emulate({ as: options.identity });
+  const params = browserWorkerParamsFromInitializationData(
+    {
+      ...options,
+      apiUrl: options.apiUrl.toString(),
+      identity: options.identity.keyPair,
+      spaceIdentity: options.spaceIdentity?.keyPair,
+    },
+    storageManager,
+    new RuntimeTelemetry(),
+  );
+  return new Runtime(runtimePresets.browserWorker(params));
+}
+
+/** Text sent to the host, including updates to an existing text node. */
+function emittedText(ops: readonly VDomOp[]): string[] {
+  return ops.filter((op) => op.op === "create-text" || op.op === "update-text")
+    .map((op) => op.text);
+}
+
+describe("render-audience", () => {
+  describe("effective worker trust", () => {
+    for (const trustSnapshot of [undefined, null]) {
+      it(`uses session-principal transaction trust for \`${trustSnapshot}\` host trust`, async () => {
+        const identity = await Identity.generate({ implementation: "noble" });
+        const session = await createSession({
+          identity,
+          spaceDid: identity.did(),
+        });
+        const options = createRuntimeClientOptions({
+          session,
+          apiUrl: new URL("http://localhost/"),
+          trustSnapshot,
+        });
+        await using runtime = createWorkerRuntime(options);
+        const tx = runtime.edit();
+        try {
+          const trust = tx.getCfcState().trustSnapshot;
+          expect(trust?.id).toBe(`principal:${identity.did()}`);
+          expect(trust?.actingPrincipal).toBe(identity.did());
+          if (trustSnapshot === null) {
+            expect(trust?.revision).toBeDefined();
+          }
+        } finally {
+          tx.abort();
+        }
+      });
+    }
+
+    it("keeps a supplied snapshot unnamed for transactions while rendering as the session identity", async () => {
+      const identity = await Identity.generate({ implementation: "noble" });
+      const session = await createSession({
+        identity,
+        spaceDid: identity.did(),
+      });
+      const trustSnapshot = { id: "unnamed-host-snapshot" };
+      const options = createRuntimeClientOptions({
+        session,
+        apiUrl: new URL("http://localhost/"),
+        cfcRenderCeiling: true,
+        trustSnapshot,
+      });
+      await using runtime = createWorkerRuntime(options);
+      const tx = runtime.edit();
+      try {
+        expect(tx.getCfcState().trustSnapshot).toEqual(trustSnapshot);
+        expect(tx.getCfcState().trustSnapshot?.actingPrincipal).toBeUndefined();
+      } finally {
+        tx.abort();
+      }
+      const membership = renderMembershipProviderFor(
+        runtime,
+        identity,
+        options.renderConfidentialityCeiling,
+      );
+      expect(membership?.readerRole(identity.did())).toBe("owner");
+      expect(options.renderConfidentialityCeiling?.atoms).toContainEqual(
+        cfcAtom.user(identity.did()),
+      );
+    });
+  });
+
+  describe("delegated rendering", () => {
+    for (const namedSpace of [false, true]) {
+      it(`renders the session's ${namedSpace ? "derived" : "identity"} workspace only while the delegate has an ACL grant`, async () => {
+        const identity = await Identity.generate({ implementation: "noble" });
+        const delegate = await Identity.generate({ implementation: "noble" });
+        const session = await createSession({
+          identity,
+          ...(namedSpace ? { spaceName: "private-workspace" } : {
+            spaceDid: identity.did(),
+          }),
+        });
+        const options = createRuntimeClientOptions({
+          session,
+          apiUrl: new URL("http://localhost/"),
+          cfcRenderCeiling: true,
+          trustSnapshot: {
+            id: `principal:${delegate.did()}`,
+            actingPrincipal: delegate.did(),
+          },
+        });
+        await using runtime = createWorkerRuntime(options);
+        const seed = runtime.edit();
+        writeSeedEnvelopeDoc(seed, session.space);
+        const notes = [
+          { text: "Workspace note", atom: cfcAtom.space(session.space) },
+          { text: "Owner identity note", atom: cfcAtom.user(identity.did()) },
+          {
+            text: "Owner personal-space note",
+            atom: cfcAtom.personalSpace(identity.did()),
+          },
+          { text: "Owner DID note", atom: identity.did() },
+          { text: "Delegate note", atom: cfcAtom.user(delegate.did()) },
+        ].map(({ text, atom }) => {
+          const cell = runtime.getCell<WorkerRenderNode>(
+            session.space,
+            text,
+            undefined,
+            seed,
+          );
+          seed.writeOrThrow({
+            space: session.space,
+            id: cell.getAsNormalizedFullLink().id!,
+            type: "application/json",
+            path: [],
+          }, {
+            value: text,
+            cfc: {
+              version: 1,
+              schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+              labelMap: {
+                version: 1,
+                entries: [{ path: [], label: { confidentiality: [atom] } }],
+              },
+            },
+          });
+          return cell;
+        });
+        expect((await seed.commit()).error).toBeUndefined();
+
+        /** Writes the ACL without reading labeled notes into the transaction. */
+        async function setDelegateRead(granted: boolean): Promise<void> {
+          const tx = runtime.edit();
+          tx.writeOrThrow({
+            space: session.space,
+            id: `of:${session.space}`,
+            type: "application/json",
+            path: [],
+          }, {
+            value: {
+              [identity.did()]: "OWNER",
+              ...(granted ? { [delegate.did()]: "READ" } : {}),
+            },
+          });
+          expect((await tx.commit()).error).toBeUndefined();
+          await runtime.storageManager.synced();
+          await runtime.idle();
+        }
+
+        await setDelegateRead(false);
+        const ceiling = options.renderConfidentialityCeiling;
+        const membership = renderMembershipProviderFor(
+          runtime,
+          identity,
+          ceiling,
+        );
+        const resolver = renderConfidentialityResolverFor(
+          runtime,
+          identity,
+          ceiling,
+          options.spaceDid,
+          membership,
+        );
+        const ops: VDomOp[] = [];
+        const allText: string[] = [];
+        const reconciler = new WorkerReconciler({
+          onOps: (batch) => {
+            ops.push(...batch);
+            allText.push(...emittedText(batch));
+          },
+          renderDeclassificationPolicy: options.renderDeclassificationPolicy,
+          renderConfidentialityCeiling: ceiling,
+          resolveRenderConfidentiality: resolver,
+          membershipProvider: membership,
+        });
+        const cancel = reconciler.mount({
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: notes,
+        });
+        try {
+          await runtime.idle();
+          reconciler.flush();
+          expect(membership?.readerRole(session.space)).toBeNull();
+          expect(emittedText(ops)).toContain("Delegate note");
+          expect(emittedText(ops)).toContain("Content hidden by policy");
+          expect(emittedText(ops)).not.toContain("Workspace note");
+          ops.length = 0;
+          await setDelegateRead(true);
+          reconciler.flush();
+          expect(membership?.readerRole(session.space)).toBe("reader");
+          expect(emittedText(ops)).toContain("Workspace note");
+          const disclosed = ops.filter((op) => op.op === "create-text")
+            .find((op) => op.text === "Workspace note");
+          expect(disclosed).toBeDefined();
+
+          ops.length = 0;
+          await setDelegateRead(false);
+          reconciler.flush();
+          expect(membership?.readerRole(session.space)).toBeNull();
+          expect(emittedText(ops)).toContain("Content hidden by policy");
+          expect(emittedText(ops)).not.toContain("Workspace note");
+          expect(ops).toContainEqual({
+            op: "remove-node",
+            nodeId: disclosed!.nodeId,
+          });
+          for (
+            const text of [
+              "Owner identity note",
+              "Owner personal-space note",
+              "Owner DID note",
+            ]
+          ) {
+            expect(allText).not.toContain(text);
+          }
+        } finally {
+          cancel();
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to #6922. Add regression coverage that follows host trust options through worker runtime construction and actual render operations over emulated storage:

- Pin effective transaction trust for omitted, `null`, and unnamed host snapshots, including the unnamed snapshot's separate render-audience fallback.
- For identity and derived workspaces, verify a delegate cannot render workspace content without an ACL grant, a reader grant reveals it, and live revocation blocks it and removes the disclosed text node.
- Keep the session owner's `User`, `PersonalSpace`, and legacy DID labels private throughout, while admitting the delegate's own label.

Correct the remaining lib-shell comments and experimental flag documentation to describe current exchange resolution and the distinction between transaction trust and render audience.

Validation: repository-wide `deno fmt --check`, `deno lint`, and `deno task check`; both affected packages' `deno task test` suites (34 top-level tests, 701 steps); polling, package-cycle, and test-topology gates. The new regression suite also fails as expected when either the delegate membership guard or the acting-principal ceiling fix is deliberately reversed. The renderer tests run in process; they do not launch a browser worker.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

