### PR TITLE
fix(schema-generator): a synthetic `readonly T[]` keeps its element shape

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -83,13 +83,21 @@ triggers are documented in the ts-transformers behavior spec §12.
 `src/schema-generator.ts`) handles: `TypeLiteral` nodes (properties
 with `questionToken` optionality; string/number index signatures →
 `additionalProperties`, first non-undefined wins, no JSDoc),
-`ArrayTypeNode`, unions (`true` member short-circuits, `false`
+`readonly` type-operator nodes (analyze the wrapped type), `ArrayTypeNode`,
+unions (`true` member short-circuits, `false`
 members filtered, singletons unwrapped), literal nodes
 `TypeReference` nodes (wrapper detection first, then a
 scope-based name-resolution fallback for unbindable synthetic references via
 `checker.getSymbolsInScope` — plus a `Date`-by-name
 special case), keyword types, and a final
 resolve-else-`true` fallback.
+
+`readonly` marks mutability and contributes no JSON Schema keyword. A
+synthetic `readonly T[]` therefore has the same schema as its wrapped `T[]`.
+In particular, `readonly unknown[]` emits
+`{ type: "array", items: { type: "unknown" } }`, preserving the element's
+reference-only semantics. The synthetic readonly array cases in
+`test/schema-generator.test.ts` cover unknown, string, and object elements.
 
 **Observed node/type divergence — literal encodings.** The node path emits
 `const` (`{ type: "string", const: "x" }`); the type path emits

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1930,6 +1930,13 @@ Special path:
   schema).
 - `unknown` is emitted distinctly as `{ type: "unknown" }`; `any` remains `true`
 - arrays of `unknown` emit `items: { type: "unknown" }`
+- the node-based generator analyzes through a `readonly` type operator to
+  its wrapped array type. A pattern-scope `.get()` on a `Cell<unknown[]>`
+  lowers to a lift with result type `readonly unknown[]` and result schema
+  `{ type: "array", items: { type: "unknown" } }`. The derived cell keeps
+  this reference-only element schema. The
+  `schema-injection/cell-get-readonly-array-result` fixture pins the emitted
+  lift schemas, including a `number[]` control.
 - synthetic unions preserve explicit `{ type: "unknown" }` members in `anyOf`
   rather than collapsing them away
 - `Reactive<T>` does not emit an opaque marker. Cell, stream, and opaque

--- a/packages/runner/test/pattern-scope-array-read-schema.test.ts
+++ b/packages/runner/test/pattern-scope-array-read-schema.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import { ContextualFlowControl } from "../src/cfc.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("pattern scope array read schema");
+
+// A pattern-scope `.get()` of an array cell lowers to a derived cell that
+// holds the read. What schema that cell carries decides what a sync of it
+// asks the server for: a trivially-permissive schema is a request for the
+// cell's whole reachable graph, which is what the setup kick and the resume
+// wave issue when they load it. `unknown` is the reference-only declaration
+// (docs/specs/link-schema-precedence.md) — compare by identity, do not read
+// through — so a view of `unknown[]` must keep that declaration rather than
+// widen to everything. The view reads back as `readonly unknown[]`, and the
+// schema generator used to lose the shape at the `readonly` operator.
+const PROGRAM = (elements: string) => `
+import { type Default, pattern, type Writable } from 'commonfabric';
+export default pattern<
+  { members: Writable<${elements}[] | Default<[]>> },
+  { count: number }
+>(({ members }) => {
+  const view = members.get();
+  const count = view.length;
+  return { count };
+});`;
+
+describe("pattern-scope array read schema", () => {
+  let server: ReturnType<typeof newSharedServer>;
+  let sm: EmulatedStorageManager;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    sm = EmulatedStorageManager.connectTo(server, { as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await sm.close();
+    await server.close();
+  });
+
+  const viewDescriptor = async (elements: string) => {
+    const pattern = await runtime.patternManager.compilePattern(
+      PROGRAM(elements),
+    );
+    const descriptor = pattern.derivedInternalCells?.find((candidate) =>
+      candidate.partialCause === "view"
+    );
+    expect(descriptor).toBeDefined();
+    return descriptor!;
+  };
+
+  it("keeps a view of `unknown[]` reference-only rather than open", async () => {
+    const { schema } = await viewDescriptor("unknown");
+    expect(schema).toEqual({ type: "array", items: { type: "unknown" } });
+    expect(ContextualFlowControl.isTrueSchema(schema!)).toBe(false);
+  });
+
+  it("keeps a view of `number[]` shaped", async () => {
+    const { schema } = await viewDescriptor("number");
+    expect(schema).toEqual({ type: "array", items: { type: "number" } });
+  });
+});

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -778,6 +778,21 @@ export class SchemaGenerator {
       return schema;
     }
 
+    // A `readonly T[]` node is the operator form the checker prints a
+    // ReadonlyArray in, and it is what a synthetic result type built from a
+    // cell read looks like (`cell.get()` on a `Cell<T[]>` reads back
+    // `readonly T[]`). Readonly-ness is a mutability marker with no JSON
+    // Schema counterpart, so the node carries exactly the shape of `T[]`.
+    // Without this branch the node fell through to the accept-anything
+    // fallback at the end, which turned a read of `unknown[]` — the
+    // reference-only declaration — into a schema that walks everything.
+    if (
+      ts.isTypeOperatorNode(typeNode) &&
+      typeNode.operator === ts.SyntaxKind.ReadonlyKeyword
+    ) {
+      return this.#analyzeTypeNodeStructure(typeNode.type, checker, context);
+    }
+
     // Handle ArrayTypeNode (e.g., number[], string[])
     if (ts.isArrayTypeNode(typeNode)) {
       const elementType = typeRegistry?.get(typeNode.elementType) ??

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -96,6 +96,82 @@ type CalculatorRequest = {
     });
   });
 
+  describe("synthetic readonly arrays", () => {
+    // The checker prints a ReadonlyArray as the `readonly T[]` type-operator
+    // form, and a synthetic result type built from a cell read is exactly
+    // that: `cell.get()` on a `Cell<T[]>` reads back `readonly T[]`. The
+    // node-based analyzer used to have no branch for the operator node and
+    // fell through to the accept-anything fallback, so a read of `unknown[]`
+    // — the reference-only declaration — came out as `true`.
+    const readonlyArrayOf = (element: ts.TypeNode) =>
+      ts.factory.createTypeOperatorNode(
+        ts.SyntaxKind.ReadonlyKeyword,
+        ts.factory.createArrayTypeNode(element),
+      );
+
+    it("keeps the element shape of a synthetic `readonly unknown[]`", async () => {
+      const generator = new SchemaGenerator();
+      const { checker } = await getTypeFromCode(
+        "type Dummy = unknown;",
+        "Dummy",
+      );
+      const schema = generator.generateSchemaFromSyntheticTypeNode(
+        readonlyArrayOf(
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+        ),
+        checker,
+      ) as Record<string, unknown>;
+
+      expect(schema.type).toBe("array");
+      expect(schema.items).toEqual({ type: "unknown" });
+    });
+
+    it("keeps the element shape of a synthetic `readonly string[]`", async () => {
+      const generator = new SchemaGenerator();
+      const { checker } = await getTypeFromCode(
+        "type Dummy = unknown;",
+        "Dummy",
+      );
+      const schema = generator.generateSchemaFromSyntheticTypeNode(
+        readonlyArrayOf(
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+        ),
+        checker,
+      ) as Record<string, unknown>;
+
+      expect(schema.type).toBe("array");
+      expect(schema.items).toEqual({ type: "string" });
+    });
+
+    it("analyzes through `readonly` to a synthetic object element", async () => {
+      const generator = new SchemaGenerator();
+      const { checker } = await getTypeFromCode(
+        "type Dummy = unknown;",
+        "Dummy",
+      );
+      const schema = generator.generateSchemaFromSyntheticTypeNode(
+        readonlyArrayOf(
+          ts.factory.createTypeLiteralNode([
+            ts.factory.createPropertySignature(
+              undefined,
+              ts.factory.createIdentifier("id"),
+              undefined,
+              ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+            ),
+          ]),
+        ),
+        checker,
+      ) as Record<string, unknown>;
+
+      expect(schema.type).toBe("array");
+      expect(schema.items).toEqual({
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      });
+    });
+  });
+
   describe("synthetic type literals", () => {
     it("preserves numeric literal property names", async () => {
       const generator = new SchemaGenerator();

--- a/packages/ts-transformers/test/fixtures/schema-injection/cell-get-readonly-array-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/cell-get-readonly-array-result.expected.jsx
@@ -1,0 +1,146 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { type Default, pattern, type Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+const __cfLift_1 = __cfHelpers.lift<{
+    mentioned: Writable<unknown[] | Default<[
+    ]>>;
+}, readonly unknown[]>(({ mentioned }) => mentioned.get(), {
+    type: "object",
+    properties: {
+        mentioned: {
+            type: "array",
+            items: {
+                type: "unknown"
+            },
+            "default": [],
+            asCell: ["readonly"]
+        }
+    },
+    required: ["mentioned"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "unknown"
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    mentionedView: readonly unknown[];
+}, boolean>(({ mentionedView }) => mentionedView.length > 0, {
+    type: "object",
+    properties: {
+        mentionedView: {
+            type: "array",
+            items: {
+                type: "unknown"
+            }
+        }
+    },
+    required: ["mentionedView"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_3 = __cfHelpers.lift<{
+    nums: Writable<number[] | Default<[
+    ]>>;
+}, readonly number[]>(({ nums }) => nums.get(), {
+    type: "object",
+    properties: {
+        nums: {
+            type: "array",
+            items: {
+                type: "number"
+            },
+            "default": [],
+            asCell: ["readonly"]
+        }
+    },
+    required: ["nums"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "number"
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_4 = __cfHelpers.lift<{
+    numsView: readonly number[];
+}, number>(({ numsView }) => numsView.length, {
+    type: "object",
+    properties: {
+        numsView: {
+            type: "array",
+            items: {
+                type: "unknown"
+            }
+        }
+    },
+    required: ["numsView"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: cell-get-readonly-array-result
+// Verifies: a pattern-scope `.get()` of an array cell lowers to a lift whose
+// RESULT schema keeps the array's shape. The read types as `readonly T[]`,
+// which the checker prints as a `readonly` type-operator node; the generator
+// analyzes through it rather than falling back to `true`. For `unknown[]` —
+// the reference-only declaration — that fallback turned "compare, don't read
+// through" into a schema that walks everything reachable.
+export default pattern((__cf_pattern_input) => {
+    const mentioned = __cf_pattern_input.key("mentioned");
+    const nums = __cf_pattern_input.key("nums");
+    const mentionedView = __cfLift_1({ mentioned: mentioned }).for("mentionedView", true);
+    const hasMentioned = __cfLift_2({ mentionedView: mentionedView }).for("hasMentioned", true);
+    const numsView = __cfLift_3({ nums: nums }).for("numsView", true);
+    const count = __cfLift_4({ numsView: numsView }).for("count", true);
+    return { hasMentioned, count };
+}, {
+    type: "object",
+    properties: {
+        mentioned: {
+            type: "array",
+            items: {
+                type: "unknown"
+            },
+            "default": [],
+            asCell: ["cell"]
+        },
+        nums: {
+            type: "array",
+            items: {
+                type: "number"
+            },
+            "default": [],
+            asCell: ["cell"]
+        }
+    },
+    required: ["mentioned", "nums"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        hasMentioned: {
+            type: "boolean"
+        },
+        count: {
+            type: "number"
+        }
+    },
+    required: ["hasMentioned", "count"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/cell-get-readonly-array-result.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/cell-get-readonly-array-result.input.tsx
@@ -1,0 +1,23 @@
+import { type Default, pattern, type Writable } from "commonfabric";
+
+// FIXTURE: cell-get-readonly-array-result
+// Verifies: a pattern-scope `.get()` of an array cell lowers to a lift whose
+// RESULT schema keeps the array's shape. The read types as `readonly T[]`,
+// which the checker prints as a `readonly` type-operator node; the generator
+// analyzes through it rather than falling back to `true`. For `unknown[]` —
+// the reference-only declaration — that fallback turned "compare, don't read
+// through" into a schema that walks everything reachable.
+
+export default pattern<
+  {
+    mentioned: Writable<unknown[] | Default<[]>>;
+    nums: Writable<number[] | Default<[]>>;
+  },
+  { hasMentioned: boolean; count: number }
+>(({ mentioned, nums }) => {
+  const mentionedView = mentioned.get();
+  const hasMentioned = mentionedView.length > 0;
+  const numsView = nums.get();
+  const count = numsView.length;
+  return { hasMentioned, count };
+});


### PR DESCRIPTION
A pattern-scope read of an array cell — `const view = members.get()` — lowers to a lift whose result type is `readonly T[]`. The checker prints that as a `readonly` type-operator node. When the transformer hands the schema generator a type it will not trust structurally (any type containing `unknown`), the generator analyzes the node instead of the type, and the node-based analyzer had no branch for the operator node: it fell through to the accept-anything fallback. So a read of `unknown[]` — the reference-only declaration, "compare by identity, do not read through" (docs/specs/link-schema-precedence.md) — was emitted as schema `true`, while the same type in argument position was emitted correctly as an array of `unknown`.

| `members: Writable<…>` | argument schema for `members` | lowered lift's **result** schema, before | after |
| --- | --- | --- | --- |
| `unknown[] \| Default<[]>` | `array, items: {type: unknown}` | `true` | `array, items: {type: unknown}` |
| `number[] \| Default<[]>` | `array, items: number` | `array, items: number` | unchanged |

## Why it matters at the runtime

That `true` lands on the derived cell that holds the read, and a sync honoring a trivially-permissive schema asks the server for the cell's whole reachable graph. The Topics board's topic pattern reads its `mentioned` list exactly this way (`mentionedView = mentioned.get()` in `packages/patterns/topics/topic.tsx`), so every setup or `setsrc` of a topic issued one open-schema selector walking the board — the 7,327-document read in the 8/31 census. #6627 clamped that at the runner's locality syncs; this is the cause it was standing in for. The clamp is up for reversion in #7071, and once this deploys, the clamp has nothing left to act on for them. No re-apply is needed: a piece stores its pattern as source, and `packages/schema-generator` is a compile-fingerprint input (`compiler-fingerprint.deno.ts`), so a build carrying this change moves the compile-cache version and every stored piece recompiles from its source closure on its next load (`#tryColdLoadByIdentity`).

## The change

One branch in `SchemaGenerator.#analyzeTypeNodeStructure`: a `readonly` type-operator node is analyzed through to the array it wraps. Readonly-ness is a mutability marker with no JSON Schema counterpart, so the node carries exactly the shape of `T[]`. No argument or result contract changes (pattern-compat is green); what narrows is the internal derived-cell descriptor of any pattern-scope array read whose element type the transformer treats as not structurally precise — `true` becomes the array's shape.

## Tests

Pinned at three levels, each verified red without the branch:

- `packages/schema-generator/test/schema-generator.test.ts` — synthetic `readonly unknown[]`, `readonly string[]`, and a readonly array of a synthetic object literal keep their element shape.
- `packages/ts-transformers/test/fixtures/schema-injection/cell-get-readonly-array-result` — the lowered lift's result schema is an array of `unknown`, next to a `number` control.
- `packages/runner/test/pattern-scope-array-read-schema.test.ts` — the compiled pattern's derived-cell descriptor is `{type: "array", items: {type: "unknown"}}` and not trivially permissive: the schema that actually reaches a sync.

## Gates run locally

- `packages/schema-generator`: 57 passed, 0 failed (three new cases included).
- `packages/ts-transformers`: 1,164 passed, 0 failed; no existing golden changed.
- `packages/runner` full suite: 1,390 passed, 1 failed. The one failure is `executor-cooperative-yield.test.ts` (stage C tuning T3, step ii, the mid-wave lease renew), which failed identically on stock main in this environment while main's CI was green — a local condition unrelated to schema generation. After rebasing onto #7081, which fixed that test's lease-expiry read, it passes locally too.
- `packages/patterns` unit tests (the non-browser task): 62 passed, 0 failed.
- `deno task pattern-compat`: 325 patterns can be updated from every recorded contract.
- `deno task pattern-vintage`: replayed 8 vintages, 134 recorded instantiations all mappable, 77 targets updated cleanly with no state stranded. The four `piece-start-commit-failed` retry lines in its log reproduce identically on stock main.
- `deno fmt`, `deno lint`, `deno check` on the changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



