### PR TITLE
test(runner): read the lease expiry as a REAL, not a 32-bit integer

### DIFF
--- a/packages/runner/test/executor-cooperative-yield.test.ts
+++ b/packages/runner/test/executor-cooperative-yield.test.ts
@@ -74,9 +74,17 @@ const burn = (ms: number): void => {
 const WALK_STEPS = 30;
 const STEP_MS = 40;
 
+// Read as a REAL: the engine opens its database with the driver's default
+// integer mode, which hands a JS caller the low 32 bits of an INTEGER
+// column. An epoch-millisecond expiry is well past 32 bits, so the raw read
+// is a wrapped value whose SIGN flips every 2^31 ms (~24.9 days) — the row
+// stayed correct and the lease's own liveness checks compare inside SQL,
+// but the raw number read here went negative on 2026-09-08 07:51 UTC and
+// failed the `> 0` pin below. A REAL is exact for any millisecond timestamp.
 const leaseExpiry = (engine: Engine.Engine): number =>
   (engine.database.prepare(
-    `SELECT expires_at FROM execution_lease WHERE space = :space`,
+    `SELECT CAST(expires_at AS REAL) AS expires_at FROM execution_lease
+      WHERE space = :space`,
   ).get({ space }) as { expires_at: number } | undefined)?.expires_at ?? 0;
 
 describe("stage C tuning T3: cooperative yield + mid-wave renew", () => {


### PR DESCRIPTION
## Summary

`Runner Tests (7/8)` has been red on main and on every PR since 2026-09-08 07:51 UTC. The failing step is `executor-cooperative-yield.test.ts` "(ii) a wave longer than TTL/3 renews the lease MID-WAVE", at its first assertion:

```
AssertionError: Expected -2114469196 to be greater than 0
```

The test helper reads `execution_lease.expires_at` back through the engine's database, which is opened in `@db/sqlite`'s default integer mode: a JS caller receives the low 32 bits of an INTEGER column. An epoch-millisecond expiry is well past 32 bits, so the raw read is a wrapped value whose sign flips every 2^31 ms (about 24.9 days). It flipped negative this morning; it flips back positive on 2026-10-03 04:22 UTC and negative again on 2026-10-28.

The lease itself is unaffected. Acquire, renew and release compare `expires_at` against a bound `:now` inside SQL, and the memory package's own lease test injects a small synthetic clock that never reaches 32 bits. Only this helper's raw read was wrong.

## Fix

Read the column as `CAST(expires_at AS REAL)`, which is exact for any millisecond timestamp. The comment on the helper carries the mechanism.

## Validation

- Driver probe on the same `@db/sqlite` build: default mode returns `-2113627700` for a stored `1788887734732`; `CAST(... AS REAL)` returns `1788887734732`; the SQL comparison `expires_at > :now` is `1` in both modes.
- The test fails on pristine `main` (`0d4dca379`) locally with the same negative shape and passes with this change, twice in a row.
- `deno fmt --check` and `deno lint` clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


