### PR TITLE
fix(ci): the topology accounts for the tests and records it had missed

### DIFF
--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -31,7 +31,11 @@ score and its cost, the catches behind that score with how many were on
 the default branch and across how many distinct sources, when the most
 recent one was, its churn and flake rate, and whether it is withheld and
 why. An identity the store has never seen is reported as mandatory, which
-is what an identity with no history is.
+is what an identity with no history is — unless it sits in a unit the
+topology declares unavailable, and then the answer is that nothing runs
+it, with the reason the suite gave. Such a unit has no record for the
+same reason it has no lane, so reading its silence as a new test would
+say the opposite of what happens.
 
 The identity resolves through `tasks/test-identity-aliases.jsonl` first,
 so asking about a renamed test under either name finds the joined history.

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -385,8 +385,10 @@ the set is a decision to spend part of every lane's budget forever.
 
 ### Today's jobs as suites
 
-The 18 job definitions in `deno.yml` become the following suites. This
-table is the migration's checklist.
+The 18 job definitions in `deno.yml` become the following suites, along
+with two the lanes do not run: the tests whose equipment a runner does
+not have, and the commands a job records after the lanes or on a
+schedule of its own. This table is the migration's checklist.
 
 | Suite | Today's jobs | Record variant | Capabilities |
 | --- | --- | --- | --- |
@@ -401,6 +403,8 @@ table is the migration's checklist.
 | `package-integration` | `Package Integration Tests (3 suites)` | — | `deno`, `toolshed`, `browser` |
 | `package-integration-opposite` | the posture opposite the server-execution default | resolved arm variant | `deno`, `toolshed-baked-opposite`, `browser` |
 | `deployed-topology` | the background-service and cf-harness default-posture gates | — | `deno`, `toolshed`, `bg-piece-service-binary` |
+| `harness-equipment` | no job; the cf-harness integration tests whose equipment a runner does not have | — | `deno` |
+| `out-of-lane` | `Coverage Check`, and the nightly `CFC Property Suite` workflow | — | none |
 | `cli-core` | `CLI Integration Tests (3 suites)` | — | `deno`, `toolshed`, `cf`, `jq` |
 | `cli-fuse` | the FUSE steps of the third CLI suite | — | `deno`, `toolshed`, `cf`, `fuse` |
 | `cli-deno` | the Deno-based CLI integration step | — | `deno`, `toolshed`, `cf` |
@@ -995,6 +999,14 @@ that `enumerate()` returns and that no run has ever produced a record for
 is either a test that never runs or a mapping that is wrong, and both are
 worth knowing about without blocking anybody. Entries in its unavailable
 list are reported separately and do not count as missing records.
+
+What the store half asks of a recorded identity holds for every record a
+run writes, including the ones the lanes did not produce. The coverage
+gate runs after the lanes and joins what they measured, and the nightly
+property suite runs on a schedule of its own; both record through the
+same wrapper every gate uses. The `out-of-lane` suite is where those are
+declared, each as an unavailable unit carrying the reason no lane runs
+it, so the guard finds a claim and the packer finds nothing to offer.
 
 Together these are what make "no continuous-integration change needed" a
 checked property rather than a hope.
@@ -3388,15 +3400,11 @@ exercised on the branch on its own.
       would be found only on `main`.
 - [x] `tasks/check-test-topology.ts`, both halves, wired into
       `repo-gates`, with exact variant matching and one source-item claim
-      allowed per variant. Two test files under
-      `packages/cf-harness/integration/` are reached only by a package
-      task nothing dispatches; they are recorded with the reason each
-      runs nowhere and reported rather than failed on, so a new
-      unclaimed surface still fails. Eight paths that look like tests
-      and are not are declared as the fixtures they are: the five
-      projects under `packages/deno-web-test/test/` that the harness
-      drives, and the three command-line tours the verb-session gate
-      holds the documentation to rather than running.
+      allowed per variant. Eight paths that look like tests and are not
+      are declared as the fixtures they are: the five projects under
+      `packages/deno-web-test/test/` that the harness drives, and the
+      three command-line tours the verb-session gate holds the
+      documentation to rather than running.
 - [x] Extract the part of `tasks/test-records-gather.ts` that reads records,
       ingests JUnit, and applies a declared variant as the shared gather
       function. Its command-line entry point and `tasks/ci-lane.ts` both

--- a/tasks/check-test-topology.test.ts
+++ b/tasks/check-test-topology.test.ts
@@ -252,23 +252,23 @@ describe("what the tree half looks at", () => {
     }
   });
 
-  it("holds a listed exception to still being in the tree", () => {
+  it("holds a listed fixture to still being in the tree", () => {
     // A file that gets registered or deleted takes its line with it,
     // which is what stops the list describing a tree nobody has.
     const findings = checkTree([], [], {
-      unregistered: [{ path: "packages/gone.test.ts", reason: "moved away" }],
+      fixtures: [{ path: "packages/gone.test.ts", reason: "moved away" }],
     });
     expect(findings.map((finding) => finding.fails)).toEqual([true]);
     expect(findings[0]!.message).toContain("no longer holds it");
   });
 
-  it("holds a listed exception to still being unclaimed", () => {
+  it("holds a listed fixture to still being unclaimed", () => {
     const claimed = suite({ id: "workspace-unit", units: ["a.test.ts"] });
     const findings = checkTree([claimed], ["a.test.ts"], {
       fixtures: [{ path: "a.test.ts", reason: "a fixture a test drives" }],
     });
     expect(findings.map((finding) => finding.fails)).toEqual([true]);
-    expect(findings[0]!.message).toContain("still listed as unclaimed");
+    expect(findings[0]!.message).toContain("still listed as a fixture");
   });
 });
 
@@ -324,16 +324,15 @@ describe("reading a run's records", () => {
 });
 
 describe("what the guard declines to fail on", () => {
-  it("accepts a declared fixture and reports a declared unrun test", () => {
+  it("accepts a declared fixture and fails on anything else", () => {
     const findings = checkTree([], ["fixture.test.ts", "unrun.test.ts"], {
       fixtures: [{ path: "fixture.test.ts", reason: "a test drives it" }],
-      unregistered: [{ path: "unrun.test.ts", reason: "no suite runs it" }],
     });
-    // A fixture is not a test surface and says nothing. A test nothing
-    // runs is a defect, reported so somebody can act on it, and not a
-    // failure, because registering one means deciding where it runs.
-    expect(findings.map((finding) => finding.fails)).toEqual([false]);
-    expect(findings[0]!.message).toContain("runs nowhere");
+    // A fixture is not a test surface and says nothing. Everything else
+    // is, so a suite has to account for it — a suite that runs it, or one
+    // that holds it and says why this configuration does not.
+    expect(findings.map((finding) => finding.fails)).toEqual([true]);
+    expect(findings[0]!.message).toBe("unrun.test.ts is claimed by no suite");
   });
 
   it("counts one recorded identity once, however often it was run", () => {

--- a/tasks/check-test-topology.ts
+++ b/tasks/check-test-topology.ts
@@ -142,33 +142,6 @@ const NOT_A_TEST_SURFACE: ReadonlyArray<{ path: string; reason: string }> = [
   },
 ];
 
-/**
- * Test files no suite runs, which is a defect rather than a decision.
- * Each is a test somebody wrote that nothing in this repository executes,
- * so it neither passes nor fails and nobody is told. They are reported
- * rather than failed on, because registering one means deciding where it
- * runs and finding out whether it still passes, and that is its own
- * change. A new unclaimed surface fails; these do not.
- *
- * An entry that stops applying fails as well, so a file that gets
- * registered or deleted takes its line with it.
- */
-const UNREGISTERED_SURFACES: ReadonlyArray<{ path: string; reason: string }> = [
-  {
-    path: "packages/cf-harness/integration/engine.integration.test.ts",
-    reason:
-      "reached only by the package's own `test:integration` task, which " +
-      "nothing dispatches",
-  },
-  {
-    path:
-      "packages/cf-harness/integration/pattern-index-live.integration.test.ts",
-    reason:
-      "reached only by the package's own `test:integration` task, which " +
-      "nothing dispatches",
-  },
-];
-
 /** One thing the check found. */
 export interface Finding {
   /** Whether it fails the check or is only reported. */
@@ -199,16 +172,12 @@ export function checkTree(
   candidates: readonly string[],
   declared: {
     fixtures?: ReadonlyArray<{ path: string; reason: string }>;
-    unregistered?: ReadonlyArray<{ path: string; reason: string }>;
   } = {},
 ): Finding[] {
   const findings: Finding[] = [];
   const claims = suites.map((suite) => ({ suite, ...claimsOf(suite) }));
   const fixtures = new Map(
     (declared.fixtures ?? []).map((entry) => [entry.path, entry.reason]),
-  );
-  const unregistered = new Map(
-    (declared.unregistered ?? []).map((entry) => [entry.path, entry.reason]),
   );
   const held = new Set<string>();
   for (const candidate of candidates) {
@@ -234,27 +203,18 @@ export function checkTree(
       }
     }
     if (exact.length > 0) {
-      const reason = fixtures.get(candidate) ?? unregistered.get(candidate);
+      const reason = fixtures.get(candidate);
       if (reason !== undefined) {
         findings.push({
           fails: true,
           message: `${candidate} is claimed by a suite and is still listed ` +
-            `as unclaimed: ${reason}`,
+            `as a fixture: ${reason}`,
         });
       }
       continue;
     }
     if (fixtures.has(candidate)) {
       held.add(candidate);
-      continue;
-    }
-    const unregisteredReason = unregistered.get(candidate);
-    if (unregisteredReason !== undefined) {
-      held.add(candidate);
-      findings.push({
-        fails: false,
-        message: `${candidate} runs nowhere: ${unregisteredReason}`,
-      });
       continue;
     }
     // A suite whose units are coarser than a file — a workspace member
@@ -273,12 +233,12 @@ export function checkTree(
       message: `${candidate} is claimed by no suite`,
     });
   }
-  for (const path of [...fixtures.keys(), ...unregistered.keys()]) {
+  for (const path of fixtures.keys()) {
     if (held.has(path)) continue;
     if (candidates.includes(path)) continue;
     findings.push({
       fails: true,
-      message: `${path} is listed as unclaimed and the tree no longer holds it`,
+      message: `${path} is listed as a fixture and the tree no longer holds it`,
     });
   }
   return findings;
@@ -414,7 +374,7 @@ export async function check(
   const findings = checkTree(
     suites,
     await candidateSurfaces(options.root),
-    { fixtures: NOT_A_TEST_SURFACE, unregistered: UNREGISTERED_SURFACES },
+    { fixtures: NOT_A_TEST_SURFACE },
   );
   if (options.records !== undefined) {
     findings.push(...checkStore(suites, await readRecords(options.records)));

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -98,6 +98,19 @@ describe("test-selection", () => {
       expect(lines.join("\n")).toContain("no record of it");
     });
 
+    it("says nothing runs an identity inside an unavailable unit", () => {
+      // A unit no configuration runs has no record for the same reason it
+      // has no lane, so the rule that an identity with no history runs
+      // would answer the opposite of what happens.
+      const text = explainLines(manifest(), { ...TEST, n: "never seen" }, {
+        selected: false,
+        unavailable: "the equipment it wants is a workstation's",
+      }).join("\n");
+      expect(text).toContain("Nothing runs it");
+      expect(text).toContain("the equipment it wants is a workstation's");
+      expect(text).not.toContain("mandatory");
+    });
+
     it("prints the catches behind a score", () => {
       const held = manifest();
       held.entries[0]!.inputs = {
@@ -299,6 +312,28 @@ describe("verdictFor()", () => {
     expect(verdict.selected).toBe(true);
     expect(verdict.repeats).toBeGreaterThanOrEqual(1);
     expect(verdict.unschedulable).toBeUndefined();
+  });
+
+  it("reads the reason nothing runs a unit out of the topology", () => {
+    // An unavailable unit has no manifest entry to carry its reason, so
+    // the verdict asks the suite that declared it.
+    const unavailable = suiteHolding(["packages/memory/test/memory.test.ts"]);
+    unavailable.unavailable = [{
+      unit: "packages/memory/test/memory.test.ts",
+      reason: "the equipment it wants is a workstation's",
+    }];
+    unavailable.locate = () => ({
+      level: "unit",
+      unit: "packages/memory/test/memory.test.ts",
+    });
+    const verdict = verdictFor(sampleManifest({ entries: [] }), [unavailable], {
+      k: "unit",
+      s: "memory",
+      n: "anything",
+    });
+    expect(verdict.unavailable).toBe(
+      "the equipment it wants is a workstation's",
+    );
   });
 
   it("carries the cost the bound was compared against", () => {

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -29,7 +29,11 @@ import {
   LANES,
 } from "./test-selection/policy.ts";
 import { fetchManifest } from "./test-selection/store.ts";
-import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
+import {
+  capabilitiesBySuite,
+  claimsFor,
+  loadTopology,
+} from "./test-topology.ts";
 import { type Suite, unavailableUnits } from "./test-topology/suite.ts";
 import { census } from "./test-selection/census.ts";
 import type { Manifest } from "./test-selection/manifest.ts";
@@ -178,6 +182,14 @@ export interface PlanVerdict {
   unschedulable?: boolean;
 
   /**
+   * Why nothing runs it, for an identity inside a unit its suite declares
+   * unavailable. Such a unit is never packed and never expected to
+   * record, so the rule that an identity with no history runs does not
+   * reach it.
+   */
+  unavailable?: string;
+
+  /**
    * What a lane running nothing else would pay for it: its corrected own
    * time plus every overhead and setup that lane would open. This is the
    * figure the hard bound is compared against, so it is the one to report
@@ -196,6 +208,17 @@ export function explainLines(
   const entry = manifest.entries.find(
     (candidate) => testIdentityKey(candidate.test) === key,
   );
+  // Asked before the store is, because a unit nothing runs has no record
+  // for the same reason it has no lane, and answering that it is
+  // mandatory would say the opposite of what happens.
+  if (verdict.unavailable !== undefined) {
+    return [
+      `${key}`,
+      `  Nothing runs it: ${verdict.unavailable}.`,
+      "  Its unit is one the topology declares unavailable, so no lane is",
+      "  offered it and no run is expected to record it.",
+    ];
+  }
   if (entry === undefined) {
     return [
       `${key}`,
@@ -373,7 +396,31 @@ export function verdictFor(
     verdict.unschedulable = true;
     verdict.loneSeconds = refused.cost;
   }
+  const withheld = unavailableReason(suites, test);
+  if (withheld !== undefined) verdict.unavailable = withheld;
   return verdict;
+}
+
+/**
+ * Why nothing runs an identity, where its suite declares the unit it sits
+ * in unavailable.
+ *
+ * Asked of the topology rather than of the manifest: an unavailable unit
+ * has no manifest entry to carry the reason, which is the whole of why
+ * the question needs asking somewhere else.
+ */
+function unavailableReason(
+  suites: readonly Suite[],
+  test: TestIdentity,
+): string | undefined {
+  for (const claim of claimsFor(suites, { test })) {
+    const entry = claim.suite.unavailable.find(
+      (candidate) =>
+        candidate.unit === claim.unit && candidate.leafName === undefined,
+    );
+    if (entry !== undefined) return entry.reason;
+  }
+  return undefined;
 }
 
 /** What comparing the manifest against the working tree found. */

--- a/tasks/test-topology.ts
+++ b/tasks/test-topology.ts
@@ -24,6 +24,7 @@ import type { CapabilityId } from "./ci-capabilities.ts";
 import { loadBinarySuites } from "./test-topology/binaries.ts";
 import { loadCliSuites } from "./test-topology/cli.ts";
 import { loadGateSuites } from "./test-topology/gates.ts";
+import { loadOutOfLaneSuite } from "./test-topology/out-of-lane.ts";
 import { loadPackageIntegrationSuites } from "./test-topology/package-integration.ts";
 import { loadPatternSuites } from "./test-topology/patterns.ts";
 import { loadUnitSuites } from "./test-topology/unit.ts";
@@ -62,6 +63,7 @@ export async function loadTopology(
     ...await loadPackageIntegrationSuites(root),
     ...await loadCliSuites(root),
     ...loadBinarySuites(),
+    loadOutOfLaneSuite(),
   ];
 }
 

--- a/tasks/test-topology/out-of-lane.test.ts
+++ b/tasks/test-topology/out-of-lane.test.ts
@@ -1,0 +1,54 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { loadOutOfLaneSuite } from "./out-of-lane.ts";
+import { unavailableUnits } from "./suite.ts";
+
+const suite = loadOutOfLaneSuite();
+
+describe("the commands no lane runs", () => {
+  it("claims the identities the jobs outside the lanes record", () => {
+    // Every one of these is a command continuous integration runs and
+    // records, so the store half of the drift guard meets it on a run of
+    // the default branch and has to find a suite that claims it.
+    for (
+      const test of [
+        { k: "gate", s: "repo", n: "coverage-check" },
+        { k: "test", s: "cf-harness", n: "cfc-properties" },
+        { k: "gate", s: "cf-harness", n: "cfc-audit-properties" },
+      ]
+    ) {
+      expect(suite.locate({ test })).toEqual({ level: "unit", unit: test.n });
+    }
+  });
+
+  it("declines a name it holds under a surface it does not", () => {
+    // The audit records under the harness's own scope, and a gate of the
+    // repository's by that name would be a different thing.
+    expect(
+      suite.locate({ test: { k: "gate", s: "repo", n: "cfc-properties" } }),
+    ).toBeUndefined();
+  });
+
+  it("makes every one of them unavailable, with the reason in words", () => {
+    expect([...unavailableUnits(suite)].sort()).toEqual(
+      [...suite.units].sort(),
+    );
+    for (const entry of suite.unavailable) {
+      expect(entry.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("refuses a request for a unit, naming what was asked for", () => {
+    // A packer that reached past the unavailable list would otherwise
+    // get an empty command list back, run nothing, and report the batch
+    // green.
+    const context = { root: "/repo", outputDir: "/out" };
+    expect(() => suite.command([{ unit: "coverage-check", skip: [] }], context))
+      .toThrow("coverage-check");
+  });
+
+  it("builds no command when it is asked for nothing", async () => {
+    expect(await suite.command([], { root: "/repo", outputDir: "/out" }))
+      .toEqual([]);
+  });
+});

--- a/tasks/test-topology/out-of-lane.ts
+++ b/tasks/test-topology/out-of-lane.ts
@@ -1,0 +1,116 @@
+/**
+ * The commands continuous integration records that no lane can run.
+ *
+ * The topology's claim is that it declares every test surface, and the
+ * store half of the drift guard holds it to that: an identity a run
+ * produced that no suite claims fails. Two jobs produce such identities,
+ * and neither is work a lane can be handed.
+ *
+ * The run's coverage gate joins every lane's coverage report, so it can
+ * only start once the lanes have finished. It is a step of the run
+ * rather than part of the corpus the run executes.
+ *
+ * The nightly property suite stands up real runtimes and real prompt
+ * loops to write one corpus, and the audit beside it reads that corpus
+ * as a population — a refusal count across the whole of it, a posture
+ * held uniform across the whole of it — which is a question no single
+ * run answers. The tests it runs also run on every change inside
+ * `workspace-unit`, where each audits only its own run.
+ *
+ * So each is a unit and every one of them is unavailable, with the
+ * reason it runs nowhere in the manifest beside every other deliberate
+ * non-run. What runs them is the workflow, which is also where the
+ * artifacts they read are fetched.
+ */
+
+import {
+  claimsIdentity,
+  type Invocation,
+  type Location,
+  type RecordSurface,
+  type Suite,
+  type Unavailable,
+} from "./suite.ts";
+
+/** One command a job records and no lane runs. */
+interface OutOfLane {
+  /** The kind and scope its record carries. */
+  surface: RecordSurface;
+
+  /** The name its record carries, which is also its unit. */
+  name: string;
+
+  /** Why no lane runs it. */
+  reason: string;
+}
+
+const OUT_OF_LANE: readonly OutOfLane[] = [
+  {
+    surface: { kind: "gate", scope: "repo" },
+    name: "coverage-check",
+    reason: "it joins every lane's coverage report, so it can only run " +
+      "once the lanes have finished",
+  },
+  {
+    surface: { kind: "test", scope: "cf-harness" },
+    name: "cfc-properties",
+    reason: "it runs nightly, writing the one corpus its audit reads as a " +
+      "population; every test in it also runs per change under " +
+      "workspace-unit, auditing its own run",
+  },
+  {
+    surface: { kind: "gate", scope: "cf-harness" },
+    name: "cfc-audit-properties",
+    reason: "it reads the corpus the nightly property suite wrote, which " +
+      "no lane produces",
+  },
+];
+
+/** The suite over those commands, every unit of it unavailable. */
+export function loadOutOfLaneSuite(): Suite {
+  const recordSurfaces: RecordSurface[] = [
+    ...new Map(
+      OUT_OF_LANE.map((entry) => [
+        `${entry.surface.kind}\t${entry.surface.scope}`,
+        entry.surface,
+      ]),
+    ).values(),
+  ];
+  const byName = new Map(OUT_OF_LANE.map((entry) => [entry.name, entry]));
+  const unavailable: Unavailable[] = OUT_OF_LANE.map((entry) => ({
+    unit: entry.name,
+    reason: entry.reason,
+  }));
+  return {
+    id: "out-of-lane",
+    recordSurfaces,
+    needs: [],
+    units: OUT_OF_LANE.map((entry) => entry.name),
+    unavailable,
+
+    locate(record): Location | undefined {
+      if (!claimsIdentity({ recordSurfaces }, record.test)) return undefined;
+      const entry = byName.get(record.test.n);
+      if (entry === undefined) return undefined;
+      return entry.surface.scope === record.test.s &&
+          entry.surface.kind === record.test.k
+        ? { level: "unit", unit: entry.name }
+        : undefined;
+    },
+
+    // Every unit is unavailable, so a request naming one is a packer
+    // that reached past that. Answering with no command would run
+    // nothing and report the batch green, so it is refused instead, and
+    // what runs these stays the workflow that fetches what they read.
+    command(requests): Promise<Invocation[]> {
+      if (requests.length > 0) {
+        throw new Error(
+          `out-of-lane was asked to run ${
+            requests.map((request) => request.unit).join(", ")
+          }, and no lane runs any of it`,
+        );
+      }
+      return Promise.resolve([]);
+    },
+  };
+}

--- a/tasks/test-topology/package-integration.ts
+++ b/tasks/test-topology/package-integration.ts
@@ -145,5 +145,71 @@ export async function loadPackageIntegrationSuites(
       parts: opposites,
     }),
     deployedTopology,
+    await harnessEquipmentSuite(root),
   ];
+}
+
+/**
+ * The cf-harness integration tests, and the equipment each needs that a
+ * job does not have: a gVisor sandbox runtime with a Fabric mount
+ * bind-mounted into it, and a deployed pattern index with a keyfile that
+ * index authorizes. Each file says as much at the top of itself, and the
+ * package's own `test:integration` task is what a person runs them with.
+ *
+ * `packages/cf-harness/integration/` holds nothing else but the posture
+ * gate the deployed-topology suite owns, and
+ * `package-integration.test.ts` holds this list to that.
+ */
+export const HARNESS_EQUIPMENT: ReadonlyArray<
+  { file: string; reason: string }
+> = [
+  {
+    file: "integration/engine.integration.test.ts",
+    reason: "every case runs a container under the runsc-cfc gVisor " +
+      "runtime, and some reach into a Fabric mount bind-mounted into it",
+  },
+  {
+    file: "integration/pattern-index-live.integration.test.ts",
+    reason: "it searches a deployed pattern index, signed with an identity " +
+      "that index authorizes",
+  },
+];
+
+/**
+ * A suite over the tests above. Every one of its units is unavailable, so
+ * no lane is ever asked for one and no run is expected to record one.
+ *
+ * A test the tree holds and this configuration does not run is described
+ * here rather than left for a reader to come across, which is the same
+ * answer a configuration-specific skip gets and reached the same way.
+ *
+ * A unit is what the tree holds rather than what the list names, so a
+ * file that moves away takes its unit with it. That its entry above
+ * still names it is what `package-integration.test.ts` fails on.
+ */
+async function harnessEquipmentSuite(root: string): Promise<Suite> {
+  const packageDir = "packages/cf-harness";
+  const present = new Set(await integrationFiles(root, packageDir));
+  const held = HARNESS_EQUIPMENT
+    .map((entry) => ({ ...entry, unit: `${packageDir}/${entry.file}` }))
+    .filter((entry) => present.has(entry.unit));
+  return fileSuite({
+    id: "harness-equipment",
+    needs: ["deno"],
+    parts: [{
+      packageDir,
+      flags: ["--no-check", "-A"],
+      env: { CF_HARNESS_INTEGRATION: "1" },
+      junit: {
+        kind: "integration",
+        scope: "cf-harness",
+        filePrefix: packageDir,
+      },
+      files: held.map((entry) => entry.unit),
+      unavailable: held.map((entry) => ({
+        unit: entry.unit,
+        reason: entry.reason,
+      })),
+    }],
+  });
 }

--- a/tasks/test-topology/patterns.test.ts
+++ b/tasks/test-topology/patterns.test.ts
@@ -244,7 +244,7 @@ describe("the pattern and package suites", () => {
     }
   });
 
-  it("asks for none of the tests whose equipment a job lacks", async () => {
+  it("asks for none of the tests whose equipment a job lacks", () => {
     // Every unit of the suite is unavailable, each with the equipment it
     // wants said in words, so nothing can be packed into a lane and no
     // run is expected to record one.

--- a/tasks/test-topology/patterns.test.ts
+++ b/tasks/test-topology/patterns.test.ts
@@ -3,8 +3,11 @@ import { describe, it } from "@std/testing/bdd";
 import { SKIP_LIST_VARIABLE } from "@commonfabric/test-support/records";
 import { serverExecutionCiLane } from "../server-execution-ci.ts";
 import { loadPatternSuites } from "./patterns.ts";
-import { loadPackageIntegrationSuites } from "./package-integration.ts";
-import type { Suite } from "./suite.ts";
+import {
+  HARNESS_EQUIPMENT,
+  loadPackageIntegrationSuites,
+} from "./package-integration.ts";
+import { type Suite, unavailableUnits } from "./suite.ts";
 
 const root = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
 const suites = [
@@ -28,6 +31,20 @@ describe("the pattern and package suites", () => {
     expect(invocation!.cwd).toBe(`${root}/packages/patterns`);
     expect(invocation!.env?.HEADLESS).toBe("1");
     expect(invocation!.junit?.[0]?.scope).toBe("patterns");
+  });
+
+  it("leaves the pattern integration type check to the type check", async () => {
+    // `packages/patterns/integration` is one of the paths
+    // `tasks/typecheck.ts` lists, so a run that checks them again is
+    // doing that work twice.
+    for (const id of ["pattern-integration", "pattern-integration-opposite"]) {
+      const suite = byId(id);
+      const [invocation] = await suite.command(
+        [{ unit: suite.units[0]!, skip: [] }],
+        { root, outputDir: await outputDir() },
+      );
+      expect(invocation!.command).toContain("--no-check");
+    }
   });
 
   it("runs the opposite arm with an explicit define and history", async () => {
@@ -196,6 +213,48 @@ describe("the pattern and package suites", () => {
     for (const id of ["pattern-unit", "generated-patterns"]) {
       expect(await byId(id).command([], { root, outputDir: "/out" }))
         .toEqual([]);
+    }
+  });
+
+  it("holds every cf-harness integration test to being accounted for", async () => {
+    // The directory divides in two: the posture gate the
+    // deployed-topology suite runs, and the tests whose equipment a job
+    // does not have. A file that belongs to neither is a test nothing
+    // runs, so the two suites' units together are the whole directory.
+    const accounted = suites.flatMap((suite) => suite.units)
+      .filter((unit) => unit.startsWith("packages/cf-harness/integration/"));
+    const present: string[] = [];
+    for await (
+      const entry of Deno.readDir(`${root}/packages/cf-harness/integration`)
+    ) {
+      if (entry.isFile && entry.name.endsWith(".test.ts")) {
+        present.push(`packages/cf-harness/integration/${entry.name}`);
+      }
+    }
+    expect(accounted.sort()).toEqual(present.sort());
+  });
+
+  it("holds each recorded piece of equipment to a file that exists", async () => {
+    // A unit is what the tree holds rather than what the list names, so
+    // an entry naming a file that moved away would otherwise sit there
+    // describing nothing.
+    for (const entry of HARNESS_EQUIPMENT) {
+      const at = `${root}/packages/cf-harness/${entry.file}`;
+      expect((await Deno.stat(at)).isFile).toBe(true);
+    }
+  });
+
+  it("asks for none of the tests whose equipment a job lacks", async () => {
+    // Every unit of the suite is unavailable, each with the equipment it
+    // wants said in words, so nothing can be packed into a lane and no
+    // run is expected to record one.
+    const suite = byId("harness-equipment");
+    expect(suite.units.length).toBeGreaterThan(0);
+    expect([...unavailableUnits(suite)].sort()).toEqual(
+      [...suite.units].sort(),
+    );
+    for (const entry of suite.unavailable) {
+      expect(entry.reason.length).toBeGreaterThan(0);
     }
   });
 });

--- a/tasks/test-topology/patterns.ts
+++ b/tasks/test-topology/patterns.ts
@@ -78,6 +78,9 @@ async function patternIntegrationSuites(
   const packageDir = "packages/patterns";
   const files = await filesIn(root, `${packageDir}/integration`);
   const flags = [
+    // `packages/patterns/integration` is one of the paths the type check
+    // owns, so checking it again here is the same work a second time.
+    "--no-check",
     "-A",
     "--v8-flags=--max-old-space-size=4096",
     "--trace-leaks",


### PR DESCRIPTION
Four corrections to `tasks/test-topology/`, found by reading each job `.github/workflows/deno.yml` still holds against the suite meant to replace it, and by running the drift guard's store half against a run on the default branch.

Three of them change nothing until the lanes run, since nothing dispatches a suite today and no workflow invokes the guard. They land apart from the switch so that each can be read, and reverted, without the other.

**The pattern integration suites type-checked everything twice.** `tasks/typecheck.ts` lists `packages/patterns/integration` among the paths it checks, and the job these suites replace passes `--no-check` for that reason. The suites did not, so a lane that takes a file from that directory would check it again before running it, and the opposite server-execution arm would do it a second time. The result is the same either way; the difference is the time.

**Two tests in the tree ran nowhere and said so only in a list of their own.** `packages/cf-harness/integration/engine.integration.test.ts` runs every case in a container under the runsc-cfc gVisor runtime, some of them reaching into a Fabric mount bind-mounted into it; `pattern-index-live.integration.test.ts` searches a deployed pattern index, signed with an identity that index authorizes. Neither is a runner's to hold, each says so at the top of itself, and the package's own `test:integration` task is what a person runs them with. The drift guard carried both in a list of defects it reported without failing on, which is a second way of saying what the topology already says: a suite declares which of its units this configuration does not run and why, the manifest carries those reasons, and the packer never offers an unavailable unit to a lane. A `harness-equipment` suite holds both files as unavailable units, and the guard's parallel list goes. What the guard loses is the middle ground: a test file no suite claims now fails, and registering one means deciding either where it runs or why it does not.

**Three recorded identities no suite claimed.** The store half fails on any recorded identity nothing claims, and it asks that of every record a run wrote rather than only of the ones a lane produced. `gate repo coverage-check` is the run's own coverage gate, which joins every lane's coverage report and so starts only once the lanes have finished; it is recorded on every push to the default branch, so the store half fails on it whenever it is run against one — which is the check the plan asks for before the lanes replace the matrix. `test cf-harness cfc-properties` and `gate cf-harness cfc-audit-properties` come from the nightly CFC property workflow, which writes one corpus its own audit reads as a population, a question no single run answers, while every test in it also runs per change under `workspace-unit`. An `out-of-lane` suite declares all three as unavailable units. It builds no command and refuses a request naming one: what runs them is the workflow that fetches the artifacts they read, and answering with an empty command list would run nothing and report the batch green.

**`explain` said a test nothing runs was mandatory.** It is the mode that answers "why did my test not run?", and asked about an identity inside an unavailable unit it fell through to the rule that an identity with no history runs. Both halves of that are wrong, and for the same reason: such a unit is never packed, so it never records, so the store has nothing for it. The verdict now carries the reason nothing runs it, read from the suite that declared the unit rather than from the manifest, since an unavailable unit has no manifest entry to carry one. Nothing in the tree was unavailable before this change — the four server-execution skip lists are empty — so the answer has been wrong only for as long as it has been reachable. This is the one correction here that a person feels today, `explain` being a command somebody runs.

`patterns.test.ts` holds the two cf-harness suites' units together to being the whole of that directory, so a file added there cannot land in neither, and holds the equipment list to naming files that exist.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

