### PR TITLE
fix(toolshed): the generateObject route checks its own request shape

### DIFF
--- a/packages/llm/README.md
+++ b/packages/llm/README.md
@@ -65,8 +65,9 @@ Four declarations say that, and they have to agree.
   argument contract of every pattern using an LLM builtin. It describes rather
   than polices: the runtime enforces an `enum` neither on read nor on write.
 - `llmMessageProblem()` in [`src/types.ts`](src/types.ts) is the check that
-  refuses one, reached through `llmRequestProblem()`, which is what the toolshed
-  handler gates an incoming payload on.
+  refuses one, reached through `llmRequestProblem()` and
+  `llmGenerateObjectRequestProblem()`, which are what the toolshed handlers gate
+  an incoming payload on.
 - `MessageSchema` in
   [`packages/toolshed/routes/ai/llm/llm.routes.ts`](../toolshed/routes/ai/llm/llm.routes.ts)
   is the route's own validator, and the one a caller sending JSON meets first:

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -218,6 +218,24 @@ export function extractTextFromLLMResponse(response: LLMResponse): string {
 }
 
 /**
+ * Names what stops `messages` from being a conversation to send a model, or
+ * `undefined` when nothing does. Every request carries one, and this is what
+ * they check it with.
+ */
+function conversationProblem(messages: unknown): string | undefined {
+  if (!Array.isArray(messages)) return "'messages' must be an array.";
+  // The model provider refuses an empty conversation, `system` field or no,
+  // so a request carrying one is the caller's to fix rather than the
+  // provider's to report.
+  if (messages.length === 0) return "'messages' must not be empty.";
+  for (const [index, message] of messages.entries()) {
+    const problem = llmMessageProblem(message);
+    if (problem !== undefined) return `Message ${index} ${problem}.`;
+  }
+  return undefined;
+}
+
+/**
  * Names what stops `input` from being an `LLMRequest`, or `undefined` when
  * nothing does. A route that refuses a request returns this text, so its
  * caller learns which part of the payload to change.
@@ -225,15 +243,8 @@ export function extractTextFromLLMResponse(response: LLMResponse): string {
 export function llmRequestProblem(input: unknown): string | undefined {
   if (!isObjectNotArray(input)) return "The request must be an object.";
   if (typeof input.model !== "string") return "'model' must be a string.";
-  if (!Array.isArray(input.messages)) return "'messages' must be an array.";
-  // The model provider refuses an empty conversation, `system` field or no,
-  // so a request carrying one is the caller's to fix rather than the
-  // provider's to report.
-  if (input.messages.length === 0) return "'messages' must not be empty.";
-  for (const [index, message] of input.messages.entries()) {
-    const problem = llmMessageProblem(message);
-    if (problem !== undefined) return `Message ${index} ${problem}.`;
-  }
+  const conversation = conversationProblem(input.messages);
+  if (conversation !== undefined) return conversation;
   if (!("cache" in input)) return "'cache' must be present.";
   if ("system" in input && typeof input.system !== "string") {
     return "'system' must be a string.";
@@ -270,6 +281,37 @@ export function llmRequestProblem(input: unknown): string | undefined {
     return `'nativeModelToolIds' must be an array drawn from ${
       LLM_NATIVE_MODEL_TOOL_IDS.join(", ")
     }.`;
+  }
+  return undefined;
+}
+
+/**
+ * Names what stops `input` from being an `LLMGenerateObjectRequest`, or
+ * `undefined` when nothing does. A route that refuses a request returns this
+ * text, so its caller learns which part of the payload to change.
+ */
+export function llmGenerateObjectRequestProblem(
+  input: unknown,
+): string | undefined {
+  if (!isObjectNotArray(input)) return "The request must be an object.";
+  if (!isObjectNotArray(input.schema)) return "'schema' must be an object.";
+  if ("model" in input && typeof input.model !== "string") {
+    return "'model' must be a string.";
+  }
+  const conversation = conversationProblem(input.messages);
+  if (conversation !== undefined) return conversation;
+  if ("cache" in input && typeof input.cache !== "boolean") {
+    return "'cache' must be a boolean.";
+  }
+  if ("system" in input && typeof input.system !== "string") {
+    return "'system' must be a string.";
+  }
+  if ("maxTokens" in input && typeof input.maxTokens !== "number") {
+    return "'maxTokens' must be a number.";
+  }
+  if ("metadata" in input && !isLLMRequestMetadata(input.metadata)) {
+    return "'metadata' must be an object whose values ordinary JSON " +
+      "serialization carries faithfully.";
   }
   return undefined;
 }

--- a/packages/llm/test/types.test.ts
+++ b/packages/llm/test/types.test.ts
@@ -1,11 +1,16 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { BuiltInLLMContent, BuiltInLLMMessage } from "@commonfabric/api";
+import type {
+  BuiltInLLMContent,
+  BuiltInLLMMessage,
+  JSONSchema,
+} from "@commonfabric/api";
 import {
   DEFAULT_GENERATE_OBJECT_MODEL,
   DEFAULT_MODEL_NAME,
   GOOGLE_SEARCH_NATIVE_MODEL_TOOL,
   isLLMTool,
+  llmGenerateObjectRequestProblem,
   llmRequestProblem,
   type LLMTool,
 } from "../src/types.ts";
@@ -23,6 +28,13 @@ const TOOL: LLMTool = {
 const request = (input: object) => ({
   cache: true,
   model: DEFAULT_MODEL_NAME,
+  messages: [{ role: "user", content: "Hi" }] satisfies BuiltInLLMMessage[],
+  ...input,
+});
+
+/** A well-formed generateObject request, with `input` written over it. */
+const objectRequest = (input: object) => ({
+  schema: { type: "object" } satisfies JSONSchema,
   messages: [{ role: "user", content: "Hi" }] satisfies BuiltInLLMMessage[],
   ...input,
 });
@@ -181,6 +193,61 @@ describe("types", () => {
       // gateway's models wherever the gateway answers, where a name qualified
       // by a direct provider registers only where that provider's key is set.
       expect(DEFAULT_GENERATE_OBJECT_MODEL.startsWith("gateway:")).toBe(true);
+    });
+  });
+
+  describe("llmGenerateObjectRequestProblem()", () => {
+    // The route this guards accepts a body of any content type, and only an
+    // `application/json` one meets the route validator first. So every case
+    // here is one a caller can reach with the guard as the sole check. The
+    // conversation walk the two checkers share is covered above; one case
+    // here pins that this checker reaches it.
+
+    it("returns `undefined` for the requests it accepts", () => {
+      // The fixture names no model, which is a request this accepts: the
+      // route picks a default for one that names none.
+      expect(llmGenerateObjectRequestProblem(objectRequest({})))
+        .toBeUndefined();
+      expect(llmGenerateObjectRequestProblem(objectRequest({
+        model: DEFAULT_MODEL_NAME,
+        system: "System prompt",
+        maxTokens: 4096,
+        cache: false,
+        metadata: { context: "piece" },
+      }))).toBeUndefined();
+    });
+
+    it("returns text naming `schema` or `messages` when a request omits one", () => {
+      const messages: BuiltInLLMMessage[] = [{ role: "user", content: "Hi" }];
+      expect(llmGenerateObjectRequestProblem({ messages })).toContain(
+        "'schema'",
+      );
+      expect(llmGenerateObjectRequestProblem({ schema: { type: "object" } }))
+        .toContain("'messages'");
+    });
+
+    it("returns text naming `schema` for a schema given as a boolean", () => {
+      // JSON Schema admits `true` and `false` as schemas. The route declares
+      // an object, and this holds the guard to the same shape.
+      expect(llmGenerateObjectRequestProblem(objectRequest({ schema: true })))
+        .toContain("'schema'");
+    });
+
+    it("returns text naming the field whose value is of the wrong type", () => {
+      // `model` and `cache` are the two this checker states for itself.
+      const named = (input: object, field: string) =>
+        expect(llmGenerateObjectRequestProblem(objectRequest(input)))
+          .toContain(field);
+      named({ model: 7 }, "'model'");
+      named({ cache: "yes" }, "'cache'");
+    });
+
+    it("returns text naming the `system` field for a system-role message", () => {
+      const problem = llmGenerateObjectRequestProblem(objectRequest({
+        messages: [{ role: "system", content: "Be brief" }],
+      }));
+      expect(problem).toContain("Message 0");
+      expect(problem).toContain("'system' field");
     });
   });
 

--- a/packages/llm/test/types.test.ts
+++ b/packages/llm/test/types.test.ts
@@ -233,13 +233,22 @@ describe("types", () => {
         .toContain("'schema'");
     });
 
+    it("returns text naming the request for input that is not an object", () => {
+      expect(llmGenerateObjectRequestProblem(null)).toContain("an object");
+      expect(llmGenerateObjectRequestProblem([])).toContain("an object");
+    });
+
     it("returns text naming the field whose value is of the wrong type", () => {
-      // `model` and `cache` are the two this checker states for itself.
+      // Every scalar field this checker states, which is all of them but the
+      // conversation: the two checkers share only the walk over `messages`.
       const named = (input: object, field: string) =>
         expect(llmGenerateObjectRequestProblem(objectRequest(input)))
           .toContain(field);
       named({ model: 7 }, "'model'");
       named({ cache: "yes" }, "'cache'");
+      named({ system: {} }, "'system'");
+      named({ maxTokens: "4096" }, "'maxTokens'");
+      named({ metadata: "via piece" }, "'metadata'");
     });
 
     it("returns text naming the `system` field for a system-role message", () => {

--- a/packages/toolshed/routes/ai/llm/llm.handlers.ts
+++ b/packages/toolshed/routes/ai/llm/llm.handlers.ts
@@ -1,5 +1,10 @@
 import { type BuiltInLLMMessage } from "@commonfabric/api";
-import { type LLMRequest, llmRequestProblem } from "@commonfabric/llm/types";
+import {
+  type LLMGenerateObjectRequest,
+  llmGenerateObjectRequestProblem,
+  type LLMRequest,
+  llmRequestProblem,
+} from "@commonfabric/llm/types";
 import type { Context } from "@hono/hono";
 import * as HttpStatusCodes from "stoker/http-status-codes";
 
@@ -279,18 +284,17 @@ export const generateObject: AppRouteHandler<GenerateObjectRoute> = async (
   if (!body.ok) {
     return c.json({ error: body.error }, HttpStatusCodes.BAD_REQUEST);
   }
-  const payload = body.payload;
-
-  if (!payload.messages || !payload.schema) {
-    const missing = [
-      !payload.messages && "'messages'",
-      !payload.schema && "'schema'",
-    ].filter(Boolean).join(" and ");
+  const problem = llmGenerateObjectRequestProblem(body.payload);
+  if (problem !== undefined) {
     return c.json(
-      { error: `Missing required field(s): ${missing}` },
+      { error: `Invalid request: ${problem}` },
       HttpStatusCodes.BAD_REQUEST,
     );
   }
+  // `llmGenerateObjectRequestProblem()` answering `undefined` is what makes
+  // this hold, and it is the only thing that does: `body.payload` is whatever
+  // the JSON parser returned.
+  const payload: LLMGenerateObjectRequest = body.payload;
 
   if (!payload.metadata) {
     payload.metadata = {};

--- a/packages/toolshed/routes/ai/llm/llm.status.test.ts
+++ b/packages/toolshed/routes/ai/llm/llm.status.test.ts
@@ -98,10 +98,11 @@ async function withMockModel<T>(
 async function post(
   path: string,
   requestBody: unknown,
+  contentType = "application/json",
 ): Promise<{ status: number; error: string }> {
   const response = await app.request(path, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": contentType },
     body: typeof requestBody === "string"
       ? requestBody
       : JSON.stringify(requestBody),
@@ -251,4 +252,46 @@ Deno.test("a model generateObject does not carry is the caller's mistake", async
     (await response.json()).error,
     "Unsupported model: mock:no-such-model",
   );
+});
+
+//
+// The two routes read their bodies with `c.req.json()`, which parses whatever
+// arrives, while the route validator only reads `application/json`. A body
+// sent as anything else meets the handler's own guard and nothing before it,
+// which is the path these three cover.
+//
+
+Deno.test("a system-role message sent as text is refused by generateObject", async () => {
+  const { status, error } = await post(
+    "/api/ai/llm/generateObject",
+    {
+      messages: [{ role: "system", content: "Be brief" }],
+      schema: { type: "object" },
+      cache: false,
+    },
+    "text/plain",
+  );
+  assertEquals(status, 400);
+  assertStringIncludes(error, "Message 0");
+  assertStringIncludes(error, "'system' field");
+});
+
+Deno.test("a generateObject body that is not an object is the caller's mistake", async () => {
+  const { status, error } = await post(
+    "/api/ai/llm/generateObject",
+    null,
+    "text/plain",
+  );
+  assertEquals(status, 400);
+  assertStringIncludes(error, "must be an object");
+});
+
+Deno.test("an empty conversation sent to generateObject is the caller's mistake", async () => {
+  const { status, error } = await post(
+    "/api/ai/llm/generateObject",
+    { messages: [], schema: { type: "object" }, cache: false },
+    "text/plain",
+  );
+  assertEquals(status, 400);
+  assertStringIncludes(error, "'messages'");
 });


### PR DESCRIPTION
`/api/ai/llm/generateObject` accepted whatever its caller sent. The handler checked that `messages` and `schema` were present and nothing more, so a payload that got past the route validator traveled on to the AI SDK, which answered in its own vocabulary rather than this API's.

Getting past the route validator takes only a content type. The handler reads its body with `c.req.json()`, which parses whatever arrives, while `@hono/zod-openapi` validates `application/json` alone. A request sent as `text/plain` therefore meets no schema check at all. One carrying `messages: [{ role: "system", content: "Be brief" }]` reached the provider, which refused it and named its own `instructions` option, an option this API does not have. The same body sent as `application/json` is refused by the route validator with a 422 naming the field to move the instruction to.

Two such payloads did worse than answer in the wrong vocabulary. A body of `null` made the handler read a field off `null`, and a `metadata` of the wrong type did the same through `payload.metadata.user = user` once a `Tailscale-User-Login` header was present. Both threw where nothing catches them, and the caller got a bare `500 Internal Server Error` in `text/plain`, which is not even the shape `failureResponses` declares for a failure.

The sibling route `/api/ai/llm` has no such hole, because its handler gates the payload on `llmRequestProblem()`. This gives `generateObject` the same kind of gate, `llmGenerateObjectRequestProblem()`. `LLMGenerateObjectRequest` is not `LLMRequest`: `schema` is required, `model` is not, and there is no `stream`, `stop`, `mode`, `tools`, or `nativeModelToolIds`. The two share the conversation walk, which is the part of the check with any substance to it, and each states its own scalar fields around that. `llmRequestProblem()` therefore reads clause for clause as it did, and answers a given payload as it did.

Where the two shapes differ, the new checker follows its own route. `cache` is checked for its type when present rather than required present, because the generateObject handler reads an absent `cache` as permission to serve the response from its cache. `schema` must be an object, which is what `GenerateObjectRequestSchema` declares; the guard says on the mislabelled path what the route already says on the JSON one.

The route-level tests drive the real router over the path nothing else covers. Two of the three fail without the guard, and fail because the payload sails past the handler and the caller gets `Unsupported model` from the model lookup further down rather than the field at fault.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

