### PR TITLE
fix(cf-harness): a refused resume names the setting it refused

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -547,9 +547,13 @@ someone to act before a retry means anything, so it stays unset, as does a host
 that broke unexpectedly and cannot say. A failure is `invalid-request` only
 while the argv and the recorded binding are still being checked; once a run
 starts being built, an infrastructure fault reports `internal-error`, so a host
-can keep a retry policy keyed on the code. Run state, manifests, reports, child
-manifests, and structured batch results record only provider, the non-secret
-auth-source label, and the fixed owner reference.
+can keep a retry policy keyed on the code. A resume that cannot be reconciled
+with the run it names is neither of those — a requested setting contradicts the
+recorded one, or the record lacks something a resume needs — and reports
+`provider-mismatch`, with a message naming what was refused, whether the CLI
+refused it or the engine did. Run state, manifests, reports, child manifests,
+and structured batch results record only provider, the non-secret auth-source
+label, and the fixed owner reference.
 
 Hosted or multi-user Loom must not reuse this single-user adapter. A trusted
 multi-user host must instead:

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -154,6 +154,7 @@ import { parseInputCellArgument } from "./input-cells.ts";
 import {
   HarnessControlError,
   type HarnessControlErrorCode,
+  harnessResumeRefusal,
 } from "./control-errors.ts";
 
 const DEFAULT_MODEL = "gpt-5.6-sol";
@@ -3283,7 +3284,7 @@ export const runCfHarnessCli = async (
         },
       );
       if (artifacts.runState.lineage?.role === "subagent") {
-        throw new Error(
+        throw harnessResumeRefusal(
           `Cannot resume subagent run ${artifacts.runState.runId} as a top-level run; resume root run ${artifacts.runState.lineage.rootRunId} instead.`,
         );
       }
@@ -3295,8 +3296,7 @@ export const runCfHarnessCli = async (
         requestedProvider !== undefined &&
         requestedProvider !== recordedProvider
       ) {
-        throw new HarnessControlError(
-          "provider-mismatch",
+        throw harnessResumeRefusal(
           `resume provider mismatch: run uses ${recordedProvider}, requested ${requestedProvider}`,
         );
       }
@@ -3304,8 +3304,8 @@ export const runCfHarnessCli = async (
       if (
         modelProvider === "openai-codex" && parsed.gatewayConfigurationExplicit
       ) {
-        throw new Error(
-          "gateway URL/auth options cannot be used with openai-codex",
+        throw harnessResumeRefusal(
+          "gateway URL/auth options cannot be used with openai-codex, which is the provider this run recorded",
         );
       }
       if (
@@ -3325,8 +3325,7 @@ export const runCfHarnessCli = async (
         parsed.docsCorpus !== undefined && recordedDocsCorpus !== undefined &&
         !harnessDocsCorpusRecordsEqual(parsed.docsCorpus, recordedDocsCorpus)
       ) {
-        throw new HarnessControlError(
-          "provider-mismatch",
+        throw harnessResumeRefusal(
           `resume docs corpus mismatch: run uses ${
             describeHarnessDocsCorpus(recordedDocsCorpus)
           }, requested ${describeHarnessDocsCorpus(parsed.docsCorpus)}`,
@@ -3338,8 +3337,7 @@ export const runCfHarnessCli = async (
         artifacts.runState.model !== undefined &&
         runManifest.model !== artifacts.runState.model
       ) {
-        throw new HarnessControlError(
-          "provider-mismatch",
+        throw harnessResumeRefusal(
           `resume model mismatch: run uses ${artifacts.runState.model}, requested manifest uses ${runManifest.model}`,
         );
       }
@@ -3352,8 +3350,7 @@ export const runCfHarnessCli = async (
           credentialOwner,
         )
       ) {
-        throw new HarnessControlError(
-          "provider-mismatch",
+        throw harnessResumeRefusal(
           "resume credential owner mismatch: requested owner does not match the recorded run",
         );
       }

--- a/packages/cf-harness/src/control-errors.ts
+++ b/packages/cf-harness/src/control-errors.ts
@@ -18,3 +18,14 @@ export class HarnessControlError extends Error {
     this.name = "HarnessControlError";
   }
 }
+
+/**
+ * Refuses a resume that cannot be reconciled with the run it names: a
+ * requested setting contradicts the recorded one, or the record lacks
+ * something a resume needs. Both tiers of resume checking raise this — the
+ * CLI's, and the engine constructor's — so that a host reading a structured
+ * failure is told which setting was refused wherever the check that refused
+ * it lives, and tells a refusal apart from a host that broke.
+ */
+export const harnessResumeRefusal = (message: string): HarnessControlError =>
+  new HarnessControlError("provider-mismatch", message);

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -7,6 +7,7 @@ import {
 import { normalize as normalizeSandboxPath } from "@std/path/posix";
 
 import {
+  type CfcConfClause,
   type CfcLabelView,
   type CfcPostureReport,
   inheritedCfcPostureReport,
@@ -76,6 +77,7 @@ import {
   type ToolResultRef,
 } from "./contracts/tool-result.ts";
 import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
+import { harnessResumeRefusal } from "./control-errors.ts";
 import {
   classifyBuiltinToolFailure,
   classifyHarnessPolicyEventFailure,
@@ -435,7 +437,7 @@ const resolveInitialCurrentDir = (
 ): string => {
   if (runState !== undefined) {
     if (runState.currentDir === undefined) {
-      throw new Error(
+      throw harnessResumeRefusal(
         "run state is missing currentDir; older cf-harness runs cannot be resumed",
       );
     }
@@ -516,7 +518,7 @@ export class CfHarnessEngine {
     if (resumedLineage !== undefined) {
       const resumeContext = options.subagentResumeContext;
       if (resumeContext === undefined) {
-        throw new Error(
+        throw harnessResumeRefusal(
           `resumed subagent run ${
             options.runState!.runId
           } requires trusted parent resume context`,
@@ -529,7 +531,7 @@ export class CfHarnessEngine {
         resumeContext.parentRunId !== resumedLineage.parentRunId ||
         resumeContext.parentToolCallId !== resumedLineage.parentToolCallId
       ) {
-        throw new Error(
+        throw harnessResumeRefusal(
           `resumed subagent run ${
             options.runState!.runId
           } does not match trusted parent resume context`,
@@ -542,7 +544,7 @@ export class CfHarnessEngine {
       options.runState !== undefined && options.modelProvider !== undefined &&
       options.modelProvider !== recordedProvider
     ) {
-      throw new Error(
+      throw harnessResumeRefusal(
         `resumed run provider ${recordedProvider} does not match requested provider ${options.modelProvider}`,
       );
     }
@@ -551,7 +553,7 @@ export class CfHarnessEngine {
       options.model !== undefined && options.runState.model !== undefined &&
       options.model !== options.runState.model
     ) {
-      throw new Error(
+      throw harnessResumeRefusal(
         `resumed openai-codex run model ${options.runState.model} does not match requested model ${options.model}`,
       );
     }
@@ -564,7 +566,7 @@ export class CfHarnessEngine {
       requestedOwner !== undefined &&
       !harnessCredentialOwnersEqual(recordedOwner, requestedOwner)
     ) {
-      throw new Error(
+      throw harnessResumeRefusal(
         "resumed run credential owner does not match requested credential owner",
       );
     }
@@ -577,7 +579,7 @@ export class CfHarnessEngine {
       requestedHomeIdentity !== undefined &&
       recordedHomeIdentity !== requestedHomeIdentity
     ) {
-      throw new Error(
+      throw harnessResumeRefusal(
         "resumed run harness home does not match requested harness home",
       );
     }
@@ -590,7 +592,7 @@ export class CfHarnessEngine {
       requestedAuthSource !== undefined &&
       recordedAuthSource !== requestedAuthSource
     ) {
-      throw new Error(
+      throw harnessResumeRefusal(
         "resumed run model auth source does not match requested model auth source",
       );
     }
@@ -600,15 +602,15 @@ export class CfHarnessEngine {
       options.credentialOwnerKey !== undefined &&
       options.credentialOwnerKey !== options.runState.credentialOwnerKey
     ) {
-      throw new Error(
-        "resumed run credential owner does not match requested credential owner",
+      throw harnessResumeRefusal(
+        "resumed openai-codex run credential owner key does not match requested credential owner key",
       );
     }
     if (
       options.runState !== undefined &&
       options.runState.cfcEnforcementMode === undefined
     ) {
-      throw new Error(
+      throw harnessResumeRefusal(
         "run state is missing cfcEnforcementMode; older cf-harness runs cannot be resumed",
       );
     }
@@ -651,7 +653,7 @@ export class CfHarnessEngine {
       options.runState !== undefined &&
       this.config.cfcEnforcementMode !== options.runState.cfcEnforcementMode
     ) {
-      throw new Error(
+      throw harnessResumeRefusal(
         this.config.cfcEnforcementModeSource === "fabric-session"
           ? `resumed run CFC enforcement mode ${options.runState.cfcEnforcementMode} does not match the ${this.config.cfcEnforcementMode} its fabric session raises the harness dial to; lower --fabric-cfc-enforcement-mode to resume this run`
           : `resumed run CFC enforcement mode ${options.runState.cfcEnforcementMode} does not match requested CFC enforcement mode ${this.config.cfcEnforcementMode}`,
@@ -858,23 +860,58 @@ export class CfHarnessEngine {
       const recorded = options.runState.fabricSessionCfc;
       if (recorded === undefined) {
         if (fabricSessionCfc.posture !== undefined) {
-          throw new Error(
+          throw harnessResumeRefusal(
             `fabric session CFC posture mismatch on resume: run state ` +
               `records no fabric-session posture, so it cannot attest the ` +
               `${fabricSessionCfc.posture} bundle the session ` +
               `configuration resolves`,
           );
         }
-      } else if (
-        recorded.enforcementMode !== fabricSessionCfc.enforcementMode ||
-        recorded.flowLabels !== fabricSessionCfc.flowLabels ||
-        recorded.posture !== fabricSessionCfc.posture ||
-        // The read ceiling too: a resume that would read wider (or under
-        // another ceiling) than the artifacts attest is the same
-        // contradiction as a moved dial.
-        JSON.stringify(recorded.readMaxConfidentiality) !==
-          JSON.stringify(fabricSessionCfc.readMaxConfidentiality) ||
-        recorded.readOnExceed !== fabricSessionCfc.readOnExceed ||
+      } else {
+        // A ceiling is compared by its clauses and stated by their count: a
+        // clause is a confidentiality label atom, which names spaces and
+        // carries field commitments, and this message leaves the harness.
+        const clauseCount = (clauses?: readonly CfcConfClause[]) =>
+          clauses === undefined
+            ? "none"
+            : `${clauses.length} clause${clauses.length === 1 ? "" : "s"}`;
+        const differences = [
+          ...([
+            [
+              "enforcement mode",
+              recorded.enforcementMode,
+              fabricSessionCfc.enforcementMode,
+            ],
+            ["flow labels", recorded.flowLabels, fabricSessionCfc.flowLabels],
+            [
+              "posture bundle",
+              recorded.posture ?? "none",
+              fabricSessionCfc.posture ?? "none",
+            ],
+            [
+              "read ceiling overflow",
+              recorded.readOnExceed ?? "none",
+              fabricSessionCfc.readOnExceed ?? "none",
+            ],
+          ] as const)
+            .filter(([, recordedDial, resolved]) => recordedDial !== resolved)
+            .map(([dial, recordedDial, resolved]) =>
+              `${dial} (${recordedDial} against ${resolved})`
+            ),
+          // The read ceiling too: a resume that would read wider (or under
+          // another ceiling) than the artifacts attest is the same
+          // contradiction as a moved dial.
+          ...(JSON.stringify(recorded.readMaxConfidentiality) !==
+              JSON.stringify(fabricSessionCfc.readMaxConfidentiality)
+            ? [
+              `read ceiling (${
+                clauseCount(recorded.readMaxConfidentiality)
+              } against ${
+                clauseCount(fabricSessionCfc.readMaxConfidentiality)
+              })`,
+            ]
+            : []),
+        ];
         // The whole record too, where the run recorded one. The two dials
         // above can agree while a dial neither of them names has moved under
         // the run — a changed runtime default, a changed posture bundle — and
@@ -884,16 +921,24 @@ export class CfHarnessEngine {
         // resume that drops the session the record came from: a run that
         // recorded an inherited record and is resumed without the parent
         // session behind it resolves a different record, or none, and either
-        // way the artifacts would stop describing what executes.
-        (recorded.record !== undefined &&
+        // way the artifacts would stop describing what executes. The record
+        // is named rather than printed: it lists every sink the runtime
+        // governs and every deviation it publishes, which is a security
+        // posture rather than a dial an operator moves, and this message
+        // leaves the harness.
+        if (
+          recorded.record !== undefined &&
           JSON.stringify(recorded.record) !==
-            JSON.stringify(fabricSessionCfc.record))
-      ) {
-        throw new Error(
-          `fabric session CFC posture mismatch on resume: run state records ` +
-            `${JSON.stringify(recorded)} but the session configuration ` +
-            `resolves ${JSON.stringify(fabricSessionCfc)}`,
-        );
+            JSON.stringify(fabricSessionCfc.record)
+        ) {
+          differences.push("the runtime posture record the dials resolve to");
+        }
+        if (differences.length > 0) {
+          throw harnessResumeRefusal(
+            `fabric session CFC posture mismatch on resume: the run and the ` +
+              `session configuration differ on ${differences.join(", ")}`,
+          );
+        }
       }
     }
     this.#runState = options.runState ??

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -40,6 +40,7 @@ import {
   type RunHarnessPromptOptions,
   type RunHarnessTranscriptOptions,
 } from "../src/prompt-loop.ts";
+import type { HarnessRunState } from "../src/run-state.ts";
 import {
   chatViewOfRequest,
   responsesBodyFromChatFixture,
@@ -6790,6 +6791,146 @@ Deno.test("Codex cross-model resume fails before creating a model client", async
   assertEquals(stderr, [
     "resumed openai-codex run model gpt-recorded does not match requested model gpt-different\n",
   ]);
+});
+
+Deno.test("a refused resume names the setting, whichever tier refused it", async () => {
+  // The CLI checks the argv and the run manifest against the recorded run,
+  // and the engine constructor checks the settings the CLI hands it. A host
+  // that reports structured failures reads both tiers through one mapping, so
+  // a refusal from either arrives carrying the setting that was refused. The
+  // provider case is the anchor: it already refused this way, and the rest
+  // report as it does.
+
+  const baseRunState = {
+    status: "failed" as const,
+    createdAt: "2026-07-23T20:00:00.000Z",
+    updatedAt: "2026-07-23T20:00:01.000Z",
+    cfcEnforcementMode: "disabled" as const,
+    currentDir: "/workspace",
+    model: "gpt-recorded",
+    credentialOwnerKey: "local",
+    policyEvents: [],
+    toolOutputs: [],
+  };
+  const refuse = async (
+    argv: readonly string[],
+    runState: Partial<HarnessRunState> & { runId: string },
+    manifest?: Record<string, unknown>,
+  ): Promise<{ code: string; message: string }> => {
+    const buffers = createIoBuffers();
+    let modelClientsCreated = 0;
+    let promptLoopsCreated = 0;
+    let providerRequests = 0;
+    const exitCode = await runCfHarnessCli(argv, {
+      io: buffers.io,
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_API_KEY: "test-key" },
+      structuredHostFailures: true,
+      readRunArtifacts: () =>
+        Promise.resolve({
+          runRoot: "/tmp/run",
+          runStatePath: "/tmp/run/run-state.json",
+          transcriptPath: "/tmp/run/transcript.json",
+          runState: { ...baseRunState, ...runState },
+          transcript: [{ role: "user" as const, content: "Continue" }],
+        }),
+      ...(manifest !== undefined
+        ? { readTextFile: () => Promise.resolve(JSON.stringify(manifest)) }
+        : {}),
+      createModelClient: () => {
+        modelClientsCreated += 1;
+        throw new Error("must not create a model client");
+      },
+      createPromptLoop: () => {
+        promptLoopsCreated += 1;
+        throw new Error("must not construct a prompt loop");
+      },
+      fetchFn: () => {
+        providerRequests += 1;
+        return Promise.reject(new Error("must not request a provider"));
+      },
+    });
+    assertEquals(exitCode, 1);
+    // The refusal is settled against the recorded run alone, so nothing has
+    // reached a credential store or a provider by the time it is reported.
+    assertEquals(modelClientsCreated, 0);
+    assertEquals(promptLoopsCreated, 0);
+    assertEquals(providerRequests, 0);
+    assertEquals(buffers.stdout, []);
+    assertEquals(buffers.stderr.length, 1);
+    const failure = JSON.parse(buffers.stderr[0]);
+    assertEquals(failure.type, "cf-harness.host-failure");
+    assertEquals(failure.version, 1);
+    assertEquals(failure.ok, false);
+    return failure.error;
+  };
+
+  // The CLI's own checks: the provider the argv asks for, and a run whose
+  // lineage makes it somebody else's child.
+  const provider = await refuse(
+    ["--resume-run", "/tmp/run", "--model-provider", "openai-codex"],
+    { runId: "run-gateway", modelProvider: "openai-compatible-gateway" },
+  );
+  assertEquals(provider.code, "provider-mismatch");
+  assertStringIncludes(provider.message, "openai-compatible-gateway");
+  assertStringIncludes(provider.message, "openai-codex");
+
+  const subagent = await refuse(["--resume-run", "/tmp/run"], {
+    runId: "root.subagent.1",
+    modelProvider: "openai-codex",
+    lineage: {
+      role: "subagent",
+      rootRunId: "root",
+      parentRunId: "root",
+      parentToolCallId: "call-child",
+      depth: 1,
+    },
+  });
+  assertEquals(subagent.code, "provider-mismatch");
+  assertStringIncludes(subagent.message, "root.subagent.1");
+  assertStringIncludes(subagent.message, "resume root run root");
+
+  // The engine constructor's checks: a Codex run asked for another model, and
+  // a run asked to answer out of another credential home.
+  const model = await refuse(
+    ["--resume-run", "/tmp/run", "--model", "gpt-different"],
+    { runId: "run-codex", modelProvider: "openai-codex" },
+  );
+  assertEquals(model.code, "provider-mismatch");
+  assertStringIncludes(model.message, "gpt-recorded");
+  assertStringIncludes(model.message, "gpt-different");
+
+  const home = await refuse(
+    ["--resume-run", "/tmp/run", "--run-manifest", "/tmp/resume.json"],
+    {
+      runId: "run-home",
+      modelProvider: "openai-compatible-gateway",
+      harnessHomeIdentity: "sha256:recorded-home",
+    },
+    {
+      type: "cf-harness.loom-run-manifest",
+      version: 1,
+      source: "loom",
+      harnessHomeIdentity: "sha256:requested-home",
+    },
+  );
+  assertEquals(home.code, "provider-mismatch");
+  assertStringIncludes(home.message, "harness home");
+
+  // Gateway options against a run that recorded Codex contradict the record
+  // rather than the rest of the argv, which the message says.
+  const gateway = await refuse(
+    [
+      "--resume-run",
+      "/tmp/run",
+      "--gateway-base-url",
+      "https://gateway.example/",
+    ],
+    { runId: "run-codex-gateway", modelProvider: "openai-codex" },
+  );
+  assertEquals(gateway.code, "provider-mismatch");
+  assertStringIncludes(gateway.message, "gateway URL/auth options");
+  assertStringIncludes(gateway.message, "this run recorded");
 });
 
 Deno.test("resume rejects manifest provider and credential-owner switches", async () => {

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -10,6 +10,7 @@ import { createHarnessPolicyEvent } from "../src/contracts/policy.ts";
 import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
 import type { HarnessSkillResourceReads } from "../src/contracts/skill.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
+import { HarnessControlError } from "../src/control-errors.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import {
@@ -481,16 +482,17 @@ Deno.test("CfHarnessEngine refuses to resume under a harness CFC enforcement dia
   }).getRunState();
   assertEquals(runState.cfcEnforcementMode, "observe");
 
-  assertThrows(
+  const stated = assertThrows(
     () =>
       new CfHarnessEngine({
         workspaceHostPath: "/host/project",
         runState,
         cfcEnforcementModeOverride: "disabled",
       }),
-    Error,
+    HarnessControlError,
     "resumed run CFC enforcement mode observe does not match requested CFC enforcement mode disabled",
   );
+  assertEquals(stated.code, "provider-mismatch");
 
   // The configured dial the override stands in front of, refused the same
   // way: what the resume states is what it asked the run to enforce at.
@@ -597,7 +599,7 @@ Deno.test("CfHarnessEngine refuses a run state recorded before the CFC enforceme
   // The resume reads the recorded mode to resolve against, so a run state too
   // old to carry one is refused for what it is, rather than reported as a
   // mismatch against a mode it never named.
-  assertThrows(
+  const legacy = assertThrows(
     () =>
       new CfHarnessEngine({
         sandboxRuntime: new FakeSandboxRuntime(),
@@ -612,9 +614,111 @@ Deno.test("CfHarnessEngine refuses a run state recorded before the CFC enforceme
           failureRecords: [],
         } as unknown as HarnessRunState,
       }),
-    Error,
+    HarnessControlError,
     "run state is missing cfcEnforcementMode; older cf-harness runs cannot be resumed",
   );
+  assertEquals(legacy.code, "provider-mismatch");
+});
+
+Deno.test("a refused resume names the dials without publishing the posture record", () => {
+  // The refusal message leaves the harness — a host that asks for structured
+  // failures puts it on stderr and in an HTTP response body — while the
+  // posture record lists every sink the runtime governs and every deviation
+  // it publishes, and a read ceiling's clauses name spaces. So the message
+  // names those without printing them, and names outright the dials an
+  // operator can move. Every session dial pinned below is read back by the
+  // assertion on the message it produces.
+
+  const posturedSession = {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "my-space",
+    cfcPosture: "max-enforcement",
+  } as const;
+  const runState = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: posturedSession,
+  }).getRunState();
+
+  const dials = assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        fabricSession: {
+          apiUrl: posturedSession.apiUrl,
+          identityKeyPath: posturedSession.identityKeyPath,
+          space: posturedSession.space,
+        },
+        runState,
+      }),
+    HarnessControlError,
+    "posture bundle (max-enforcement against none)",
+  );
+  assertEquals(dials.code, "provider-mismatch");
+  assertEquals(dials.message.includes("policyDigest"), false);
+
+  const drifted = structuredClone(runState) as {
+    fabricSessionCfc?: { record?: { writeFloor: { rung: string } } };
+  } & typeof runState;
+  drifted.fabricSessionCfc!.record!.writeFloor.rung = "off";
+  const record = assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        fabricSession: posturedSession,
+        runState: drifted,
+      }),
+    HarnessControlError,
+    "the runtime posture record the dials resolve to",
+  );
+  assertEquals(record.code, "provider-mismatch");
+  assertEquals(record.message.includes("writeFloor"), false);
+
+  const ceilinged = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: {
+      ...posturedSession,
+      cfcReadMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
+    },
+  }).getRunState();
+  const ceiling = assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        fabricSession: {
+          ...posturedSession,
+          cfcReadMaxConfidentiality: ["did:key:zOwner"],
+        },
+        runState: ceilinged,
+      }),
+    HarnessControlError,
+    "read ceiling (2 clauses against 1 clause)",
+  );
+  assertEquals(ceiling.code, "provider-mismatch");
+  assertEquals(ceiling.message.includes("did:key:"), false);
+});
+
+Deno.test("a run recorded without a working directory is refused, not reported as a fault", () => {
+  // The refusal is deliberate — such a run predates what a resume needs — so
+  // the operator is told that, rather than that the harness broke.
+
+  const runState = new CfHarnessEngine({ workspaceHostPath: "/host/project" })
+    .getRunState();
+  const legacy = structuredClone(runState) as
+    & Omit<HarnessRunState, "currentDir">
+    & { currentDir?: string };
+  delete legacy.currentDir;
+
+  const refusal = assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        runState: legacy as HarnessRunState,
+      }),
+    HarnessControlError,
+    "run state is missing currentDir",
+  );
+  assertEquals(refusal.code, "provider-mismatch");
 });
 
 Deno.test("CfHarnessEngine grants no well-known handles without a fabric session", async () => {
@@ -1753,7 +1857,7 @@ Deno.test("CfHarnessEngine keeps a resumed run's recorded provider authoritative
         credentialOwnerKey: "loom:user-2",
       }),
     Error,
-    "credential owner does not match",
+    "credential owner key does not match",
   );
   assertThrows(
     () =>


### PR DESCRIPTION
A resume whose requested settings contradict the recorded run is refused in two places. The CLI checks the model provider, the docs corpus, the run manifest's model and the credential owner, and raises a `HarnessControlError` for each. The engine constructor checks the rest — the Codex model binding, the harness home identity, the model auth source, the credential owner key, the subagent resume context and the fabric-session CFC posture — and raised a plain `Error` for each.

That difference decided what an operator was told. A host that asks for structured failures, which is what `loom-local-host.ts` does on both of its call sites, reads every thrown value through one mapping at the end of `runCfHarnessCli`. The mapping passes a `HarnessControlError` through and replaces anything else with a generic code and a generic message. So a resume refused by the CLI came back as

    {"code":"provider-mismatch",
     "message":"resume provider mismatch: run uses
                openai-compatible-gateway, requested openai-codex"}

while a resume refused by the engine came back as

    {"code":"internal-error",
     "message":"The local cf-harness host operation failed"}

naming neither the setting nor the record it contradicted. Both branches of that mapping produce a generic message, so this was not a question of which side of `requestAccepted` the constructor runs on.

The classification now has one home. `harnessResumeRefusal` builds the error both tiers raise, and its doc comment states what the family is: a requested setting contradicts the recorded one, or the record lacks something a resume needs. It carries `provider-mismatch`, which is the code the CLI's own resume checks already used for this family and which every host boundary passes through by name. Sixteen sites call it.

Three refusals join the ones this started from, having reported as faults for the same reason. Resuming a subagent run as a top-level run was a plain `Error` in the CLI, so the one tier that already refused properly was itself inconsistent. Gateway URL and auth options passed to a resume of a run that recorded Codex contradict the record rather than the rest of the argv; the identical check on the fresh-run path stays as it is, because there it is argv against argv. A run state with no `currentDir` cannot be resumed, which the README documents as deliberate, while the operator was told the host had broken.

`requestAccepted` stays where it is. It marks the boundary the README describes, where a fault stops being the caller's mistake and starts being the host's, and a host keys its retry policy on that. A refusal is neither of those two codes now, so it reaches the operator from either side of the boundary without blurring it. On the interactive path this also means an HTTP 409 rather than a 500: `chatError` in `loom-local-host.ts` carries the four provider codes across by name and sends everything else to `internal_error`, and the console server maps `provider-mismatch` to 409.

Once these messages carry, what they carry matters. The fabric-session CFC refusal built its message by serializing both posture records whole, which was harmless while the message was thrown away. A `CfcPostureReport` names every dial with its diagnostic-only flag, the policy digest, every sink with its confidentiality ceiling or the reason it has none, and every published deviation — what is not enforced, who owns it, and what would retire it. Measured through the CLI with structured host failures on, one such refusal wrote 4.8 KB to stderr, and the interactive path puts the same text in an HTTP 409 body. The refusal now names the dials that differ and their two values, and names the record without printing it. It reports the same conditions as before: the itemized dials, the posture bundle, the read ceiling the session applies, and the whole record where the run recorded one.

The read ceiling gets the record's treatment for the record's reason. A ceiling is a list of confidentiality clauses, and a clause is a label atom naming a space, so ceilings are compared by their clauses and stated by their count. The ceiling's overflow behavior is a two-valued dial and is stated outright.

The two credential-owner refusals raised the same sentence for different checks — the full owner reference and, for Codex, the owner key — so an operator could not tell which had fired. The second now says so.

The new CLI test drives one refusal from each tier through the structured-host-failure path and asserts the shape, the code and the message, and asserts that no model client, prompt loop or provider request was made, so a refusal stays settled against the record alone. Two engine tests cover what the messages may carry: the CFC refusal names the dials and carries neither the policy digest, nor a sink list, nor a ceiling's DIDs, and a run state with no `currentDir` is refused rather than reported as a fault. Each case fails with its own fix reverted — serializing the ceiling's clauses, for instance, fails on a message reading `["did:key:zOwner","did:key:zFacet"] against ["did:key:zOwner"]`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

