### PR TITLE
fix(llm): an LLM request that leaves `cache` out is cached

### DIFF
--- a/packages/llm/README.md
+++ b/packages/llm/README.md
@@ -76,6 +76,37 @@ Four declarations say that, and they have to agree.
 `docs/history/features/llm-message-role-narrowing-break.md` records why the role
 left, and what that cost the patterns whose contracts carried it.
 
+## A request that leaves `cache` out asks for caching
+
+`cache` is optional, and a request that leaves it out asks for its response to
+be cached. Only `cache: false` declines.
+
+Four declarations say that, and they have to agree.
+
+- `LLMRequest` and `LLMGenerateObjectRequest` in [`src/types.ts`](src/types.ts)
+  declare the field optional. TypeScript has no way to state a default, so their
+  doc comments carry it.
+- `llmRequestProblem()` and `llmGenerateObjectRequestProblem()` in the same
+  file, which the two POST handlers gate their payloads on, take a request that
+  leaves the field out and refuse a value that is not a boolean, so a caller
+  sending `cache: "yes"` is told which field to change.
+- `LLMRequestSchema` and `GenerateObjectRequestSchema` in
+  [`packages/toolshed/routes/ai/llm/llm.routes.ts`](../toolshed/routes/ai/llm/llm.routes.ts)
+  publish the field as optional with a default of `true`. That is the OpenAPI
+  document, and it is what a caller writing against this API reads.
+- `requestsCaching()` in
+  [`packages/toolshed/routes/ai/llm/cache.ts`](../toolshed/routes/ai/llm/cache.ts)
+  is where the default is applied, and both POST handlers ask it.
+
+What the field asks for is not the whole decision. `/api/ai/llm` answers a
+request naming a provider-native tool such as Google Search live whatever
+`cache` says, because those results are time-sensitive.
+
+Both handlers read the raw body rather than the value their route's validator
+parsed, which is how a body sent under another content type reaches the same
+check. The default therefore has to be applied in the handler as well as
+declared in the schema.
+
 ## The routes on the other side
 
 | Route                        | Method | What it does                                 |

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -116,7 +116,13 @@ export type LLMToolResult = {
 export type LLMRequestMetadata = Record<string, JSONValue | undefined>;
 
 export type LLMRequest = {
+  /**
+   * Whether this request asks for its response to be cached. A request that
+   * leaves the field out asks for caching; only `false` declines. The
+   * toolshed may answer live for reasons of its own.
+   */
   cache?: boolean;
+
   messages: readonly BuiltInLLMMessage[];
   model: ModelName;
   system?: string;
@@ -134,7 +140,14 @@ export type LLMGenerateObjectRequest = {
   messages: readonly BuiltInLLMMessage[];
   model?: ModelName;
   system?: string;
+
+  /**
+   * Whether this request asks for its response to be cached. A request that
+   * leaves the field out asks for caching; only `false` declines. The
+   * toolshed may answer live for reasons of its own.
+   */
   cache?: boolean;
+
   maxTokens?: number;
   metadata?: LLMRequestMetadata;
 };
@@ -245,7 +258,9 @@ export function llmRequestProblem(input: unknown): string | undefined {
   if (typeof input.model !== "string") return "'model' must be a string.";
   const conversation = conversationProblem(input.messages);
   if (conversation !== undefined) return conversation;
-  if (!("cache" in input)) return "'cache' must be present.";
+  if ("cache" in input && typeof input.cache !== "boolean") {
+    return "'cache' must be a boolean.";
+  }
   if ("system" in input && typeof input.system !== "string") {
     return "'system' must be a string.";
   }

--- a/packages/llm/test/types.test.ts
+++ b/packages/llm/test/types.test.ts
@@ -26,7 +26,6 @@ const TOOL: LLMTool = {
 
 /** A well-formed request, with `input` written over it. */
 const request = (input: object) => ({
-  cache: true,
   model: DEFAULT_MODEL_NAME,
   messages: [{ role: "user", content: "Hi" }] satisfies BuiltInLLMMessage[],
   ...input,
@@ -68,6 +67,12 @@ describe("types", () => {
       }))).toBeUndefined();
     });
 
+    it("returns `undefined` for a request that leaves `cache` out, turns caching on, or turns it off", () => {
+      expect(llmRequestProblem(request({}))).toBeUndefined();
+      expect(llmRequestProblem(request({ cache: true }))).toBeUndefined();
+      expect(llmRequestProblem(request({ cache: false }))).toBeUndefined();
+    });
+
     it("returns `undefined` for any metadata value JSON carries faithfully", () => {
       expect(llmRequestProblem(request({
         metadata: {
@@ -83,13 +88,10 @@ describe("types", () => {
 
     it("returns text naming each required field a request leaves out", () => {
       const messages: BuiltInLLMMessage[] = [{ role: "user", content: "Hi" }];
-      expect(llmRequestProblem({ messages, cache: true })).toContain("'model'");
-      expect(
-        llmRequestProblem({ model: DEFAULT_MODEL_NAME, cache: true }),
-      ).toContain("'messages'");
-      expect(
-        llmRequestProblem({ model: DEFAULT_MODEL_NAME, messages }),
-      ).toContain("'cache'");
+      expect(llmRequestProblem({ messages })).toContain("'model'");
+      expect(llmRequestProblem({ model: DEFAULT_MODEL_NAME })).toContain(
+        "'messages'",
+      );
     });
 
     it("returns text naming `messages` for an empty conversation", () => {
@@ -102,6 +104,8 @@ describe("types", () => {
     it("returns text naming the field whose value is of the wrong type", () => {
       const named = (input: object, field: string) =>
         expect(llmRequestProblem(request(input))).toContain(field);
+      named({ cache: "yes" }, "'cache'");
+      named({ cache: null }, "'cache'");
       named({ maxTokens: "4096 " }, "'maxTokens'");
       named({ system: {} }, "'system'");
       named({ stop: {} }, "'stop'");

--- a/packages/toolshed/routes/ai/llm/cache.test.ts
+++ b/packages/toolshed/routes/ai/llm/cache.test.ts
@@ -1,0 +1,168 @@
+/**
+ * The response cache's policy. `requestsCaching()` reads an LLM request's
+ * `cache` field, and `/api/ai/llm` acts on what it reads. The default the
+ * field carries when a request leaves it out is part of what both POST routes
+ * publish in their OpenAPI schemas, so it is pinned here at both levels.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { type LanguageModel } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+
+import { CACHE_DIR, requestsCaching } from "./cache.ts";
+import router from "./llm.index.ts";
+import { MODELS } from "./models.ts";
+import createApp from "@/lib/create-app.ts";
+
+const app = createApp().route("/", router);
+
+const MOCK_MODEL_NAME = "mock:cache-model";
+
+/** A model that answers with the number of times it has been asked. */
+function countingModel(): { model: LanguageModel; asked: () => number } {
+  let asked = 0;
+  const model = new MockLanguageModelV4({
+    doStream: () => {
+      asked += 1;
+      const answer = `Answer ${asked}`;
+      return Promise.resolve({
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            controller.enqueue({ type: "text-start", id: "1" });
+            controller.enqueue({ type: "text-delta", id: "1", delta: answer });
+            controller.enqueue({ type: "text-end", id: "1" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: { unified: "stop", raw: "end_turn" },
+              usage: {
+                inputTokens: {
+                  total: 1,
+                  noCache: 1,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                },
+                outputTokens: { total: 1, text: 1, reasoning: 0 },
+              },
+            });
+            controller.close();
+          },
+        }),
+      });
+    },
+  });
+  return { model, asked: () => asked };
+}
+
+/** The names of the files the response cache is holding right now. */
+async function cachedFiles(): Promise<Set<string>> {
+  const names = new Set<string>();
+  try {
+    for await (const entry of Deno.readDir(CACHE_DIR)) names.add(entry.name);
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) throw error;
+  }
+  return names;
+}
+
+/**
+ * Registers `model` under a name `findModel` resolves, runs `body`, then takes
+ * the registration back out and removes whatever `body` left in the response
+ * cache.
+ */
+async function withMockModel<T>(
+  model: LanguageModel,
+  body: () => Promise<T>,
+): Promise<T> {
+  MODELS[MOCK_MODEL_NAME] = {
+    model,
+    name: MOCK_MODEL_NAME,
+    capabilities: {
+      contextWindow: 1000,
+      maxOutputTokens: 100,
+      streaming: true,
+      systemPrompt: true,
+      stopSequences: true,
+      prefill: false,
+      images: false,
+      reasoning: false,
+    },
+    aliases: [],
+  };
+  const before = await cachedFiles();
+  try {
+    return await body();
+  } finally {
+    delete MODELS[MOCK_MODEL_NAME];
+    for (const name of await cachedFiles()) {
+      if (!before.has(name)) await Deno.remove(`${CACHE_DIR}/${name}`);
+    }
+  }
+}
+
+/** Posts a body and returns the status and the message content it carried. */
+async function post(
+  requestBody: unknown,
+): Promise<{ status: number; content: unknown }> {
+  const response = await app.request("/api/ai/llm", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(requestBody),
+  });
+  return { status: response.status, content: (await response.json()).content };
+}
+
+describe("cache", () => {
+  describe("requestsCaching()", () => {
+    it("returns `true` for a request that leaves `cache` out", () => {
+      expect(requestsCaching({})).toBe(true);
+    });
+
+    it("returns `true` for `cache: true`", () => {
+      expect(requestsCaching({ cache: true })).toBe(true);
+    });
+
+    it("returns `false` for `cache: false`", () => {
+      expect(requestsCaching({ cache: false })).toBe(false);
+    });
+  });
+
+  describe("POST /api/ai/llm", () => {
+    // Each case sends a conversation no earlier run can have sent, so what it
+    // finds in the cache is only what it put there.
+
+    it("answers an identical second request without asking the model again", async () => {
+      const { model, asked } = countingModel();
+      await withMockModel(model, async () => {
+        const request = {
+          model: MOCK_MODEL_NAME,
+          messages: [{ role: "user", content: `Hi ${crypto.randomUUID()}` }],
+        };
+        const first = await post(request);
+        const second = await post(request);
+        expect(first.status).toBe(200);
+        expect(second.status).toBe(200);
+        expect(second.content).toEqual(first.content);
+        expect(asked()).toBe(1);
+      });
+    });
+
+    it("asks the model again for a request that sets `cache` to `false`", async () => {
+      const { model, asked } = countingModel();
+      await withMockModel(model, async () => {
+        const request = {
+          model: MOCK_MODEL_NAME,
+          messages: [{ role: "user", content: `Hi ${crypto.randomUUID()}` }],
+          cache: false,
+        };
+        const first = await post(request);
+        const second = await post(request);
+        expect(first.status).toBe(200);
+        expect(second.status).toBe(200);
+        expect(second.content).not.toEqual(first.content);
+        expect(asked()).toBe(2);
+      });
+    });
+  });
+});

--- a/packages/toolshed/routes/ai/llm/cache.ts
+++ b/packages/toolshed/routes/ai/llm/cache.ts
@@ -1,6 +1,7 @@
 import { ensureDir } from "@std/fs";
 
 import { type BuiltInLLMMessage } from "@commonfabric/api";
+import { type LLMRequest } from "@commonfabric/llm/types";
 
 import { colors, timestamp } from "./cli.ts";
 import env from "@/env.ts";
@@ -13,6 +14,15 @@ export interface CacheItem {
   model?: string;
   system?: string;
   stopSequences?: string[];
+}
+
+/**
+ * Whether `request` asks for its response to be cached. A request that leaves
+ * `cache` out asks for caching; only `false` declines it. This is the whole of
+ * what the field says, and a route may answer live for reasons of its own.
+ */
+export function requestsCaching(request: Pick<LLMRequest, "cache">): boolean {
+  return request.cache !== false;
 }
 
 export async function hashKey(key: string): Promise<string> {

--- a/packages/toolshed/routes/ai/llm/llm.handlers.ts
+++ b/packages/toolshed/routes/ai/llm/llm.handlers.ts
@@ -8,7 +8,13 @@ import {
 import type { Context } from "@hono/hono";
 import * as HttpStatusCodes from "stoker/http-status-codes";
 
-import { CacheItem, hashKey, loadFromCache, saveToCache } from "./cache.ts";
+import {
+  CacheItem,
+  hashKey,
+  loadFromCache,
+  requestsCaching,
+  saveToCache,
+} from "./cache.ts";
 import { httpStatusForError } from "./errors.ts";
 import { generateObject as generateObjectCore } from "./generateObject.ts";
 import { generateText as generateTextCore } from "./generateText.ts";
@@ -192,7 +198,7 @@ export const generateText: AppRouteHandler<GenerateTextRoute> = async (c) => {
   //
   // Provider-native tools such as Google Search are intentionally time-sensitive.
   // Treat them as live requests until we have a freshness-aware cache policy.
-  const shouldCache = payload.cache === true &&
+  const shouldCache = requestsCaching(payload) &&
     (payload.nativeModelToolIds?.length ?? 0) === 0;
 
   let cacheKey: string | undefined;
@@ -308,9 +314,10 @@ export const generateObject: AppRouteHandler<GenerateObjectRoute> = async (
   const cacheKey = await hashKey(
     JSON.stringify(removeNonCacheableFields(payload)),
   );
+  const shouldCache = requestsCaching(payload);
 
   // Check cache if enabled
-  if (payload.cache !== false) {
+  if (shouldCache) {
     const cachedResult = await loadFromCache(cacheKey);
     if (cachedResult) {
       return c.json({
@@ -323,7 +330,7 @@ export const generateObject: AppRouteHandler<GenerateObjectRoute> = async (
     const result = await generateObjectCore(payload);
 
     // Save to cache if enabled
-    if (payload.cache !== false) {
+    if (shouldCache) {
       try {
         await saveToCache(cacheKey, {
           ...removeNonCacheableFields(payload),

--- a/packages/toolshed/routes/ai/llm/llm.routes.test.ts
+++ b/packages/toolshed/routes/ai/llm/llm.routes.test.ts
@@ -2,7 +2,20 @@ import { assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { BuiltInLLMMessage } from "@commonfabric/api";
+
+import createApp from "@/lib/create-app.ts";
+import router from "./llm.index.ts";
 import { MessageSchema } from "./llm.routes.ts";
+
+/** The request body schema this route publishes, as JSON Schema. */
+function publishedRequestSchema(path: string): Record<string, any> {
+  const document = createApp().route("/", router).getOpenAPIDocument({
+    openapi: "3.0.0",
+    info: { version: "1.0.0", title: "Toolshed API" },
+  });
+  const operation = (document.paths as Record<string, any>)[path].post;
+  return operation.requestBody.content["application/json"].schema;
+}
 
 /**
  * `BuiltInLLMMessage`'s roles written out as values. The `satisfies` clause
@@ -23,6 +36,33 @@ type EveryRoleIsListed = AssertNever<
 >;
 
 describe("llm.routes", () => {
+  describe("LLMRequestSchema", () => {
+    // `cache` is the one field of a request whose absence means something
+    // other than "leave it alone", so what the document says about it when it
+    // is left out is part of the contract rather than an implementation
+    // detail.
+
+    it("publishes `cache` as optional, with a default of `true`", () => {
+      const schema = publishedRequestSchema("/api/ai/llm");
+      expect(schema.required).not.toContain("cache");
+      expect(schema.properties.cache).toEqual({
+        type: "boolean",
+        default: true,
+      });
+    });
+  });
+
+  describe("GenerateObjectRequestSchema", () => {
+    it("publishes `cache` as optional, with a default of `true`", () => {
+      const schema = publishedRequestSchema("/api/ai/llm/generateObject");
+      expect(schema.required).not.toContain("cache");
+      expect(schema.properties.cache).toEqual({
+        type: "boolean",
+        default: true,
+      });
+    });
+  });
+
   describe("MessageSchema", () => {
     it("accepts the roles `BuiltInLLMMessage` carries and no others", () => {
       // The route's validator is the fourth declaration of the role set, after

--- a/packages/toolshed/routes/ai/llm/llm.status.test.ts
+++ b/packages/toolshed/routes/ai/llm/llm.status.test.ts
@@ -184,6 +184,22 @@ Deno.test("a tool the model cannot serve is the caller's mistake", async () => {
   assertStringIncludes(error, "is not supported by model");
 });
 
+Deno.test("a request that leaves `cache` out reaches the provider", async () => {
+  // `cache` is optional, so the status is the provider's refusal rather than
+  // the guard's. The body posted here is the one the OpenAPI document
+  // publishes as valid: a model and a conversation, and nothing else.
+
+  const { status } = await withMockModel(
+    rejectingWith(429, "Rate limit exceeded"),
+    () =>
+      post("/api/ai/llm", {
+        model: MOCK_MODEL_NAME,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+  );
+  assertEquals(status, 429);
+});
+
 //
 // A body sent as JSON is parsed by the route's own validator, which answers
 // its own 422 before the handler runs. A body sent as anything else reaches


### PR DESCRIPTION
Three declarations disagreed about whether an LLM request's `cache` field is required, and the guard's check for it tested something no other clause of that function tested.

`LLMRequest` declared `cache?: boolean`, and `LLMRequestSchema` published it to the OpenAPI document as optional with a default of `true`. But `llmRequestProblem()` required the key to be present, so a body valid against both the TypeScript type and the published document -- `{"model": "default", "messages": [{"role": "user", "content": "hi"}]}` -- came back as a 400 saying `'cache' must be present.` The schema's default never applied, because the handler reads the raw body from `readJsonBody()` rather than the value the route's validator parsed. It does that so a body sent under another content type meets the same check.

The second half was in the same clause. Every other clause checks the type of the value when the key is present; `cache` alone checked only that the key was there, so `cache: "yes"` and `cache: null` both satisfied it and then failed `payload.cache === true` in the handler. Caching switched off instead of the invalid value being refused.

This settles the field as optional, defaulting to on, which is what four of the five statements about it already said: both request types declare it optional, both route schemas publish `default: true`, the runner builtins send `cache ?? true`, and the `generateObject` handler reads it as `cache !== false`. Only the guard and the `generateText` handler's `cache === true` said otherwise, and the guard was masking the handler -- no request without the field ever reached it.

So the guard now takes a request that leaves `cache` out and refuses a value that is not a boolean, and the default is applied in one named place that both POST handlers ask:

    export function requestsCaching(
      request: Pick<LLMRequest, "cache">,
    ): boolean {
      return request.cache !== false;
    }

What the field asks for is not the whole decision, and the name says only what it answers: `/api/ai/llm` also refuses to cache a request naming a provider-native tool such as Google Search, because those results are time-sensitive. Folding that check into the function would read better but would change behavior, because `generateObject` requests carry `nativeModelToolIds` in practice, through a conditional spread in the runner's builtin, and that route ignores them entirely.

Both request types carry a doc comment for the default, which TypeScript cannot state. `packages/llm/README.md` gains a section naming the four declarations that have to agree about `cache`, alongside the one it already has for the message roles.

The route schemas needed no change:
`z.boolean().default(true).optional()` already renders as an optional property with `default: true`, and `LLMRequestSchema.parse()` already fills it in. Tests pin what the routes publish, since the OpenAPI document is what a caller writing against this API reads, and two route-level cases pin the wiring between the predicate and the handlers, which replacing either handler's use of it with a constant would otherwise leave green. Each of those sends a conversation no earlier run can have sent, and removes the cache entry it leaves.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

