### PR TITLE
fix(fuse): a mount refuses a CFC mode that is not on the ladder

### DIFF
--- a/packages/cli/lib/completion/static.ts
+++ b/packages/cli/lib/completion/static.ts
@@ -7,6 +7,8 @@
  */
 
 import type { Option } from "@cliffy/command";
+
+import { CFC_ENFORCEMENT_MODES } from "@commonfabric/runner/cfc";
 import { languageNames } from "../view/languages/language.ts";
 import type { AnyCommand, CompletionLine, PreParseGlobal } from "./line.ts";
 import { longName, PRE_PARSE_GLOBALS } from "./line.ts";
@@ -34,7 +36,7 @@ const ENUMERATED_OPTION_VALUES: Readonly<Record<string, readonly string[]>> = {
   "log-level": ["debug", "info", "warn", "error", "silent"],
   "color": ["auto", "always", "never"],
   "language": languageNames(),
-  "cfc-mode": ["off", "warn", "enforce"],
+  "cfc-mode": [...CFC_ENFORCEMENT_MODES],
   // `cf piece map --format`.
   "format": ["ascii", "dot"],
   // `cf piece survey --side`: which document holds the collection.

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -340,10 +340,12 @@ workloads.
 ### CFC Annotations
 
 `cf fuse mount --cfc-mode=<mode>` selects the FUSE-side CFC guardrail mode:
-`disabled`, `observe`, `enforce-explicit`, or `enforce-strict`. When no mode is
-provided, FUSE uses the runner default (`disabled` today). `observe` and both
-enforcing modes publish annotations automatically. `--cfc-annotations` still
-forces annotation output for local debugging even when the mode is `disabled`.
+`disabled`, `observe`, `enforce-explicit`, or `enforce-strict`. `CF_CFC_MODE`
+names the mode when the flag does not. A mount that names a mode nowhere runs at
+`disabled`. A name outside those four is rejected from whichever of the two
+named it, and the mount does not start. `observe` and both enforcing modes
+publish annotations automatically. `--cfc-annotations` still forces annotation
+output for local debugging even when the mode is `disabled`.
 
 By default the local mount exposes both the protected namespace `trusted.cfc.*`
 and the compatibility namespace `user.commonfabric.cfc.*`. Use

--- a/packages/fuse/cfc-writeback.test.ts
+++ b/packages/fuse/cfc-writeback.test.ts
@@ -1,4 +1,11 @@
-import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
+import { CFC_ENFORCEMENT_MODES } from "@commonfabric/runner/cfc";
+
 import { FsTree } from "./tree.ts";
 import {
   CfcProjectionAnnotator,
@@ -21,7 +28,6 @@ import {
   CfcWritebackStore,
   metadataFieldsForSetattrFlags,
   normalizeCfcWritebackXattrName,
-  parseCfcMode,
   resolveCfcMode,
   safeReconcileCfcWritebacks,
   shouldEnableCfcAnnotations,
@@ -104,12 +110,11 @@ function prepareJson(
   });
 }
 
-Deno.test("CFC mode parsing and annotation defaults match runner modes", () => {
-  assertEquals(parseCfcMode("disabled"), "disabled");
-  assertEquals(parseCfcMode("observe"), "observe");
-  assertEquals(parseCfcMode("enforce-explicit"), "enforce-explicit");
-  assertEquals(parseCfcMode("enforce-strict"), "enforce-strict");
-  assertEquals(parseCfcMode("bogus"), undefined);
+Deno.test("CFC mode resolution and annotation defaults match runner modes", () => {
+  for (const mode of CFC_ENFORCEMENT_MODES) {
+    assertEquals(resolveCfcMode({ cliMode: mode }), mode);
+    assertEquals(resolveCfcMode({ envMode: mode }), mode);
+  }
 
   assertEquals(
     resolveCfcMode({ cliMode: "observe", envMode: "enforce-strict" }),
@@ -120,6 +125,10 @@ Deno.test("CFC mode parsing and annotation defaults match runner modes", () => {
     "enforce-explicit",
   );
   assertEquals(resolveCfcMode({}), "disabled");
+  // An empty string is a source that stated nothing, not a name off the
+  // ladder: the mount reads an absent flag as "" and so does an exported but
+  // unset environment variable.
+  assertEquals(resolveCfcMode({ cliMode: "", envMode: "" }), "disabled");
 
   assertEquals(
     shouldEnableCfcAnnotations({
@@ -141,6 +150,31 @@ Deno.test("CFC mode parsing and annotation defaults match runner modes", () => {
       mode: "observe",
     }),
     true,
+  );
+});
+
+Deno.test("an off-ladder CFC mode is reported rather than coerced", () => {
+  // A misspelled enforcing mode is refused, not resolved onto the weakest
+  // rung.
+  for (
+    const [options, source] of [
+      [{ cliMode: "enforce-stricct" }, "--cfc-mode"],
+      [{ envMode: "enforce-stricct" }, "CF_CFC_MODE"],
+    ] as const
+  ) {
+    const error = assertThrows(
+      () => resolveCfcMode(options),
+      Error,
+      `${source}=enforce-stricct is not a CFC enforcement mode`,
+    );
+    assertStringIncludes(error.message, CFC_ENFORCEMENT_MODES.join(", "));
+  }
+
+  // Only the source that decides is checked, so a flag naming a mode starts a
+  // mount whose environment holds something else.
+  assertEquals(
+    resolveCfcMode({ cliMode: "enforce-strict", envMode: "enforce-stricct" }),
+    "enforce-strict",
   );
 });
 

--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -3,8 +3,10 @@ import { encodeHex } from "@std/encoding/hex";
 import { sha256 } from "@commonfabric/content-hash";
 import { cloneIfNecessary, type FabricValue } from "@commonfabric/data-model";
 import {
+  CFC_ENFORCEMENT_MODES,
   type CfcEnforcementMode as RunnerCfcEnforcementMode,
   DEFAULT_CFC_ENFORCEMENT_MODE,
+  isCfcEnforcementMode,
 } from "@commonfabric/runner/cfc";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 
@@ -203,30 +205,44 @@ export function safeReconcileCfcWritebacks(options: {
   }
 }
 
-const CFC_MODES = [
-  "disabled",
-  "observe",
-  "enforce-explicit",
-  "enforce-strict",
-] as const satisfies readonly CfcEnforcementMode[];
-
-export function parseCfcMode(
-  value: string | undefined,
-): CfcEnforcementMode | undefined {
-  return (CFC_MODES as readonly string[]).includes(value ?? "")
-    ? value as CfcEnforcementMode
-    : undefined;
+/**
+ * The mode a source states, checked against the ladder.
+ *
+ * @throws Error when the source states a name the ladder does not hold.
+ */
+function statedCfcMode(
+  value: string,
+  source: string,
+): CfcEnforcementMode {
+  if (!isCfcEnforcementMode(value)) {
+    throw new Error(
+      `${source}=${value} is not a CFC enforcement mode; expected one of ${
+        CFC_ENFORCEMENT_MODES.join(", ")
+      }`,
+    );
+  }
+  return value;
 }
 
+/**
+ * The mode a mount runs its CFC guardrails at.
+ *
+ * `--cfc-mode` decides when it names a mode, `CF_CFC_MODE` decides otherwise,
+ * and a mount that names a mode nowhere runs at
+ * {@link DEFAULT_CFC_ENFORCEMENT_MODE}. An empty value names nothing: the
+ * mount reads an absent flag as one, and so is an exported but unset
+ * environment variable.
+ *
+ * @throws Error when the deciding source names a mode off the ladder, giving
+ * the value, the source that named it, and the accepted names.
+ */
 export function resolveCfcMode(options: {
   cliMode?: string;
   envMode?: string;
-  runtimeMode?: CfcEnforcementMode;
 }): CfcEnforcementMode {
-  return parseCfcMode(options.cliMode) ??
-    parseCfcMode(options.envMode) ??
-    options.runtimeMode ??
-    DEFAULT_CFC_ENFORCEMENT_MODE;
+  if (options.cliMode) return statedCfcMode(options.cliMode, "--cfc-mode");
+  if (options.envMode) return statedCfcMode(options.envMode, "CF_CFC_MODE");
+  return DEFAULT_CFC_ENFORCEMENT_MODE;
 }
 
 export function shouldEnableCfcAnnotations(options: {

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -45,7 +45,6 @@ import {
   isCfcEnforcing,
   metadataFieldsForSetattrFlags,
   normalizeCfcWritebackXattrName,
-  parseCfcMode,
   resolveCfcMode,
   safeReconcileCfcWritebacks,
   shouldEnableCfcAnnotations,
@@ -469,54 +468,6 @@ export async function main(argv: string[] = Deno.args) {
     };
   }
 
-  // CF_FUSE_DEBUG=1 enables debug logging even when --debug isn't passed.
-  // --debug is forwarded through every spawn layer (mount -> supervisor ->
-  // daemon child), and env vars are inherited too, so either switch works.
-  const debug = args.debug || Deno.env.get("CF_FUSE_DEBUG") === "1";
-  const dangerouslyAllowIncompatibleSchema = Boolean(
-    args["dangerously-allow-incompatible-schema"],
-  );
-  const requestedCfcMode = String(args["cfc-mode"] ?? "");
-  if (requestedCfcMode && !parseCfcMode(requestedCfcMode)) {
-    console.warn(
-      `[FUSE] Unknown --cfc-mode=${requestedCfcMode}; using runner default`,
-    );
-  }
-  const cfcMode: CfcEnforcementMode = resolveCfcMode({
-    cliMode: requestedCfcMode || undefined,
-    envMode: Deno.env.get("CF_CFC_MODE") ?? undefined,
-  });
-  const cfcAnnotationsEnabled = shouldEnableCfcAnnotations({
-    annotationsRequested: Boolean(args["cfc-annotations"]),
-    mode: cfcMode,
-  });
-  const cfcWritebackXattrs = Boolean(args["cfc-writeback-xattrs"]);
-  const cfcXattrNamespace = parseCfcXattrNamespace(
-    String(args["cfc-xattr-namespace"] ?? DEFAULT_CFC_XATTR_NAMESPACE),
-  );
-  if (!cfcXattrNamespace) {
-    console.error(
-      `[FUSE] Unknown --cfc-xattr-namespace=${
-        args["cfc-xattr-namespace"]
-      }; expected trusted, compat, or both`,
-    );
-    Deno.exit(1);
-  }
-
-  let cacheOptions: MountCacheOptions;
-  try {
-    cacheOptions = resolveMountCacheOptions({
-      noattrcache: Boolean(args.noattrcache),
-      attrcacheTimeout: String(args["attrcache-timeout"] ?? ""),
-      attrcacheTimeoutGiven: argv.some((arg) =>
-        arg === "--attrcache-timeout" || arg.startsWith("--attrcache-timeout=")
-      ),
-    });
-  } catch (e) {
-    console.error(`[FUSE] ${e instanceof Error ? e.message : e}`);
-    return Deno.exit(1);
-  }
-
   const mountpoint = args._[0] as string;
   if (!mountpoint) {
     console.error(
@@ -579,6 +530,67 @@ export async function main(argv: string[] = Deno.args) {
       state,
       extra,
     );
+
+  /**
+   * Report a startup failure and stop.
+   *
+   * The message goes to stderr and to the supervisor status channel. A
+   * background mount's stderr goes nowhere its parent reads, and the channel
+   * is what `cf fuse mount` blocks on.
+   */
+  const failStartup = async (message: string): Promise<never> => {
+    await writeFailedSupervisorStartupStatus(
+      `[FUSE] ${message}`,
+      reportSupervisorState,
+    );
+    return Deno.exit(1);
+  };
+
+  // CF_FUSE_DEBUG=1 enables debug logging even when --debug isn't passed.
+  // --debug is forwarded through every spawn layer (mount -> supervisor ->
+  // daemon child), and env vars are inherited too, so either switch works.
+  const debug = args.debug || Deno.env.get("CF_FUSE_DEBUG") === "1";
+  const dangerouslyAllowIncompatibleSchema = Boolean(
+    args["dangerously-allow-incompatible-schema"],
+  );
+  let cfcMode: CfcEnforcementMode;
+  try {
+    cfcMode = resolveCfcMode({
+      cliMode: String(args["cfc-mode"] ?? ""),
+      envMode: Deno.env.get("CF_CFC_MODE") ?? undefined,
+    });
+  } catch (e) {
+    return await failStartup(e instanceof Error ? e.message : String(e));
+  }
+  const cfcAnnotationsEnabled = shouldEnableCfcAnnotations({
+    annotationsRequested: Boolean(args["cfc-annotations"]),
+    mode: cfcMode,
+  });
+  const cfcWritebackXattrs = Boolean(args["cfc-writeback-xattrs"]);
+  const cfcXattrNamespace = parseCfcXattrNamespace(
+    String(args["cfc-xattr-namespace"] ?? DEFAULT_CFC_XATTR_NAMESPACE),
+  );
+  if (!cfcXattrNamespace) {
+    return await failStartup(
+      `Unknown --cfc-xattr-namespace=${
+        args["cfc-xattr-namespace"]
+      }; expected trusted, compat, or both`,
+    );
+  }
+
+  let cacheOptions: MountCacheOptions;
+  try {
+    cacheOptions = resolveMountCacheOptions({
+      noattrcache: Boolean(args.noattrcache),
+      attrcacheTimeout: String(args["attrcache-timeout"] ?? ""),
+      attrcacheTimeoutGiven: argv.some((arg) =>
+        arg === "--attrcache-timeout" || arg.startsWith("--attrcache-timeout=")
+      ),
+    });
+  } catch (e) {
+    return await failStartup(e instanceof Error ? e.message : String(e));
+  }
+
   try {
     await writeSupervisorStatus("starting");
   } catch (error) {

--- a/packages/fuse/mount-cli.test.ts
+++ b/packages/fuse/mount-cli.test.ts
@@ -1,7 +1,7 @@
 // The daemon entrypoint's option contract, exercised through a real process.
 //
-// main() validates the cache mount flags before it opens libfuse or creates
-// the mountpoint, so these runs need no FUSE provider and mount nothing. The
+// main() validates its mount flags before it opens libfuse or creates the
+// mountpoint, so these runs need no FUSE provider and mount nothing. The
 // checks cannot run in-process: main() reports a rejected flag by exiting.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
@@ -18,9 +18,14 @@ const decoder = new TextDecoder();
 /** Run the daemon entrypoint and capture how it exited. */
 async function runDaemon(
   args: string[],
-): Promise<{ code: number; stderr: string }> {
+  env: Record<string, string> = {},
+): Promise<{ code: number; stderr: string; stdout: string }> {
   const output = await runDenoCommandWithTemporaryLock({
     root: repoRoot,
+    // The child inherits this process's environment, and a mount reads
+    // CF_CFC_MODE from it. An empty value names no mode, so a run that names
+    // none gets none.
+    env: { CF_CFC_MODE: "", ...env },
     args: (lockPath) => [
       "run",
       `--lock=${lockPath}`,
@@ -32,7 +37,11 @@ async function runDaemon(
       ...args,
     ],
   });
-  return { code: output.code, stderr: decoder.decode(output.stderr) };
+  return {
+    code: output.code,
+    stderr: decoder.decode(output.stderr),
+    stdout: decoder.decode(output.stdout),
+  };
 }
 
 /** A mountpoint path the daemon must reject before ever creating. */
@@ -109,4 +118,85 @@ Deno.test("daemon accepts the cache flags it supports", async () => {
     assertEquals(code, 1, `expected usage exit for ${accepted.join(" ")}`);
     assertStringIncludes(stderr, "Usage: mod.ts <mountpoint>");
   }
+});
+
+Deno.test("daemon rejects an unrecognized --cfc-mode", async () => {
+  const mountpoint = unusedMountpoint();
+  const { code, stderr } = await runDaemon([
+    mountpoint,
+    "--cfc-mode=enforce-stricct",
+  ]);
+
+  assertEquals(code, 1);
+  assertStringIncludes(
+    stderr,
+    "--cfc-mode=enforce-stricct is not a CFC enforcement mode",
+  );
+  assertStringIncludes(
+    stderr,
+    "disabled, observe, enforce-explicit, enforce-strict",
+  );
+  assertEquals(existsSync(mountpoint), false);
+});
+
+Deno.test("daemon rejects an unrecognized CF_CFC_MODE", async () => {
+  const mountpoint = unusedMountpoint();
+  const { code, stderr } = await runDaemon(
+    [mountpoint],
+    { CF_CFC_MODE: "enforce-stricct" },
+  );
+
+  assertEquals(code, 1);
+  assertStringIncludes(
+    stderr,
+    "CF_CFC_MODE=enforce-stricct is not a CFC enforcement mode",
+  );
+  assertStringIncludes(
+    stderr,
+    "disabled, observe, enforce-explicit, enforce-strict",
+  );
+  assertEquals(existsSync(mountpoint), false);
+});
+
+Deno.test("daemon accepts the CFC modes on the ladder", async () => {
+  // Reaching the usage message proves the mode was accepted: it is reported
+  // only once the flags have parsed.
+  for (
+    const mode of [
+      "disabled",
+      "observe",
+      "enforce-explicit",
+      "enforce-strict",
+    ]
+  ) {
+    const { code, stderr } = await runDaemon([`--cfc-mode=${mode}`]);
+    assertEquals(code, 1, `expected usage exit for --cfc-mode=${mode}`);
+    assertStringIncludes(stderr, "Usage: mod.ts <mountpoint>");
+  }
+});
+
+Deno.test("a rejected mount flag reaches the parent on the status channel", async () => {
+  // A background mount's stderr goes nowhere its parent reads. `cf fuse mount`
+  // learns why a mount did not start from the supervisor status channel.
+  const statusPath = join(
+    Deno.makeTempDirSync({ prefix: "cf-fuse-cli-test-" }),
+    "supervisor-status.json",
+  );
+  const { code, stdout } = await runDaemon([
+    unusedMountpoint(),
+    `--supervisor-status=${statusPath}`,
+    "--cfc-mode=enforce-stricct",
+  ]);
+
+  assertEquals(code, 1);
+  const published = stdout.trim().split("\n").map((line) => JSON.parse(line));
+  assertEquals(published.at(-1)?.state, "failed");
+  assertStringIncludes(
+    String(published.at(-1)?.error),
+    "--cfc-mode=enforce-stricct is not a CFC enforcement mode",
+  );
+  assertStringIncludes(
+    String(JSON.parse(Deno.readTextFileSync(statusPath)).error),
+    "--cfc-mode=enforce-stricct is not a CFC enforcement mode",
+  );
 });


### PR DESCRIPTION
A mount reads its CFC enforcement mode from `--cfc-mode` and from `CF_CFC_MODE`. A name outside the four-rung ladder was refused from neither source. The flag printed a warning and carried on; the environment spelling said nothing at all. Both then fell through to `DEFAULT_CFC_ENFORCEMENT_MODE`, which is `disabled`. A misspelled `--cfc-mode=enforce-stricct` therefore left the mount on the weakest rung, and the warning said the opposite of what happened: it named the runner default, and the runner's construction default is `enforce-explicit`.

That mode gates every FUSE-side CFC decision, through the four `isCfcEnforcing` calls in `mod.ts` covering existing-file writes, creates, namespace mutations and metadata mutations. An operator who asked for enforcement and misspelled it got none, and was told the mount had fallen back to something stricter than it had.

`resolveCfcMode` now refuses a name the ladder does not hold, naming the offending value, the source that named it, and the accepted names; the mount reports the refusal and exits rather than mounting. Only the source that decides is checked: `--cfc-mode` decides when it names a mode and `CF_CFC_MODE` decides otherwise, so a stale environment variable does not veto a command line that named a valid mode, and there is nowhere to scrub that variable on the way, since no spawn site sets the child's environment. `packages/cf-harness/src/cli.ts` resolves its own enforcement mode the same way.

The private ladder and parser, `CFC_MODES` and `parseCfcMode`, are gone. `CFC_ENFORCEMENT_MODES` and `isCfcEnforcementMode`, exported from `packages/runner/src/cfc/mod.ts`, are now the one statement of what the accepted names are, and the refusal message reads the ladder from there rather than restating it. `resolveCfcMode` also drops its `runtimeMode` parameter, which no caller ever passed: `cfc-writeback.ts` is imported only from within `packages/fuse`, so the chain stated a rung of precedence that could not be reached.

A mount that names no mode anywhere still runs at
`DEFAULT_CFC_ENFORCEMENT_MODE`, `disabled`. The two defaults answer different questions. `DEFAULT_CFC_ENFORCEMENT_MODE` is the mode a field of this shape holds when nothing set it.
`RUNTIME_CFC_DIAL_DEFAULTS.cfcEnforcementMode`, `enforce-explicit`, is the mode a `Runtime` constructed without a stated dial runs at. A mount constructs no runtime, and the mode resolved here gates the mount's own writeback guardrails, so the first question is the one being asked. Moving the mount to `enforce-explicit` would turn fail-closed guardrails on for every mount that names no mode, which is a change to make deliberately and on its own rather than as a side effect of fixing a refusal.

Two neighbouring holes came out of reviewing this, and are fixed alongside.

A rejected mount flag reached no operator on any path `cf fuse mount` uses. Both the foreground and the background path pass `--log-file`, and the daemon's redirected `console.error` tees back to real stderr only when stderr is a terminal. A background mount is spawned with `stderr: "null"` at both hops, in `packages/cli/commands/fuse.ts` and in `packages/cli/lib/fuse-supervisor.ts`. So a background mount with a bad flag reported `Background FUSE process exited during startup`, naming neither the flag nor the log file holding the reason. The daemon already has a channel for this: `writeFailedSupervisorStartupStatus` records `failed` with the reason and announces it on the pipe the parent blocks on, and `awaitBackgroundMountStartup` reports whatever `error` the child published. The flag validation could not use it, because it ran before the status writer was built. The mountpoint and the supervisor status machinery now come first, and every rejected flag goes through one `failStartup` helper: the CFC mode, the CFC xattr namespace and the cache flags alike. The message still reaches stderr, so a foreground mount at a terminal reads as it did before.

The shell completion table in `packages/cli/lib/completion/static.ts` offered `off`, `warn` and `enforce` as the values for `--cfc-mode`. None of the three is a CFC enforcement mode, so completing the flag handed the operator a value the mount will not take. The table now reads `CFC_ENFORCEMENT_MODES`, which is the ladder the mount checks against.

The tests cover both spellings and the reporting channel. `packages/fuse/cfc-writeback.test.ts` checks that `resolveCfcMode` throws for an off-ladder name from the flag and from the environment, and that a valid flag still decides over an off-ladder environment. `packages/fuse/mount-cli.test.ts` runs the daemon entrypoint as a real process with each spelling, checks it exits reporting the name and the ladder, checks the refusal reaches a parent on the supervisor status channel and in the status file, and checks every name on the ladder is still accepted. That file also clears `CF_CFC_MODE` from the environment it hands the daemon: `Deno.Command` merges rather than replaces, so every daemon run had been inheriting whatever the test runner was started with, and with a bad value exported six of eight cases failed, the four cache-flag cases included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

