### PR TITLE
test(memory): read the lease expiry as a REAL in leaseRows

### DIFF
--- a/packages/memory/test/v2-execution-lease.test.ts
+++ b/packages/memory/test/v2-execution-lease.test.ts
@@ -9,7 +9,7 @@
 // succession (DR1), and the same-process residue is closed by the in-process
 // abort-before-reacquire discipline. A lease renewal is NEVER a commit.
 
-import { assert, assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertGreater, assertThrows } from "@std/assert";
 import { toFileUrl } from "@std/path";
 import { Database } from "@db/sqlite";
 import {
@@ -53,11 +53,17 @@ const setCommit = (localSeq: number, id: string): ClientCommit => ({
   operations: [{ op: "set", id, value: { value: { n: localSeq } } }],
 });
 
+/** Reads every lease row, with the expiry read through SQLite's REAL accessor. */
 const leaseRows = (
   engine: Engine,
 ): { space: string; holder: string; expires_at: number }[] =>
   engine.database.prepare(
-    `SELECT space, holder, expires_at FROM execution_lease ORDER BY space`,
+    // The engine's INTEGER accessor truncates to 32 bits; millisecond
+    // timestamps are exactly representable as REAL values. The synthetic-
+    // clock assertions (t0 = 1_000_000) fit in 32 bits either way; only a
+    // live-clock expiry needs the CAST to read back exactly.
+    `SELECT space, holder, CAST(expires_at AS REAL) AS expires_at
+     FROM execution_lease ORDER BY space`,
   ).all() as { space: string; holder: string; expires_at: number }[];
 
 const commitRows = (
@@ -561,6 +567,11 @@ Deno.test("replay: a byte-identical retry answers from the store after the lease
       holder,
       now: LIVE_NOW(),
     }));
+    // The live-clock expiry reads back as the real millisecond timestamp:
+    // leaseRows reads the column as a REAL, so this is not the low 32 bits
+    // of the epoch (which went negative on 2026-09-08 and flip sign every
+    // ~24.9 days).
+    assertGreater(leaseRows(engine)[0].expires_at, Date.now());
     const first = applyCommit(engine, {
       sessionId: holder,
       space: SPACE,


### PR DESCRIPTION
## Summary

Follow-up to #7081, which fixed the runner's `leaseExpiry` helper. The same latent hazard remained in the memory package's own lease test: `leaseRows(engine)` in `packages/memory/test/v2-execution-lease.test.ts` read `execution_lease.expires_at` raw through the engine's `@db/sqlite` connection, which is opened without `int64` and so hands JavaScript the low 32 bits of an INTEGER column. An epoch-millisecond expiry wraps, and its sign flips every 2^31 ms (about 24.9 days; it went negative 2026-09-08 07:51 UTC, next flip 2026-10-28).

It was safe only by accident: the two assertions that compare the value use a synthetic clock (`t0 = 1_000_000`, which fits in 32 bits), and no live-clock test asserted on the expiry. A future assertion on a live-clock lease would have silently seen the wrapped value.

`expires_at` is the only millisecond-timestamp INTEGER column in the v2 engine schema, and `read-pool.ts` already opens its pooled connections with `int64`, so this was the last raw reader.

## Fix

- `leaseRows` selects `CAST(expires_at AS REAL) AS expires_at` (exact for any millisecond timestamp), same return shape. The comment on the helper carries the mechanism, mirroring the runner's.
- One new assertion in the RELEASED replay test reads the row's expiry right after a `LIVE_NOW()` acquire and checks it is greater than `Date.now()`, the memory-package twin of the runner's `expiryAtStart` check. This pins the exact-read property with a real timestamp.

## Validation

- Instrument check: with the new assertion in place but the helper still raw, the test fails today with exactly the predicted shape, `AssertionError: Expect -2109228227 > 1788892119205`, and the other 601 tests pass (so the synthetic-clock assertions were never at risk).
- With the CAST: `cd packages/memory && deno task test` is 602 passed / 0 failed, matching main.
- `deno fmt --check` and `deno lint` clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

