### PR TITLE
fix(cli): bin/cf on PATH, the printed `$link` object as an argument, and a keyfile error naming its remedy

### DIFF
--- a/.claude/commands/deps.md
+++ b/.claude/commands/deps.md
@@ -1,6 +1,6 @@
 MUST HAVE:
 - deno 2, pinned in mise.toml — install via mise https://mise.jdx.dev/
-  (`mise trust && mise install` in the repo); a manually installed deno 2
+  (`mise install` in the repo); a manually installed deno 2
   within the `tasks/check.sh` range also works
 
 REALLY SHOULD HAVE:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,12 +104,13 @@ comments a pull request collects.
 
 ### Running the CLI
 
-The `cf` CLI runs from source through `bin/cf`, and `skills/cf/SKILL.md` covers
-invoking it. `deno task cf …` runs the same CLI from any directory inside the
-checkout and needs nothing on PATH, which makes it the spelling for a shell
-where `cf` is not found — the usual case in an agent's non-interactive shell.
-The two differ in one respect: `cf which`, which reports the checkout a `cf`
-would run, is answered by `bin/cf` alone.
+The `cf` CLI runs from source through `bin/cf`, which `deno task install-cf`
+puts on PATH once per machine, and `skills/cf/SKILL.md` covers invoking it.
+`deno task cf …` runs the same CLI from any directory inside the checkout and
+needs nothing on PATH, which makes it the spelling for a shell where `cf` is not
+found, as an agent's non-interactive shell is on a machine that never ran the
+install. The two differ in one respect: `cf which`, which reports the checkout a
+`cf` would run, is answered by `bin/cf` alone.
 
 ### Avoid timeouts, retry loops, and sleeps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,12 @@ there to what your task needs.
 When authoring or reviewing a skill itself, read
 `docs/development/skill-authoring.md` and `docs/development/skill-audit.md`.
 
+The `cf` CLI runs from source through `bin/cf`, and `skills/cf/SKILL.md` covers
+invoking it. An agent's non-interactive shell has usually not run the mise hook
+that puts `bin` on PATH, so `cf` is not found there until the checkout's `bin`
+is prepended to PATH; `deno task cf` also works from anywhere inside the
+checkout.
+
 For reading or changing Topics on Estuary, use `skills/topics/SKILL.md`.
 
 ### Runtime Development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,15 @@ is not a substitute for it.
 `docs/development/pr-review-comments.md` covers reading and answering the review
 comments a pull request collects.
 
+### Running the CLI
+
+The `cf` CLI runs from source through `bin/cf`, and `skills/cf/SKILL.md` covers
+invoking it. `deno task cf …` runs the same CLI from any directory inside the
+checkout and needs nothing on PATH, which makes it the spelling for a shell
+where `cf` is not found — the usual case in an agent's non-interactive shell.
+The two differ in one respect: `cf which`, which reports the checkout a `cf`
+would run, is answered by `bin/cf` alone.
+
 ### Avoid timeouts, retry loops, and sleeps
 
 Timeouts cause flakiness because they put an upper bound on success: anything
@@ -136,12 +145,6 @@ there to what your task needs.
 
 When authoring or reviewing a skill itself, read
 `docs/development/skill-authoring.md` and `docs/development/skill-audit.md`.
-
-The `cf` CLI runs from source through `bin/cf`, and `skills/cf/SKILL.md` covers
-invoking it. An agent's non-interactive shell has usually not run the mise hook
-that puts `bin` on PATH, so `cf` is not found there until the checkout's `bin`
-is prepended to PATH; `deno task cf` also works from anywhere inside the
-checkout.
 
 For reading or changing Topics on Estuary, use `skills/topics/SKILL.md`.
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,10 @@ can run their own spaces or use hosted versions.
 1. Install [mise](https://mise.jdx.dev/getting-started.html) and activate it in
    your shell
 2. Clone this repo
-3. Run `mise trust && mise install` in the repo to install the pinned Deno
-   version
+3. Run `mise install` in the repo to install the pinned Deno version
 4. Install the Git hooks: `deno task install-hooks` (optional)
-   - mise puts this checkout's `bin/` on PATH, so `cf` works as a plain command.
-     Without mise: `deno task install-cf`. Shell completion needs it — see
+   - Put `cf` on PATH once: `deno task install-cf`. The copy it installs serves
+     every checkout, and shell completion needs it — see
      [Installing `cf` on PATH](./packages/cli/README.md#installing-cf-on-path).
 5. Start local dev servers: `./scripts/start-local-dev.sh`
 6. Access the application at <http://localhost:8000>

--- a/bin/cf
+++ b/bin/cf
@@ -6,9 +6,8 @@
 # is silently dead for anyone without a `cf` on PATH — including for
 # `deno task cf <TAB>`, since the same function services the `deno` binding.
 #
-# Two ways to pick this up, neither of which needs the binary built:
-#   - mise users get it automatically (`_.path` in mise.toml)
-#   - everyone else: deno task install-cf
+# Pick it up with `deno task install-cf`, which copies this file to a directory
+# on PATH: that needs no binary built, and one copy serves every checkout.
 #
 # Runs from source, so it never goes stale against the checkout. `dist/cf` is
 # deliberately not used here — see "Why not dist/cf" in packages/cli/README.md.
@@ -30,8 +29,8 @@ set -e
 #      to it fall through to their own checkout. Neither applies while you are
 #      inside a checkout, which is the overwhelmingly common case.
 #
-# This mirrors what mise already does for route 2 (`_.path` resolves relative
-# to the mise.toml declaring it), so all install routes agree.
+# Route 2 is what lets one installed copy serve every checkout: the copy has no
+# checkout of its own, and the directory you stand in decides.
 
 # Rewritten by scripts/install-cf.sh when it installs a copy. Empty here: the
 # in-repo file is reached through a checkout by definition.

--- a/bin/cfsh
+++ b/bin/cfsh
@@ -9,9 +9,8 @@
 # vendored labs, symlinks walked by hand because `readlink -f` is not on a
 # stock macOS -- and it would drift.
 #
-# Two ways to pick this up, the same two `cf` has:
-#   - mise users get it automatically (`_.path` in mise.toml)
-#   - everyone else: `deno task install-cf`, which installs this beside `cf`
+# Pick it up the way `cf` is picked up: `deno task install-cf` installs this
+# beside `cf`.
 #
 # Being a forward is also what lets a copy of this file work anywhere: it finds
 # `cf` by name, so it depends on PATH and on nothing about where it sits.
@@ -20,8 +19,7 @@ set -e
 
 if ! command -v cf >/dev/null 2>&1; then
   echo "cfsh: no \`cf\` on PATH, and \`cf sh\` is what this runs." >&2
-  echo "    Put one there with 'deno task install-cf' from a labs checkout," >&2
-  echo "    or let mise do it (it adds each checkout's bin/ to PATH)." >&2
+  echo "    Put one there with 'deno task install-cf' from a labs checkout." >&2
   exit 127
 fi
 

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -778,7 +778,10 @@ alike, and nothing in the output could tell one item from two.
 
 That spelling — the address exactly as a read printed it — dispatches where
 the verb declares a reference, and the edge that lands is the target rather
-than a copy. The dispatch gate reads the DECLARED contract
+than a copy. So does the `{"$link": …}` object a marked read renders the
+address in, alone or beside contents the same read projected: the address
+inside is what the position takes, and those contents, the target's own
+fields, are not sent. The dispatch gate reads the DECLARED contract
 ([verb input contract](../../history/plans/verb-input-contract.md)) to know
 which positions declare references, and the same contract refuses the two
 payloads that could only ever be mistakes at one:

--- a/docs/common/verbs/the-verb-session.md
+++ b/docs/common/verbs/the-verb-session.md
@@ -608,7 +608,9 @@ $ cf piece call -s demo /of:fid1:SKf22px…N5UfM blockOn --on /of:fid1:d4ppvfP�
 ```
 
 The `on` address that came back is `d4ppvfP…Pqsls` — the same string that went
-in. What landed is an *edge to that item*, not a copy of its contents.
+in. What landed is an *edge to that item*, not a copy of its contents. It would
+go in again either way: as that bare string, or inside the `{"$link": …}`
+object the read printed it in, which the gate reads as the address it carries.
 
 Two payloads could only ever be mistakes at a position like this, and both are
 refused by name.

--- a/docs/plans/references-as-arguments.md
+++ b/docs/plans/references-as-arguments.md
@@ -100,6 +100,7 @@ At the CLI that table now reads:
 | --- | --- |
 | the address a read emits (`/of:…`) | converted to the link envelope; the edge lands on the target |
 | the runtime link envelope | accepted (#5880); the edge lands on the target |
+| the `{"$link": "/of:…"}` object a marked read renders, alone or with projected contents beside it | converted as the address inside it; the edge lands on the target |
 | a string in no address form | refused naming the position and the `/of:…` form |
 | a literal shape-matching object | refused — an inline copy would store a detached document |
 

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -224,7 +224,7 @@ invisible, the prompt renders the whole ambient record — place and scope
     whichever checkout `bin/cf` resolved from the working directory. The
     forward carries no checkout logic of its own — `exec` leaves the working
     directory alone, so both hops mean the same checkout — and it finds `cf`
-    by name, where mise and `install-cf` put it. `install-cf` installs
+    by name, where `install-cf` put it. `install-cf` installs
     `cfsh` beside `cf`, without which the spelling this decision settles on
     is one nobody has on their PATH.
 20. **Scope is the cwd's second dimension.** Per-identity overlays

--- a/mise.toml
+++ b/mise.toml
@@ -1,12 +1,9 @@
 [tools]
 deno = "2.9.4"
 
-# Puts this checkout's `bin/cf` on PATH, so `cf` resolves to the worktree you
-# are standing in. Shell completion needs a `cf` on PATH to work at all — see
+# The pin is all this file does. A tools-only file loads without `mise trust`,
+# so a fresh worktree needs no step before `deno` resolves. `cf` on PATH is
+# `deno task install-cf`, once per machine, for mise users and everyone else:
+# an `[env]` entry here would reach only shells whose mise hook ran for this
+# directory, and would need the trust prompt in every new worktree. See
 # "Installing cf on PATH" in packages/cli/README.md.
-#
-# mise is not guaranteed (README.md blesses a direct Deno install, and
-# tasks/check.sh only reads the pin out of this file), so this is a convenience
-# for mise users, not the mechanism. Non-mise users symlink bin/cf themselves.
-[env]
-_.path = ["bin"]

--- a/packages/cf-harness/ONBOARDING.md
+++ b/packages/cf-harness/ONBOARDING.md
@@ -45,10 +45,10 @@ first run does without.
    deno --version
    ```
 
-   Success is a version matching the pin. For `mise` users: a fresh checkout or
-   worktree is untrusted, so `mise where deno` fails until you run `mise trust`
-   in it. Either trust it, or skip the shims and put the install on `PATH`
-   directly:
+   Success is a version matching the pin. For `mise` users: the repo's
+   `mise.toml` pins Deno and nothing else, so a fresh checkout or worktree
+   resolves it with no `mise trust` step. To skip the shims, put the install on
+   `PATH` directly:
 
    ```sh
    export PATH="$HOME/.local/share/mise/installs/deno/<pinned-version>/bin:$PATH"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1516,7 +1516,7 @@ does not strand it.
 
 Several checkouts coexisting is normal — worktrees, and a vendored labs inside
 another repo (a supported, tested layout: see `test/launcher.test.ts`). So the
-symlink above does **not** pin `cf` to the checkout you installed it from. It
+copy above does **not** pin `cf` to the checkout you installed it from. It
 selects, in order:
 
 1. **`$CF_LABS_ROOT`**, when set — the explicit override for when your cwd

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1484,19 +1484,19 @@ itself, and local runs of those same scripts set `CF_CLI_INTEGRATION_USE_LOCAL`
 to force the source CLI.)
 
 `bin/cf` is the install, with `bin/cfsh` beside it for the interactive shell.
-Both run from source, so neither goes stale against the checkout:
+Both run from source, so neither goes stale against the checkout. One route,
+once per machine, mise or not:
 
 ```bash
-# mise users: nothing to do. mise.toml puts this checkout's bin/ on PATH.
-mise trust    # only if this checkout has not been trusted yet
-
-# everyone else (mise is recommended in README.md but not required):
 deno task install-cf              # --dry-run to see what it would do
 ```
 
-The mise route depends on mise's hook having applied `_.path` for this
-directory, which an agent's non-interactive shell has usually not seen. There,
-`deno task cf` needs nothing on PATH.
+It is a real file in a directory on PATH, so every shell sees it: a login shell,
+an agent's non-interactive one, `make`, an editor's task runner. The repo's
+`mise.toml` pins Deno and declares no PATH entry, since a per-directory entry
+reaches only shells whose mise hook ran for that directory and needs
+`mise trust` in every new worktree. Where `cf` is not on PATH at all,
+`deno task cf` runs the same CLI and needs nothing.
 
 `install-cf` copies `bin/cf` and `bin/cfsh` to a directory already on your PATH
 — refusing to guess if there isn't one, since installing somewhere unreachable
@@ -1554,11 +1554,10 @@ is always `packages/cli/mod.ts`, which _is_ the CLI (it ends in
 `if (import.meta.main)` and nothing outside `packages/cli/` imports it as a
 library).
 
-Rule 2 is what mise already does for its route (`_.path` resolves relative to
-the `mise.toml` declaring it), so both install routes agree on which checkout
-you get. The consequence worth knowing: `cf` inside checkout B runs B's code
-even though you installed the link from A. That is the point, but it means a
-stack trace is the quickest way to confirm which checkout answered.
+Rule 2 is what lets one installed copy serve every checkout. The consequence
+worth knowing: `cf` inside checkout B runs B's code even though you installed
+the copy from A. That is the point, but it means a stack trace is the quickest
+way to confirm which checkout answered.
 
 ### Why not `dist/cf`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1494,6 +1494,10 @@ mise trust    # only if this checkout has not been trusted yet
 deno task install-cf              # --dry-run to see what it would do
 ```
 
+The mise route depends on the mise hook having run for this directory, which an
+agent's non-interactive shell usually has not. There, prepend the checkout's
+`bin` to PATH, or use `deno task cf`.
+
 `install-cf` copies `bin/cf` and `bin/cfsh` to a directory already on your PATH
 — refusing to guess if there isn't one, since installing somewhere unreachable
 would reproduce the silent failure this exists to prevent. A copy rather than a

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1494,9 +1494,9 @@ mise trust    # only if this checkout has not been trusted yet
 deno task install-cf              # --dry-run to see what it would do
 ```
 
-The mise route depends on the mise hook having run for this directory, which an
-agent's non-interactive shell usually has not. There, prepend the checkout's
-`bin` to PATH, or use `deno task cf`.
+The mise route depends on mise's hook having applied `_.path` for this
+directory, which an agent's non-interactive shell has usually not seen. There,
+`deno task cf` needs nothing on PATH.
 
 `install-cf` copies `bin/cf` and `bin/cfsh` to a directory already on your PATH
 — refusing to guess if there isn't one, since installing somewhere unreachable

--- a/packages/cli/commands/completion.ts
+++ b/packages/cli/commands/completion.ts
@@ -38,7 +38,7 @@ REQUIRES '${cliName()}' ON PATH:
   The installed function calls '${cliName()} completion complete' on every Tab,
   and swallows its errors, so without a '${cliName()}' on PATH completion
   silently yields nothing — including for "deno task ${cliName()} <TAB>".
-  mise puts the checkout's bin/ on PATH; otherwise symlink bin/${cliName()}.
+  Put one there once with 'deno task install-cf'.
   See "Installing ${cliName()} on PATH" in packages/cli/README.md.
 
 INSTALL (zsh), in ~/.zshrc after compinit:

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -436,6 +436,18 @@ else
     --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
     jq -r '.[2]["$link"] // empty')
   check "$OTHER" "$EDGE3" "and its edge is the target, not a copy"
+  # The same object with the contents the read projected beside the address,
+  # which is what a `--select @,title` row looks like. The address is what the
+  # position takes; the title beside it is not the target's, so a stored copy
+  # would read differently from the edge.
+  BLOCKED4=$($CF piece call --quiet --piece "$KID" $ARGS \
+    blockOn "{\"on\":{\"\$link\":\"$OTHER\",\"title\":\"a projected copy\"}}" 2>/dev/null)
+  check "4" "$(echo "$BLOCKED4" | jq -r '.result.blockedOnCount // empty')" \
+    "the \$link object with projected contents beside it dispatches as the address"
+  EDGE4=$($CF cell get --quiet --piece "$KID" blockedOn $ARGS \
+    --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
+    jq -r '.[3]["$link"] // empty')
+  check "$OTHER" "$EDGE4" "and its edge is the target, not the copy beside the address"
   # The refusals guarding the same position, each matched against its
   # SPECIFIC message: a renamed verb or a server hiccup also exits nonzero,
   # and a probe that reads any failure as the refusal is a probe that cannot

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -388,7 +388,7 @@ V=$($CF piece call --quiet --piece "$KID" $ARGS archive '{}' 2>/dev/null)
 check "settled" "$(echo "$V" | jq -r '.status')" "archive settled"
 check "{}" "$(echo "$V" | jq -c '.result // {}')" "its result is the empty witness"
 
-step "10. A reference argument dispatches — the envelope, and the address as emitted"
+step "10. A reference argument dispatches — the envelope, the address as emitted, and the object a read renders it in"
 # blockOn declares `on: Writable<ItemOutput>` — a reference. #5880 landed the
 # ENVELOPE spelling: a link envelope in that position passes the gate and the
 # edge that comes back is the target, not a copy. The round-trip spelling
@@ -426,6 +426,16 @@ else
     --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
     jq -r '.[1]["$link"] // empty')
   check "$OTHER" "$EDGE2" "and its edge is the target, not a copy"
+  # The rendered spelling: the same address inside the `{"$link": …}` object
+  # a marked read prints it in, fed back as that object.
+  BLOCKED3=$($CF piece call --quiet --piece "$KID" $ARGS \
+    blockOn "{\"on\":{\"\$link\":\"$OTHER\"}}" 2>/dev/null)
+  check "3" "$(echo "$BLOCKED3" | jq -r '.result.blockedOnCount // empty')" \
+    "the \$link object a marked read renders, fed back as printed, dispatches"
+  EDGE3=$($CF cell get --quiet --piece "$KID" blockedOn $ARGS \
+    --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
+    jq -r '.[2]["$link"] // empty')
+  check "$OTHER" "$EDGE3" "and its edge is the target, not a copy"
   # The refusals guarding the same position, each matched against its
   # SPECIFIC message: a renamed verb or a server hiccup also exits nonzero,
   # and a probe that reads any failure as the refusal is a probe that cannot

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -45,6 +45,7 @@ import {
   type CellSelection,
   CellSelectionError,
   deriveSelectedValue,
+  LINK_MARKER_KEY,
 } from "./cell-selection.ts";
 import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
 import type { ExecCommandSpec } from "./exec-schema.ts";
@@ -460,6 +461,17 @@ function carriesCellMarker(node: Record<string, unknown>): boolean {
   return node.asCell !== undefined || node.asStream !== undefined;
 }
 
+/** The address inside the `{"$link": "/of:…"}` object a marked read renders
+ * (`composeLinkAddresses`, cell-selection.ts), whether the address stands
+ * alone there or the contents the same read projected sit beside it.
+ * `undefined` for every other value, a `$link` holding no string included:
+ * `{"$link": true}` is the projection-schema marker, not an address. */
+function printedAddressOf(value: unknown): string | undefined {
+  if (!isObjectNotArray(value)) return undefined;
+  const address = (value as Record<string, unknown>)[LINK_MARKER_KEY];
+  return typeof address === "string" ? address : undefined;
+}
+
 /**
  * The first field the payload carries that the schema at its position does not
  * declare, walking the PAYLOAD (finite JSON the caller supplied, so the walk
@@ -872,7 +884,11 @@ export function verbInputSchemaError(
  * event schema keeps and a link-derived dispatch schema does not, see
  * `CallableResolution.declaredEvent` — a string holding the address a read
  * emits (`/of:…`, the canonical fabric reference) converts to the link
- * envelope dispatch already accepts.
+ * envelope dispatch already accepts. So does the `{"$link": "/of:…"}` object
+ * a marked read renders that address in, alone or joined by the contents the
+ * same read projected: the address inside is what the position takes, and
+ * the contents beside it are the target's own fields, which a reference
+ * never stores.
  * An address printed by one command is now a verb argument in the next,
  * which is the property the CLI surface states for commands, one level in.
  *
@@ -909,10 +925,11 @@ export function resolveEmittedAddressArguments(
   // authored cell wrapper was declared, so the pre-resolution node is
   // checked as well as the target.
   if (!atRoot && (carriesCellMarker(schema) || carriesCellMarker(node))) {
-    if (typeof value === "string") {
+    const spelled = printedAddressOf(value) ?? value;
+    if (typeof spelled === "string") {
       let parsed: NormalizedLLMFriendlyRef | undefined;
       try {
-        parsed = normalizeLLMFriendlyRef(value);
+        parsed = normalizeLLMFriendlyRef(spelled);
       } catch {
         parsed = undefined;
       }
@@ -926,7 +943,8 @@ export function resolveEmittedAddressArguments(
       ) {
         return {
           value,
-          refusal: `${JSON.stringify(value)} at ${path} is not an address — ` +
+          refusal:
+            `${JSON.stringify(spelled)} at ${path} is not an address — ` +
             `the position declares a reference, and takes the /of:… form ` +
             `a read prints`,
         };

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -461,11 +461,13 @@ function carriesCellMarker(node: Record<string, unknown>): boolean {
   return node.asCell !== undefined || node.asStream !== undefined;
 }
 
-/** The address inside the `{"$link": "/of:…"}` object a marked read renders
+/**
+ * The address inside the `{"$link": "/of:…"}` object a marked read renders
  * (`composeLinkAddresses`, cell-selection.ts), whether the address stands
  * alone there or the contents the same read projected sit beside it.
  * `undefined` for every other value, a `$link` holding no string included:
- * `{"$link": true}` is the projection-schema marker, not an address. */
+ * `{"$link": true}` is the projection-schema marker, not an address.
+ */
 function printedAddressOf(value: unknown): string | undefined {
   if (!isObjectNotArray(value)) return undefined;
   const address = (value as Record<string, unknown>)[LINK_MARKER_KEY];

--- a/packages/cli/lib/completion/install-check.ts
+++ b/packages/cli/lib/completion/install-check.ts
@@ -80,8 +80,8 @@ export function missingCommandWarning(name: string): string {
     `         silently do nothing — it calls '${name} completion complete' on`,
     `         every Tab, and that failure is swallowed by design.`,
     ``,
-    `  mise users: already handled by mise.toml; run 'mise trust' in the repo.`,
-    `  otherwise:  ${link}`,
+    `  Put one there once: deno task install-cf`,
+    `  or by hand:         ${link}`,
     ``,
     `  See "Installing ${name} on PATH" in packages/cli/README.md.`,
   ].join("\n");

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -15,6 +15,7 @@ import {
   verbRunsWithoutPayload,
 } from "./callable.ts";
 import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
+import { shellQuote } from "./shell-quote.ts";
 import {
   firstReadOption,
   projectionInSectionRefusal,
@@ -121,10 +122,6 @@ function schemaType(schema: JSONSchema): string | undefined {
 
 function flagNameForKey(key: string): string {
   return key.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function displayCommandPath(path: string): string {

--- a/packages/cli/lib/identity.ts
+++ b/packages/cli/lib/identity.ts
@@ -1,5 +1,6 @@
 import { Identity } from "@commonfabric/identity";
 import { decode } from "@commonfabric/utils/encoding";
+import { dirname } from "@std/path";
 import { cliText } from "./cli-name.ts";
 
 export async function pkcs8FromPassphrase(
@@ -27,7 +28,9 @@ export async function pkcs8FromEntropy(): Promise<string> {
 /**
  * A keyfile `cf` was pointed at yields no identity: the path does not exist,
  * cannot be read, or does not hold a key. The message names the path, what is
- * wrong with it, and what to do, and carries nothing from inside the file: the
+ * wrong with it, and what to do — for a path that does not exist, a line that
+ * creates the directory as well as the file, since a teammate who has never
+ * provisioned a key has neither — and carries nothing from inside the file: the
  * key decoder quotes the bytes it failed on in its own message, and a keyfile
  * that is merely corrupt may still be most of a private key, so that message
  * is not forwarded.
@@ -60,7 +63,9 @@ async function identityFromKeyfile(
         path,
         "does not exist",
         `${POINT_AT} an existing keyfile, or create one there with ` +
-          `\`${cliText("cf id new")} > ${path}\`.`,
+          `\`mkdir -p '${dirname(path)}' && ${
+            cliText("cf id new")
+          } > '${path}'\`.`,
       );
     }
     const reason = error instanceof Error ? error.message : String(error);

--- a/packages/cli/lib/identity.ts
+++ b/packages/cli/lib/identity.ts
@@ -2,6 +2,7 @@ import { Identity } from "@commonfabric/identity";
 import { decode } from "@commonfabric/utils/encoding";
 import { dirname } from "@std/path";
 import { cliText } from "./cli-name.ts";
+import { shellQuote } from "./shell-quote.ts";
 
 export async function pkcs8FromPassphrase(
   passphrase: string,
@@ -63,9 +64,9 @@ async function identityFromKeyfile(
         path,
         "does not exist",
         `${POINT_AT} an existing keyfile, or create one there with ` +
-          `\`mkdir -p '${dirname(path)}' && ${
+          `\`mkdir -p ${shellQuote(dirname(path))} && ${
             cliText("cf id new")
-          } > '${path}'\`.`,
+          } > ${shellQuote(path)}\`.`,
       );
     }
     const reason = error instanceof Error ? error.message : String(error);

--- a/packages/cli/lib/identity.ts
+++ b/packages/cli/lib/identity.ts
@@ -1,5 +1,6 @@
 import { Identity } from "@commonfabric/identity";
 import { decode } from "@commonfabric/utils/encoding";
+import { cliText } from "./cli-name.ts";
 
 export async function pkcs8FromPassphrase(
   passphrase: string,
@@ -23,15 +24,73 @@ export async function pkcs8FromEntropy(): Promise<string> {
   return decode(await Identity.generatePkcs8());
 }
 
+/**
+ * A keyfile `cf` was pointed at yields no identity: the path does not exist,
+ * cannot be read, or does not hold a key. The message names the path, what is
+ * wrong with it, and what to do, and carries nothing from inside the file: the
+ * key decoder quotes the bytes it failed on in its own message, and a keyfile
+ * that is merely corrupt may still be most of a private key, so that message
+ * is not forwarded.
+ *
+ * Reported as a data error (stderr, exit 1) rather than a Cliffy usage error:
+ * the option parsed fine, the path it carries does not yield a key.
+ */
+export class IdentityKeyfileError extends Error {
+  constructor(
+    readonly path: string,
+    readonly problem: string,
+    readonly remedy: string,
+  ) {
+    super(`Identity keyfile ${path} ${problem}. ${remedy}`);
+    this.name = "IdentityKeyfileError";
+  }
+}
+
+const POINT_AT = "Point --identity or CF_IDENTITY at";
+
+async function identityFromKeyfile(
+  path: string,
+): Promise<Identity<`did:key:${string}`>> {
+  let pkcs8: Uint8Array;
+  try {
+    pkcs8 = await Deno.readFile(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new IdentityKeyfileError(
+        path,
+        "does not exist",
+        `${POINT_AT} an existing keyfile, or create one there with ` +
+          `\`${cliText("cf id new")} > ${path}\`.`,
+      );
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new IdentityKeyfileError(
+      path,
+      `cannot be read (${reason})`,
+      `${POINT_AT} a readable keyfile.`,
+    );
+  }
+  try {
+    return await Identity.fromPkcs8(pkcs8);
+  } catch {
+    throw new IdentityKeyfileError(
+      path,
+      "does not hold an Ed25519 PKCS#8 key",
+      `${POINT_AT} a keyfile written by \`${cliText("cf id new")}\`, ` +
+        `\`${cliText("cf id derive")}\`, or ` +
+        `\`${cliText("cf id from-mnemonic")}\`.`,
+    );
+  }
+}
+
 export async function getDidFromFile(
   keypath: string,
 ): Promise<`did:key:${string}`> {
-  const keyBuffer = await Deno.readFile(keypath);
-  return (await Identity.fromPkcs8(keyBuffer)).did();
+  return (await identityFromKeyfile(keypath)).did();
 }
 
-export async function loadIdentity(
+export function loadIdentity(
   filepath: string,
 ): Promise<Identity<`did:key:${string}`>> {
-  return Identity.fromPkcs8(await Deno.readFile(filepath));
+  return identityFromKeyfile(filepath);
 }

--- a/packages/cli/lib/shell-quote.ts
+++ b/packages/cli/lib/shell-quote.ts
@@ -1,0 +1,8 @@
+/**
+ * `value` as one POSIX shell word: single-quoted, with each `'` inside it
+ * closed, escaped, and reopened, so a line that carries a path a person will
+ * paste stays one argument whatever the path holds.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -8,20 +8,22 @@ import { parse } from "./commands/mod.ts";
 import { VerbInputValidationError } from "./lib/callable.ts";
 import { cliName } from "./lib/cli-name.ts";
 import { applyColorMode } from "./lib/color-mode.ts";
+import { IdentityKeyfileError } from "./lib/identity.ts";
 import { reservesStdoutForCommandOutput } from "./lib/json-output.ts";
 import { applyLogLevel } from "./lib/log-level.ts";
 
 /**
  * The value to print for a top-level CLI failure. Validation, transformer,
- * compiler, verb-input, and slug errors carry user-facing messages, so print
- * those without a stack trace. Other Errors print their stack, falling back
- * to the message. Anything else prints as-is.
+ * compiler, verb-input, slug, and identity-keyfile errors carry user-facing
+ * messages, so print those without a stack trace. Other Errors print their
+ * stack, falling back to the message. Anything else prints as-is.
  */
 export function renderCliError(e: unknown): unknown {
   if (
     e instanceof ValidationError || e instanceof TransformerError ||
     e instanceof CompilerError || e instanceof VerbInputValidationError ||
-    e instanceof SlugResolutionError || e instanceof SlugAssignedError
+    e instanceof SlugResolutionError || e instanceof SlugAssignedError ||
+    e instanceof IdentityKeyfileError
   ) {
     return e.message;
   }

--- a/packages/cli/test/completion-install-check.test.ts
+++ b/packages/cli/test/completion-install-check.test.ts
@@ -112,7 +112,7 @@ Deno.test("the warning names the failure and both installs", () => {
   const warning = missingCommandWarning("cf");
   assertStringIncludes(warning, "not on your PATH");
   assertStringIncludes(warning, "cf completion complete");
-  assertStringIncludes(warning, "mise");
+  assertStringIncludes(warning, "deno task install-cf");
   assertStringIncludes(warning, "ln -s");
 });
 

--- a/packages/cli/test/identity.test.ts
+++ b/packages/cli/test/identity.test.ts
@@ -45,9 +45,25 @@ describe("identity", () => {
       const error = await failureOf(loadIdentity(path));
       expect(error.message).toContain(
         `Identity keyfile ${path} does not exist. Point --identity or ` +
-          "CF_IDENTITY at an existing keyfile, or create one there with `",
+          "CF_IDENTITY at an existing keyfile, or create one there with " +
+          `\`mkdir -p '${dir}' && `,
       );
-      expect(error.message).toContain(`id new > ${path}\`.`);
+      expect(error.message).toContain(`id new > '${path}'\`.`);
+    });
+
+    it("names a keyfile whose directory does not exist, with a remedy that creates it", async () => {
+      // The default keyfile lives under a directory a teammate who has never
+      // provisioned a key does not have; a remedy that only writes the file
+      // fails on the very machine it is written for.
+
+      const below = `${dir}/never/made`;
+      const path = `${below}/identity.key`;
+      const error = await failureOf(loadIdentity(path));
+      expect(error.message).toContain(
+        `Identity keyfile ${path} does not exist.`,
+      );
+      expect(error.message).toContain(`\`mkdir -p '${below}' && `);
+      expect(error.message).toContain(`id new > '${path}'\`.`);
     });
 
     it("names a path that cannot be read, with the system's reason", async () => {

--- a/packages/cli/test/identity.test.ts
+++ b/packages/cli/test/identity.test.ts
@@ -66,6 +66,21 @@ describe("identity", () => {
       expect(error.message).toContain(`id new > '${path}'\`.`);
     });
 
+    it("quotes the remedy's paths as shell words, an apostrophe included", async () => {
+      // The remedy is a line a person pastes. A path holding a quote character
+      // must still reach `mkdir` and the redirect as one argument each.
+
+      const below = `${dir}/o'brien`;
+      const path = `${below}/identity.key`;
+      const error = await failureOf(loadIdentity(path));
+      expect(error.message).toContain(
+        `\`mkdir -p '${dir}/o'\\''brien' && `,
+      );
+      expect(error.message).toContain(
+        `id new > '${dir}/o'\\''brien/identity.key'\`.`,
+      );
+    });
+
     it("names a path that cannot be read, with the system's reason", async () => {
       // A directory is the deterministic case: it exists, and reading it as
       // a file fails everywhere, unlike a permission bit that root ignores.

--- a/packages/cli/test/identity.test.ts
+++ b/packages/cli/test/identity.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import {
+  getDidFromFile,
+  IdentityKeyfileError,
+  loadIdentity,
+  pkcs8FromEntropy,
+} from "../lib/identity.ts";
+
+describe("identity", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await Deno.makeTempDir({ prefix: "cf-identity-" });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(dir, { recursive: true });
+  });
+
+  /** A keyfile as `cf id new > path` writes one, and the DID it holds. */
+  async function writeKeyfile(path: string): Promise<string> {
+    const pkcs8 = await pkcs8FromEntropy();
+    await Deno.writeTextFile(path, pkcs8);
+    const identity = await Identity.fromPkcs8(new TextEncoder().encode(pkcs8));
+    return identity.did();
+  }
+
+  async function failureOf(work: Promise<unknown>): Promise<Error> {
+    const outcome = await work.then(() => undefined, (error: unknown) => error);
+    expect(outcome).toBeInstanceOf(IdentityKeyfileError);
+    return outcome as Error;
+  }
+
+  describe("loadIdentity()", () => {
+    it("loads the identity a keyfile holds", async () => {
+      const path = `${dir}/identity.key`;
+      const did = await writeKeyfile(path);
+      expect((await loadIdentity(path)).did()).toBe(did);
+    });
+
+    it("names a missing keyfile by path, with how to create one there", async () => {
+      const path = `${dir}/missing.key`;
+      const error = await failureOf(loadIdentity(path));
+      expect(error.message).toContain(
+        `Identity keyfile ${path} does not exist. Point --identity or ` +
+          "CF_IDENTITY at an existing keyfile, or create one there with `",
+      );
+      expect(error.message).toContain(`id new > ${path}\`.`);
+    });
+
+    it("names a path that cannot be read, with the system's reason", async () => {
+      // A directory is the deterministic case: it exists, and reading it as
+      // a file fails everywhere, unlike a permission bit that root ignores.
+
+      const error = await failureOf(loadIdentity(dir));
+      expect(error.message).toContain(
+        `Identity keyfile ${dir} cannot be read (`,
+      );
+      expect(error.message).toContain(
+        "Point --identity or CF_IDENTITY at a readable keyfile.",
+      );
+    });
+
+    it("names a file that holds no key, and forwards nothing from inside it", async () => {
+      const path = `${dir}/garbage.key`;
+      await Deno.writeTextFile(path, "\u0001\u0002not-a-key");
+      const error = await failureOf(loadIdentity(path));
+      expect(error.message).toContain(
+        `Identity keyfile ${path} does not hold an Ed25519 PKCS#8 key. ` +
+          "Point --identity or CF_IDENTITY at a keyfile written by `",
+      );
+      expect(error.message).toContain("id from-mnemonic`.");
+      expect(error.message).not.toContain("not-a-key");
+    });
+  });
+
+  describe("getDidFromFile()", () => {
+    it("returns the DID of the key a file holds", async () => {
+      const path = `${dir}/identity.key`;
+      const did = await writeKeyfile(path);
+      expect(await getDidFromFile(path)).toBe(did);
+    });
+
+    it("reports a missing keyfile as loadIdentity does", async () => {
+      const path = `${dir}/missing.key`;
+      const error = await failureOf(getDidFromFile(path));
+      expect(error.message).toContain(
+        `Identity keyfile ${path} does not exist.`,
+      );
+    });
+  });
+});

--- a/packages/cli/test/render-cli-error.test.ts
+++ b/packages/cli/test/render-cli-error.test.ts
@@ -3,6 +3,7 @@ import { CompilerError, TransformerError } from "@commonfabric/js-compiler";
 import { SlugAssignedError } from "@commonfabric/piece";
 import { SlugResolutionError } from "@commonfabric/runner";
 import { ValidationError } from "@cliffy/command";
+import { IdentityKeyfileError } from "../lib/identity.ts";
 import { renderCliError } from "../mod.ts";
 
 Deno.test("renderCliError prints a TransformerError's message, not its stack", () => {
@@ -36,6 +37,18 @@ Deno.test("renderCliError prints a SlugAssignedError's message, not its stack", 
   // take it anyway. Without this the class falls through to the plain-Error
   // arm below and every such refusal reaches the operator as a stack.
   const e = new SlugAssignedError("top", "/of:fid1:abc", "Pass --force.");
+  assertEquals(renderCliError(e), e.message);
+  assert(renderCliError(e) !== e.stack);
+});
+
+Deno.test("renderCliError prints an IdentityKeyfileError's message, not its stack", () => {
+  // The message names the keyfile's path, what is wrong with it, and what to
+  // do; a stack over it buries the one line the operator acts on.
+  const e = new IdentityKeyfileError(
+    "/home/me/.config/commonfabric/identity.key",
+    "does not exist",
+    "Point --identity or CF_IDENTITY at an existing keyfile.",
+  );
   assertEquals(renderCliError(e), e.message);
   assert(renderCliError(e) !== e.stack);
 });

--- a/packages/cli/test/shell-quote.test.ts
+++ b/packages/cli/test/shell-quote.test.ts
@@ -1,0 +1,21 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { shellQuote } from "../lib/shell-quote.ts";
+
+describe("shell-quote", () => {
+  describe("shellQuote()", () => {
+    it("wraps a plain value in single quotes", () => {
+      expect(shellQuote("/home/me/identity.key")).toBe(
+        "'/home/me/identity.key'",
+      );
+    });
+
+    it("closes, escapes, and reopens around each apostrophe", () => {
+      expect(shellQuote("/Users/o'brien/x")).toBe("'/Users/o'\\''brien/x'");
+    });
+
+    it("quotes the empty string as an empty word", () => {
+      expect(shellQuote("")).toBe("''");
+    });
+  });
+});

--- a/packages/cli/test/verb-emitted-address.test.ts
+++ b/packages/cli/test/verb-emitted-address.test.ts
@@ -50,6 +50,57 @@ describe("verb-emitted-address", () => {
         .toEqual({ value: { on: ENVELOPE } });
     });
 
+    it("converts the `$link` object a marked read renders, alone or beside projected contents", () => {
+      // A read renders a marked position as `{"$link": "/of:…"}`, and joins
+      // the contents it also projected into the same object. Either way the
+      // address is what the position takes; the contents are the target's
+      // own fields, which a reference never stores.
+
+      expect(
+        resolveEmittedAddressArguments(
+          { on: { $link: ADDRESS } },
+          inlineMarker,
+        ),
+      ).toEqual({ value: { on: ENVELOPE } });
+      expect(
+        resolveEmittedAddressArguments(
+          { on: { $link: ADDRESS, title: "First note" } },
+          inlineMarker,
+        ),
+      ).toEqual({ value: { on: ENVELOPE } });
+      const listed: JSONSchema = {
+        type: "object",
+        properties: {
+          them: { type: "array", items: { type: "object", asCell: ["cell"] } },
+        },
+      };
+      expect(
+        resolveEmittedAddressArguments(
+          { them: [{ $link: ADDRESS }, ADDRESS] },
+          listed,
+        ),
+      ).toEqual({ value: { them: [ENVELOPE, ENVELOPE] } });
+    });
+
+    it("judges the string inside `$link` as it judges a bare one", () => {
+      expect(
+        resolveEmittedAddressArguments(
+          { on: { $link: "/tracker" } },
+          inlineMarker,
+        )
+          .refusal,
+      ).toContain('"/tracker" at <event>.on is not an address');
+    });
+
+    it("refuses a `$link` that holds no string as an inline copy", () => {
+      // `{"$link": true}` is the projection-schema marker, not an address.
+
+      expect(
+        resolveEmittedAddressArguments({ on: { $link: true } }, inlineMarker)
+          .refusal,
+      ).toContain("an inline copy would store a detached document");
+    });
+
     it("refuses a reference naming a piece by slug or a space by name", () => {
       // The wider vocabulary `cf`'s own intake takes stops at this seam. What
       // is built here is a stored link, which holds the id and the space
@@ -595,6 +646,14 @@ describe("verb-emitted-address", () => {
         expect(probe.storedRaw()).toHaveProperty("/");
         // And it points where the address pointed: reading through it lands
         // on the root's own field.
+        expect(probe.linkedLabel()).toBe("probe-root");
+      });
+    });
+
+    it("dispatches the `$link` object a read renders as a reference, and the edge lands on the target", async () => {
+      await withProbe("emitted-address-rendered-object", async (probe) => {
+        await probe.call("relate", { on: { $link: probe.address } });
+        expect(probe.storedRaw()).toHaveProperty("/");
         expect(probe.linkedLabel()).toBe("probe-root");
       });
     });

--- a/packages/cli/test/verb-emitted-address.test.ts
+++ b/packages/cli/test/verb-emitted-address.test.ts
@@ -658,6 +658,24 @@ describe("verb-emitted-address", () => {
       });
     });
 
+    it("dispatches the `$link` object joined by projected contents as the address alone", async () => {
+      // What a marked read that also projected fields prints: the address and
+      // the target's contents in one object. The label beside the address is
+      // deliberately not the target's, so an edge and a stored copy read
+      // differently.
+
+      await withProbe(
+        "emitted-address-rendered-object-with-contents",
+        async (probe) => {
+          await probe.call("relate", {
+            on: { $link: probe.address, label: "a projected copy" },
+          });
+          expect(probe.storedRaw()).toHaveProperty("/");
+          expect(probe.linkedLabel()).toBe("probe-root");
+        },
+      );
+    });
+
     it("refuses a string that is not an address, naming the position", async () => {
       await withProbe("emitted-address-refuses-string", async (probe) => {
         await expect(probe.call("relate", { on: "not-an-address" }))

--- a/scripts/install-cf.sh
+++ b/scripts/install-cf.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Put `cf` on PATH.
 #
-# Only needed without mise — mise.toml already adds each checkout's bin/ to
-# PATH. Shell completion is what makes this matter: the installed completion
+# The one route to a `cf` on PATH, for mise users and everyone else; mise.toml
+# pins Deno and declares no PATH entry. Shell completion is what makes this
+# matter: the installed completion
 # function calls `cf` by name on every Tab and swallows its errors, so with no
 # `cf` on PATH completion silently yields nothing.
 #

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -23,15 +23,15 @@ deno task cf check --help     # Type checking
 Three ways to run the CLI, in order of preference. All run from source, so they
 always match the working tree:
 
-1. **`cf` (via `bin/cf`)** — a plain `cf` backed by source. On PATH wherever the
-   mise hook has run; an agent's non-interactive shell usually has not, so
-   prepend the checkout's `bin` there. Otherwise `deno task install-cf`. Works
-   from any cwd, and shell completion requires a `cf` on PATH. It runs whichever
-   checkout you are standing in (nearest one walking up, or a host's
-   `vendor/labs`), not the one it was installed from — set `CF_LABS_ROOT` to
-   override when your cwd cannot say what you mean, and run `cf which` to see
-   which CLI would run and why. See "Which checkout runs" in
-   `packages/cli/README.md`.
+1. **`cf` (via `bin/cf`)** — a plain `cf` backed by source. On PATH where mise's
+   hook has applied `_.path` for this directory, which an agent's
+   non-interactive shell has usually not seen (route 2 needs nothing on PATH).
+   Otherwise `deno task install-cf`. Works from any cwd, and shell completion
+   requires a `cf` on PATH. It runs whichever checkout you are standing in
+   (nearest one walking up, or a host's `vendor/labs`), not the one it was
+   installed from — set `CF_LABS_ROOT` to override when your cwd cannot say what
+   you mean, and run `cf which` to see which CLI would run and why. See "Which
+   checkout runs" in `packages/cli/README.md`.
 
 2. **`deno task cf ...`** — works from any directory inside the repo (the
    launcher resolves the repo root itself and runs the CLI from your invoking

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -23,13 +23,15 @@ deno task cf check --help     # Type checking
 Three ways to run the CLI, in order of preference. All run from source, so they
 always match the working tree:
 
-1. **`cf` (via `bin/cf`)** — a plain `cf` backed by source. Already on PATH
-   under mise; otherwise `deno task install-cf`. Works from any cwd, and shell
-   completion requires a `cf` on PATH. It runs whichever checkout you are
-   standing in (nearest one walking up, or a host's `vendor/labs`), not the one
-   it was installed from — set `CF_LABS_ROOT` to override when your cwd cannot
-   say what you mean, and run `cf which` to see which CLI would run and why. See
-   "Which checkout runs" in `packages/cli/README.md`.
+1. **`cf` (via `bin/cf`)** — a plain `cf` backed by source. On PATH wherever the
+   mise hook has run; an agent's non-interactive shell usually has not, so
+   prepend the checkout's `bin` there. Otherwise `deno task install-cf`. Works
+   from any cwd, and shell completion requires a `cf` on PATH. It runs whichever
+   checkout you are standing in (nearest one walking up, or a host's
+   `vendor/labs`), not the one it was installed from — set `CF_LABS_ROOT` to
+   override when your cwd cannot say what you mean, and run `cf which` to see
+   which CLI would run and why. See "Which checkout runs" in
+   `packages/cli/README.md`.
 
 2. **`deno task cf ...`** — works from any directory inside the repo (the
    launcher resolves the repo root itself and runs the CLI from your invoking

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -23,15 +23,15 @@ deno task cf check --help     # Type checking
 Three ways to run the CLI, in order of preference. All run from source, so they
 always match the working tree:
 
-1. **`cf` (via `bin/cf`)** — a plain `cf` backed by source. On PATH where mise's
-   hook has applied `_.path` for this directory, which an agent's
-   non-interactive shell has usually not seen (route 2 needs nothing on PATH).
-   Otherwise `deno task install-cf`. Works from any cwd, and shell completion
-   requires a `cf` on PATH. It runs whichever checkout you are standing in
-   (nearest one walking up, or a host's `vendor/labs`), not the one it was
-   installed from — set `CF_LABS_ROOT` to override when your cwd cannot say what
-   you mean, and run `cf which` to see which CLI would run and why. See "Which
-   checkout runs" in `packages/cli/README.md`.
+1. **`cf` (via `bin/cf`)** — a plain `cf` backed by source, put on PATH once per
+   machine by `deno task install-cf`; the copy serves every checkout. On a
+   machine that never ran it — an agent's shell, often — route 2 needs nothing
+   on PATH. Works from any cwd, and shell completion requires a `cf` on PATH. It
+   runs whichever checkout you are standing in (nearest one walking up, or a
+   host's `vendor/labs`), not the one it was installed from — set `CF_LABS_ROOT`
+   to override when your cwd cannot say what you mean, and run `cf which` to see
+   which CLI would run and why. See "Which checkout runs" in
+   `packages/cli/README.md`.
 
 2. **`deno task cf ...`** — works from any directory inside the repo (the
    launcher resolves the repo root itself and runs the CLI from your invoking

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -17,9 +17,13 @@ contracts live in `packages/patterns/topics/main.tsx` and
 
 ## Deployment and identity
 
-Run from the Labs repository root so `cf` uses that checkout:
+Run from the Labs repository root so `cf` uses that checkout. Here `cf` is that
+checkout's own `bin/cf`, and the first line puts it on PATH: the mise entry that
+would do so exists only in a shell where the mise hook has run, and an agent's
+non-interactive shell usually has not.
 
 ```bash
+export PATH="$PWD/bin:$PATH"
 export CF_API_URL='https://estuary.saga-castor.ts.net'
 export CF_SPACE='topics-dev-476ea34f'
 export TOPICS_BOARD='/of:fid1:jtdD-DSmuGrLGSt_6sJ3DS_7jmerrkKTEnW3fZV9e34'

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -28,18 +28,15 @@ export CF_API_URL='https://estuary.saga-castor.ts.net'
 export CF_SPACE='topics-dev-476ea34f'
 export TOPICS_BOARD='/of:fid1:jtdD-DSmuGrLGSt_6sJ3DS_7jmerrkKTEnW3fZV9e34'
 export CF_IDENTITY="${CF_IDENTITY:-$HOME/.config/commonfabric/identity.key}"
-test -r "$CF_IDENTITY" || {
-  printf 'Topics identity key is not readable: %s\n' "$CF_IDENTITY" >&2
-  exit 1
-}
 ```
 
 An already-set `CF_IDENTITY` is the explicit override. Otherwise use the team's
 stable per-user default at `~/.config/commonfabric/identity.key`; the path is
 common while its contents belong to that teammate. Use the same Estuary identity
-key as your human user. If the readability check fails, stop and ask the human
-to provision that default or export the correct path. Do not search for keys,
-mint an agent key, use another human's key, or use the publicly derivable
+key as your human user. When `cf` reports that keyfile missing or unreadable,
+stop and ask the human to provision that default or export the correct path; the
+check belongs to `cf`, so the shell never touches the key. Do not search for
+keys, mint an agent key, use another human's key, or use the publicly derivable
 `implicit trust` identity. Never print or inspect key material; use
 `cf id did "$CF_IDENTITY"` when the public DID is needed for verification.
 

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -17,13 +17,13 @@ contracts live in `packages/patterns/topics/main.tsx` and
 
 ## Deployment and identity
 
-Run from the Labs repository root so `cf` uses that checkout. Here `cf` is that
-checkout's own `bin/cf`, and the first line puts it on PATH: the mise entry that
-would do so exists only in a shell where the mise hook has run, and an agent's
-non-interactive shell usually has not.
+Run from inside the Labs checkout. The commands here are spelled `deno task cf`,
+which runs that checkout's CLI from any directory in it and needs nothing on
+PATH; `skills/cf/SKILL.md` covers the other routes. Shell state rarely survives
+between an agent's tool calls, so set these in the same invocation as the
+command that needs them:
 
 ```bash
-export PATH="$PWD/bin:$PATH"
 export CF_API_URL='https://estuary.saga-castor.ts.net'
 export CF_SPACE='topics-dev-476ea34f'
 export TOPICS_BOARD='/of:fid1:jtdD-DSmuGrLGSt_6sJ3DS_7jmerrkKTEnW3fZV9e34'
@@ -38,7 +38,8 @@ stop and ask the human to provision that default or export the correct path; the
 check belongs to `cf`, so the shell never touches the key. Do not search for
 keys, mint an agent key, use another human's key, or use the publicly derivable
 `implicit trust` identity. Never print or inspect key material; use
-`cf id did "$CF_IDENTITY"` when the public DID is needed for verification.
+`deno task cf id did "$CF_IDENTITY"` when the public DID is needed for
+verification.
 
 Every authored-content mutation carries `agentName` in the same event. Use one
 stable agent name, without decorating titles, labels, bodies, or comments with a
@@ -53,21 +54,21 @@ reference edge, take no `agentName`, and return no value.
 The running piece is authoritative. Orient before mutating it:
 
 ```bash
-cf piece verbs --cell "$TOPICS_BOARD" --json
+deno task cf piece verbs --cell "$TOPICS_BOARD" --json
 ```
 
 That listing includes the deployed pattern reference, callable prose, and input
-and output schemas. `cf piece describe --cell "$TOPICS_BOARD" --json` returns a
-superset of it (the same verb rows plus name, purpose, state, and inputs) for
-the same bounded discovery load. Neither command starts the piece; the reason to
-default to `verbs` is payload, not time: the listing is the smaller document to
-hold in context, and it is complete for calling. Use `describe` when you need
-the piece-wide purpose, state, or input documentation. Use
-`cf piece call --cell "$TOPICS_BOARD" <verb> --help --json` only after choosing
-a verb and when its generated flags or standalone help are useful; help is
-served through the dispatch path, which also starts the space root, so it is the
-most expensive of the three. Each command is an independent cold CLI process, so
-do not run all three by default.
+and output schemas. `deno task cf piece describe --cell "$TOPICS_BOARD" --json`
+returns a superset of it (the same verb rows plus name, purpose, state, and
+inputs) for the same bounded discovery load. Neither command starts the piece;
+the reason to default to `verbs` is payload, not time: the listing is the
+smaller document to hold in context, and it is complete for calling. Use
+`describe` when you need the piece-wide purpose, state, or input documentation.
+Use `deno task cf piece call --cell "$TOPICS_BOARD" <verb> --help --json` only
+after choosing a verb and when its generated flags or standalone help are
+useful; help is served through the dispatch path, which also starts the space
+root, so it is the most expensive of the three. Each command is an independent
+cold CLI process, so do not run all three by default.
 
 The deployment can be well behind the checkout the CLI runs from, and that gap
 explains board behavior that would otherwise read as a defect. Ask it which
@@ -113,10 +114,10 @@ retained deliberately.
 
 `editComment` and `removeComment` name their target by REFERENCE, and a comment
 is not a piece: it has no fid to write into an inline JSON event, so these are
-reachable from a reader that holds the row, not from a bare `cf piece call`.
-`removeLink` is the exception and takes `url` for exactly that reason,
-retracting the most recently added link still present with that URL — so
-retracting twice retracts two rather than re-stamping one.
+reachable from a reader that holds the row, not from a bare
+`deno task cf piece call`. `removeLink` is the exception and takes `url` for
+exactly that reason, retracting the most recently added link still present with
+that URL — so retracting twice retracts two rather than re-stamping one.
 
 ## Discover and read
 
@@ -124,7 +125,7 @@ Survey through the compact `index`. Its rows are Topics, and `@` asks for each
 row's canonical address without expanding its body, thread, or verbs:
 
 ```bash
-cf cell get "$TOPICS_BOARD" index --step \
+deno task cf cell get "$TOPICS_BOARD" index --step \
   --select @,title,createdAt,lastActivityAt,commentCount,createdBy.kind,createdBy.name
 ```
 
@@ -150,11 +151,11 @@ evidence the edge is wrong.
 Read one Topic's durable input before changing it:
 
 ```bash
-cf cell get --cell "$TOPIC" title --input
-cf cell get --cell "$TOPIC" body --input
-cf cell get --cell "$TOPIC" comments --input \
+deno task cf cell get --cell "$TOPIC" title --input
+deno task cf cell get --cell "$TOPIC" body --input
+deno task cf cell get --cell "$TOPIC" comments --input \
   --select sentAt,author.kind,author.name,body
-cf cell get --cell "$TOPIC" links --input \
+deno task cf cell get --cell "$TOPIC" links --input \
   --select kind,url,label,addedAt,addedBy.kind,addedBy.name
 ```
 
@@ -177,18 +178,18 @@ it. `addTopic` returns the name it allocated as `name` beside the created
 in one bounded read:
 
 ```bash
-cf cell get "$TOPICS_BOARD" index --step --select @,title,shortName
+deno task cf cell get "$TOPICS_BOARD" index --step --select @,title,shortName
 ```
 
 The number is what a short reference is written with. Once the board's `names`
 map is bound as a slug, `<collection>/<member>` names a Topic wherever an
-address is taken — `cf cell get /@<space>/top/42 title`,
-`cf piece describe --cell /@<space>/top/42`,
-`cf piece call --cell /@<space>/top/42 setTitle '{...}'` — and exactly one
-segment reaches a member, so `/@<space>/top/42/title` is that Topic's `title`
-field. A name with no member after it is refused, naming the piece holding the
-collection; and `no member 999 in top` is the refusal for a member the board
-does not hold. `packages/cli/README.md` is the whole grammar, and
+address is taken — `deno task cf cell get /@<space>/top/42 title`,
+`deno task cf piece describe --cell /@<space>/top/42`,
+`deno task cf piece call --cell /@<space>/top/42 setTitle '{...}'` — and exactly
+one segment reaches a member, so `/@<space>/top/42/title` is that Topic's
+`title` field. A name with no member after it is refused, naming the piece
+holding the collection; and `no member 999 in top` is the refusal for a member
+the board does not hold. `packages/cli/README.md` is the whole grammar, and
 `docs/specs/collection-naming.md` the design.
 
 A member name is the board's, not the fabric's: it means something only through
@@ -214,8 +215,8 @@ reuse that id only to retry the same mutation. Create through the board and
 project the returned Topic to its address:
 
 ```bash
-export CF_INVOCATION_SESSION="$(cf invocation-session new)"
-CREATE="$(cf piece call --cell "$TOPICS_BOARD" \
+export CF_INVOCATION_SESSION="$(deno task cf invocation-session new)"
+CREATE="$(deno task cf piece call --cell "$TOPICS_BOARD" \
   --invocation '<unique-topic-create-id>' \
   addTopic \
   '{"title":"<title>","body":"<initial living document>","agentName":"Sol"}' \
@@ -252,8 +253,8 @@ creating another Topic. Retrying on the strength of a timeout is how one Topic
 becomes two.
 
 ```bash
-cf cell get "$TOPICS_BOARD" index --step --select @,title
-cf cell get --cell "$TOPIC" title --input
+deno task cf cell get "$TOPICS_BOARD" index --step --select @,title
+deno task cf cell get --cell "$TOPIC" title --input
 ```
 
 Use one invocation session per agent run and an explicit invocation id per
@@ -264,13 +265,13 @@ pair. The full retry and receipt model is in `skills/cf/SKILL.md` and
 ## Update through Topic verbs
 
 ```bash
-cf piece call --cell "$TOPIC" --invocation '<unique-set-title-id>' setTitle \
+deno task cf piece call --cell "$TOPIC" --invocation '<unique-set-title-id>' setTitle \
   '{"title":"<complete new title>","agentName":"Sol"}'
-cf piece call --cell "$TOPIC" --invocation '<unique-set-body-id>' setBody \
+deno task cf piece call --cell "$TOPIC" --invocation '<unique-set-body-id>' setBody \
   '{"body":"<complete revised body>","agentName":"Sol"}'
-cf piece call --cell "$TOPIC" --invocation '<unique-add-comment-id>' addComment \
+deno task cf piece call --cell "$TOPIC" --invocation '<unique-add-comment-id>' addComment \
   '{"body":"<point-in-time update>","agentName":"Sol"}'
-cf piece call --cell "$TOPIC" --invocation '<unique-add-link-id>' addLink \
+deno task cf piece call --cell "$TOPIC" --invocation '<unique-add-link-id>' addLink \
   '{"url":"<PR URL>","kind":"pr","label":"<label>","agentName":"Sol"}'
 ```
 
@@ -290,9 +291,9 @@ passes in that position as it was printed, too:
 
 ```bash
 export OTHER_TOPIC='<canonical /of:... address from another index row>'
-cf piece call --cell "$TOPIC" --invocation '<unique-mention-id>' mention \
+deno task cf piece call --cell "$TOPIC" --invocation '<unique-mention-id>' mention \
   "{\"topic\":\"$OTHER_TOPIC\"}"
-cf piece call --cell "$TOPIC" --invocation '<unique-unmention-id>' unmention \
+deno task cf piece call --cell "$TOPIC" --invocation '<unique-unmention-id>' unmention \
   "{\"topic\":\"$OTHER_TOPIC\"}"
 ```
 
@@ -343,7 +344,7 @@ and `ownName` in `packages/patterns/collection-naming/naming.ts` is the lookup.
 A parent writes its member's result and never its member's argument, so
 `backfillNames` names a Topic filed before the namespace in the board's map
 while that Topic goes on reading no name. No pattern can close that gap. One
-`cf piece link` per Topic can, and this is that procedure.
+`deno task cf piece link` per Topic can, and this is that procedure.
 
 It was established by a clone rehearsal, and the evidence — every command, its
 output, and the counts and timings behind the claims here — is
@@ -400,46 +401,48 @@ that before deciding anything this procedure says needs deciding.
 
    **Skipping it leaves a usable board.** A Topic still on pre-graft source is
    named by `backfillNames` like any other member, answers to
-   `cf cell get /top/<n> title`, and reads back as an ordinary `index` row with
-   no `shortName` and no damage to the array around it. So naming, `/top/<n>`
-   addressing and index membership all survive the step being skipped, and
-   `shortName` — the badge, and the number on the index row — is what is absent.
-   That bounds what skipping costs from BELOW, not from above: no run against a
-   populated board has forced a Topic update, so what else a completed one would
-   change there is not known, and the record says so. Step 4's refusal on such a
-   Topic is this state being enforced rather than an error.
+   `deno task cf cell get /top/<n> title`, and reads back as an ordinary `index`
+   row with no `shortName` and no damage to the array around it. So naming,
+   `/top/<n>` addressing and index membership all survive the step being
+   skipped, and `shortName` — the badge, and the number on the index row — is
+   what is absent. That bounds what skipping costs from BELOW, not from above:
+   no run against a populated board has forced a Topic update, so what else a
+   completed one would change there is not known, and the record says so. Step
+   4's refusal on such a Topic is this state being enforced rather than an
+   error.
 
 3. **`backfillNames` once**, through the board. It returns the names it wrote,
    in filing order, and is idempotent: a second run writes nothing and returns
    an empty list.
 
-4. **`cf piece link` once per Topic that `addTopic` did not wire** — that is,
-   per Topic that took step 2. A Topic that skipped it has no `boardNames` input
-   to bind, and the bind says so.
+4. **`deno task cf piece link` once per Topic that `addTopic` did not wire** —
+   that is, per Topic that took step 2. A Topic that skipped it has no
+   `boardNames` input to bind, and the bind says so.
 
 ### The two commands
 
 ```bash
-cf piece call --cell "$TOPICS_BOARD" --invocation '<id>' backfillNames \
+deno task cf piece call --cell "$TOPICS_BOARD" --invocation '<id>' backfillNames \
   '{"agentName":"Sol"}'
-cf piece link "$TOPICS_BOARD/namesTable" "$TOPIC/boardNames"
+deno task cf piece link "$TOPICS_BOARD/namesTable" "$TOPIC/boardNames"
 ```
 
 Between them is the gap this procedure exists for: the board's `names` map and
 `namesTable` hold the name, and the Topic does not.
 
 ```
-$ cf cell get --cell "$TOPIC" shortName --step
+$ deno task cf cell get --cell "$TOPIC" shortName --step
 Cannot read piece result at "shortName": stored data is present, but its schema
 could not resolve all required values. The piece was stepped, but the required
 value still did not materialize.
 ```
 
 After the bind that read answers with the number, the board's `index` row for
-that Topic carries it as `shortName`, and `cf cell get /top/<n> title` returns
-its title. A Topic left unbound keeps reporting the message above, which is what
-a half-finished run looks like: the board serves every Topic either way, named
-beside unnamed, and the repair is to bind the rest. Nothing has to be undone.
+that Topic carries it as `shortName`, and `deno task cf cell get /top/<n> title`
+returns its title. A Topic left unbound keeps reporting the message above, which
+is what a half-finished run looks like: the board serves every Topic either way,
+named beside unnamed, and the repair is to bind the rest. Nothing has to be
+undone.
 
 The bind is idempotent — repeating it with the same two endpoints changes
 nothing and commits nothing. Note that `wrote to space` prints either way, so it
@@ -459,7 +462,7 @@ laptop; run it from somewhere that record vindicates.
 The derived `shortName` is the wrong thing to audit — read the durable argument:
 
 ```bash
-cf cell get --cell "$TOPIC" boardNames --input --select name
+deno task cf cell get --cell "$TOPIC" boardNames --input --select name
 ```
 
 A bound Topic returns the whole names table (`[{"name":"1"},…]`); an unbound one
@@ -489,12 +492,13 @@ Use --allow-non-existing to link anyway.
 ```
 
 Taking that suggestion prints `Linked …` and buys nothing: the Topic's input map
-does not gain the key — neither `cf cell get --cell "$TOPIC" --input` nor
-`cf piece inspect`'s Source (Inputs) shows it — and its name never appears. What
-it does do is write the link into the argument document, where the pattern
-cannot reach it but `cf cell get --cell "$TOPIC" boardNames --input` can, which
-is what makes the audit above read it as bound. The next `setsrc` of that Topic
-then fails with an extra
+does not gain the key — neither `deno task cf cell get --cell "$TOPIC" --input`
+nor `deno task cf piece inspect`'s Source (Inputs) shows it — and its name never
+appears. What it does do is write the link into the argument document, where the
+pattern cannot reach it but
+`deno task cf cell get --cell "$TOPIC" boardNames --input` can, which is what
+makes the audit above read it as bound. The next `setsrc` of that Topic then
+fails with an extra
 `updated arguments do not match the candidate schema: boardNames: value does not
 match type array`
 that a clean control piece does not produce. The forced bind poisons the Topic
@@ -502,7 +506,7 @@ against its own migration.
 
 **`setsrc --check` is not read-only against the store** (#6964). It writes, even
 when it refuses and replaces nothing, so a rehearsal clone is spent after one
-and a second pass needs `cf space reset`. Nothing authored moves.
+and a second pass needs `deno task cf space reset`. Nothing authored moves.
 
 **Binding a piece the board does not hold** does nothing wrong and nothing
 useful: it succeeds, and the Topic reads no name. The lookup is by identity —

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -288,7 +288,8 @@ computed, such as a count or board-index row.
 A cross-Topic connection is a reference, not an address pasted into prose. Pass
 the canonical reference in the declared reference position; the CLI turns it
 into the live piece link the verb expects. Set `OTHER_TOPIC` to the `$link` from
-the index row for the Topic being referenced:
+the index row for the Topic being referenced; the row's `{"$link": …}` object
+passes in that position as it was printed, too:
 
 ```bash
 export OTHER_TOPIC='<canonical /of:... address from another index row>'


### PR DESCRIPTION
Three gaps an agent hits following `skills/topics/SKILL.md` from a non-interactive shell, each reported from the field, each fixed where it originates. Reworked after review: the PATH mechanism is settled rather than annotated.

## `cf` is not on PATH in an agent's shell (commits 1, 6, 7)

`mise.toml` declared a per-directory PATH entry for the checkout's `bin`, delivered through mise's shell hook. A non-interactive shell — an agent's, `make`, an editor's task runner — either never ran that hook or inherited a PATH computed for the parent's directory, so `cf` was "command not found" even on a machine with mise installed and the checkout trusted. The entry also forced `mise trust` in every new worktree, which a tools-only file does not.

The entry is gone. `deno task install-cf` is the one route to a `cf` on PATH, for mise users and everyone else: a real file in a directory every shell sees, and one copy serves every checkout because `bin/cf` resolves the checkout from the directory it is run in. Every site that said mise put `bin` on PATH now says the one thing — the root README's quick start, `mise.toml`, both launchers and `cfsh`'s error, the CLI README's install section, the completion command's help and its install warning, the cf-harness onboarding note, the deps command, the shuttle plan, the installer's header, the cf skill, and AGENTS.md, which gains a "Running the CLI" section of its own.

The topics skill spells its commands `deno task cf`, which runs the checkout's CLI from any directory inside it and needs nothing on PATH, and says to set its exports in the same invocation as the command, since an agent's shell state rarely survives between tool calls. `cf which` is answered by `bin/cf` alone; AGENTS.md says so.

**Team impact:** a mise user whose `cf` came only from the removed entry runs `deno task install-cf` once, on each machine; until then, bare `cf` stops resolving inside checkouts and shell completion goes quiet. Nothing else changes: `deno task cf` keeps working everywhere, the Deno pin still applies, and a fresh worktree no longer needs `mise trust` before `deno` resolves.

## A reference position refuses the `$link` object a read prints (commits 2, 5)

A marked read renders an address as `{"$link": "/of:…"}`. At a declared reference position the dispatch gate accepted the bare string and the link envelope, and refused every other object as an inline copy with "send the address a read printed" — which is exactly what the `$link` object is. The gate now takes the address out of that object, alone or joined by the contents the same read projected, and judges it as it judges the bare string. A `$link` holding no string (`{"$link": true}` is the projection-schema marker) still falls to the inline-copy refusal.

- unit + live cases beside the existing spellings in `verb-emitted-address.test.ts`, including the object with projected contents beside the address, sent with a label that is not the target's so an edge and a stored copy read differently; a mutant with the unwrap disabled fails exactly the dependent steps
- `verb-session-gaps.sh` step 10 asserts both rendered spellings apart from the envelope and the bare address — run end to end against a local toolshed, 52/52
- the two verb-session documents and `docs/plans/references-as-arguments.md` name the spelling beside the others; the topics skill says an index row's `$link` object passes as printed

## A missing keyfile is a stack trace (commits 3, 4)

`cf` pointed at a keyfile that does not exist died with a raw `NotFound` stack from `loadIdentity`, which is why the topics skill carried a shell `test -r` preflight naming the key on a command line. `loadIdentity` and `getDidFromFile` share one loader that reports an `IdentityKeyfileError` by path and remedy, printed message-only at the top level beside the other data errors:

```
Identity keyfile /x/identity.key does not exist. Point --identity or CF_IDENTITY at an existing keyfile, or create one there with `mkdir -p '/x' && cf id new > '/x/identity.key'`.
Identity keyfile /tmp cannot be read (Is a directory (os error 21): readfile '/tmp'). Point --identity or CF_IDENTITY at a readable keyfile.
Identity keyfile /x/garbage.key does not hold an Ed25519 PKCS#8 key. Point --identity or CF_IDENTITY at a keyfile written by `cf id new`, `cf id derive`, or `cf id from-mnemonic`.
```

The remedy creates the directory as well as the file, since the default keyfile lives under one a teammate who has never provisioned a key does not have; the line was run exactly as printed against a missing directory and the key it wrote resolved. The key decoder's own error quotes the bytes it failed on, and a corrupt keyfile may still be most of a private key, so the third message forwards nothing from inside the file; `identity.test.ts` pins that with a garbage keyfile, and a mutant that forwards the decoder's message fails exactly that test. The skill's environment block is exports only: the check belongs to `cf`, so the shell never touches the key.

## Not in this PR

- Whether `cf` should default to `~/.config/commonfabric/identity.key` when neither `--identity` nor `CF_IDENTITY` is given, which would take the key path out of the skill entirely — a team question, open separately.
- The fourth field report (a `search` verb the board has never had, from an out-of-repo checklist) — being taken up directly with its author first.

## Gates

Repo-wide `deno fmt --check` and `deno lint`, `deno task check`, the full `packages/cli` suite, `check-skill-facts`, `check-verb-session-sync`, `check-docs`, `check-command-docs`, `check-completion-slots`, control characters and conflict markers — all green on the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
