### PR TITLE
test(cli): pin the three own-key sites #6849 changed without a witness

### DIFF
--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@commonfabric/runner/shared";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
+  boundReadValue,
   CellSelectionError,
   deriveSelectedValue,
   evaluateSelectionPredicate,
@@ -411,6 +412,30 @@ describe("cf cell get transforms", () => {
     });
     expect(Object.keys((selected as { properties: object }).properties))
       .toEqual(["visible"]);
+  });
+
+  it("drops a required entry named like a prototype member that the mask did not select", () => {
+    // `required` is filtered to the SELECTED properties. That test must ask
+    // whether the selection holds the key as its own: a `required` entry
+    // spelled `toString` is found on every object by `in`, and an unselected
+    // one used to survive into the selected schema's `required`.
+    const properties: Record<string, JSONSchema> = {
+      label: { type: "string" },
+    };
+    properties["toString"] = { type: "string" };
+    const source: JSONSchema = {
+      type: "object",
+      properties,
+      required: ["label", "toString"],
+    };
+    const selected = selectSourceSchema(source, {
+      type: "object",
+      properties: { label: true },
+      additionalProperties: false,
+    }) as { properties: object; required?: string[] };
+
+    expect(Object.keys(selected.properties)).toEqual(["label"]);
+    expect(selected.required).toEqual(["label"]);
   });
 
   it("collapses overlapping concise paths without exposing siblings", async () => {
@@ -2143,6 +2168,78 @@ describe("cf cell get transforms", () => {
     expect(JSON.stringify(result)).toBe(
       '{"label":"first","id":1,"alpha":"a","toString":"own","zeta":"z"}',
     );
+  });
+
+  it("orders an open projection's declared keys first across an array of objects", async () => {
+    const setup = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "transform-open-projection-array-order-source",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "number" },
+            label: { type: "string" },
+            extra: { type: "string" },
+          },
+        },
+      },
+      setup,
+    );
+    source.set([
+      { id: 1, label: "first", extra: "kept" },
+      { id: 2, label: "second", extra: "kept" },
+    ]);
+    expect((await setup.commit()).ok).toBeDefined();
+
+    // The open × array combination: `projectValue` decomposes the array
+    // projection to its item schema, and each element renders its declared
+    // keys in schema order (label before id) with the retained extra after.
+    const result = await deriveSelectedValue(runtime, space, source, {
+      projection: await parseSelectionProjection(
+        '{"type":"array","items":{"type":"object","properties":{"label":true,"id":true},"additionalProperties":true}}',
+      ),
+    });
+    expect(JSON.stringify(result)).toBe(
+      '[{"label":"first","id":1,"extra":"kept"},{"label":"second","id":2,"extra":"kept"}]',
+    );
+  });
+
+  it("a bound read composes no address for a marked position the value does not hold, prototype names included", async () => {
+    // A declared result whose recursion re-enters at a property spelled like
+    // an `Object.prototype` member: the cut marks that position, and the
+    // bound read composes an address for it only where the value holds the
+    // key as its own. `in` found `Object.prototype.toString` on a value
+    // without one and composed an address for a key the value never had.
+    const setup = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "transform-bound-read-prototype-source",
+      { type: "object", properties: { label: { type: "string" } } },
+      setup,
+    );
+    source.set({ label: "held" });
+    expect((await setup.commit()).ok).toBeDefined();
+
+    const nodeProperties: Record<string, JSONSchema> = {
+      label: { type: "string" },
+    };
+    nodeProperties["toString"] = { $ref: "#/$defs/Node" };
+    const declared: JSONSchema = {
+      $defs: { Node: { type: "object", properties: nodeProperties } },
+      $ref: "#/$defs/Node",
+    };
+
+    const result = await boundReadValue(
+      source,
+      declared,
+      { label: "held" },
+      space,
+    ) as Record<string, unknown>;
+    expect(Object.keys(result)).toEqual(["label"]);
+    expect(Object.hasOwn(result, "toString")).toBe(false);
   });
 
   it("a closed projection emits only keys the value holds, prototype names included", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #6849, from @mpsalisbury's approving re-review: the two nits it left unpinned, plus the array-shaped pin that had been rewritten away.

#6849 moved five membership tests in `cell-selection.ts` from `in` to `Object.hasOwn` and pinned two of them (the open-branch key list and the closed branch). This adds one pin for each remaining behavior change, and restores the open × array combination:

- **open × array**: an open projection over an array of objects renders each element's declared keys first, in schema order, with the retained extra after — red when the open branch iterates the value.
- **`selectedRequired`**: a mask that does not select `toString` drops it from the selected schema's `required` — red with `in` back at that site, where `Object.prototype.toString` counted as selected.
- **marker walk**: a declared result whose recursion cut lands on a `toString` position composes no address for a value that does not hold that key — red with `in` back in `markersHeldBy`, which then emits a `toString` address for a key the value never had.

Tests only; no behavior change.

## Verification

- `piece-get-transform` 120 steps green; each pin red under its mutation, restored after
- the seven selection suites green
- `deno fmt --check`, `deno lint`, `deno check` on the test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

