### PR TITLE
fix(test-selection): say what the publisher's two counts mean

### DIFF
--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -222,6 +222,114 @@ deno run --allow-read --allow-env --allow-net --allow-write \
 That writes the manifest and the aggregate as plain JSON where you can
 read them, and creates nothing in the store.
 
+## What a run leaves out
+
+A run's log names two kinds of identity that did not reach the manifest.
+The first is the design working. The second is either a set of identities
+whose next record will say enough, or a surface whose records never say
+enough, and the run says which.
+
+The first is the identities that measure a whole invocation:
+
+```
+test selection: 8 identities measure a whole invocation rather than one
+unit, so they are left out. The steps inside the invocation are measured
+separately, so nothing is missing and there is nothing to act on.
+```
+
+A script that records each of its steps also records its own run from end
+to end, and the topology tells the two apart. The whole-invocation record
+names no unit, so no lane can be asked to run it, and adding its time to
+the time of the steps inside it would count that work twice. The count is
+that separation working. It changes when a suite gains or loses such a
+record, and there is nothing to do about it either way.
+
+The second is the identities the topology has no unit for:
+
+```
+test selection: the topology has no unit for 3295 identities, so no lane
+can be asked to run one. An identity is left out until one of its records
+says enough to work out which unit it is in.
+test selection: those 3295 were recorded by 12 surface(s): unit:utils 742,
+unit:runtime-client 509, unit:ts-transformers 379,
+unit:schema-generator 314, unit:js-compiler 153, and 7 more
+```
+
+A surface is the kind of check a record is, the workspace member that owns
+it, and the configuration it ran under where that is not the default one.
+It says which part of the tree the count is about. The worst five are
+named and the rest are counted, so that reading the count does not mean
+reproducing the publisher against the store by hand.
+
+What decides an identity's unit is its own records. Where a suite's units
+are files, the answer is the file on the record, and a record has one when
+the report it came from could name one: the registration preload captures
+which module registered each test and leaves that map beside the report,
+and ingestion otherwise reads the file from the report's own class names,
+which needs the working directory the test process ran in. A report that
+supplies neither has no file on any of its records, and neither does a
+name that two files in one report both report. Where a suite's units are
+not files — a dispatch arm, a pattern key — the answer is the recorded
+name instead, and a name no suite recognizes leaves the identity without a
+unit the same way. An identity that matches two suites is left out as
+well, which is a topology defect the drift guard fails on separately. What
+is not in the count is the lane measuring its own setup and its own
+batches. Those records travel the same path as a test's, but nothing
+enumerates them and no lane can be asked to run one, so no suite has a
+unit for them and none should. `isLaneMeasurement` is what says so, and
+everything that reads a recorded identity asks it: the drift guard, the
+publisher, and the list the publisher keeps from one run to the next.
+
+The publisher leaves all of those out rather than putting an entry in the
+manifest that no lane could run. The next record that says enough puts the
+identity back in.
+
+A count on its own says nothing about which of the two it holds, so the
+aggregate keeps the identities that have no unit and removes each one when
+the topology has a unit for it, or when it names something the count no
+longer holds. A run compares its own list against that one:
+
+```
+test selection: 2900 of them were in this count at the last publish too,
+so more of their records have been read since and those records still do
+not say which unit. A surface whose records never say which unit is worth
+fixing. See docs/development/test-selection.md.
+test selection: those 2900 were recorded by 9 surface(s): unit:utils 742,
+unit:runtime-client 509, unit:ts-transformers 379,
+unit:schema-generator 314, unit:js-compiler 153, and 4 more
+```
+
+The second line is the one to act on. It is the same breakdown, over the
+part of the count that two runs both left without a unit.
+
+A run reads each identity's records only from the objects it folded for
+the first time, so every identity in its count was recorded in an object
+no earlier publish had read. One that was already on the list has
+therefore been recorded twice over and had no unit either time. That is a
+surface whose records never say which unit, rather than an identity whose
+next record will say. The list is kept across runs rather than replaced by
+each one, because a surface recording less often than the publisher runs
+is absent from most runs, and a list replaced each time would treat such a
+surface as new every time it did record.
+
+What to check is that surface's wiring, which
+[the record guide](test-records.md#covering-a-new-test-surface) covers: a
+JUnit path on the job's ship step, the `--preload` naming
+`packages/test-support/src/records/preload.ts` where the surface is
+`deno test`, and the working directory that relative class names are
+joined onto. Where the records do have a file, the file is one no suite
+has a unit for, and the answer is in the topology rather than in the job.
+
+Where none of them were on the list, the run says so instead:
+
+```
+test selection: none of them were in this count at the last publish, so
+nothing has been recorded twice with no unit.
+```
+
+A run folding into an empty aggregate has nothing to compare against, and
+says neither.
+
 ## What the wall shows
 
 Two tiles read the newest manifest. The flake tile reports how many tests

--- a/tasks/check-test-topology.ts
+++ b/tasks/check-test-topology.ts
@@ -37,7 +37,7 @@ import {
   type TestIdentity,
   testIdentityKey,
 } from "@commonfabric/test-support/records";
-import { isLaneMeasurement } from "./ci-lane.ts";
+import { isLaneMeasurement } from "./lane-measurement.ts";
 import { dayOf } from "./test-selection/build.ts";
 import { DENO_TEST_FILE } from "./test-topology/deno-task.ts";
 import { claimsFor, loadTopology } from "./test-topology.ts";

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -34,7 +34,6 @@ import * as path from "@std/path";
 import {
   FragmentWriter,
   recordsDir,
-  type TestIdentity,
   testIdentityKey,
   type TestRecord,
 } from "@commonfabric/test-support/records";
@@ -57,6 +56,10 @@ import {
 import { type Census, census } from "./test-selection/census.ts";
 import type { Manifest, WithheldReason } from "./test-selection/manifest.ts";
 import { LANES } from "./test-selection/policy.ts";
+import {
+  LANE_MEASUREMENT_PREFIX,
+  LANE_MEASUREMENT_SURFACE,
+} from "./lane-measurement.ts";
 
 /** What the lane was asked to do. */
 export interface LaneOptions {
@@ -341,28 +344,6 @@ export async function runInvocation(
   };
 }
 
-/** The record surface the lane measures itself on. */
-export const LANE_MEASUREMENT_SURFACE = { kind: "gate", scope: "ci" };
-
-/** What the lane's own measurements are named for. */
-export const LANE_MEASUREMENT_PREFIX = "ci-lane ";
-
-/**
- * Whether an identity is the lane measuring itself rather than a test.
- *
- * The topology claims test surfaces, and these are not one: nothing
- * enumerates them, nothing scores them, and no lane can be asked to run
- * one. They would therefore be identities no suite claims, which is what
- * the store half of the drift guard exists to fail on, so the guard is
- * told about them here — beside the code that writes them, rather than in
- * a second list that could describe something this no longer produces.
- */
-export function isLaneMeasurement(test: TestIdentity): boolean {
-  return test.k === LANE_MEASUREMENT_SURFACE.kind &&
-    test.s === LANE_MEASUREMENT_SURFACE.scope &&
-    test.n.startsWith(LANE_MEASUREMENT_PREFIX);
-}
-
 /**
  * A record measuring the lane machinery rather than a test. The publisher
  * fits `setupCost`, `suiteOverhead` and `correction` from these, so they
@@ -469,7 +450,11 @@ export async function runBatch(
   if (spool !== undefined) {
     spoolRecords(spool, [
       ...records,
-      timingRecord(`ci-lane batch ${batch.suite.id}`, seconds, ok),
+      timingRecord(
+        `${LANE_MEASUREMENT_PREFIX}batch ${batch.suite.id}`,
+        seconds,
+        ok,
+      ),
     ]);
   }
   return { ok, records, conflicts, seconds };
@@ -834,7 +819,11 @@ export async function runLane(
     spoolRecords(
       spool,
       opened.timings.map((timing) =>
-        timingRecord(`ci-lane setup ${timing.capability}`, timing.seconds, true)
+        timingRecord(
+          `${LANE_MEASUREMENT_PREFIX}setup ${timing.capability}`,
+          timing.seconds,
+          true,
+        )
       ),
     );
   }

--- a/tasks/lane-measurement.ts
+++ b/tasks/lane-measurement.ts
@@ -1,0 +1,30 @@
+/**
+ * The records a lane writes about itself, and how everything else knows
+ * one when it sees it.
+ *
+ * A lane measures its own setup and its own batches through the record
+ * machinery every test uses, so those measurements arrive as ordinary
+ * records and travel the same path. They are not test surfaces: nothing
+ * enumerates them, nothing scores them, and no lane can be asked to run
+ * one. Every reader that asks the topology where a record belongs asks
+ * this first.
+ *
+ * The surface and the name prefix a measurement is written from are here
+ * beside the predicate that recognizes one, so the lane and its readers
+ * name the same thing.
+ */
+
+import type { TestIdentity } from "@commonfabric/test-support/records";
+
+/** The record surface the lane measures itself on. */
+export const LANE_MEASUREMENT_SURFACE = { kind: "gate", scope: "ci" };
+
+/** What the lane's own measurements are named for. */
+export const LANE_MEASUREMENT_PREFIX = "ci-lane ";
+
+/** Whether an identity is the lane measuring itself rather than a test. */
+export function isLaneMeasurement(test: TestIdentity): boolean {
+  return test.k === LANE_MEASUREMENT_SURFACE.kind &&
+    test.s === LANE_MEASUREMENT_SURFACE.scope &&
+    test.n.startsWith(LANE_MEASUREMENT_PREFIX);
+}

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -5,6 +5,7 @@ import {
   byDayThenName,
   dayPartitions,
   inputChoice,
+  namingSurfaces,
   parseArgs,
   partitionOf,
   publish,
@@ -21,6 +22,7 @@ import {
   type TestRecord,
 } from "@commonfabric/test-support/records";
 import {
+  type AggregateState,
   emptyAggregate,
   Fold,
   parseAggregate,
@@ -28,6 +30,7 @@ import {
 } from "./test-selection/build.ts";
 import type { Suite } from "./test-topology/suite.ts";
 import { join } from "@std/path";
+import { stateObjectName } from "./test-selection/store.ts";
 
 /**
  * A topology holding the one suite these cases record against. Supplied
@@ -49,6 +52,43 @@ const TOPOLOGY: Suite[] = [{
 }];
 
 const suites = () => Promise.resolve(TOPOLOGY);
+
+/** The one unit that topology holds. */
+const UNIT = "packages/memory/test/space.test.ts";
+
+/**
+ * A topology whose one suite places a record by the file it carries, the
+ * way a suite whose units are files does. A record with no file reaches
+ * no unit, which is what leaves an identity unplaced in practice.
+ */
+const needsFile = () =>
+  Promise.resolve<Suite[]>([{
+    ...TOPOLOGY[0]!,
+    locate: (record) =>
+      record.file === UNIT ? { level: "unit", unit: UNIT } : undefined,
+  }]);
+
+/** Everything a call said on the standard output, as one string. */
+async function saying(call: () => Promise<unknown>): Promise<string> {
+  const lines: string[] = [];
+  const log = console.log;
+  console.log = (line: string) => lines.push(line);
+  try {
+    await call();
+  } finally {
+    console.log = log;
+  }
+  return lines.join("\n");
+}
+
+/** The aggregate of the newest state object a run created. */
+async function newestState(
+  created: Map<string, Uint8Array>,
+): Promise<AggregateState> {
+  const newest = [...created.keys()].filter((name) => name.includes("/state/"))
+    .sort().at(-1)!;
+  return JSON.parse(await gunzipToText(created.get(newest)!));
+}
 
 const CI = (day: string, run: string) =>
   `labs/test-records/submissions/ci/v1/${day}/run-${run}-a.ndjson`;
@@ -92,6 +132,48 @@ describe("test-selection-publish", () => {
       expect(parseArgs(["--days"])).toBeUndefined();
       expect(parseArgs(["--concurrency", "x"])).toBeUndefined();
       expect(parseArgs(["--out"])).toBeUndefined();
+    });
+  });
+
+  describe("namingSurfaces()", () => {
+    const key = (kind: string, scope: string, name: string, variant?: string) =>
+      JSON.stringify(
+        variant === undefined
+          ? [kind, scope, name]
+          : [kind, scope, name, variant],
+      );
+
+    it("names the worst first, with its own count", () => {
+      expect(namingSurfaces([
+        key("unit", "utils", "a"),
+        key("unit", "llm", "b"),
+        key("unit", "utils", "c"),
+      ])).toBe("2 surface(s): unit:utils 2, unit:llm 1");
+    });
+
+    it("separates a variant from the surface it varies", () => {
+      // The two run in different configurations and are fixed in
+      // different places, so they are not one surface.
+      expect(namingSurfaces([
+        key("integration", "patterns", "a"),
+        key("integration", "patterns", "b", "server-execution"),
+      ])).toBe(
+        "2 surface(s): integration:patterns 1, " +
+          "integration:patterns:server-execution 1",
+      );
+    });
+
+    it("counts the surfaces it does not name", () => {
+      const keys = ["a", "b", "c", "d", "e", "f", "g"].map((scope) =>
+        key("unit", scope, "one")
+      );
+      expect(namingSurfaces(keys)).toContain("7 surface(s): ");
+      expect(namingSurfaces(keys)).toContain(", and 2 more");
+    });
+
+    it("passes over a key that names no identity", () => {
+      expect(namingSurfaces(["not an identity key", key("unit", "utils", "a")]))
+        .toBe("1 surface(s): unit:utils 1");
     });
   });
 
@@ -224,6 +306,7 @@ function object(
   outcome: TestRecord["outcome"],
   at: string,
   branch = "main",
+  file?: string,
 ): string {
   const context: RunContext = {
     schema: 1,
@@ -251,6 +334,7 @@ function object(
     test: { k: "unit", s: "memory", n: "space > writes" },
     outcome,
     durationMs: 40,
+    ...(file === undefined ? {} : { file }),
   };
   return buildObjectBody(context, [record]);
 }
@@ -350,7 +434,139 @@ describe("publish()", () => {
       await gunzipToText(created.get(manifestName!)!),
     );
     expect(manifest!.entries).toEqual([]);
-    expect(lines.join("\n")).toContain("1 identities no suite claims");
+    expect(lines.join("\n")).toContain(
+      "the topology has no unit for 1 identities",
+    );
+  });
+
+  it("says which unplaced identities recorded again with no file", async () => {
+    // An identity still waiting for its next record leaves the count when
+    // that record arrives. One that is unplaced twice over has recorded
+    // more since and said too little both times, which is a surface the
+    // topology does not account for.
+    const objects = seed();
+    const { store } = fakeStore(objects);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    objects[CI(DAY, "3")] = object("c3", "pass", "2026-08-20T03:00:00.000Z");
+    const lines = await saying(() =>
+      publish(["--days", "1"], store, NOW, needsFile)
+    );
+    expect(lines).toContain(
+      "1 of them were in this count at the last publish too",
+    );
+  });
+
+  it("holds an unplaced identity through a run that reads none of it", async () => {
+    // A surface records on its own schedule, and one recording less often
+    // than the publisher runs is in no fresh object most of the time. A
+    // list replaced each run would call it new every time it did record.
+    const objects = seed();
+    const { store } = fakeStore(objects);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    await publish(["--days", "1"], store, NOW, needsFile);
+    objects[CI(DAY, "3")] = object("c3", "pass", "2026-08-20T03:00:00.000Z");
+    const lines = await saying(() =>
+      publish(["--days", "1"], store, NOW, needsFile)
+    );
+    expect(lines).toContain(
+      "1 of them were in this count at the last publish too",
+    );
+  });
+
+  it("drops what the count no longer holds from an older list", async () => {
+    // An aggregate written before the lane's own measurements left the
+    // count still names them, and nothing places one, so an entry that
+    // only left when placed would stay there for good.
+    const laneKey = JSON.stringify(["gate", "ci", "ci-lane batch memory"]);
+    const objects = seed();
+    const { store, created } = fakeStore(objects);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    const older = await newestState(created);
+    objects[stateObjectName("2026-08-19", "01AAAA")] = JSON.stringify({
+      ...older,
+      unclaimed: [...older.unclaimed ?? [], laneKey],
+    });
+    created.clear();
+    objects[CI(DAY, "3")] = object("c3", "pass", "2026-08-20T03:00:00.000Z");
+    await publish(["--days", "1"], store, NOW, needsFile);
+    expect((await newestState(created)).unclaimed).not.toContain(laneKey);
+  });
+
+  it("drops an identity from the list once something places it", async () => {
+    // The list is what the tree does not account for, so a record naming
+    // a file a suite claims takes its identity out of it.
+    const objects = seed();
+    const { store, created } = fakeStore(objects);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    objects[CI(DAY, "3")] = object(
+      "c3",
+      "pass",
+      "2026-08-20T03:00:00.000Z",
+      "main",
+      UNIT,
+    );
+    await publish(["--days", "1"], store, NOW, needsFile);
+    expect((await newestState(created)).unclaimed).toEqual([]);
+  });
+
+  it("says so when nothing unplaced was unplaced before", async () => {
+    // The same count means two different things, and which one it is
+    // rests on what no run had placed before this one.
+    const objects: Record<string, string> = {
+      [CI(DAY, "1")]: object(
+        "c1",
+        "fail",
+        "2026-08-20T01:00:00.000Z",
+        "main",
+        UNIT,
+      ),
+      [CI(DAY, "2")]: object(
+        "c2",
+        "pass",
+        "2026-08-20T02:00:00.000Z",
+        "main",
+        UNIT,
+      ),
+    };
+    const { store } = fakeStore(objects);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    objects[CI(DAY, "3")] = object("c3", "pass", "2026-08-20T03:00:00.000Z");
+    const lines = await saying(() =>
+      publish(["--days", "1"], store, NOW, needsFile)
+    );
+    expect(lines).toContain(
+      "none of them were in this count at the last publish",
+    );
+  });
+
+  it("names the surfaces the stuck identities came from", async () => {
+    // A count says how much there is to fix, and the surface says which
+    // part of the tree it is in. Both the whole count and the part of it
+    // that did not move name the worst of theirs.
+    const objects = seed();
+    const { store } = fakeStore(objects);
+    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    objects[CI(DAY, "3")] = object("c3", "pass", "2026-08-20T03:00:00.000Z");
+    const lines = await saying(() =>
+      publish(["--days", "1"], store, NOW, needsFile)
+    );
+    expect(lines).toContain(
+      "those 1 were recorded by 1 surface(s): unit:memory 1",
+    );
+    expect(lines).toContain(
+      "those 1 were recorded by 1 surface(s): unit:memory 1",
+    );
+  });
+
+  it("compares against nothing when it folds into an empty aggregate", async () => {
+    // A bootstrap has no previous publish, so it counts what it could not
+    // place and says nothing about whether that is falling.
+    const { store } = fakeStore(seed());
+    const lines = await saying(() =>
+      publish(["--bootstrap", "--days", "1"], store, NOW, needsFile)
+    );
+    expect(lines).toContain("the topology has no unit for 1 identities");
+    expect(lines).not.toContain("at the last publish");
   });
 
   it("carries what each configuration declares unavailable", async () => {
@@ -411,7 +627,9 @@ describe("publish()", () => {
     } finally {
       console.log = log;
     }
-    expect(lines.join("\n")).toContain("1 identities measure a suite");
+    expect(lines.join("\n")).toContain(
+      "1 identities measure a whole invocation",
+    );
   });
 
   it("folds from the state it left rather than the objects again", async () => {

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -48,11 +48,14 @@ import {
   dayOf,
   emptyAggregate,
   Fold,
+  identityOfKey,
   locateSurfaces,
   parseAggregate,
   partitionOf,
+  surfaceName,
   type Unplaced,
 } from "./test-selection/build.ts";
+import { isLaneMeasurement } from "./lane-measurement.ts";
 import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
 import type { Suite } from "./test-topology/suite.ts";
 import {
@@ -568,6 +571,24 @@ export async function publish(
   // built without it names surfaces nothing in the tree answers to.
   const suites = await topology();
   const { placed, unplaced } = locateSurfaces(suites, folded.surfaces);
+  // What nothing has worked out a unit for, kept from one publish to the
+  // next. A surface records on its own schedule, and a run reads surfaces
+  // only from the objects it folds for the first time, so a surface
+  // recording less often than this runs is absent from most runs. An
+  // entry is removed when the topology has a unit for its identity, and
+  // one an earlier run wrote is removed as soon as it names something the
+  // count no longer holds.
+  const stillUnplaced = (key: string): boolean => {
+    if (placed.has(key)) return false;
+    const test = identityOfKey(key);
+    return test !== undefined && !isLaneMeasurement(test);
+  };
+  folded.aggregate.unclaimed = [
+    ...new Set([
+      ...(aggregate.unclaimed ?? []).filter(stillUnplaced),
+      ...unplaced.unclaimed,
+    ]),
+  ].sort();
   const states = new Map(
     [...folded.states].filter(([key]) => placed.has(key)),
   );
@@ -613,7 +634,13 @@ export async function publish(
       })),
   }));
 
-  summarize(manifest, reference, folded.observations, unplaced);
+  summarize(
+    manifest,
+    reference,
+    folded.observations,
+    unplaced,
+    aggregate.unclaimed,
+  );
 
   if (options.out !== undefined) {
     await Deno.mkdir(options.out, { recursive: true });
@@ -652,12 +679,51 @@ export async function publish(
   return 0;
 }
 
-/** What the job summary says: the shape of what this run decided. */
+/** How many of the worst surfaces a summary line names. */
+const NAMED_SURFACES = 5;
+
+/**
+ * The record surfaces that wrote a set of identities, worst first, as one
+ * phrase. The count says how much there is to fix, and the surface says
+ * which part of the tree it is in.
+ */
+export function namingSurfaces(keys: readonly string[]): string {
+  const counts = new Map<string, number>();
+  for (const key of keys) {
+    const test = identityOfKey(key);
+    if (test === undefined) continue;
+    const surface = surfaceName(test);
+    counts.set(surface, (counts.get(surface) ?? 0) + 1);
+  }
+  // By count and then by name, so that two surfaces of the same size come
+  // out in the same order every run.
+  const ordered = [...counts].sort((left, right) =>
+    right[1] - left[1] || left[0].localeCompare(right[0])
+  );
+  const named = ordered.slice(0, NAMED_SURFACES).map(([surface, count]) =>
+    `${surface} ${count}`
+  );
+  const rest = ordered.length - named.length;
+  return `${ordered.length} surface(s): ${named.join(", ")}` +
+    (rest > 0 ? `, and ${rest} more` : "");
+}
+
+/**
+ * What the job summary says: the shape of what this run decided.
+ *
+ * `wasUnclaimed` is everything no run had worked out a unit for by the
+ * previous publish, from the aggregate this run read. It separates an
+ * identity recorded once and not yet given a unit from one whose records
+ * keep arriving and keep saying too little. A run folding into an empty
+ * aggregate has nothing to compare against, and so does one reading an
+ * aggregate that records no such list; both say neither.
+ */
 function summarize(
   manifest: ReturnType<typeof buildManifest>,
   reference: ReturnType<typeof plan>,
   observations: number,
   unplaced: Unplaced,
+  wasUnclaimed: readonly string[] | undefined,
 ): void {
   console.log(
     `test selection: folded ${observations} execution(s) into ` +
@@ -666,17 +732,44 @@ function summarize(
   if (unplaced.suiteLevel.length > 0) {
     console.log(
       `test selection: ${unplaced.suiteLevel.length} identities measure a ` +
-        `suite rather than anything a lane can be asked to run`,
+        `whole invocation rather than one unit, so they are left out. The ` +
+        `steps inside the invocation are measured separately, so nothing ` +
+        `is missing and there is nothing to act on.`,
     );
   }
   if (unplaced.unclaimed.length > 0) {
-    // Almost always an identity whose records predate the registration
-    // preload, so nothing knows which file registers it. It is placed
-    // again the first time it runs and records one.
     console.log(
-      `test selection: ${unplaced.unclaimed.length} identities no suite ` +
-        `claims, so no lane can run them`,
+      `test selection: the topology has no unit for ` +
+        `${unplaced.unclaimed.length} identities, so no lane can be asked ` +
+        `to run one. An identity is left out until one of its records ` +
+        `says enough to work out which unit it is in.`,
     );
+    console.log(
+      `test selection: those ${unplaced.unclaimed.length} were recorded ` +
+        `by ${namingSurfaces(unplaced.unclaimed)}`,
+    );
+    if (wasUnclaimed !== undefined) {
+      const before = new Set(wasUnclaimed);
+      const stuck = unplaced.unclaimed.filter((key) => before.has(key));
+      if (stuck.length === 0) {
+        console.log(
+          `test selection: none of them were in this count at the last ` +
+            `publish, so nothing has been recorded twice with no unit.`,
+        );
+      } else {
+        console.log(
+          `test selection: ${stuck.length} of them were in this count at ` +
+            `the last publish too, so more of their records have been ` +
+            `read since and those records still do not say which unit. A ` +
+            `surface whose records never say which unit is worth fixing. ` +
+            `See docs/development/test-selection.md.`,
+        );
+        console.log(
+          `test selection: those ${stuck.length} were recorded by ` +
+            `${namingSurfaces(stuck)}`,
+        );
+      }
+    }
   }
   const held = new Map<string, number>();
   for (const entry of manifest.withheld) {

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -431,6 +431,28 @@ describe("build", () => {
       expect(parseAggregate(JSON.stringify(aggregate))).toEqual(aggregate);
     });
 
+    it("carries what could not be placed into the next run", () => {
+      // A run compares what it cannot place against what the previous one
+      // could not, which is what tells an identity waiting for a record
+      // that places it from a surface whose records never carry one.
+      const aggregate = emptyAggregate("2026-08-20");
+      aggregate.unclaimed = [KEY];
+      expect(parseAggregate(JSON.stringify(aggregate))?.unclaimed)
+        .toEqual([KEY]);
+    });
+
+    it("reads a malformed unplaced list as nothing to compare against", () => {
+      // Nothing in the fold reads this list, so an aggregate carrying
+      // something else in its place is read as holding no list rather
+      // than refused outright.
+      const older = { ...emptyAggregate("2026-08-20") } as Record<
+        string,
+        unknown
+      >;
+      older.unclaimed = [7];
+      expect(parseAggregate(JSON.stringify(older))?.unclaimed).toBeUndefined();
+    });
+
     it("returns undefined for anything that is not one", () => {
       expect(parseAggregate("{not json")).toBeUndefined();
       expect(parseAggregate('{"schema":99}')).toBeUndefined();
@@ -558,6 +580,28 @@ describe("build", () => {
       );
       expect(placed.size).toBe(0);
       expect(unplaced.unclaimed).toEqual([KEY]);
+    });
+
+    it("leaves out the lane measuring itself", () => {
+      // A lane measures its own setup and its own batches through the
+      // record machinery every test uses. Those are not test surfaces, so
+      // they are neither placed nor counted as unplaced, and the suite
+      // here claims everything to show which of the two decides.
+      const key = testIdentityKey({
+        k: "gate",
+        s: "ci",
+        n: "ci-lane batch workspace-unit",
+      });
+      const { placed, unplaced } = locateSurfaces(
+        [claiming("workspace-unit", () => ({ level: "unit", unit: "one" }))],
+        new Map([[key, {
+          suite: "gate:ci",
+          unit: "ci-lane batch workspace-unit",
+          fromFile: false,
+        }]]),
+      );
+      expect(placed.size).toBe(0);
+      expect(unplaced).toEqual({ suiteLevel: [], unclaimed: [] });
     });
 
     it("passes over a key that names no identity", () => {

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -40,6 +40,7 @@ import {
   value,
 } from "./score.ts";
 import { claimsFor } from "../test-topology.ts";
+import { isLaneMeasurement } from "../lane-measurement.ts";
 import type { Suite } from "../test-topology/suite.ts";
 import {
   type Calibration,
@@ -98,6 +99,19 @@ export interface AggregateState {
   compacted: string[];
 
   states: Record<string, IdentityState>;
+
+  /**
+   * Every identity no run has worked out a unit for, kept from one
+   * publish to the next. A run reads surfaces only from the objects it
+   * folds for the first time, so a surface recording less often than the
+   * publisher runs is absent from most runs; keeping the list across them
+   * is what lets a run tell an identity recorded once and not yet given a
+   * unit from one whose records keep arriving and keep saying too little.
+   * An entry is removed when the topology has a unit for its identity, or
+   * when it names something the count no longer holds, so the list is
+   * what the tree still says nothing about.
+   */
+  unclaimed?: string[];
 }
 
 /** A fresh aggregate, for a cold start. */
@@ -183,6 +197,13 @@ export function parseAggregate(text: string): AggregateState | undefined {
   const compacted = state.compacted === undefined
     ? (written as string[]).map((day) => sourceDateKey(CI_SOURCE, day))
     : written as string[];
+  // What was unplaced last time is compared against rather than folded,
+  // so an aggregate written without it, or with something that is not a
+  // list of identities, is read as having nothing to compare against.
+  const unclaimed = Array.isArray(state.unclaimed) &&
+      state.unclaimed.every((key) => typeof key === "string")
+    ? state.unclaimed as string[]
+    : undefined;
   return {
     schema: MANIFEST_SCHEMA_VERSION,
     day: state.day,
@@ -190,6 +211,7 @@ export function parseAggregate(text: string): AggregateState | undefined {
     context: serializeContext(parseContext(state.context)),
     compacted,
     states: state.states as Record<string, IdentityState>,
+    ...(unclaimed === undefined ? {} : { unclaimed }),
   };
 }
 
@@ -319,10 +341,22 @@ export function recordSurface(
   test: TestIdentity,
   file: string | undefined,
 ): Surface {
-  const suite = test.v === undefined
+  return {
+    suite: surfaceName(test),
+    unit: file ?? test.n,
+    fromFile: file !== undefined,
+  };
+}
+
+/**
+ * The surface an identity's own record names: the kind of check, the
+ * workspace member that owns it, and the configuration it ran under where
+ * that is not the default one.
+ */
+export function surfaceName(test: TestIdentity): string {
+  return test.v === undefined
     ? `${test.k}:${test.s}`
     : `${test.k}:${test.s}:${test.v}`;
-  return { suite, unit: file ?? test.n, fromFile: file !== undefined };
 }
 
 /** What the topology could not place, and why. */
@@ -337,10 +371,21 @@ export interface Unplaced {
   suiteLevel: string[];
 
   /**
-   * Identities no suite claims at a unit level. An identity recorded
-   * before the registration preload carried its file is the usual one:
-   * the store knows the test and nothing knows which file registers it,
-   * so it will be placed again the first time it runs and records one.
+   * Identities the topology has no unit for. What decides an identity's
+   * unit is its own records: the file, for a suite whose units are files,
+   * and the recorded name for one whose units are not. An identity whose
+   * records say neither is given a unit the first time it records one the
+   * tree holds. An identity that matches two suites is here as well, which
+   * is a topology defect the drift guard fails on rather than a record
+   * that says too little. The lane's measurements of itself are not here:
+   * they are not test surfaces, and `isLaneMeasurement` is what says so.
+   *
+   * A count of these alone says nothing about which of those it holds. A
+   * run reads surfaces only from the objects it folds for the first time,
+   * so an identity here that `AggregateState.unclaimed` already held has
+   * recorded more since and still has no unit. That is a surface whose
+   * records never say which unit, rather than one whose next record
+   * will.
    */
   unclaimed: string[];
 }
@@ -370,6 +415,9 @@ export function locateSurfaces(
   for (const [key, surface] of surfaces) {
     const test = identityOfKey(key);
     if (test === undefined) continue;
+    // A lane's measurement of its own setup or of one of its batches is
+    // not a test surface: no suite claims one, and none should.
+    if (isLaneMeasurement(test)) continue;
     const claims = claimsFor(suites, {
       test,
       // The unit a record's own surface fell back to is the file where


### PR DESCRIPTION
The publisher prints a count of the identities that measure a whole invocation rather than one unit, and a count of the identities the topology has no unit for. Both were worded as bare statements that something could not be run, and both were read as error material in a pull request review. Neither is an error. One of them can be hiding one, and nothing said which.

The first is the design working. A script that records each of its steps also records its own run from end to end, and `locate` tells the two apart: the whole-invocation record names no unit, and adding its time to the time of the steps inside it would count that work twice. The line says that, and says there is nothing to act on.

The second needed more than wording. An identity is left out when its own records do not say enough to work out which unit it is in, and the same count holds two unlike things: identities whose next record will say, and surfaces whose records never say. The second is a defect wearing the clothes of the first, and a count cannot tell them apart. The publisher can. It reads each identity's records only from the objects it folds for the first time, so an identity in the count was recorded in an object no earlier publish had read; one that was already in the count has therefore been recorded twice over and had no unit either time. So the aggregate keeps the identities nothing has worked out a unit for, an entry is removed when the topology has a unit for it, and a run compares its own count against that list.

That list is kept across publishes rather than replaced by each one. A surface records on its own schedule, and one recording less often than the publisher runs is absent from most runs, so a list holding only the previous run's answer called such a surface new every time it recorded, which is the reassuring answer in exactly the case the comparison exists to catch.

Two things stood between the count and somebody acting on it. The lane's measurements of its own setup and its own batches were in it: nothing enumerates them and no lane can be asked to run one, so no suite has a unit for them and none should. `checkStore` was told that and `locateSurfaces` was not, so those identities were a floor under the count of identities recorded twice with no unit, which is the count that says there is something to fix. `locateSurfaces` now asks the same predicate, which moved into `tasks/lane-measurement.ts` beside the surface and prefix a measurement is written from; the alternative was `tasks/test-selection/build.ts` importing the lane command, and the lane already imports half of `test-selection`. The lane wrote its record names as literals while that prefix sat unused beside the predicate matching on it, so it now names them from the constant.

The other is that a count says how much there is to fix and nothing about where. A record's kind, scope and variant name the surface that wrote it, so both counts name the worst five surfaces behind them and count the rest. Reading the log no longer means reproducing the publisher against the store by hand.

Reproducing it that way is also what retired the framing this started from. The count was described as a backlog that empties rather than damage that accumulates, and measuring the population showed nearly every identity in it had no file on any of its records, from surfaces whose reporting never carried one. So the line states the count and the mechanism and leaves the verdict to the comparison, which is the only thing that has the evidence for one.

The messages describe the machinery plainly. They had said that an identity was placed on a unit, came back, returned, or came from a surface, as though it travelled, and that a suite claimed an identity, as though the two were in competition for it. Neither says what happens.

`docs/development/test-selection.md` carries the same explanation, so that somebody reading the log has somewhere to go, and names the wiring to check when a surface's records never say which unit.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

