### PR TITLE
fix(piece): validate contracts before binding input links

### DIFF
--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -592,8 +592,19 @@ another ordinary piece that passes the root-interface compatibility check.
 
 Uploading, compiling, or publishing content-addressed pattern source does not
 change an existing piece. These operations have no prior piece contract to
-compare, so piece compatibility does not gate them. Compatibility is evaluated
-when a candidate pattern is applied to an existing piece.
+compare, so piece compatibility does not gate them. Source-update compatibility
+is evaluated when a candidate pattern is applied to an existing piece.
+
+New input bindings made by `PiecesController.link` undergo contract validation
+in the transaction that commits the binding. A producer with durable schema
+metadata must satisfy the consumer's read contract and, for writable handles,
+accept the consumer's writes. Ordinary cells and externally injected handles
+without that metadata remain dynamic bindings: destination scope checks apply,
+but no static producer payload or capability proof is available. A known Piece
+whose producer contract cannot be recovered is refused. Raw writes that bypass
+this API, such as `setRawUntyped` and `cf cell set`, can store links without its
+admission check. The presence of a stored link alone therefore does not prove
+that its producer contract was checked when it was created.
 
 The runtime can compare the previous and candidate argument schemas, result
 schemas, and retained input links. Before a manual source replacement, the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -440,6 +440,30 @@ because the serialized link has no durable source contract. The superseded
 `cf set` spelling mounts this same command and has identical validation
 behavior.
 
+## Linking piece inputs
+
+`cf piece link <source>/<path> <target>/<path>` stores a live connection in the
+target piece's argument. Rebinding a terminal path replaces that connection; it
+does not write through the previous producer. Binding a Stream stores its handle
+without sending an event.
+
+The Piece API checks the binding before committing it. A producer with durable
+schema metadata must supply values the consumer can read. A writable consumer
+must also restrict its writes to values the producer accepts. Capability and
+scope constraints apply, and a rejected binding leaves the previous argument
+unchanged. `--allow-non-existing` only overrides the CLI's path-existence check;
+it does not waive contract validation.
+
+Ordinary cells and externally injected handles, including SQLite sources, can
+lack durable producer schema metadata. These remain supported as dynamic
+bindings, with destination scope checks but without a static producer payload or
+capability proof. A known Piece document whose producer contract cannot be
+recovered is refused. A piece without an argument schema imposes no consumer
+schema constraints, and plain-cell targets retain their ordinary binding
+behavior. Successful linking does not establish compatibility with a future
+producer schema; producer enforcement still applies when values are accessed or
+written.
+
 ## Updating piece source
 
 Run `cf piece setsrc --check` before every source update to a piece whose state
@@ -747,8 +771,7 @@ memo, which names a space once for the life of the process.
   callable's section — directly after the verb, before any `--`.
 - A `cf cell get` path that doesn't resolve prints a one-line error on stderr
   and exits 1 — it is a data error, not a usage error. A `piece link` that fails
-  validation (a source/target piece or path that doesn't exist) reports the same
-  way.
+  endpoint or contract validation reports the same way.
 - The launcher spawns the child CLI with `deno run --quiet` so Deno's own
   warnings (npm "Ignored build scripts" banner) never reach users.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -447,6 +447,10 @@ target piece's argument. Rebinding a terminal path replaces that connection; it
 does not write through the previous producer. Binding a Stream stores its handle
 without sending an event.
 
+After the binding commits, linking starts the target piece and materializes its
+result. `--no-start` stores the binding without starting the target. A rejected
+binding leaves a stopped target stopped.
+
 The Piece API checks the binding before committing it. A producer with durable
 schema metadata must supply values the consumer can read. A writable consumer
 must also restrict its writes to values the producer accepts. Capability and

--- a/packages/cli/integration/topics-restore-drill.sh
+++ b/packages/cli/integration/topics-restore-drill.sh
@@ -231,6 +231,19 @@ LIVE_COMMENTS="$(
 )"
 [ "$LIVE_COMMENTS" = "2" ] && ok "both comments back" ||
   bad "comments: $LIVE_COMMENTS"
+# The mention universe is a derived board index. Recompute its owner before
+# checking the restored connection: a plain cell read returns stored output
+# and cannot establish whether a cold index reflects the restored content.
+$CF cell get -q --piece "$BOARD" --space "$SPACE" --api-url "$API_URL" \
+  --step mentionable --select title > "$WORK/mention-index.json" \
+  2> "$WORK/mention-index.err" &&
+  jq -e --slurpfile index "$WORK/mention-index.json" \
+    '($index[0] | length) == 1 and .topics[0].content.title == $index[0][0].title' \
+    "$WORK/export.json" > /dev/null &&
+  ok "board mention index reflects the restored title" || {
+  bad "board mention index did not reflect the restored content"
+  cat "$WORK/mention-index.err" >&2
+}
 MENTION_TITLES="$(
   $CF cell get -q --piece "$TOPIC" --space "$SPACE" --api-url "$API_URL" \
     --input mentionable --select title 2> /dev/null | jq 'length'

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2348,14 +2348,15 @@ export function assertSuppliedLinkSchemasCompatible(
 
     /**
      * The prior pattern's argument schema, supplied only on a pattern update
-     * over existing state. A linked document with no producer-owned metadata —
+     * over existing state. For callers without `allowUnprovenSource`, a
+     * linked document with no producer-owned metadata —
      * e.g. a mergeable-push element doc, which is created under the piece's
      * own write authority and never carries any — is then held to the prior
      * contract at the link's own path instead of failing closed outright: the
      * proof becomes prior-contract ⊆ candidate, so a candidate that narrows
-     * away values the piece may already hold is still rejected. Without this
-     * prior contract or an explicit `allowUnprovenSource`, a source without
-     * durable metadata is refused.
+     * away values the piece may already hold is still rejected. Absent this
+     * option (every non-update flow), an unprovable source stays a hard error,
+     * so a fresh link to an arbitrary contract-less document is still refused.
      */
     priorArgumentSchema?: JSONSchema;
 

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1913,8 +1913,8 @@ function deriveTargetContracts(
 /**
  * Parse a supplied link and recover its producer's durable schema contract.
  * A metadata-less linked document is held to the prior argument contract on
- * a pattern update (see the `priorArgumentSchema` option's doc on
- * `assertSuppliedLinkSchemasCompatible`); otherwise it is refused outright.
+ * a pattern update. Dynamic binding can explicitly accept an unproven source;
+ * other supplied-link operations require the durable contract.
  */
 function resolveDurableSource(
   suppliedLink: SuppliedLink,
@@ -1924,10 +1924,11 @@ function resolveDurableSource(
   pieces: PiecesController,
   priorArgumentSchema: JSONSchema | undefined,
   displayPath: string,
+  allowUnprovenSource: boolean,
 ): {
   link: NormalizedLink;
   linkedCell: Cell<unknown>;
-  durableSource: DurableSourceContract;
+  durableSource: DurableSourceContract | undefined;
 } {
   const link = parseLinkOrThrow(suppliedLink.value, linkBase);
   const linkedCell = pieces.runtime.getCellFromLink(
@@ -1937,7 +1938,7 @@ function resolveDurableSource(
   );
   // A direct Cell view can be narrowed with asSchema() just as easily as a
   // serialized alias can carry a narrowed schema. Neither is a future-value
-  // invariant, so every durable link needs producer-owned Piece metadata.
+  // invariant, so a static producer proof needs producer-owned metadata.
   let durableSource = durableSourceContract(linkedCell, pieces);
   if (durableSource === undefined && priorArgumentSchema !== undefined) {
     // Pattern update over existing state: hold a metadata-less linked doc to
@@ -1953,11 +1954,36 @@ function resolveDurableSource(
       }],
     };
   }
-  if (durableSource === undefined) {
+  if (durableSource === undefined && !allowUnprovenSource) {
     throw incompatibleLinkError(
       displayPath,
       "source has no durable schema contract",
     );
+  }
+  if (durableSource === undefined) {
+    // An ordinary document is dynamic; a known Piece document whose contract
+    // cannot be recovered is unproved. Check both metadata partitions, as for
+    // scoped producer-contract recovery, before admitting a dynamic binding.
+    const sourceLink = linkedCell.getAsNormalizedFullLink();
+    const scopes = sourceLink.scope === "space"
+      ? [sourceLink.scope]
+      : [sourceLink.scope, "space"] as const;
+    for (const scope of scopes) {
+      const root = pieces.runtime.getCellFromLink(
+        { ...sourceLink, path: [], schema: undefined, scope },
+        undefined,
+        linkedCell.tx,
+      );
+      if (
+        root.getMetaRaw("result") !== undefined ||
+        getPatternIdentityRef(root) !== undefined
+      ) {
+        throw incompatibleLinkError(
+          displayPath,
+          "source Piece metadata cannot establish a durable schema contract",
+        );
+      }
+    }
   }
   return { link, linkedCell, durableSource };
 }
@@ -2169,8 +2195,7 @@ function policePreservedEnvelope(
   // so only the serialized case needs this check (`policeRebuiltAlias`
   // polices the same forgery for rebuilt links). A serialized link only
   // reaches here when it is identical to already-committed state, but
-  // committed does not mean vetted — raw write paths
-  // (`PiecesController.link`) commit links without ever running this
+  // committed does not mean vetted — stored links can originate outside this
   // validator — so re-assert it: a carried wrapper's `asCell` STACK (kind
   // and scope, per `asCellShapesMatch`; payload schemas are proved
   // separately against the durable contracts) has to match every durable
@@ -2312,15 +2337,25 @@ export function assertSuppliedLinkSchemasCompatible(
     destinationRoot?: JSONSchema;
 
     /**
+     * Admit a live source handle without producer-owned schema metadata. This
+     * preserves ordinary-cell and externally injected capability bindings in
+     * `PiecesController.link`; it provides no static payload or capability
+     * proof for such a source. Destination scope checks still apply. A source
+     * with a durable contract always undergoes the full proof; known Piece
+     * ownership without a recoverable contract is refused.
+     */
+    allowUnprovenSource?: boolean;
+
+    /**
      * The prior pattern's argument schema, supplied only on a pattern update
      * over existing state. A linked document with no producer-owned metadata —
      * e.g. a mergeable-push element doc, which is created under the piece's
      * own write authority and never carries any — is then held to the prior
      * contract at the link's own path instead of failing closed outright: the
      * proof becomes prior-contract ⊆ candidate, so a candidate that narrows
-     * away values the piece may already hold is still rejected. Absent this
-     * option (every non-update flow), an unprovable source stays a hard error,
-     * so a fresh link to an arbitrary contract-less document is still refused.
+     * away values the piece may already hold is still rejected. Without this
+     * prior contract or an explicit `allowUnprovenSource`, a source without
+     * durable metadata is refused.
      */
     priorArgumentSchema?: JSONSchema;
 
@@ -2374,6 +2409,7 @@ export function assertSuppliedLinkSchemasCompatible(
       pieces,
       options.priorArgumentSchema,
       displayPath,
+      options.allowUnprovenSource === true && isCell(suppliedLink.value),
     );
     const { localizedTargets, targetOuter } = localizeTargetOuter(
       targetContracts,
@@ -2388,6 +2424,9 @@ export function assertSuppliedLinkSchemasCompatible(
     );
     if (preservedOuter !== undefined) preservedDirectHandles.add(suppliedLink);
 
+    assertSourceScopeFits(targetContracts, linkedCell, displayPath);
+    if (durableSource === undefined) continue;
+
     const { rawSourceContracts, sourceContracts } = buildSourceContracts(
       durableSource,
       preservedOuter !== undefined,
@@ -2401,8 +2440,6 @@ export function assertSuppliedLinkSchemasCompatible(
         displayPath,
       );
     }
-    assertSourceScopeFits(targetContracts, linkedCell, displayPath);
-
     if (preservedOuter === undefined) {
       proveRebuiltContracts(sourceContracts, targetContracts, displayPath);
     } else {

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -1834,6 +1834,7 @@ export class PiecesController<T = unknown> {
     }
 
     if (targetIsPiece && start) {
+      await this.runtime.start(targetCell);
       await this.getResult(targetCell).pull();
     }
     await this.synced();

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -88,7 +88,11 @@ import {
   HOME_PATTERN_SOURCE,
   patternSourceUrl,
 } from "../system-pattern-url.ts";
-import { PieceController } from "./piece-controller.ts";
+import {
+  assertSuppliedLinkSchemasCompatible,
+  assertWritablePiecePath,
+  PieceController,
+} from "./piece-controller.ts";
 import { reconcilePieceSource } from "./piece-origin.ts";
 import { compileProgram } from "./utils.ts";
 import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
@@ -1726,6 +1730,11 @@ export class PiecesController<T = unknown> {
    * Set the target cell's argument cell at target path to be a link to the
    * link cell's content at linkPath.
    *
+   * Piece inputs validate the binding against durable producer metadata in
+   * the write transaction. Sources without that metadata remain dynamic
+   * bindings without a static producer-contract proof. Binding a Stream
+   * stores its handle; it does not send an event.
+   *
    * @param linkPieceId
    * @param linkPath
    * @param targetPieceId
@@ -1744,7 +1753,7 @@ export class PiecesController<T = unknown> {
     },
   ): Promise<void> {
     const start = options?.start ?? true;
-    let linkCell = this.runtime.getCellFromEntityId(
+    const linkCell = this.runtime.getCellFromEntityId(
       this.#space,
       entityIdFrom(linkPieceId),
       [],
@@ -1753,8 +1762,6 @@ export class PiecesController<T = unknown> {
       options?.sourceScope,
     );
     await linkCell.sync();
-    linkCell = linkCell.asSchemaFromLinks(); // Make sure we have the full schema
-    linkCell = linkCell.key(...linkPath);
     // Keep Piece result links anchored at the public result projection. Its
     // durable, monotonically narrowing result schema is the producer contract;
     // resolving through an alias here would discard that contract and point at
@@ -1766,10 +1773,13 @@ export class PiecesController<T = unknown> {
         this,
         targetPieceId,
         "Target",
-        options,
+        { ...options, start: false },
       );
 
     const result = await this.runtime.editWithRetry((tx) => {
+      // Recover the producer view in the transaction that commits the binding,
+      // so a concurrent contract change invalidates the transaction's reads.
+      const source = linkCell.withTx(tx).asSchemaFromLinks().key(...linkPath);
       let targetInputCell = targetCell.withTx(tx);
       if (targetIsPiece) {
         // For pieces, target fields are in the result cell's argument
@@ -1789,17 +1799,39 @@ export class PiecesController<T = unknown> {
           undefined,
           tx,
         );
+        const targetSchema = targetArgumentLink.schema ?? true;
+        assertWritablePiecePath(
+          targetSchema,
+          targetPath,
+          true,
+          false,
+          targetInputCell,
+        );
+        assertSuppliedLinkSchemasCompatible(
+          [{ path: targetPath, value: source }],
+          targetSchema,
+          targetInputCell,
+          this,
+          { allowUnprovenSource: true },
+        );
       }
 
       targetInputCell.key(...targetPath).setRawUntyped(
-        linkCell.getAsLink({
+        source.getAsLink({
           base: targetInputCell,
           includeSchema: true,
           keepAsCell: KeepAsCell.OnlyStream,
         }),
       );
     });
-    if (result.error) throw result.error;
+    if (result.error) {
+      throw new Error(
+        `Cannot link ${linkPieceId}/${linkPath.join("/")} to ${targetPieceId}/${
+          targetPath.join("/")
+        }: ${result.error.message}`,
+        { cause: result.error },
+      );
+    }
 
     if (targetIsPiece && start) {
       await this.getResult(targetCell).pull();

--- a/packages/piece/test/ops/piece-link-contracts.test.ts
+++ b/packages/piece/test/ops/piece-link-contracts.test.ts
@@ -1,0 +1,449 @@
+/** Contract admission and binding preservation at the Piece link boundary. */
+
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { valueEqual } from "@commonfabric/data-model";
+import { createSession, Identity } from "@commonfabric/identity";
+import {
+  isLink,
+  parseLinkOrThrow,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
+
+import { assertSuppliedLinkSchemasCompatible } from "../../src/ops/piece-controller.ts";
+import { PiecesController } from "../../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("piece link contract tests");
+
+/** Packages a compiler fixture. */
+function program(contents: string): RuntimeProgram {
+  return { main: "/main.tsx", files: [{ name: "/main.tsx", contents }] };
+}
+
+/** Publishes a row contract independently of whether any rows are present. */
+function rowProducer(empty = false): RuntimeProgram {
+  return program(`
+    import { NAME, pattern } from "commonfabric";
+    interface Row { [NAME]: string; title: string; piece: unknown; }
+    export default pattern<Record<string, never>, { rows: Row[] }>(() => ({
+      rows: ${
+    empty ? "[]" : '[{ [NAME]: "A", title: "A", piece: "reference" }]'
+  },
+    }));
+  `);
+}
+
+/** Declares the consumer's access independently of its row projection. */
+function rowConsumer(
+  kind: "ReadonlyCell" | "Writable",
+  fields = "title: string;",
+): RuntimeProgram {
+  return program(`
+    import { Default, lift, NAME, pattern, ReadonlyCell, Writable } from "commonfabric";
+    interface Row { [NAME]: string; ${fields} }
+    interface Input { rows?: ${kind}<Row[] | Default<[]>>; }
+    const label = lift((rows: ReadonlyCell<Row[]>) => rows.get()?.[0]?.[NAME] ?? "empty");
+    export default pattern<Input, { label: string }>(({ rows }) => ({
+      label: label(rows!),
+    }));
+  `);
+}
+
+/** Publishes a scalar backed by authored input. */
+function scalarProducer() {
+  return program(`
+    import { pattern, ReadonlyCell, Writable } from "commonfabric";
+    export default pattern<{ value: Writable<string> }, { value: Writable<string> }>(
+      ({ value }) => ({ value }),
+    );
+  `);
+}
+
+/** Reads a scalar through the selected consumer capability and scope. */
+function scalarConsumer(type = 'ReadonlyCell<string | Default<"seed">>') {
+  return program(`
+    import { Default, lift, pattern, PerSpace, ReadonlyCell, Writable } from "commonfabric";
+    const read = lift((value: ReadonlyCell<string>) => value.get());
+    export default pattern<{ value: ${type} }, { value: string }>(
+      ({ value }) => ({ value: read(value) }),
+    );
+  `);
+}
+
+describe("PiecesController", () => {
+  describe("instance members", () => {
+    describe("link()", () => {
+      let storage: ReturnType<typeof StorageManager.emulate>;
+      let runtime: Runtime;
+      let pieces: PiecesController;
+
+      beforeEach(async () => {
+        storage = StorageManager.emulate({ as: signer });
+        runtime = new Runtime({
+          apiUrl: new URL("http://toolshed.test"),
+          storageManager: storage,
+        });
+        pieces = new PiecesController(
+          await createSession({
+            identity: signer,
+            spaceName: crypto.randomUUID(),
+          }),
+          runtime,
+        );
+        await pieces.synced();
+      });
+
+      afterEach(async () => {
+        await runtime.dispose();
+        await storage.close();
+      });
+
+      it("refuses a writable row projection before changing either endpoint", async () => {
+        const source = await pieces.create(rowProducer());
+        const target = await pieces.create(rowConsumer("Writable"));
+        const argument = await target.input.getCell();
+        const before = argument.getRawUntyped();
+        const sourceBefore = source.getCell().getRawUntyped();
+
+        await expect(pieces.link(source.id, ["rows"], target.id, ["rows"]))
+          .rejects.toThrow("rows[].piece");
+
+        expect(valueEqual(argument.getRawUntyped(), before)).toBe(true);
+        expect(valueEqual(source.getCell().getRawUntyped(), sourceBefore)).toBe(
+          true,
+        );
+        expect(await target.result.get()).toEqual({ label: "empty" });
+      });
+
+      it("refuses an incompatible writable contract even when the producer array is empty", async () => {
+        const source = await pieces.create(rowProducer(true));
+        const target = await pieces.create(rowConsumer("Writable"));
+        await expect(pieces.link(source.id, ["rows"], target.id, ["rows"]))
+          .rejects.toThrow("rows[].piece");
+      });
+
+      it("binds a read-only row projection and preserves the public producer address", async () => {
+        const source = await pieces.create(rowProducer());
+        const sourceId = source.getCell().getAsNormalizedFullLink().id;
+        const targetProgram = rowConsumer("ReadonlyCell");
+        const target = await pieces.create(targetProgram);
+
+        await pieces.link(source.id, ["rows"], target.id, ["rows"]);
+
+        const argument = await target.input.getCell();
+        const raw = argument.key("rows").getRawUntyped();
+        expect(isLink(raw)).toBe(true);
+        const link = parseLinkOrThrow(raw, argument);
+        expect(link.id).toBe(sourceId);
+        expect(link.path).toEqual(["rows"]);
+        expect(await target.result.get()).toEqual({ label: "A" });
+        expect((await target.checkPattern(targetProgram)).compatible).toBe(
+          true,
+        );
+      });
+
+      it("binds a writable row that preserves the producer's required reference", async () => {
+        const source = await pieces.create(rowProducer());
+        const target = await pieces.create(
+          rowConsumer("Writable", "title: string; piece: unknown;"),
+        );
+        await pieces.link(source.id, ["rows"], target.id, ["rows"]);
+        expect(await target.result.get()).toEqual({ label: "A" });
+      });
+
+      it("refuses a read-only projection with an incompatible field type", async () => {
+        const source = await pieces.create(rowProducer());
+        const target = await pieces.create(
+          rowConsumer("ReadonlyCell", "title: number;"),
+        );
+        await expect(pieces.link(source.id, ["rows"], target.id, ["rows"]))
+          .rejects.toThrow("rows[].title");
+      });
+
+      it("refuses to expose a read-only producer as a writable handle", async () => {
+        // Seed the durable capability contract directly: compiled pattern
+        // results publish ordinary scalar schemas for these output wrappers.
+
+        const source = runtime.getCell(pieces.getSpace(), "readonly producer");
+        const { error } = await runtime.editWithRetry((tx) => {
+          source.withTx(tx).set({ value: "A" });
+          source.withTx(tx).setMetaRaw("schema", {
+            type: "object",
+            properties: { value: { type: "string", asCell: ["readonly"] } },
+            required: ["value"],
+          }, rawMetaWriteAuthorization);
+        });
+        expect(error).toBeUndefined();
+        const target = await pieces.create(
+          scalarConsumer('Writable<string | Default<"seed">>'),
+        );
+        await expect(
+          pieces.link(
+            source.getAsNormalizedFullLink().id,
+            ["value"],
+            target.id,
+            ["value"],
+          ),
+        )
+          .rejects.toThrow("readonly capability cannot be exposed as cell");
+      });
+
+      it("refuses to bind beneath a read-only ancestor", async () => {
+        const source = await pieces.create(scalarProducer(), {
+          input: { value: "A" },
+        });
+        const target = await pieces.create(program(`
+          import { Default, pattern, ReadonlyCell } from "commonfabric";
+          interface Input { group: ReadonlyCell<{ value: string } | Default<{ value: "seed" }>>; }
+          export default pattern<Input, { label: string }>(() => ({ label: "target" }));
+        `));
+        const argument = await target.input.getCell();
+        const before = argument.getRawUntyped();
+        await expect(
+          pieces.link(source.id, ["value"], target.id, ["group", "value"]),
+        )
+          .rejects.toThrow("readonly Cell path is not writable");
+        expect(valueEqual(argument.getRawUntyped(), before)).toBe(true);
+      });
+
+      it("checks the producer's flow policy for a new binding", async () => {
+        const source = await pieces.create(
+          program(`
+          import {
+            Cfc, CurrentPrincipal, handler, pattern, RepresentsCurrentUser,
+            Writable, WriteAuthorizedBy,
+          } from "commonfabric";
+          const setValue = handler<string, { value: Writable<string> }>(
+            (event, { value }) => value.set(event),
+          );
+          type Owned = RepresentsCurrentUser<Cfc<
+            WriteAuthorizedBy<string, typeof setValue>,
+            { ownerPrincipal: CurrentPrincipal }
+          >>;
+          export default pattern<{ value: string }, { value: Owned }>(
+            ({ value }) => ({ value }),
+          );
+        `),
+          { input: { value: "A" } },
+        );
+        const target = await pieces.create(scalarConsumer());
+        const argument = await target.input.getCell();
+        const before = argument.getRawUntyped();
+        await expect(pieces.link(source.id, ["value"], target.id, ["value"]))
+          .rejects.toThrow("ifc changed");
+        expect(valueEqual(argument.getRawUntyped(), before)).toBe(true);
+      });
+
+      it("refuses a user-scoped source for a space-scoped input", async () => {
+        const source = await pieces.create(scalarProducer(), {
+          input: { value: "A" },
+        });
+        const target = await pieces.create(
+          scalarConsumer('ReadonlyCell<PerSpace<string | Default<"seed">>>'),
+        );
+        await expect(
+          pieces.link(source.id, ["value"], target.id, ["value"], {
+            sourceScope: "user",
+          }),
+        )
+          .rejects.toThrow(
+            "source Cell scope user exceeds the destination scope",
+          );
+        await pieces.link(source.id, ["value"], target.id, ["value"]);
+        expect(await target.result.get()).toEqual({ value: "A" });
+      });
+
+      it("checks the destination scope even when the source has no durable schema", async () => {
+        const root = runtime.getCell(
+          pieces.getSpace(),
+          "scoped dynamic source",
+        );
+        const source = runtime.getCellFromLink({
+          ...root.getAsNormalizedFullLink(),
+          scope: "user",
+        });
+        const { error } = await runtime.editWithRetry((tx) =>
+          source.withTx(tx).set({ value: "A" })
+        );
+        expect(error).toBeUndefined();
+        const target = await pieces.create(
+          scalarConsumer('ReadonlyCell<PerSpace<string | Default<"seed">>>'),
+        );
+        await expect(
+          pieces.link(
+            source.getAsNormalizedFullLink().id,
+            ["value"],
+            target.id,
+            ["value"],
+            { sourceScope: "user" },
+          ),
+        )
+          .rejects.toThrow(
+            "source Cell scope user exceeds the destination scope",
+          );
+      });
+
+      it("binds a Stream handle without sending an event and preserves later sends", async () => {
+        const source = await pieces.create(program(`
+          import { Default, handler, pattern, Stream, Writable } from "commonfabric";
+          const record = handler<string, { values: Writable<string[]> }>((event, { values }) => values.push(event));
+          export default pattern<{ values: Writable<string[] | Default<[]>> }, { send: Stream<string>; values: string[] }>(
+            ({ values }) => ({ send: record({ values }), values }),
+          );
+        `));
+        const target = await pieces.create(program(`
+          import { pattern, Stream } from "commonfabric";
+          interface Input { send?: Stream<string>; }
+          export default pattern<Input, Input>(({ send }) => ({ send }));
+        `));
+        await pieces.link(source.id, ["send"], target.id, ["send"]);
+        expect(await source.input.get(["values"])).toEqual([]);
+        (await target.result.getCell()).key("send").send("recorded");
+        await runtime.idle();
+        expect(await source.input.get(["values"])).toEqual(["recorded"]);
+      });
+
+      it("refuses an ordinary Cell where the destination requires a Stream", async () => {
+        const source = await pieces.create(scalarProducer(), {
+          input: { value: "A" },
+        });
+        const target = await pieces.create(program(`
+          import { pattern, Stream } from "commonfabric";
+          interface Input { send?: Stream<string>; }
+          export default pattern<Input, Input>(({ send }) => ({ send }));
+        `));
+        await expect(pieces.link(source.id, ["value"], target.id, ["send"]))
+          .rejects.toThrow("Cell handle is not accepted as stream");
+      });
+
+      it("replaces a terminal binding without writing through the old producer", async () => {
+        const first = await pieces.create(scalarProducer(), {
+          input: { value: "first" },
+        });
+        const second = await pieces.create(scalarProducer(), {
+          input: { value: "second" },
+        });
+        const target = await pieces.create(scalarConsumer());
+        await pieces.link(first.id, ["value"], target.id, ["value"]);
+        const firstBefore = first.getCell().getRawUntyped();
+
+        await pieces.link(second.id, ["value"], target.id, ["value"]);
+
+        expect(valueEqual(first.getCell().getRawUntyped(), firstBefore)).toBe(
+          true,
+        );
+        expect(await first.result.get()).toEqual({ value: "first" });
+        expect(await target.result.get()).toEqual({ value: "second" });
+        await second.input.set("updated", ["value"]);
+        expect(await target.result.get()).toEqual({ value: "updated" });
+      });
+
+      it("preserves an existing binding when its replacement is incompatible", async () => {
+        const first = await pieces.create(scalarProducer(), {
+          input: { value: "first" },
+        });
+        const source = await pieces.create(rowProducer());
+        const target = await pieces.create(scalarConsumer());
+        await pieces.link(first.id, ["value"], target.id, ["value"]);
+        const argument = await target.input.getCell();
+        const before = argument.getRawUntyped();
+
+        await expect(pieces.link(source.id, ["rows"], target.id, ["value"]))
+          .rejects.toThrow("input link at value");
+
+        expect(valueEqual(argument.getRawUntyped(), before)).toBe(true);
+        expect(await target.result.get()).toEqual({ value: "first" });
+      });
+
+      it("checks an incompatible legacy binding again when asked to bind the same source", async () => {
+        // Raw stored state may predate admission checks. Rebinding it is a new
+        // operation even when the supplied address is already in the slot.
+
+        const source = await pieces.create(rowProducer());
+        const target = await pieces.create(rowConsumer("Writable"));
+        const argument = await target.input.getCell();
+        const { error } = await runtime.editWithRetry((tx) => {
+          argument.withTx(tx).key("rows").setRawUntyped(
+            source.getCell().key("rows").getAsLink({ base: argument }),
+          );
+        });
+        expect(error).toBeUndefined();
+        const before = argument.getRawUntyped();
+        await expect(pieces.link(source.id, ["rows"], target.id, ["rows"]))
+          .rejects.toThrow("rows[].piece");
+        expect(valueEqual(argument.getRawUntyped(), before)).toBe(true);
+      });
+
+      it("keeps a source without durable schema metadata as a dynamic binding", async () => {
+        const source = runtime.getCell(pieces.getSpace(), "dynamic source");
+        const { error } = await runtime.editWithRetry((tx) => {
+          source.withTx(tx).set({ value: "dynamic" });
+        });
+        expect(error).toBeUndefined();
+        const target = await pieces.create(scalarConsumer());
+        await pieces.link(
+          source.getAsNormalizedFullLink().id,
+          ["value"],
+          target.id,
+          ["value"],
+        );
+        expect(await target.result.get()).toEqual({ value: "dynamic" });
+
+        const candidate = await runtime.patternManager.compilePattern(
+          scalarConsumer(),
+          { space: pieces.getSpace() },
+        );
+        expect(() =>
+          assertSuppliedLinkSchemasCompatible(
+            [{ path: ["value"], value: source.key("value") }],
+            candidate.argumentSchema,
+            pieces.getArgument(target.getCell()),
+            pieces,
+          )
+        ).toThrow("source has no durable schema contract");
+        expect(() =>
+          assertSuppliedLinkSchemasCompatible(
+            [{ path: ["value"], value: source.key("value").getAsLink() }],
+            candidate.argumentSchema,
+            pieces.getArgument(target.getCell()),
+            pieces,
+            { allowUnprovenSource: true },
+          )
+        ).toThrow("source has no durable schema contract");
+      });
+
+      it("refuses a known Piece document whose producer contract is unavailable", async () => {
+        const owner = runtime.getCell(pieces.getSpace(), "unavailable owner");
+        const source = runtime.getCell(pieces.getSpace(), "owned document");
+        const { error } = await runtime.editWithRetry((tx) => {
+          source.withTx(tx).set({ value: "A" });
+          source.withTx(tx).setMetaRaw(
+            "result",
+            owner.getAsLink(),
+            rawMetaWriteAuthorization,
+          );
+        });
+        expect(error).toBeUndefined();
+        const target = await pieces.create(scalarConsumer());
+        const argument = await target.input.getCell();
+        const before = argument.getRawUntyped();
+        await expect(
+          pieces.link(
+            source.getAsNormalizedFullLink().id,
+            ["value"],
+            target.id,
+            ["value"],
+          ),
+        )
+          .rejects.toThrow(
+            "source Piece metadata cannot establish a durable schema contract",
+          );
+        expect(valueEqual(argument.getRawUntyped(), before)).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/piece/test/ops/piece-link-contracts.test.ts
+++ b/packages/piece/test/ops/piece-link-contracts.test.ts
@@ -4,7 +4,7 @@ import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { valueEqual } from "@commonfabric/data-model";
-import { createSession, Identity } from "@commonfabric/identity";
+import { createSession, Identity, type Session } from "@commonfabric/identity";
 import {
   isLink,
   parseLinkOrThrow,
@@ -78,8 +78,20 @@ describe("PiecesController", () => {
   describe("instance members", () => {
     describe("link()", () => {
       let storage: ReturnType<typeof StorageManager.emulate>;
+      let session: Session;
       let runtime: Runtime;
       let pieces: PiecesController;
+
+      /** Opens the stored pieces in a runtime with no running graphs. */
+      async function reopenPieces(): Promise<void> {
+        await runtime.dispose({ closeStorage: false });
+        runtime = new Runtime({
+          apiUrl: new URL("http://toolshed.test"),
+          storageManager: storage,
+        });
+        pieces = new PiecesController(session, runtime);
+        await pieces.synced();
+      }
 
       beforeEach(async () => {
         storage = StorageManager.emulate({ as: signer });
@@ -87,19 +99,75 @@ describe("PiecesController", () => {
           apiUrl: new URL("http://toolshed.test"),
           storageManager: storage,
         });
-        pieces = new PiecesController(
-          await createSession({
-            identity: signer,
-            spaceName: crypto.randomUUID(),
-          }),
-          runtime,
-        );
+        session = await createSession({
+          identity: signer,
+          spaceName: crypto.randomUUID(),
+        });
+        pieces = new PiecesController(session, runtime);
         await pieces.synced();
       });
 
       afterEach(async () => {
         await runtime.dispose();
         await storage.close();
+      });
+
+      it("starts a cold target and materializes the admitted binding by default", async () => {
+        const source = await pieces.create(rowProducer());
+        const targetId = (await pieces.create(rowConsumer("ReadonlyCell"))).id;
+        await reopenPieces();
+        const target = await pieces.get(targetId, false);
+        expect(runtime.runner.cancels.size).toBe(0);
+        expect(pieces.getResult(target.getCell()).get()).toEqual({
+          label: "empty",
+        });
+
+        await pieces.link(source.id, ["rows"], target.id, ["rows"]);
+
+        expect(pieces.getResult(target.getCell()).get()).toEqual({
+          label: "A",
+        });
+        expect(runtime.runner.cancels.size).toBeGreaterThan(0);
+      });
+
+      it("stores an admitted binding with start false while the cold target stays stopped", async () => {
+        const source = await pieces.create(rowProducer());
+        const targetId = (await pieces.create(rowConsumer("ReadonlyCell"))).id;
+        await reopenPieces();
+        const target = await pieces.get(targetId, false);
+        expect(runtime.runner.cancels.size).toBe(0);
+
+        await pieces.link(source.id, ["rows"], target.id, ["rows"], {
+          start: false,
+        });
+
+        expect(runtime.runner.cancels.size).toBe(0);
+        const argument = pieces.getArgument(target.getCell());
+        const link = parseLinkOrThrow(argument.key("rows").getRaw(), argument);
+        expect(link.id).toBe(source.getCell().getAsNormalizedFullLink().id);
+        expect(link.path).toEqual(["rows"]);
+        expect(pieces.getResult(target.getCell()).get()).toEqual({
+          label: "empty",
+        });
+      });
+
+      it("leaves a cold target stopped and unchanged when admission fails", async () => {
+        const source = await pieces.create(rowProducer());
+        const targetId = (await pieces.create(rowConsumer("Writable"))).id;
+        await reopenPieces();
+        const target = await pieces.get(targetId, false);
+        const argument = pieces.getArgument(target.getCell());
+        const before = argument.getRawUntyped();
+        expect(runtime.runner.cancels.size).toBe(0);
+
+        await expect(pieces.link(source.id, ["rows"], target.id, ["rows"]))
+          .rejects.toThrow("rows[].piece");
+
+        expect(runtime.runner.cancels.size).toBe(0);
+        expect(valueEqual(argument.getRawUntyped(), before)).toBe(true);
+        expect(pieces.getResult(target.getCell()).get()).toEqual({
+          label: "empty",
+        });
       });
 
       it("refuses a writable row projection before changing either endpoint", async () => {

--- a/scripts/topics-rehearsal-lib.ts
+++ b/scripts/topics-rehearsal-lib.ts
@@ -251,9 +251,11 @@ export interface TopicsExport {
  * one points at. A document write cannot carry a `$link`, so these are routed
  * aside and re-linked after the apply.
  *
- * Three today: `mentionable` (the board's universe), `boardCrossrefs` (its
- * reference pivot), and `boardNames` (its names table, which a topic reads its
- * own member name out of).
+ * Three today: `mentionable` (the board's derived mention index),
+ * `boardCrossrefs` (its reference pivot), and `boardNames` (its names table,
+ * which a topic reads its own member name out of). The mention index publishes
+ * display rows with stable strings and unread member references, matching
+ * the wiring the board supplies when it creates a topic.
  *
  * Adding a wiring input to the topic pattern means adding it here. Leaving it
  * out is not silent: `buildRestoreDocument` throws on any link-valued field it
@@ -263,7 +265,7 @@ export interface TopicsExport {
  * throw into a failing check rather than a surprise mid-incident.
  */
 export const STRUCTURAL_LINK_SOURCES: Record<string, string> = {
-  mentionable: "topics",
+  mentionable: "mentionable",
   boardCrossrefs: "crossrefs",
   boardNames: "namesTable",
 };

--- a/scripts/topics-restore.ts
+++ b/scripts/topics-restore.ts
@@ -30,7 +30,7 @@
  * `cf piece link` against the board recorded in the export.
  *
  * Those wiring links are `STRUCTURAL_LINK_SOURCES`, which maps each one to
- * the board path it points at: `mentionable` to the board's `topics`,
+ * the board path it points at: `mentionable` to the board's `mentionable` index,
  * `boardCrossrefs` to its `crossrefs`, and `boardNames` to its `namesTable`.
  * A link-valued field absent from that map stops the restore rather than
  * being guessed at, so a wiring input added to the topic pattern announces


### PR DESCRIPTION
Fixes #7092.

A producer can publish rows that require `piece` while a writable consumer accepts rows that omit it. `PiecesController.link` now rejects that binding before it changes the destination, using the canonical supplied-link validator and writable-path guard in the transaction that commits the binding.

Producer metadata is read in that transaction. After a successful commit, default linking starts the target and materializes its result. `start: false` / `--no-start` stores the binding without starting the target; a rejected link leaves a stopped target stopped. Rebinding replaces the terminal connection without writing through the old producer. Stream binding stores a handle without sending an event. Errors identify both endpoints and retain the contract failure.

Compatibility policy:

- Sources with durable producer metadata undergo the canonical read/write, capability, scope, and IFC checks. A known Piece document with an unrecoverable contract is refused.
- Ordinary untyped cells and injected capabilities such as SQLite remain supported as dynamic bindings, with destination scope checks but no static producer payload/capability proof. This exception accepts live handles only; existing serialized supplied-link paths remain strict.
- Schema-less Piece arguments remain unconstrained, and plain-cell targets retain their existing behavior.
- Each bind/rebind is checked independently of #7086's retained-handle update policy. Creation-time admission does not prove compatibility with future producer schemas. Raw writes that bypass this API can omit admission, as the lifecycle spec now explicitly documents.

The CLI inherits the API check, including with `--allow-non-existing`. The Topics restore caller reconnects `mentionable` to the board's published mention index, matching creation wiring. Its drill explicitly computes that derived index and checks the restored title before reading through the connection.

Validation:

- Fresh GitHub CI at `94d118740`: 66 checks passed, 3 skipped ([run](https://github.com/commontoolsinc/labs/actions/runs/34386917392)).
- 20 binding regression cases, including three cases that reopen stored pieces in a fresh Runtime. The default-start case reproduces the stale result before the fix and passes afterward.
- Full Piece suite: 57 groups / 863 steps, passing.
- Full CLI suite: all three phases passing (1,813 + 1 + 218 groups), with the host's forced `NO_COLOR` unset for the enabled-color tests.
- Repository type check, format, lint, and documentation code checks: passing (595 documentation blocks).
- Combined with #7086 at `0c8115040`: full Piece suite passes 58 groups / 875 steps; focused binding and retained-input suites pass with `EXPERIMENTAL_MODERN_CELL_REP=true` (2 groups / 29 steps).
- The Topics restore fix was separately verified at `cd78a79bd`: full `core-piece-call` integration section passing, including all 16 restore checks, bulk-survey, and shuttle; scripts suite passing 7 groups / 51 steps.

Merge coordination with #7086: its retained-row fixture already seeds the legacy link directly in `0c8115040`; no fixture adjustment remains. The `priorArgumentSchema` comment is arranged so both PRs' qualifications merge automatically. Full-tree merge checks succeed against both that head and main at `48b0131c5`. The lifecycle spec distinguishes checked API bindings from raw writes that bypass admission; the exact clarification for #7086's additional retention paragraph is retained in [the coordination reply](https://github.com/commontoolsinc/labs/pull/7101#discussion_r3971561747).

Implemented and self-reviewed by Codex (Astra), on behalf of @mathpirate.