### PR TITLE
dashboard: give the two test tiles a page to say the rest on

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -286,6 +286,28 @@ pressure people into gaming it, leave it off. This is a quiet instrument panel a
 tired person should be able to trust at 2am, not a scoreboard and not a
 surveillance tool.
 
+A tile is about as wide as a business card, and every line on it is set without
+wrapping. A line longer than that width is not shortened by the renderer so much
+as cut off by it, and a line that ends in an ellipsis has taken the whole line
+and delivered none of it. So the headline figure and the sub line under it are
+what a tile has room to say. Text can go below them — the host names down the
+production tile, the run list on the full-width recent runs — but only text
+short enough to be read whole at the width the tile is actually given. Something
+longer is not a longer tile, it is a page.
+
+That page is an ordinary drill-down — a route the tile declares, reached through
+the tile's `href`, and named on the tile by its `hint` so that a person can see
+there is something behind it. `/bench` holds the histories behind the benchmark
+and duration tiles, and `/test-selection` holds the manifest behind the two test
+tiles. A page has the width to spell a test's whole name, so nothing on one has
+to be abbreviated.
+
+Where a tile has more than one candidate for its sub line, the one that explains
+the color it is wearing wins. The test selection tile carries the share of the
+corpus a pull request would run while it is green, and gives that line up to
+name the lane that went past its budget once one has, because that lane is what
+turned the tile red.
+
 ### The `TileView` a tile returns
 
 | field | meaning |
@@ -311,6 +333,9 @@ surveillance tool.
 | commit CI Gantt → `/ci-gantt` | job and step timing for every successful main workflow run attached to one commit, linked from run durations in recent main runs | `GH_TOKEN` |
 | CI duration history → `/bench?view=ci` | labs and loom job, shard-group, and end-to-end workflow duration trends. The duration tiles open their matching repository view | `GH_TOKEN` |
 | CI run Gantt → `/bench?view=gantt` | detailed labs or loom job phases from `scripts/ci-gantt.ts`, backed by the CI history cache | `GH_TOKEN` |
+| flaky tests | how many tests the test-selection publisher measured disagreeing with themselves often enough to keep off pull requests, read from the newest selection manifest. The headline names what it counts, so it reads `25 flaky tests`, or `no flaky tests` when there are none. The line under it says what the count was drawn from: the span of history a flake share is measured over, which the manifest's `FLAKE_WINDOW_DAYS` dial names, and how long ago the publisher measured. Which tests they are is on the page behind it. Amber from one, red from ten | none |
+| test selection | what share of the corpus the newest selection manifest would have a pull request run, read from the same manifest. The manifest's packing is built with nothing mandatory, so the share is the one a pull request touching no test would get; a real one re-packs against its own diff and spends part of the same budget on what that diff makes mandatory. Amber once that manifest is over eight hours old, because selection quality decays with it, and red when a lane's projected work is past the budget the manifest was packed to, which is the one condition the sub line gives up the corpus share to name | none |
+| test selection detail → `/test-selection` | the manifest behind both test tiles, at full width: every lane against its budget and how many tests it holds, every test held back as flaky with the rate it was measured at, every test held back while main is red, and every test no lane can hold. Both tiles link here, the flaky tests tile straight to its flaky section | none |
 | coverage debt | the repository's whole uncovered-line count and what a median day does to it, read from the `perf-metrics` artifact of each day's newest successful `main` run (`docs/development/COVERAGE.md`). The headline is the count; under it a signed rate gives the median day's move over the last three weeks, and the chart shows eight weeks with those days picked out. Amber means that median is a rise, which takes more than half the days in the window, so a day that added debt says nothing on its own. It never turns red, and it goes gray rather than stand on a stale number: when five days have passed with nothing measured, and until the window holds a week of days to take a median over. A run whose pattern compile cache missed is passed over, because a cold run reaches branches a warm one does not and reads about a tenth of a percent low. It looks for a landing every five minutes, which costs one request when none has happened; the figure itself cannot exist until a run's Coverage Check uploads it, about twelve minutes after the commit lands | `GH_TOKEN` |
 | production | a direct synthetic HTTP check of the public common.tools site, synthetic HTTP checks of `/_health` on estuary and rapids, plus a name or reachability check for all three and for the bastion, the production and staging shells, the LLM gateway, and the sandbox service. When every host is well the headline counts them up. When a host has nothing behind it at all, the headline names that host, as in `bastion down`, and counts them when there is more than one, as in `2 hosts down`. Otherwise it names the worst condition seen, such as a response time or an HTTP status. Estuary and rapids keep their response times in the body while the tile is green or orange. Common.tools stays out of the body while it is good. Hosts without a health request stay out for as long as they answer, and a red tile drops all the green hosts. Red means the tile found nothing at the other end — a name with no A or AAAA record, a tailnet host the proxy cannot reach, or an HTTP request that never connected — and it also means a server health response other than 200, a health response over 1000 ms, or a common.tools 5xx response. Orange means a health response over 500 ms, a common.tools 4xx response or response over 2500 ms, or a resolver that failed, which leaves the tile unable to say either way. Hosts outside the tailnet are looked up by the dashboard itself. Tailnet hosts go through `PROD_PROXY`, because a dashboard that needs that proxy has no view of Tailscale's MagicDNS. Estuary and rapids are covered there by their health requests. The bastion has no health endpoint, so it gets a SOCKS5 connect that leaves the name for the proxy to resolve. The bastion records that connect in its own logs, so a bastion that answers is left alone for an hour and counts as reachable in between. One that does not answer is asked again on the next refresh, since a connect that reaches nothing leaves nothing behind. With no `PROD_PROXY` set, every host is looked up locally | optional `COMMON_TOOLS_URL`, `ESTUARY_URL`, `RAPIDS_URL`, `BASTION_HOST`, `PROD_PROXY`; `PROD_URL` remains an alias for `ESTUARY_URL` |
 | prod errors | SigNoz trace error rate for one service (errored spans / all spans): last-12h headline, with a per-hour sparkline over the retained trace history (~2 weeks) and the last-12h slice that feeds the headline highlighted. Scoped to `PROD_SERVICE` — the same SigNoz holds staging and one-off perf runs, whose rates are not production's. Gray (not red) when SigNoz is unreachable. Pops out to the SigNoz logs explorer | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `SIGNOZ_UI_URL` for the pop-out |

--- a/packages/dashboard/detail-page.ts
+++ b/packages/dashboard/detail-page.ts
@@ -1,0 +1,20 @@
+/**
+ * Holds the chrome a page behind a tile starts from: the page frame, the
+ * line of navigation back to the wall at the top of it, the heading above a
+ * section, and the footnote at the bottom. A drill-down adds what its own
+ * subject needs on top of these, and may narrow one of them as the CI Gantt
+ * page narrows the frame.
+ */
+
+import { DASHBOARD_THEME_STYLES } from "./theme.ts";
+
+/** The frame, the navigation, and the type a drill-down page shares. */
+export const DETAIL_PAGE_STYLES = `
+  ${DASHBOARD_THEME_STYLES}
+  body{box-sizing:border-box;width:100%;margin:0 auto;background:var(--page);color:var(--text);font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px}
+  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:14px;flex-wrap:wrap}
+  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:var(--text-faint)}
+  a.back{color:var(--accent);text-decoration:none;font-size:13px}
+  h2{font-size:12px;letter-spacing:.04em;color:var(--text-subtle);font-weight:600;margin:20px 0 8px;font-family:ui-monospace,Menlo,monospace}
+  .empty{color:var(--text-muted);font-size:14px}
+  .note{font-size:11px;color:var(--text-faint);margin-top:22px}.note a{color:var(--accent);text-decoration:none}`;

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
-import { budgetStatus, clampInt, concDot, daysLabel, durationTag, escapeHtml, friendlyError, humanDur, humanSpan, jsonFromZip, landingHref, lighten, median, multiSparkline, readBudget, sparkline, strip, thin, usd } from "./lib.ts";
+import { budgetStatus, clampInt, compactSpan, concDot, daysLabel, durationTag, escapeHtml, friendlyError, groupDigits, humanDur, humanSpan, jsonFromZip, landingHref, lighten, median, multiSparkline, readBudget, sparkline, strip, thin, usd } from "./lib.ts";
 import { artifactZip, bytes, makeZip } from "./test/artifact-zip.ts";
 
 Deno.test("landingHref: squash-merge trailing (#N) -> the PR", () => {
@@ -32,6 +32,25 @@ Deno.test("concDot: only genuine failures are red", () => {
   assertEquals(concDot("timed_out", 1), "red");
   assertEquals(concDot("cancelled", 1), "gray"); // non-verdict, not a failure
   assertEquals(concDot(null, 1), "gray");
+});
+
+Deno.test("compactSpan: minutes, then hours, then days", () => {
+  assertEquals(compactSpan(0), "0m");
+  assertEquals(compactSpan(12 * 60_000), "12m");
+  assertEquals(compactSpan(3_600_000), "1h");
+  assertEquals(compactSpan(28 * 3_600_000), "28h");
+  assertEquals(compactSpan(48 * 3_600_000), "2d");
+  assertEquals(compactSpan(7 * 86_400_000), "7d");
+  assertEquals(compactSpan(-5_000), "0m");
+});
+
+Deno.test("groupDigits: separates thousands, rounding first", () => {
+  assertEquals(groupDigits(78101), "78,101");
+  assertEquals(groupDigits(999), "999");
+  assertEquals(groupDigits(1000), "1,000");
+  assertEquals(groupDigits(1234567), "1,234,567");
+  assertEquals(groupDigits(0), "0");
+  assertEquals(groupDigits(30.6), "31");
 });
 
 Deno.test("daysLabel: consistent 'x days' text", () => {

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -13,20 +13,24 @@ import {
   performanceGitHubRateLimit,
 } from "./github-rate-limit.ts";
 import {
+  compactSpan,
   daysLabel,
   DURATION_LABEL_HEIGHT,
   durationTag,
   escapeHtml,
+  groupDigits,
   humanSpan,
   SPARKLINE_HEIGHT,
   STATUS_DOT,
 } from "./tile-render-values.ts";
 
 export {
+  compactSpan,
   daysLabel,
   DURATION_LABEL_HEIGHT,
   durationTag,
   escapeHtml,
+  groupDigits,
   humanSpan,
   SPARKLINE_HEIGHT,
   STATUS_DOT,

--- a/packages/dashboard/performance-views.ts
+++ b/packages/dashboard/performance-views.ts
@@ -6,12 +6,13 @@
  * the bounds on how a history is scaled to a chart.
  */
 
+import { DETAIL_PAGE_STYLES } from "./detail-page.ts";
 import { escapeHtml } from "./lib.ts";
 import {
   STATUS_EDGE,
   STATUS_WASH,
 } from "./palette.ts";
-import { DASHBOARD_THEME_STYLES, statusLayer } from "./theme.ts";
+import { statusLayer } from "./theme.ts";
 
 export type PerformanceView = "runtime" | "ci" | "gantt";
 
@@ -46,11 +47,7 @@ export const PERFORMANCE_PROGRESS_STYLES = `
   #fetch-detail{font-size:11px;margin:0}`;
 
 export const PERFORMANCE_VIEW_STYLES = `
-  ${DASHBOARD_THEME_STYLES}
-  body{box-sizing:border-box;width:100%;margin:0 auto;background:var(--page);color:var(--text);font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px}
-  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:14px;flex-wrap:wrap}
-  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:var(--text-faint)}
-  a.back{color:var(--accent);text-decoration:none;font-size:13px}
+  ${DETAIL_PAGE_STYLES}
   .views{display:flex;gap:6px;margin:0 0 14px}
   .views a,.controls a{font-size:13px;color:var(--text-secondary);text-decoration:none;border:1px solid var(--border-strong);border-radius:6px;padding:4px 10px}
   .controls a{font-variant-numeric:tabular-nums}.controls a:hover{border-color:var(--border-hover)}
@@ -66,7 +63,6 @@ export const PERFORMANCE_VIEW_STYLES = `
   .legend{font-size:11px;color:var(--text-subtle);margin:0 0 12px}
   ${PERFORMANCE_PROGRESS_STYLES}
   .axisrow{display:flex;gap:18px;margin:0 14px 4px}.timeaxis{flex:0 0 42%;display:flex;justify-content:space-between;color:var(--text-faint);font-size:10px}
-  h2{font-size:12px;letter-spacing:.04em;color:var(--text-subtle);font-weight:600;margin:20px 0 8px;font-family:ui-monospace,Menlo,monospace}
   .blist,.clist{display:flex;flex-direction:column;gap:7px}
   .brow,.crow{display:flex;align-items:center;gap:18px;background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:8px 14px}
 ${ROW_RULES}
@@ -76,8 +72,7 @@ ${ROW_RULES}
   .bname,.cname{font-size:13px;color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
   .bval,.cval{color:var(--text);font-size:18px;font-weight:600;font-variant-numeric:tabular-nums}
   .btrend,.ctrend{font-size:11px;font-weight:400;color:var(--text-muted)}
-  .empty,.refresh-error{color:var(--text-muted);font-size:14px}.refresh-error{color:var(--status-warn-text)}
-  .note{font-size:11px;color:var(--text-faint);margin-top:22px}.note a{color:var(--accent);text-decoration:none}
+  .refresh-error{color:var(--status-warn-text);font-size:14px}
   @media(max-width:640px){.timeaxis{flex:1}.brow,.crow{align-items:stretch;gap:7px;flex-wrap:wrap}.bspark,.cspark{flex:1 0 100%}.controls .field,.controls .choice-group{flex:1 1 100%}.controls input[type=range]{flex:1;width:auto;min-width:0}.controls label.trailing{margin-left:0}}`;
 
 const labels: Record<PerformanceView, string> = {

--- a/packages/dashboard/test-selection-manifest.test.ts
+++ b/packages/dashboard/test-selection-manifest.test.ts
@@ -1,17 +1,26 @@
-import { assertEquals } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import {
   sampleEntry,
   sampleManifest,
   serializeManifest,
 } from "@commonfabric/test-support/records";
 
-import { generatedAtOf, newestManifest } from "./test-selection-manifest.ts";
-import { makeTestFlakes } from "./tiles/test-flakes.ts";
 import {
+  FLAKE_WINDOW_FALLBACK_DAYS,
+  generatedAtOf,
   LANE_BUDGET_FALLBACK_SECONDS,
   laneBudgetOf,
-  makeTestSelection,
-} from "./tiles/test-selection.ts";
+  type ManifestReader,
+  newestManifest,
+} from "./test-selection-manifest.ts";
+import { makeTestFlakes } from "./tiles/test-flakes.ts";
+import { makeTestSelection } from "./tiles/test-selection.ts";
+import { TEST_SELECTION_PATH } from "./test-selection-page.ts";
 import type { Ctx } from "./types.ts";
 
 const PREFIX = "labs/test-selection/v1";
@@ -61,14 +70,22 @@ Deno.test("newestManifest takes the newest object under the prefix", async () =>
   assertEquals(found?.generatedAt, "2026-08-20T04:00:00.000Z");
 });
 
-Deno.test("newestManifest treats a malformed manifest as absent", async () => {
-  const found = await newestManifest({
-    fetchImpl: storeOf({
-      [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-b.json.gz`]:
-        "{not a manifest",
-    }),
-  });
-  assertEquals(found, undefined);
+Deno.test("newestManifest reports a body that is not a manifest", async () => {
+  await assertRejects(
+    () =>
+      newestManifest({
+        fetchImpl: storeOf({
+          [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-b.json.gz`]:
+            "{not a manifest",
+        }),
+      }),
+    Error,
+    "not a manifest",
+  );
+});
+
+Deno.test("newestManifest reports nothing when the store holds none", async () => {
+  assertEquals(await newestManifest({ fetchImpl: storeOf({}) }), undefined);
 });
 
 /**
@@ -89,31 +106,44 @@ function storeRefusing(answer: () => Promise<Response>): typeof fetch {
   }) as typeof fetch;
 }
 
-Deno.test("newestManifest treats a refused manifest as absent", async () => {
+Deno.test("newestManifest reports a refused manifest", async () => {
   // Listed but not readable, which is what a manifest deleted between
   // the listing and the read looks like.
   for (const status of [403, 404, 500]) {
-    const found = await newestManifest({
-      fetchImpl: storeRefusing(() =>
-        Promise.resolve(new Response("", { status }))
-      ),
-    });
-    assertEquals(found, undefined);
+    await assertRejects(
+      () =>
+        newestManifest({
+          fetchImpl: storeRefusing(() =>
+            Promise.resolve(new Response("", { status }))
+          ),
+        }),
+      Error,
+      `HTTP ${status}`,
+    );
   }
 });
 
-Deno.test("newestManifest treats a failed read as absent", async () => {
-  const found = await newestManifest({
-    fetchImpl: storeRefusing(() => Promise.reject(new Error("no network"))),
-  });
-  assertEquals(found, undefined);
+Deno.test("newestManifest reports a failed read", async () => {
+  await assertRejects(
+    () =>
+      newestManifest({
+        fetchImpl: storeRefusing(() => Promise.reject(new Error("no network"))),
+      }),
+    Error,
+    "no network",
+  );
 });
 
-Deno.test("newestManifest treats an unreachable store as absent", async () => {
-  const found = await newestManifest({
-    fetchImpl: (() => Promise.reject(new Error("no network"))) as typeof fetch,
-  });
-  assertEquals(found, undefined);
+Deno.test("newestManifest reports an unreachable store", async () => {
+  await assertRejects(
+    () =>
+      newestManifest({
+        fetchImpl: (() =>
+          Promise.reject(new Error("no network"))) as typeof fetch,
+      }),
+    Error,
+    "no network",
+  );
 });
 
 const CTX: Ctx = {
@@ -122,20 +152,23 @@ const CTX: Ctx = {
   env: () => undefined,
 };
 
-/** A store holding one manifest under a fixed name. */
-function storeHolding(manifest: Parameters<typeof serializeManifest>[0]) {
-  return storeOf({
+/** A reader over a store holding one manifest under a fixed name. */
+function reading(
+  manifest: Parameters<typeof serializeManifest>[0],
+): ManifestReader {
+  const fetchImpl = storeOf({
     [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-a.json.gz`]:
       serializeManifest(manifest),
   });
+  return () => newestManifest({ fetchImpl });
 }
 
 Deno.test("both test tiles are unknown when there is no manifest", async () => {
-  const empty = storeOf({});
+  const empty: ManifestReader = () => Promise.resolve(undefined);
   for (
     const tile of [
-      makeTestFlakes({ fetchImpl: empty }),
-      makeTestSelection({ fetchImpl: empty }),
+      makeTestFlakes({ read: empty }),
+      makeTestSelection({ read: empty }),
     ]
   ) {
     const view = await tile.collect(CTX);
@@ -145,13 +178,19 @@ Deno.test("both test tiles are unknown when there is no manifest", async () => {
 });
 
 Deno.test("the flake tile is green when nothing is withheld as flaky", async () => {
-  const tile = makeTestFlakes({ fetchImpl: storeHolding(sampleManifest()) });
+  const tile = makeTestFlakes({
+    read: reading(sampleManifest()),
+    now: () => Date.parse("2026-08-20T00:30:00.000Z"),
+  });
   const view = await tile.collect(CTX);
   assertEquals(view.status, "good");
-  assertEquals(view.value, "0");
+  assertEquals(view.value, "no flaky tests");
+  // What the conclusion was drawn from: the window the share is measured
+  // over, and how long ago the publisher measured it.
+  assertEquals(view.sub, `${FLAKE_WINDOW_FALLBACK_DAYS} days of runs · 30m old`);
 });
 
-Deno.test("the flake tile counts what selection held back, and names the worst", async () => {
+Deno.test("the flake tile counts what selection held back, and points at them", async () => {
   const longName = "space > flakes with a name that keeps going past the tile limit";
   const noisy = sampleEntry({ k: "unit", s: "memory", n: longName, v: "worker" }, {
     flakeRate: 0.4,
@@ -160,21 +199,17 @@ Deno.test("the flake tile counts what selection held back, and names the worst",
     entries: [noisy],
     withheld: [{ test: noisy.test, suite: noisy.suite, reason: "flaky" }],
   });
-  const view = await makeTestFlakes({ fetchImpl: storeHolding(manifest) })
-    .collect(CTX);
+  const view = await makeTestFlakes({
+    read: reading(manifest),
+    now: () => Date.parse("2026-08-20T04:00:00.000Z"),
+  }).collect(CTX);
   assertEquals(view.status, "warn");
-  assertEquals(view.value, "1");
-  assertEquals(view.extra?.includes('class="tile-detail-list"'), true);
-  assertEquals(view.extra?.includes('role="region"'), true);
-  assertEquals(view.extra?.includes('tabindex="0"'), true);
-  assertEquals(view.extra?.includes("scroll for more"), false);
-  assertEquals(
-    view.extra?.includes(
-      `title="40.0% · unit · memory: ${longName.replace(">", "&gt;")} (worker)"`,
-    ),
-    true,
-  );
-  assertEquals(view.extra?.includes("… (worker)</div>"), true);
+  assertEquals(view.value, "1 flaky test");
+  assertEquals(view.sub, `${FLAKE_WINDOW_FALLBACK_DAYS} days of runs · 4h old`);
+  // The count is the whole tile: no name reaches it to be cut in half.
+  assertEquals(view.extra, undefined);
+  assertEquals(view.href, "/test-selection#flaky");
+  assertEquals(view.hint, "flakes ↗");
 });
 
 Deno.test("the selection tile says what share of the corpus would run", async () => {
@@ -192,24 +227,23 @@ Deno.test("the selection tile says what share of the corpus would run", async ()
     }],
   });
   const view = await makeTestSelection({
-    fetchImpl: storeHolding(manifest),
+    read: reading(manifest),
     now: () => Date.parse("2026-08-20T05:00:00.000Z"),
   }).collect(CTX);
   assertEquals(view.status, "good");
   assertEquals(view.value, "50%");
-  assertEquals(
-    view.sub,
-    `1 of 2 tests · fullest lane 3s of ${LANE_BUDGET_FALLBACK_SECONDS}s`,
-  );
+  assertEquals(view.sub, "1 of 2 tests");
+  assertEquals(view.href, "/test-selection");
+  assertEquals(view.hint, "lanes ↗");
 });
 
 Deno.test("the selection tile goes amber once the manifest has gone stale", async () => {
   const view = await makeTestSelection({
-    fetchImpl: storeHolding(sampleManifest()),
+    read: reading(sampleManifest()),
     now: () => Date.parse("2026-08-21T04:00:00.000Z"),
   }).collect(CTX);
   assertEquals(view.status, "warn");
-  assertEquals(view.aside, "28h old");
+  assertEquals(view.aside, '<span class="hmtd" title="28h old">28h old</span>');
 });
 
 Deno.test("the lane budget comes from the manifest that named it", () => {
@@ -233,8 +267,62 @@ Deno.test("the selection tile goes red when a lane is past its budget", async ()
     }],
   });
   const view = await makeTestSelection({
-    fetchImpl: storeHolding(manifest),
+    read: reading(manifest),
     now: () => Date.parse("2026-08-20T05:00:00.000Z"),
   }).collect(CTX);
   assertEquals(view.status, "bad");
+  // The overrun is why the tile is red, so it takes the line the share holds.
+  assertEquals(
+    view.sub,
+    `fullest lane 400s of ${LANE_BUDGET_FALLBACK_SECONDS}s`,
+  );
+});
+
+Deno.test("the selection tile serves the page both tiles link to", async () => {
+  const tile = makeTestSelection({ read: reading(sampleManifest()) });
+  const route = tile.routes?.find((r) => r.path === TEST_SELECTION_PATH);
+  assertExists(route);
+  const url = new URL(`http://wall${TEST_SELECTION_PATH}`);
+  const response = await route.handler(new Request(url), url);
+  assertEquals(
+    response.headers.get("content-type"),
+    "text/html; charset=utf-8",
+  );
+  assertStringIncludes(await response.text(), "<title>Test selection</title>");
+});
+
+Deno.test("both tiles link into the page the route serves", async () => {
+  const read = reading(sampleManifest());
+  const flakes = await makeTestFlakes({ read }).collect(CTX);
+  const selection = await makeTestSelection({ read }).collect(CTX);
+  assertEquals(selection.href, TEST_SELECTION_PATH);
+  assertEquals(flakes.href?.split("#")[0], TEST_SELECTION_PATH);
+});
+
+Deno.test("a tile lets a store failure through, for the wall to gray it", async () => {
+  // The wall turns a collection that throws into a gray tile carrying the
+  // reason, which is what separates an unreadable store from an empty one.
+  const failing: ManifestReader = () => Promise.reject(new Error("no network"));
+  for (
+    const tile of [
+      makeTestFlakes({ read: failing }),
+      makeTestSelection({ read: failing }),
+    ]
+  ) {
+    await assertRejects(() => tile.collect(CTX), Error, "no network");
+  }
+});
+
+Deno.test("the page says a store could not be read, rather than that it is empty", async () => {
+  const tile = makeTestSelection({
+    read: () => Promise.reject(new Error("no network")),
+  });
+  const route = tile.routes?.find((r) => r.path === TEST_SELECTION_PATH);
+  assertExists(route);
+  const url = new URL(`http://wall${TEST_SELECTION_PATH}`);
+  const response = await route.handler(new Request(url), url);
+  assertEquals(response.status, 503);
+  const body = await response.text();
+  assertStringIncludes(body, "could not be read: source unreachable");
+  assertEquals(body.includes("has been published yet"), false);
 });

--- a/packages/dashboard/test-selection-manifest.ts
+++ b/packages/dashboard/test-selection-manifest.ts
@@ -1,8 +1,15 @@
 /**
- * Reads the newest test-selection manifest from the store. The bucket is
- * publicly readable, so no credential is involved, and a manifest is
+ * Reads the newest test-selection manifest from the store, and answers the
+ * questions a tile or a page asks of the manifest it gets back. The bucket
+ * is publicly readable, so no credential is involved, and a manifest is
  * untrusted input like every record line: it goes through the shared
- * validator whole, and a manifest that fails it is treated as absent.
+ * validator whole.
+ *
+ * A store that cannot be read, and a body that is not a manifest, are
+ * faults, and are raised as such: the wall grays a tile whose collection
+ * throws and puts the reason under it. Reporting nothing is reserved for a
+ * store that holds no manifest, which is the one case where "none has been
+ * published" is true.
  *
  * Following the dashboard's values (README.md): what this feeds reports on
  * the system. It names tests, never people.
@@ -10,10 +17,12 @@
 
 import {
   listObjects,
+  type LanePlan,
   type Manifest,
   objectUrl,
   parseManifest,
 } from "@commonfabric/test-support/records";
+import { memo } from "./lib.ts";
 
 export const TEST_SELECTION_BUCKET = "cf-ci-metadata";
 // The trailing slash is what keeps the listing inside this version. A
@@ -28,7 +37,7 @@ export function generatedAtOf(objectName: string): string | undefined {
   )?.[1];
 }
 
-/** Fetches the newest manifest, or undefined when there is not one. */
+/** Fetches the newest manifest, or `undefined` when the store holds none. */
 export async function newestManifest(options: {
   bucket?: string;
   prefix?: string;
@@ -37,23 +46,88 @@ export async function newestManifest(options: {
   const bucket = options.bucket ?? TEST_SELECTION_BUCKET;
   const prefix = options.prefix ?? TEST_SELECTION_PREFIX;
   const doFetch = options.fetchImpl ?? fetch;
-  let names: string[];
-  try {
-    names = await listObjects({ bucket, prefix, fetch: doFetch });
-  } catch {
-    return undefined;
-  }
+  const names = await listObjects({ bucket, prefix, fetch: doFetch });
   const newest = names.filter((name) => generatedAtOf(name) !== undefined)
     .sort().at(-1);
   if (newest === undefined) return undefined;
-  try {
-    const url = objectUrl(bucket, newest);
-    const response = await doFetch(url);
-    if (!response.ok) return undefined;
-    // The store serves these with transcoding, so a plain fetch has
-    // already decoded the gzip the object is stored under.
-    return parseManifest(await response.text());
-  } catch {
-    return undefined;
+  const response = await doFetch(objectUrl(bucket, newest));
+  if (!response.ok) {
+    throw new Error(`manifest ${newest}: HTTP ${response.status}`);
   }
+  // The store serves these with transcoding, so a plain fetch has
+  // already decoded the gzip the object is stored under.
+  const manifest = parseManifest(await response.text());
+  if (manifest === undefined) {
+    throw new Error(`manifest ${newest}: not a manifest`);
+  }
+  return manifest;
+}
+
+/**
+ * How long one read of the manifest is shared. A manifest carries an entry
+ * for every identity the store knows, so a read of one is far the largest
+ * the wall makes, and the two tiles that want one are due together on this
+ * same cadence and take a single read between them.
+ */
+export const MANIFEST_SHARE_MS = 15 * 60_000;
+
+/** Where a tile or a page gets the manifest it reports on. */
+export type ManifestReader = () => Promise<Manifest | undefined>;
+
+/** The reader the wall runs on: one shared read per share window. */
+export const sharedManifest: ManifestReader = memo(
+  MANIFEST_SHARE_MS,
+  () => newestManifest(),
+);
+
+/**
+ * A positive number the manifest's dials name, or `fallback` when they do
+ * not name one. Every manifest records the dials it was built with, so a
+ * reader takes a policy number from the manifest in front of it rather
+ * than from a copy here that would quietly disagree with it.
+ */
+export function numberDial(
+  dials: Record<string, unknown>,
+  name: string,
+  fallback: number,
+): number {
+  const value = dials[name];
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+/**
+ * Seconds of planned work a lane may hold, for a manifest whose dials do
+ * not name a budget.
+ */
+export const LANE_BUDGET_FALLBACK_SECONDS = 230;
+
+/** The budget a manifest was built with, or the fallback. */
+export function laneBudgetOf(dials: Record<string, unknown>): number {
+  return numberDial(dials, "LANE_BUDGET_SECONDS", LANE_BUDGET_FALLBACK_SECONDS);
+}
+
+/** Days of history a flake share is measured over, when the dials say. */
+export const FLAKE_WINDOW_FALLBACK_DAYS = 60;
+
+/** The flake share past which a test is held back, when the dials say. */
+export const FLAKE_EXCLUSION_FALLBACK = 0.05;
+
+/** How many identities one lane of the reference packing would run. */
+export function laneTestCount(lane: LanePlan): number {
+  return lane.batches.reduce((sum, batch) => sum + batch.identities.length, 0);
+}
+
+/** How many identities the whole packing would run. */
+export function selectedCount(manifest: Manifest): number {
+  return manifest.lanes.reduce(
+    (total, lane) => total + laneTestCount(lane),
+    0,
+  );
+}
+
+/** How many identities are held back for being too noisy to judge by. */
+export function flakyCount(manifest: Manifest): number {
+  return manifest.withheld.filter((entry) => entry.reason === "flaky").length;
 }

--- a/packages/dashboard/test-selection-page.test.ts
+++ b/packages/dashboard/test-selection-page.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Covers the page behind the two selection tiles: what it says about a
+ * manifest, and what it says when there is not one.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  type Manifest,
+  sampleEntry,
+  sampleManifest,
+} from "@commonfabric/test-support/records";
+
+import {
+  FLAKY_SECTION_ID,
+  testSelectionPage,
+} from "./test-selection-page.ts";
+import {
+  FLAKE_EXCLUSION_FALLBACK,
+  FLAKE_WINDOW_FALLBACK_DAYS,
+  LANE_BUDGET_FALLBACK_SECONDS,
+} from "./test-selection-manifest.ts";
+
+const NOW = Date.parse("2026-08-20T04:00:00.000Z");
+
+/** A manifest whose one test was held back for the reason given. */
+function heldBack(
+  reason: "flaky" | "main-red",
+  fields: Partial<Manifest> = {},
+): Manifest {
+  const entry = sampleEntry({ k: "unit", s: "memory", n: "space > writes" }, {
+    flakeRate: 0.42,
+  });
+  return sampleManifest({
+    entries: [entry],
+    withheld: [{ test: entry.test, suite: entry.suite, reason }],
+    ...fields,
+  });
+}
+
+describe("test-selection-page", () => {
+  describe("testSelectionPage()", () => {
+    it("says so when the publisher has written no manifest", () => {
+      const page = testSelectionPage(undefined, NOW);
+      expect(page).toContain("No selection manifest has been published yet.");
+      expect(page).not.toContain("<table>");
+    });
+
+    it("names a flaky test in full, beside the rate it was measured at", () => {
+      const page = testSelectionPage(heldBack("flaky"), NOW);
+      expect(page).toContain("space &gt; writes");
+      expect(page).toContain("42.0%");
+      expect(page).toContain(`id="${FLAKY_SECTION_ID}"`);
+    });
+
+    it("says the flake share counts failures rather than runs", () => {
+      // 100% is a share of one test's failures, so it says nothing about
+      // how often that test fails. A page showing the figure has to say so.
+      const page = testSelectionPage(heldBack("flaky"), NOW);
+      expect(page).toContain("counts failures rather than runs");
+      expect(page).toContain("failed once and flaked once reads 100%");
+    });
+
+    it("takes the flake window and threshold from the manifest's own dials", () => {
+      const page = testSelectionPage(
+        heldBack("flaky", {
+          dials: { FLAKE_WINDOW_DAYS: 30, FLAKE_EXCLUSION_RATE: 0.2 },
+        }),
+        NOW,
+      );
+      expect(page).toContain("over the last 30 days");
+      expect(page).toContain("Past 20.0% a test is held back");
+    });
+
+    it("falls back to the published policy when the dials name neither", () => {
+      const page = testSelectionPage(heldBack("flaky"), NOW);
+      expect(page).toContain(`over the last ${FLAKE_WINDOW_FALLBACK_DAYS} days`);
+      expect(page).toContain(
+        `Past ${(FLAKE_EXCLUSION_FALLBACK * 100).toFixed(1)}% a test`,
+      );
+    });
+
+    it("orders held-back tests by the rate that held them back", () => {
+      const worst = sampleEntry({ k: "unit", s: "memory", n: "worst" }, {
+        flakeRate: 0.9,
+      });
+      const mild = sampleEntry({ k: "unit", s: "memory", n: "mild" }, {
+        flakeRate: 0.1,
+      });
+      const page = testSelectionPage(
+        sampleManifest({
+          entries: [mild, worst],
+          withheld: [mild, worst].map((entry) => ({
+            test: entry.test,
+            suite: entry.suite,
+            reason: "flaky" as const,
+          })),
+        }),
+        NOW,
+      );
+      const worstAt = page.indexOf(">worst<");
+      const mildAt = page.indexOf(">mild<");
+      expect(worstAt).toBeGreaterThan(-1);
+      expect(mildAt).toBeGreaterThan(-1);
+      expect(worstAt).toBeLessThan(mildAt);
+    });
+
+    it("names a test held back while main is red, without a rate", () => {
+      const page = testSelectionPage(heldBack("main-red"), NOW);
+      expect(page).toContain("Held back while main is red · 1");
+      expect(page).toContain("<tr><td>unit</td>");
+      expect(page).not.toContain("42.0%");
+    });
+
+    it("leaves out a section nothing was held back for", () => {
+      const page = testSelectionPage(heldBack("flaky"), NOW);
+      expect(page).not.toContain("Held back while main is red");
+      expect(page).not.toContain("Too long for any lane");
+    });
+
+    it("names the tests that are too long for any lane", () => {
+      const huge = sampleEntry({ k: "integration", s: "cli", n: "acl.sh" }, {
+        cost: 900,
+      });
+      const page = testSelectionPage(
+        sampleManifest({
+          unschedulable: [{ test: huge.test, suite: huge.suite, cost: 900 }],
+        }),
+        NOW,
+      );
+      expect(page).toContain("Too long for any lane · 1");
+      expect(page).toContain("900s");
+      expect(page).toContain("acl.sh");
+    });
+
+    it("marks the lane whose projected work is past its budget", () => {
+      const page = testSelectionPage(
+        sampleManifest({
+          lanes: [
+            { lane: 1, projectedSeconds: 10, batches: [] },
+            {
+              lane: 2,
+              projectedSeconds: LANE_BUDGET_FALLBACK_SECONDS + 20,
+              batches: [],
+            },
+          ],
+        }),
+        NOW,
+      );
+      expect(page).toContain(`<div class="lane"><b>Lane 1</b>`);
+      expect(page).toContain(`<div class="lane over"><b>Lane 2</b>`);
+    });
+
+    it("holds a lane's bar at its budget rather than past the track", () => {
+      const page = testSelectionPage(
+        sampleManifest({
+          lanes: [{
+            lane: 1,
+            projectedSeconds: LANE_BUDGET_FALLBACK_SECONDS * 4,
+            batches: [],
+          }],
+        }),
+        NOW,
+      );
+      expect(page).toContain(`width:100.0%`);
+    });
+
+    it("says the packing assumes a pull request that made nothing mandatory", () => {
+      // A real lane re-packs against its own diff, so the figures here are
+      // the floor rather than what any one pull request runs.
+      const page = testSelectionPage(
+        sampleManifest({
+          lanes: [{ lane: 1, projectedSeconds: 10, batches: [] }],
+        }),
+        NOW,
+      );
+      expect(page).toContain("packs these with nothing mandatory");
+    });
+
+    it("counts the tests each lane holds", () => {
+      const page = testSelectionPage(
+        sampleManifest({
+          lanes: [{
+            lane: 1,
+            projectedSeconds: 10,
+            batches: [
+              { suite: "workspace-unit", identities: ["a", "b"] },
+              { suite: "workspace-browser", identities: ["c"] },
+            ],
+          }],
+        }),
+        NOW,
+      );
+      expect(page).toContain("3 tests");
+    });
+
+    it("says how long ago the manifest was generated", () => {
+      const ago = (generatedAt: string) =>
+        testSelectionPage(sampleManifest({ generatedAt }), NOW)
+          .match(/, (\S+) ago/)?.[1];
+      expect(ago("2026-08-20T03:48:00.000Z")).toBe("12m");
+      expect(ago("2026-08-19T04:00:00.000Z")).toBe("24h");
+      expect(ago("2026-08-13T04:00:00.000Z")).toBe("7d");
+    });
+
+    it("leaves a gap for a test the manifest no longer scores", () => {
+      // A test can be held back and yet be missing from the entries: an
+      // incremental manifest carries only what ran inside its window. Its
+      // rate still occupies its column, so the kind stays under "kind".
+      const scored = sampleEntry({ k: "unit", s: "memory", n: "scored" }, {
+        flakeRate: 0.5,
+      });
+      const page = testSelectionPage(
+        sampleManifest({
+          entries: [scored],
+          withheld: [scored, { test: { k: "browser", s: "shell", n: "gone" } }]
+            .map((entry) => ({
+              test: entry.test,
+              suite: "workspace-unit",
+              reason: "flaky" as const,
+            })),
+        }),
+        NOW,
+      );
+      expect(page).toContain(
+        `<tr><td class="measure">50.0%</td><td>unit</td>`,
+      );
+      expect(page).toContain(`<tr><td class="measure">—</td><td>browser</td>`);
+    });
+
+    it("escapes a test name carrying markup", () => {
+      const nasty = sampleEntry(
+        { k: "unit", s: "memory", n: `<script>alert("x")</script>`, v: "a>b" },
+        { flakeRate: 0.5 },
+      );
+      const page = testSelectionPage(
+        sampleManifest({
+          entries: [nasty],
+          withheld: [{
+            test: nasty.test,
+            suite: nasty.suite,
+            reason: "flaky",
+          }],
+        }),
+        NOW,
+      );
+      expect(page).not.toContain("<script>alert");
+      expect(page).toContain("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;");
+      expect(page).toContain("(a&gt;b)");
+    });
+  });
+});

--- a/packages/dashboard/test-selection-page.ts
+++ b/packages/dashboard/test-selection-page.ts
@@ -1,0 +1,319 @@
+/**
+ * The page behind the two selection tiles. The tiles carry one number each,
+ * which is all a wall glanced at from across a room can hold; everything a
+ * person wants once that number has caught their eye is here, at full width
+ * and with nothing abbreviated: how close each of a pull request's lanes is
+ * to its budget, and every test held back from those lanes together with the
+ * measurement that held it back.
+ *
+ * Following the dashboard's values (README.md): it reports on the system. It
+ * names tests, never the people who wrote or touched them.
+ */
+
+import {
+  type Manifest,
+  type TestIdentity,
+  testIdentityKey,
+} from "@commonfabric/test-support/records";
+import { DETAIL_PAGE_STYLES } from "./detail-page.ts";
+import {
+  compactSpan,
+  escapeHtml,
+  friendlyError,
+  groupDigits,
+} from "./lib.ts";
+import { STATUS_EDGE, STATUS_WASH } from "./palette.ts";
+import {
+  FLAKE_EXCLUSION_FALLBACK,
+  FLAKE_WINDOW_FALLBACK_DAYS,
+  flakyCount,
+  laneBudgetOf,
+  laneTestCount,
+  type ManifestReader,
+  numberDial,
+  selectedCount,
+  sharedManifest,
+} from "./test-selection-manifest.ts";
+import {
+  DASHBOARD_THEME_CLIENT,
+  DASHBOARD_THEME_HEAD,
+  dashboardThemeToggle,
+  statusLayer,
+} from "./theme.ts";
+
+/** The fragment the flaky tests tile links to. */
+export const FLAKY_SECTION_ID = "flaky";
+
+/** Where the page lives, and what both tiles link to. */
+export const TEST_SELECTION_PATH = "/test-selection";
+
+const STYLES = `
+  ${DETAIL_PAGE_STYLES}
+  .summary{display:flex;flex-wrap:wrap;gap:10px 34px;background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:12px 16px;margin-bottom:4px}
+  .summary div{display:flex;flex-direction:column;gap:2px}
+  .summary dt{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--text-subtle)}
+  .summary dd{margin:0;font-size:18px;font-weight:600;color:var(--text);font-variant-numeric:tabular-nums}
+  .lead{font-size:12px;color:var(--text-muted);margin:0 0 8px}
+  .lane{display:flex;flex-wrap:wrap;align-items:center;gap:6px 14px;background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:8px 14px;margin-bottom:7px}
+  .lane.over{border-color:${statusLayer("bad", STATUS_EDGE.bad)};background:${
+  statusLayer("bad", STATUS_WASH.bad)
+}}
+  .lane b{font-size:13px;font-weight:600;flex:none;min-width:58px}
+  .lane .fill{flex:1 1 90px;order:1;height:8px;border-radius:4px;background:var(--surface-deep);overflow:hidden}
+  @media(max-width:560px){.lane .fill{flex-basis:100%;order:2}}
+  .lane .fill span{display:block;height:100%;background:var(--accent)}
+  .lane.over .fill span{background:var(--status-bad)}
+  .lane .num{flex:none;font-size:13px;color:var(--text-muted);font-variant-numeric:tabular-nums}
+  table{border-collapse:collapse;width:100%;font-size:13px}
+  th{text-align:left;font-weight:600;color:var(--text-subtle);font-size:11px;letter-spacing:.06em;text-transform:uppercase;white-space:nowrap;padding:0 12px 5px 0}
+  td{padding:5px 12px 5px 0;border-top:1px solid var(--divider);color:var(--text-secondary);vertical-align:top}
+  td.measure{font-variant-numeric:tabular-nums;white-space:nowrap;color:var(--text)}
+  td.name{width:99%;word-break:break-word}
+  td .variant{color:var(--text-faint)}`;
+
+/** One second count, to the precision a page of them stays readable at. */
+const seconds = (value: number): string => `${value.toFixed(0)}s`;
+
+/** A flake rate as the percentage the publisher measured. */
+const percent = (rate: number): string => `${(rate * 100).toFixed(1)}%`;
+
+/** An ISO 8601 time cut to the minute, which is the precision a reader wants. */
+function minutePrecision(at: string): string {
+  return `${at.slice(0, 16).replace("T", " ")} UTC`;
+}
+
+/** The cells naming one test: its kind, its member, and its leaf name. */
+function identityCells(test: TestIdentity): string {
+  const variant = test.v === undefined
+    ? ""
+    : ` <span class="variant">(${escapeHtml(test.v)})</span>`;
+  return `<td>${escapeHtml(test.k)}</td><td>${escapeHtml(test.s)}</td>` +
+    `<td class="name">${escapeHtml(test.n)}${variant}</td>`;
+}
+
+/** One test named in a table, under the table's own measurement of it. */
+interface TestRow {
+  test: TestIdentity;
+
+  /** What the leading column says, where the table has one to say. */
+  measure?: string;
+}
+
+/** A section listing tests, or nothing at all when the list is empty. */
+function testSection(section: {
+  heading: string;
+  id?: string;
+  lead: string;
+  /** The leading column's heading, where the rows carry a measurement. */
+  measure?: string;
+  rows: TestRow[];
+}): string {
+  if (section.rows.length === 0) return "";
+  // The column and the cells are decided together, so a row that carries no
+  // measurement leaves a gap in the table rather than shifting it.
+  const measured = section.measure !== undefined;
+  const head = measured ? `<th>${escapeHtml(section.measure!)}</th>` : "";
+  const body = section.rows.map((row) =>
+    `<tr>${
+      measured
+        ? `<td class="measure">${escapeHtml(row.measure ?? "—")}</td>`
+        : ""
+    }${identityCells(row.test)}</tr>`
+  ).join("");
+  const id = section.id === undefined ? "" : ` id="${section.id}"`;
+  return `<h2${id}>${escapeHtml(section.heading)} · ${section.rows.length}</h2>
+  <p class="lead">${escapeHtml(section.lead)}</p>
+  <table><thead><tr>${head}<th>kind</th><th>member</th><th>test</th></tr></thead><tbody>${body}</tbody></table>`;
+}
+
+/**
+ * What the flake share counts. The denominator is what a reader gets
+ * wrong: the publisher divides a test's flakes by its failures, not by
+ * its runs, so a test whose one failure in the window was a flake reads
+ * 100% however reliably it passes the rest of the time.
+ */
+function flakeLead(manifest: Manifest): string {
+  const days = numberDial(
+    manifest.dials,
+    "FLAKE_WINDOW_DAYS",
+    FLAKE_WINDOW_FALLBACK_DAYS,
+  );
+  const exclusion = numberDial(
+    manifest.dials,
+    "FLAKE_EXCLUSION_RATE",
+    FLAKE_EXCLUSION_FALLBACK,
+  );
+  return `The share of each test's failures over the last ${days} days that ` +
+    "were flakes: the same commit both passing and failing, with nothing " +
+    "between the two runs but chance. It counts failures rather than runs, " +
+    `so a test that failed once and flaked once reads 100%. Past ${
+      percent(exclusion)
+    } a test is held back from pull requests, and comes back on its own ` +
+    "once it stops disagreeing.";
+}
+
+/** The tests held back as flaky, worst-measured first. *//** The tests held back as flaky, worst-measured first. */
+function flakyRows(manifest: Manifest): TestRow[] {
+  const rates = new Map(
+    manifest.entries.map((entry) => [
+      testIdentityKey(entry.test),
+      entry.flakeRate,
+    ]),
+  );
+  return manifest.withheld
+    .filter((entry) => entry.reason === "flaky")
+    .map((entry) => ({
+      test: entry.test,
+      rate: rates.get(testIdentityKey(entry.test)),
+    }))
+    .sort((a, b) => (b.rate ?? 0) - (a.rate ?? 0))
+    .map(({ test, rate }) => ({
+      test,
+      measure: rate === undefined ? undefined : percent(rate),
+    }));
+}
+
+/** The tests main being red held back, in the order the manifest names them. */
+function mainRedRows(manifest: Manifest): TestRow[] {
+  return manifest.withheld
+    .filter((entry) => entry.reason === "main-red")
+    .map((entry) => ({ test: entry.test }));
+}
+
+/** The lanes a pull request would run, each against the budget it was packed to. */
+function lanesSection(manifest: Manifest): string {
+  const budget = laneBudgetOf(manifest.dials);
+  const rows = manifest.lanes.map((lane) => {
+    const tests = laneTestCount(lane);
+    const over = lane.projectedSeconds > budget;
+    const filled = Math.min(100, (lane.projectedSeconds / budget) * 100);
+    return `<div class="lane${over ? " over" : ""}"><b>Lane ${lane.lane}</b>` +
+      `<span class="fill"><span style="width:${filled.toFixed(1)}%"></span></span>` +
+      `<span class="num">${seconds(lane.projectedSeconds)} of ${
+        seconds(budget)
+      }</span>` +
+      `<span class="num">${groupDigits(tests)} tests</span></div>`;
+  }).join("");
+  return `<h2>Lanes</h2>
+  <p class="lead">What each lane is projected to spend against the budget this manifest was packed to. The publisher packs these with nothing mandatory, so this is the run a pull request touching no test would get: a real one re-packs against its own diff, placing what that diff makes mandatory first and whatever the cost, and filling what is left of the budget from the same corpus.</p>
+  ${rows}`;
+}
+
+/** The counts the two tiles headline, spelled out. */
+function summary(manifest: Manifest): string {
+  const selected = selectedCount(manifest);
+  const known = manifest.entries.length;
+  const share = known === 0 ? 0 : (selected / known) * 100;
+  const facts: Array<[string, string]> = [
+    ["selected", `${share.toFixed(0)}%`],
+    ["tests", `${groupDigits(selected)} of ${groupDigits(known)}`],
+    ["lanes", String(manifest.lanes.length)],
+    ["flaky", groupDigits(flakyCount(manifest))],
+    ["runs seen", groupDigits(manifest.runs)],
+  ];
+  return `<dl class="summary">${
+    facts.map(([term, value]) =>
+      `<div><dt>${term}</dt><dd>${escapeHtml(value)}</dd></div>`
+    ).join("")
+  }</dl>`;
+}
+
+/** The page's frame, which every state of it wears. */
+function frame(head: string, body: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Test selection</title>
+${DASHBOARD_THEME_HEAD}
+<style>
+${STYLES}
+</style></head><body>
+  <div class="top"><a class="back" href="/">← dashboard</a><b>Test selection</b><span>${head}</span></div>
+  ${body}
+  <p class="note">What a pull request runs, from the newest manifest the selection publisher wrote.</p>
+${dashboardThemeToggle()}
+${DASHBOARD_THEME_CLIENT}
+</body></html>`;
+}
+
+/** The whole page for one manifest, or the page saying there is not one. */
+export function testSelectionPage(
+  manifest: Manifest | undefined,
+  now = Date.now(),
+): string {
+  if (manifest === undefined) {
+    return frame(
+      "",
+      `<p class="empty">No selection manifest has been published yet.</p>`,
+    );
+  }
+  const head = `commit ${escapeHtml(manifest.commit.slice(0, 7))} · generated ${
+    escapeHtml(minutePrecision(manifest.generatedAt))
+  }, ${compactSpan(now - Date.parse(manifest.generatedAt))} ago`;
+  return frame(
+    head,
+    `${summary(manifest)}
+  ${lanesSection(manifest)}
+  ${
+      testSection({
+        heading: "Held back as flaky",
+        id: FLAKY_SECTION_ID,
+        lead: flakeLead(manifest),
+        measure: "flake share",
+        rows: flakyRows(manifest),
+      })
+    }
+  ${
+      testSection({
+        heading: "Held back while main is red",
+        id: "main-red",
+        lead:
+          "Already failing on main, so a pull request learns nothing from running them.",
+        rows: mainRedRows(manifest),
+      })
+    }
+  ${
+      testSection({
+        heading: "Too long for any lane",
+        lead:
+          "One execution costs more than a whole lane's budget, so no packing can place them.",
+        measure: "cost",
+        rows: [...manifest.unschedulable]
+          .sort((a, b) => b.cost - a.cost)
+          .map((entry) => ({
+            test: entry.test,
+            measure: seconds(entry.cost),
+          })),
+      })
+    }`,
+  );
+}
+
+/**
+ * The page for a store that could not be read, which is a different thing
+ * from a store holding no manifest and says so.
+ */
+export function testSelectionUnavailable(reason: string): string {
+  return frame(
+    "",
+    `<p class="empty">The selection manifest could not be read: ${
+      escapeHtml(reason)
+    }.</p>`,
+  );
+}
+
+/** Serves the page against the manifest the tiles are already reading. */
+export async function testSelectionResponse(
+  read: ManifestReader = sharedManifest,
+  clock?: () => number,
+): Promise<Response> {
+  const html = (body: string, status: number) =>
+    new Response(body, {
+      status,
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  try {
+    return html(testSelectionPage(await read(), clock?.()), 200);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("test selection page:", message);
+    return html(testSelectionUnavailable(friendlyError(message)), 503);
+  }
+}

--- a/packages/dashboard/tile-layout-fixtures.ts
+++ b/packages/dashboard/tile-layout-fixtures.ts
@@ -136,17 +136,11 @@ const TILE_LAYOUT_FIXTURE_INPUTS: readonly TileLayoutFixture[] = [
     view: {
       label: "flaky tests",
       status: "warn",
-      value: "4",
-      sub: "too noisy to judge a change by · 4 tests",
-      extra:
-        `<div class="tile-detail-list" tabindex="0" role="region" aria-label="Flaky test details; scroll for more" title="Scroll for more details">${
-          [
-            "4.2% · package alpha: longest representative test name",
-            "3.7% · package beta: another representative test name",
-            "2.9% · package gamma: a third representative test name",
-            "2.1% · package delta: a fourth representative test name",
-          ].map((line) => `<div title="${line}">${line}</div>`).join("")
-        }</div>`,
+      value: "25 flaky tests",
+      valueLabel: "25 flaky tests",
+      sub: "60 days of runs · 3h old",
+      hint: "flakes ↗",
+      href: "/test-selection#flaky",
     },
   },
   {
@@ -155,8 +149,10 @@ const TILE_LAYOUT_FIXTURE_INPUTS: readonly TileLayoutFixture[] = [
       label: "test selection",
       status: "good",
       value: "64%",
-      sub: "640 of 1000 tests · fullest lane 280s of 300s",
-      aside: "12h old",
+      sub: "16,614 of 19,544 tests",
+      aside: `<span class="hmtd" title="12h old">12h old</span>`,
+      hint: "lanes ↗",
+      href: "/test-selection",
     },
   },
   {

--- a/packages/dashboard/tile-render-values.ts
+++ b/packages/dashboard/tile-render-values.ts
@@ -15,6 +15,11 @@ export const escapeHtml = (s: string) =>
     (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" })[c]!,
   );
 
+/** An integer with its thousands separated, the same in every locale. */
+export function groupDigits(value: number): string {
+  return String(Math.round(value)).replace(/\B(?=(\d{3})+$)/g, ",");
+}
+
 // How a sparkline caption spells a day span, consistently across tiles.
 export function daysLabel(days: number): string {
   if (days < 1) return "<1 day";
@@ -29,6 +34,18 @@ export function humanSpan(ms: number): string {
     return `${hr} hour${hr === 1 ? "" : "s"}`;
   }
   return `${Math.max(1, Math.round(ms / 60_000))} min`;
+}
+
+/**
+ * A span in the least room it can be read in: minutes, then hours, then
+ * days. For a caption sharing its line with other text, where the units
+ * `humanSpan` spells out would not fit.
+ */
+export function compactSpan(ms: number): string {
+  const minutes = Math.max(0, Math.round(ms / 60_000));
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  return hours < 48 ? `${hours}h` : `${Math.round(hours / 24)}d`;
 }
 
 export const DURATION_LABEL_HEIGHT = 9;

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -678,6 +678,22 @@ Deno.test("registry: unique ids and positive intervals", () => {
   }
 });
 
+Deno.test("every tile's drill-down link reaches a route the wall serves", () => {
+  // An unrecognized path falls through to the wall itself, so a tile linking
+  // at a page nobody serves lands the viewer back where they started.
+  const served = new Set(
+    TILES.flatMap((tile) => tile.routes ?? []).map((route) => route.path),
+  );
+  for (const { id, view } of TILE_LAYOUT_FIXTURES) {
+    if (view.href === undefined || /^https?:/.test(view.href)) continue;
+    const path = new URL(view.href, "http://wall").pathname;
+    assert(
+      served.has(path),
+      `${id} links to ${path}, which no registered tile serves`,
+    );
+  }
+});
+
 Deno.test("layout fixtures cover every registered tile in registry order", () => {
   assertEquals(
     TILE_LAYOUT_FIXTURES.map(({ id }) => id),

--- a/packages/dashboard/tiles/coverage-debt.test.ts
+++ b/packages/dashboard/tiles/coverage-debt.test.ts
@@ -26,7 +26,6 @@ import {
   coverageDebtView,
   makeCoverageDebt,
   dailyChangeLabel,
-  groupDigits,
   medianDailyChange,
   trendWindow,
 } from "./coverage-debt.ts";
@@ -94,17 +93,6 @@ const drift = (from: number, perDay: number, days: number) =>
   samplesOf(Array.from({ length: days }, (_, day) => from + day * perDay));
 
 describe("coverage-debt", () => {
-  describe("groupDigits()", () => {
-    it("returns the integer with its thousands separated", () => {
-      expect(groupDigits(78101)).toBe("78,101");
-      expect(groupDigits(999)).toBe("999");
-      expect(groupDigits(1000)).toBe("1,000");
-      expect(groupDigits(1234567)).toBe("1,234,567");
-      expect(groupDigits(0)).toBe("0");
-      expect(groupDigits(30.6)).toBe("31");
-    });
-  });
-
   describe("trendWindow()", () => {
     it("returns the samples inside the trend window", () => {
       const samples = samplesOf(Array(COVERAGE_TREND_DAYS + 10).fill(100));

--- a/packages/dashboard/tiles/coverage-debt.ts
+++ b/packages/dashboard/tiles/coverage-debt.ts
@@ -31,6 +31,7 @@ import {
   friendlyError,
   github,
   githubDownload,
+  groupDigits,
   median,
   sparkline,
 } from "../lib.ts";
@@ -72,11 +73,6 @@ const startOf = (day: string): number => Date.parse(`${day}T00:00:00Z`);
 // Both windows below are counted in whole days from the start of today, so
 // which days they hold does not turn on what time of day the tile collected.
 const todayAt = (now: number): number => Math.floor(now / DAY_MS) * DAY_MS;
-
-/** An integer with its thousands separated, the same in every locale. */
-export function groupDigits(value: number): string {
-  return String(Math.round(value)).replace(/\B(?=(\d{3})+$)/g, ",");
-}
 
 /** The tail of `samples` the median is taken over: the recent days. */
 export function trendWindow(

--- a/packages/dashboard/tiles/test-flakes.ts
+++ b/packages/dashboard/tiles/test-flakes.ts
@@ -5,14 +5,30 @@
  * than from anybody's judgement at one moment, which is what makes it
  * reverse on its own the moment a test is fixed.
  *
+ * The count is the whole of the tile, and the line under it says what the
+ * count was drawn from: how much history the publisher measured over, and
+ * how long ago it measured. Which tests they are, and what each was
+ * measured at, is a page away.
+ *
  * Following the dashboard's values (README.md): it reports on the system.
- * It names tests, never the people who wrote or touched them, and nothing
- * about it is aggregated per person.
+ * Neither the count nor the page behind it is aggregated per person, and
+ * that page names tests, never the people who wrote or touched them.
  */
 
 import type { Status, Tile, TileView } from "../types.ts";
-import { escapeHtml } from "../lib.ts";
-import { newestManifest } from "../test-selection-manifest.ts";
+import { compactSpan, groupDigits } from "../lib.ts";
+import {
+  FLAKE_WINDOW_FALLBACK_DAYS,
+  flakyCount,
+  MANIFEST_SHARE_MS,
+  type ManifestReader,
+  numberDial,
+  sharedManifest,
+} from "../test-selection-manifest.ts";
+import {
+  FLAKY_SECTION_ID,
+  TEST_SELECTION_PATH,
+} from "../test-selection-page.ts";
 
 /** How many flaky tests turn the wall amber. */
 export const FLAKES_WARN = 1;
@@ -20,80 +36,61 @@ export const FLAKES_WARN = 1;
 /** How many turn it red. */
 export const FLAKES_BAD = 10;
 
-/** How many of the worst are named under the count. */
-const NAMED = 4;
-
-/** The scope and name of an identity, short enough for a tile line. */
-function shortName(test: { s: string; n: string; v?: string }): string {
-  const name = test.n.length > 52 ? `${test.n.slice(0, 51)}…` : test.n;
-  const variant = test.v === undefined ? "" : ` (${test.v})`;
-  return `${test.s}: ${name}${variant}`;
-}
-
-function fullName(test: { k: string; s: string; n: string; v?: string }): string {
-  const variant = test.v === undefined ? "" : ` (${test.v})`;
-  return `${test.k} · ${test.s}: ${test.n}${variant}`;
-}
-
-/** Builds the tile against a store, so a test can supply its own. */
+/** Builds the tile against a reader and a clock, so a test can supply both. */
 export function makeTestFlakes(
-  options: { fetchImpl?: typeof fetch } = {},
+  options: { read?: ManifestReader; now?: () => number } = {},
 ): Tile {
+  const read = options.read ?? sharedManifest;
   return {
     id: "test-flakes",
-    intervalMs: 15 * 60_000,
-    collect: () => flakesView(options),
+    intervalMs: MANIFEST_SHARE_MS,
+    collect: () => flakesView(read, options.now),
   };
 }
 
 async function flakesView(
-  options: { fetchImpl?: typeof fetch },
+  read: ManifestReader,
+  clock?: () => number,
 ): Promise<TileView> {
-  {
-    const manifest = await newestManifest(
-      options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl },
-    );
-    if (manifest === undefined) {
-      return {
-        label: "flaky tests",
-        status: "unknown",
-        value: "—",
-        sub: "no selection manifest yet",
-      };
-    }
-    const flaky = manifest.entries
-      .filter((entry) => entry.flakeRate > 0)
-      .sort((a, b) => b.flakeRate - a.flakeRate);
-    const held = manifest.withheld.filter((entry) => entry.reason === "flaky");
-    const status: Status = held.length >= FLAKES_BAD
-      ? "bad"
-      : held.length >= FLAKES_WARN
-      ? "warn"
-      : "good";
-    const named = flaky.slice(0, NAMED);
-    const listAttributes = named.length > 2
-      ? ` aria-label="Flaky test details; scroll for more" title="Scroll for more details"`
-      : ` aria-label="Flaky test details"`;
-    const worst = named.length === 0
-      ? ""
-      : `<div class="tile-detail-list" role="region" tabindex="0"${listAttributes}>${
-        named.map((entry) => {
-          const rate = `${(entry.flakeRate * 100).toFixed(1)}%`;
-          const line = `${rate} · ${shortName(entry.test)}`;
-          const title = `${rate} · ${fullName(entry.test)}`;
-          return `<div title="${escapeHtml(title)}">${escapeHtml(line)}</div>`;
-        }).join("")
-      }</div>`;
+  const manifest = await read();
+  if (manifest === undefined) {
     return {
       label: "flaky tests",
-      status,
-      value: `${held.length}`,
-      sub: held.length === 1
-        ? "too noisy to judge a change by · 1 test"
-        : `too noisy to judge a change by · ${held.length} tests`,
-      extra: worst,
+      status: "unknown",
+      value: "—",
+      sub: "no selection manifest yet",
     };
   }
+  const held = flakyCount(manifest);
+  const status: Status = held >= FLAKES_BAD
+    ? "bad"
+    : held >= FLAKES_WARN
+    ? "warn"
+    : "good";
+  // The headline names what it counts, so the figure still means
+  // something to somebody who read it before the label above it.
+  const headline = held === 0
+    ? "no flaky tests"
+    : `${groupDigits(held)} flaky test${held === 1 ? "" : "s"}`;
+  const days = numberDial(
+    manifest.dials,
+    "FLAKE_WINDOW_DAYS",
+    FLAKE_WINDOW_FALLBACK_DAYS,
+  );
+  const age = compactSpan(
+    (clock?.() ?? Date.now()) - Date.parse(manifest.generatedAt),
+  );
+  return {
+    label: "flaky tests",
+    status,
+    value: headline,
+    valueLabel: headline,
+    // What the count was drawn from: the span of history a flake share is
+    // measured over, and how long ago the publisher measured it.
+    sub: `${days} days of runs · ${age} old`,
+    href: `${TEST_SELECTION_PATH}#${FLAKY_SECTION_ID}`,
+    hint: "flakes ↗",
+  };
 }
 
 export const testFlakes = makeTestFlakes();

--- a/packages/dashboard/tiles/test-selection.ts
+++ b/packages/dashboard/tiles/test-selection.ts
@@ -1,91 +1,91 @@
 /**
  * Reports what the newest selection manifest would have a pull request
- * run: how much of the corpus fits five lanes, and how close the fullest
- * lane is to its budget. It goes amber when the manifest has gone stale,
- * because selection quality decays with it, and red when a lane's
- * projected work is past the bound the whole design rests on.
+ * run: what share of the corpus fits five lanes. It goes amber when the
+ * manifest has gone stale, because selection quality decays with it, and
+ * red when a lane's projected work is past the bound the whole design
+ * rests on, which is the one condition the sub line gives up its share
+ * for.
+ *
+ * The packing itself — every lane, what each holds, and what each is
+ * projected to spend — is a page away.
  *
  * Following the dashboard's values (README.md): it reports on the system.
  */
 
 import type { Status, Tile, TileView } from "../types.ts";
-import { newestManifest } from "../test-selection-manifest.ts";
+import { compactSpan, groupDigits } from "../lib.ts";
+import {
+  laneBudgetOf,
+  MANIFEST_SHARE_MS,
+  type ManifestReader,
+  selectedCount,
+  sharedManifest,
+} from "../test-selection-manifest.ts";
+import {
+  TEST_SELECTION_PATH,
+  testSelectionResponse,
+} from "../test-selection-page.ts";
 
 /** Hours before a manifest is stale enough to say so. */
 export const MANIFEST_STALE_HOURS = 8;
 
-/**
- * Seconds of planned work a lane may hold, when the manifest does not say.
- * Every manifest records the dials it was built with, so the tile reads
- * the budget from the manifest in front of it rather than from a number
- * here that would quietly start lying the day the dial moved.
- */
-export const LANE_BUDGET_FALLBACK_SECONDS = 230;
-
-/** The budget a manifest was built with, or the fallback. */
-export function laneBudgetOf(dials: Record<string, unknown>): number {
-  const budget = dials.LANE_BUDGET_SECONDS;
-  return typeof budget === "number" && Number.isFinite(budget) && budget > 0
-    ? budget
-    : LANE_BUDGET_FALLBACK_SECONDS;
-}
-
-/** Builds the tile against a store and a clock, so a test can supply both. */
+/** Builds the tile against a reader and a clock, so a test can supply both. */
 export function makeTestSelection(
-  options: { fetchImpl?: typeof fetch; now?: () => number } = {},
+  options: { read?: ManifestReader; now?: () => number } = {},
 ): Tile {
+  const read = options.read ?? sharedManifest;
   return {
     id: "test-selection",
-    intervalMs: 15 * 60_000,
-    collect: () => selectionView(options),
+    intervalMs: MANIFEST_SHARE_MS,
+    routes: [{
+      path: TEST_SELECTION_PATH,
+      handler: () => testSelectionResponse(read, options.now),
+    }],
+    collect: () => selectionView(read, options.now),
   };
 }
 
 async function selectionView(
-  options: { fetchImpl?: typeof fetch; now?: () => number },
+  read: ManifestReader,
+  clock?: () => number,
 ): Promise<TileView> {
-  {
-    const manifest = await newestManifest(
-      options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl },
-    );
-    if (manifest === undefined) {
-      return {
-        label: "test selection",
-        status: "unknown",
-        value: "—",
-        sub: "no selection manifest yet",
-      };
-    }
-    const selected = manifest.lanes.reduce(
-      (total, lane) =>
-        total +
-        lane.batches.reduce((sum, batch) => sum + batch.identities.length, 0),
-      0,
-    );
-    const known = manifest.entries.length;
-    const share = known === 0 ? 0 : (selected / known) * 100;
-    const now = options.now?.() ?? Date.now();
-    const ageHours = (now - Date.parse(manifest.generatedAt)) / 3_600_000;
-    const budget = laneBudgetOf(manifest.dials);
-    const fullest = manifest.lanes.length === 0
-      ? 0
-      : Math.max(...manifest.lanes.map((lane) => lane.projectedSeconds));
-    const status: Status = fullest > budget
-      ? "bad"
-      : ageHours > MANIFEST_STALE_HOURS
-      ? "warn"
-      : "good";
+  const manifest = await read();
+  if (manifest === undefined) {
     return {
       label: "test selection",
-      status,
-      value: `${share.toFixed(0)}%`,
-      sub: `${selected} of ${known} tests · fullest lane ` +
-        `${fullest.toFixed(0)}s of ${budget}s`,
-      aside: ageHours > MANIFEST_STALE_HOURS
-        ? `${ageHours.toFixed(0)}h old`
-        : undefined,
+      status: "unknown",
+      value: "—",
+      sub: "no selection manifest yet",
     };
   }
+  const selected = selectedCount(manifest);
+  const known = manifest.entries.length;
+  const share = known === 0 ? 0 : (selected / known) * 100;
+  const age = (clock?.() ?? Date.now()) - Date.parse(manifest.generatedAt);
+  const ageHours = age / 3_600_000;
+  const budget = laneBudgetOf(manifest.dials);
+  const fullest = manifest.lanes.length === 0
+    ? 0
+    : Math.max(...manifest.lanes.map((lane) => lane.projectedSeconds));
+  const over = fullest > budget;
+  const stale = ageHours > MANIFEST_STALE_HOURS;
+  const status: Status = over ? "bad" : stale ? "warn" : "good";
+  const badge = `${compactSpan(age)} old`;
+  return {
+    label: "test selection",
+    status,
+    value: `${share.toFixed(0)}%`,
+    // A lane past its budget is what the tile turned red for, so it takes
+    // the line the corpus share otherwise holds.
+    sub: over
+      ? `fullest lane ${fullest.toFixed(0)}s of ${budget}s`
+      : `${groupDigits(selected)} of ${groupDigits(known)} tests`,
+    aside: stale
+      ? `<span class="hmtd" title="${badge}">${badge}</span>`
+      : undefined,
+    href: TEST_SELECTION_PATH,
+    hint: "lanes ↗",
+  };
 }
 
 export const testSelection = makeTestSelection();


### PR DESCRIPTION
The flaky tests tile and the test selection tile both said more than a tile can hold. The flake tile put a scrolling list of the four worst tests under its count, each line a percentage followed by a scope and a name cut to 52 characters; at the width a tile actually gets on the wall the renderer then cut what was left again, so a line read "100.0% · cli: integration.sh pie…" and named nothing. Its sub line repeated the headline count back: "25" over "too noisy to judge a change by · 25 tests". The selection tile carried two separate facts on one line, "16614 of 19544 tests · fullest lane 231s of 230s", and lost the second of them to the same cut.

A tile is one line wide. A line that ends in an ellipsis has taken the whole line and delivered none of it, so the fix is not a longer tile but a smaller claim on it, with everything else on a page.

Each tile now carries one figure and one line about it, and links to a new page at /test-selection which the selection tile declares as its route. The page reads the same manifest at full width: a summary of the counts the tiles headline, every lane against the budget the manifest was packed to with the over-budget one marked, every test held back as flaky with the rate it was measured at, every test held back while main is red, and every test no lane can hold. Names are written out in full and wrap rather than truncate. The flaky tests tile links straight to the flaky section.

The flake tile's headline names what it counts, reading "25 flaky tests", or "no flaky tests" when there are none, which is a better thing to read across a room than a bare zero. Its line says where the conclusion came from: the span of history a flake share is measured over, taken from the manifest's own `FLAKE_WINDOW_DAYS` dial, and how long ago the publisher measured. A count of tests held back is a claim about the present, and how old the evidence is decides how much of a claim it is. What being counted means is a definition rather than news, so it belongs on the page and not on a line the wall keeps showing. At the 220 pixels a tile is guaranteed the headline wants 189 of the 186 it gets; `valueLabel` carries the whole of it to the hover text, which is what the production tile already does for a headline that overruns by rather more, and at the four columns of about 266 pixels the wall lays out it fits with room.

The page says whose pull request that packing is for, because it is not any pull request's. The publisher builds the packing a manifest carries with an empty mandatory set, and no lane ever reads it: `runLane` re-packs locally against the tests its own diff makes mandatory, together with the identities the store has never seen. Those are placed first and placed whatever they cost, and the three discretionary shares are then taken over what is left of the budget. So the lanes on the page, and the share on the tile above them, describe the run a pull request touching no test would get, and both say so.

The flake tile's list also disagreed with its own headline. The count is of what the manifest withheld for flakiness, while the list under it was every entry with a nonzero rate, held back or not. A green tile reading zero could still name a test, and an amber tile reading one could name none. Both figures now come from one function.

Where the selection tile has two candidates for its sub line, the one that explains the color it is wearing wins. It carries the corpus share while it is green, and gives that line up to name the lane past its budget once one has, since that lane is what turned it red.

An unreadable store is no longer reported as an empty one. The manifest reader answered every failure the way it answered a store with nothing in it, with `undefined`, so a listing that could not be fetched, a manifest that returned 403, a fetch that never connected and a body that was not a manifest all became "no selection manifest yet". The wall's own values are against that: an honest gray beats a tile that cannot tell "healthy" from "I could not reach the source". The reader now raises a store failure. The wall already turns a collection that throws into a gray tile carrying the reason, so neither tile catches anything, and the page — which would otherwise answer with a 500 — answers 503 and says which of the two happened. Two things follow from the throw: `memo` declines to cache a rejection, so a failed read is retried on the next collection rather than held for the whole share window, and the tiles keep their previous values while the source is unreachable rather than dropping to a dash.

The page also says what the flake share is a share of. `flakeRate()` divides a test's flakes by its failures rather than by its runs, so 100% means every failure that test had in the window was a flake — for a test that failed once, a single flake — and says nothing about how often it fails. Two tests at the head of the wall's list read 100.0%, so this is the first thing a reader meets. The column is headed "flake share", and the paragraph above it names the denominator, the window the share is measured over and the threshold past which a test is held back, the last two read from the manifest's own dials rather than from constants here.

Supporting changes:

- Both tiles and the page read the manifest through one shared, memoized read rather than fetching it once per tile. A manifest carries an entry for every identity the store knows, so a read of one is far the largest the wall makes; the tiles' collection interval is the same constant as the share window, which is what makes one read serve both of them.

- The tiles and the page take a manifest reader rather than a `fetch`. Passing a fetch used to opt the caller out of the shared read as a side effect, which left the production path the only branch no test ran.

- `laneBudgetOf` and the budget fallback move from the selection tile to the manifest reader, since they describe a manifest rather than a tile, and the page needs them without depending on a tile. `numberDial` beside them reads any policy number a manifest records.

- The page frame, back link, section heading and footnote shared by every drill-down move out of `performance-views.ts` into `detail-page.ts`, so a new page starts from them rather than repeating them.

- `groupDigits` moves to `tile-render-values.ts` beside the other formatters, now that two tiles and a page use it, and `compactSpan` joins it so the tile and the page spell a manifest's age one way.

- A test fails when a tile links at a path no registered tile serves. The request handler tries each declared route and falls through to the wall itself for anything else, so such a link does not 404: it renders the wall again and returns the viewer to where they clicked with nothing to say why. Two tiles now link at a page a third file declares the route for, which is the arrangement where the two can drift apart.

- The selection tile's staleness badge is built the way the three spend tiles build their month-to-date facet, and the staleness test moves into a named local beside the one for a lane over budget.

The dashboard README gains rows for the two tiles and the page, which it did not have, and a section saying what a tile has room for and where the rest belongs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

