### PR TITLE
test: name the CFC posture three suites are written for

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1179,7 +1179,9 @@ the per-epic implementation notes).
   [`packages/shell/src/lib/render-ceiling.ts`](../../packages/shell/src/lib/render-ceiling.ts).
   Because the ceiling crosses the worker boundary in the fixed initialization
   data, flipping it takes effect on the next runtime (a reload or re-login), not
-  live.
+  live. A browser integration test states the side it needs through the
+  `renderCeiling` option of `ShellIntegration.goto`, which writes the same key
+  after the navigation and before the login.
 - **Added by.** Bernhard Seefeld, in "populate the render confidentiality
   ceiling behind a shell dogfood flag (Epic H3a)" (#4550, 2026-07-07).
 - **Purpose.** Populates the CFC render confidentiality ceiling in the shell's

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -745,7 +745,17 @@ run_mount() {
   rm -f "$MEMORY_PROXY_READY"
   MEMORY_PROXY_READY=""
 
-  MOUNT_OUTPUT=$(cf fuse mount "$MOUNTPOINT" --api-url="$FUSE_API_URL" --identity="$IDENTITY" --space="$SPACE" --background --dangerously-allow-incompatible-schema)
+  # --cfc-mode names the FUSE guardrail mode this suite's write-through phases
+  # need rather than taking whatever the runner default resolves to. One of
+  # those phases writes a handler file, and an enforcing mount refuses a
+  # handler write with EACCES at `open`. That write is a shell redirect, so
+  # under this script's `set -e` the run ends at that line with the shell's own
+  # "Permission denied" and the path it was writing to, which names no mode.
+  #
+  # The runner default is `disabled` today (DEFAULT_CFC_ENFORCEMENT_MODE in
+  # packages/runner/src/cfc/types.ts, which `resolveCfcMode` falls back to), so
+  # the flag selects the mode this mount would have resolved to without it.
+  MOUNT_OUTPUT=$(cf fuse mount "$MOUNTPOINT" --api-url="$FUSE_API_URL" --identity="$IDENTITY" --space="$SPACE" --cfc-mode=disabled --background --dangerously-allow-incompatible-schema)
   echo "$MOUNT_OUTPUT"
 
   MOUNT_PID="${MOUNT_OUTPUT#*PID }"
@@ -793,6 +803,16 @@ run_mount() {
   TOOL_FILE="$RESULT_DIR/search.tool"
 
   wait_for_path "$ENTITIES_DIR"
+
+  # `.status` carries the mode the daemon resolved, fixed before it mounted, so
+  # one read settles it. It is what names the mode at the mount when the flag
+  # above stops reaching the daemon, rather than several phases later as a
+  # permission error on a path.
+  path_exists "$STATUS_FILE" || error ".status was not mounted at the mount root."
+  STATUS_CFC_MODE=$(jq -r '.cfc.mode' "$STATUS_FILE")
+  if [ "$STATUS_CFC_MODE" != "disabled" ]; then
+    error ".status reports CFC mode $STATUS_CFC_MODE; the mount was given disabled."
+  fi
 }
 
 # Runs before any phase reads a piece: the assertion is that nothing but

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -202,6 +202,41 @@ export async function describeStateWaitFailure(
 }
 
 /**
+ * The `localStorage` key the shell's render-ceiling toggle is persisted under
+ * (packages/shell/src/lib/render-ceiling.ts).
+ */
+const RENDER_CEILING_KEY = "cfcRenderCeiling";
+
+/**
+ * Writes the shell's render-ceiling switch for `page`'s browser profile.
+ *
+ * `true` writes `"true"`, `false` writes `"false"`, and undefined removes the
+ * key. What each of those means is
+ * `packages/shell/src/lib/render-ceiling.ts`'s to decide;
+ * `isCfcRenderCeilingEnabled` reads the key as `=== "true"`, so `false` and
+ * undefined select the same profile there and differ only in what the caller
+ * said. Removing the key on undefined is what stops one navigation inheriting
+ * the side the previous navigation over the same page asked for, one page
+ * serving every case in a file.
+ *
+ * The worker runtime reads the key when it is constructed, at login, so this
+ * runs after the navigation that gives the page an origin to store it against
+ * and before the login: the same contract {@link enablePatternCoverage} runs
+ * under.
+ */
+async function seedRenderCeilingProfile(
+  page: Page,
+  enabled: boolean | undefined,
+): Promise<void> {
+  await page.evaluate<void, [string, string | null]>((key, value) => {
+    if (value === null) globalThis.localStorage.removeItem(key);
+    else globalThis.localStorage.setItem(key, value);
+  }, {
+    args: [RENDER_CEILING_KEY, enabled === undefined ? null : String(enabled)],
+  });
+}
+
+/**
  * The viewport size every page a {@link ShellIntegration} opens is set to.
  *
  * The shell's header has a narrow layout and a wide one, and lays out its
@@ -388,13 +423,23 @@ export class ShellIntegration {
    * states what it sends and what that has to reach as two separate things.
    *
    * If `identity` is provided, logs in with the identity after navigation.
+   *
+   * `renderCeiling` states the side of the shell's per-profile render ceiling
+   * switch this navigation's browser profile is on. With it on, the worker
+   * runtime carries the §8.10.6 display ceiling: display sinks admit the
+   * acting user's own identity atoms and the allow-listed influence-class
+   * caveat kinds, everything else renders as a blocked placeholder, and
+   * author-supplied render-boundary declassification is denied. Omitting it
+   * leaves the profile on the shell's own default. See
+   * {@link seedRenderCeilingProfile} for what each of the three states writes.
    */
   async goto(
-    { frontendUrl, view, urlPath, identity }: {
+    { frontendUrl, view, urlPath, identity, renderCeiling }: {
       frontendUrl: string;
       view: AppView;
       urlPath?: `/${string}`;
       identity?: Identity;
+      renderCeiling?: boolean;
     },
   ): Promise<void> {
     this.#checkIsOk();
@@ -415,6 +460,7 @@ export class ShellIntegration {
     // to be set after the page has an origin to store it against and before the
     // login below.
     await enablePatternCoverage(page);
+    await seedRenderCeilingProfile(page, renderCeiling);
     // [NDT] triage aid: seed the worker-console host toggle before login so
     // the worker runtime's console (where the storage taps live) reaches the
     // page console — and, with PIPE_CONSOLE, the test output. Same

--- a/packages/patterns/integration/cfc-render-policy-demo.test.ts
+++ b/packages/patterns/integration/cfc-render-policy-demo.test.ts
@@ -12,6 +12,7 @@ import {
   clickTrustedActionAndWaitForText,
   StepTimer,
   waitForRuntimeIdle,
+  waitForSettledText,
   waitForText,
   waitForTextAbsent,
 } from "./cfc-browser-helpers.ts";
@@ -75,6 +76,12 @@ describe("cfc render policy demo integration test", () => {
         pieceId: piece.id,
       },
       identity,
+      // The subject is the pattern's own declassification: the trusted
+      // surface's render boundary names the health label, and the reveal below
+      // is that boundary letting the value through. The render ceiling denies
+      // author-supplied declassification, so this case runs the profile
+      // without it; the case below runs the same page with it.
+      renderCeiling: false,
     });
     await waitForRuntimeIdle(page);
 
@@ -117,6 +124,59 @@ describe("cfc render policy demo integration test", () => {
           "#raw-health-attempt",
           "Sensitive health data:",
         ),
+    );
+  });
+
+  it("denies the trusted surface's declassification under the render ceiling", async () => {
+    const page = shell.page();
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: {
+        spaceName: SPACE_NAME,
+        pieceId: piece.id,
+      },
+      identity,
+      renderCeiling: true,
+    });
+    await waitForRuntimeIdle(page);
+
+    // The reveal switch is a cell of the piece and every case in this file
+    // drives the same piece, so this case sets it rather than reading whatever
+    // the case before it left. Concealing first is what makes the reveal a
+    // transition; `clickTrustedActionAndWaitForText` returns without clicking
+    // when the text it waits for is already on the page.
+    await clickTrustedActionAndWaitForText(
+      page,
+      "TrustedConcealHealthData",
+      "#reveal-state",
+      "Reveal disabled",
+    );
+    await clickTrustedActionAndWaitForText(
+      page,
+      "TrustedRevealHealthData",
+      "#reveal-state",
+      "Reveal enabled",
+    );
+
+    // With the reveal on, the pattern's own "Content hidden by policy" node is
+    // `display: none` and `deepText` skips it, so the text below is the
+    // reconciler's blocked placeholder: the ceiling denied the
+    // declassification the trusted surface declares for
+    // `SensitiveHealthRecord`, which is outside the §8.10.6 display profile.
+    await waitForSettledText(
+      page,
+      "#trusted-health-surface",
+      "Content hidden by policy",
+    );
+
+    // The value the reveal would have shown reaches no part of the document,
+    // and neither does the untrusted card, which renders the same value behind
+    // no trusted surface at all.
+    await waitForTextAbsent(page, "cf-screen", "Sensitive health data:");
+    await waitForTextAbsent(
+      page,
+      "cf-screen",
+      "Untrusted direct render attempt",
     );
   });
 });

--- a/packages/patterns/integration/cfc-spec-gallery.test.ts
+++ b/packages/patterns/integration/cfc-spec-gallery.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   clickTrustedActionAndWaitForText,
   waitForSettledText,
+  waitForTextAbsent,
 } from "./cfc-browser-helpers.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
@@ -140,6 +141,14 @@ describe("cfc spec gallery integration test", () => {
         pieceId: piece.id,
       },
       identity,
+      // The subject is what a `cf-cfc-label` shows for each of these three
+      // labels. Two of them sit outside the §8.10.6 display profile, so the
+      // render ceiling blocks their cards and takes those labels with them;
+      // this case runs the profile without the ceiling, and the case below
+      // runs the same page with it. `isCfcRenderCeilingEnabled` reads the key
+      // as `=== "true"`, so `false` selects the profile this page would take
+      // with no key at all until that reader changes.
+      renderCeiling: false,
     });
 
     await waitForCfcLabelText(page, [
@@ -147,6 +156,29 @@ describe("cfc spec gallery integration test", () => {
       "SourceProvenance",
       "fact-check-required",
     ]);
+  });
+
+  it("renders the admitted label and no other under the render ceiling", async () => {
+    const page = shell.page();
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: {
+        spaceName: SPACE_NAME,
+        pieceId: piece.id,
+      },
+      identity,
+      renderCeiling: true,
+    });
+
+    // The ceiling admits the acting user's own identity atoms and the
+    // influence-class caveat kinds, `prompt-influence` among them, so that
+    // card's label renders and a blocked placeholder stands where the other
+    // two cards were. The three strings below are the three the case above
+    // waits for, so the pair states the same page under each profile.
+    await waitForCfcLabelText(page, ["prompt-influence"]);
+    await waitForSettledText(page, "cf-screen", "Content hidden by policy");
+    await waitForTextAbsent(page, "cf-screen", "SourceProvenance");
+    await waitForTextAbsent(page, "cf-screen", "fact-check-required");
   });
 });
 


### PR DESCRIPTION
Three test surfaces assert behavior that a stricter CFC posture removes, and none of them said which posture they were written for. Each measured whichever one the environment it ran in happened to carry.

`cfc-render-policy-demo` clicks a trusted control and waits for "Sensitive health data: migraine treatment plan" to appear inside the trusted surface. That value carries a `SensitiveHealthRecord` label, and the surface's render boundary declassifies exactly that label. The §8.10.6 display ceiling denies author-supplied declassification, so under it the value never reaches the DOM and the untrusted card beside it is narrowed away whole, heading included.

`cfc-spec-gallery` waits for three `cf-cfc-label` elements. The ceiling admits the acting user's own identity atoms and the influence-class caveat kinds, so `prompt-influence` renders while the `SourceProvenance` and `fact-check-required` cards fail closed, each taking its label with it. The suite waits for three and sees one.

The FUSE exec suite writes a piece through a mounted tree, and one of its write-through phases writes a handler file. An enforcing mount refuses a handler write with EACCES at `open`. That write is a shell redirect, so under the script's `set -e` the run ends at that line with the shell's own "Permission denied" and the path it was writing to, which names no mode.

`ShellIntegration.goto` gains a `renderCeiling` option. It writes the shell's own per-profile `localStorage` key after the navigation and before the login, which is where the worker runtime reads it: the contract `enablePatternCoverage` already runs under there. `true` and `false` are written as values, and an option left unstated removes the key, so one navigation cannot inherit the side the previous navigation over the same page asked for. `isCfcRenderCeilingEnabled` reads the key as `=== "true"`, so `false` selects the profile an absent key already selects and differs from it only in what the caller stated; the helper's doc and the call site say so.

Each demo now runs a case on each side of the switch. The existing cases name the profile their subject needs, and a new case in each file opts in to the ceiling and asserts the blocking. Those two are what holds the option up today. The demo case sets the reveal switch itself rather than reading what the case before it left on the shared piece, and asserts the blocked text last rather than first: with the reveal on, the pattern's own "Content hidden by policy" node is `display: none` and `deepText` skips it, so only the reconciler's placeholder can produce that string.

The FUSE mount names `--cfc-mode=disabled`, and the mount phase reads the resolved mode back off the daemon's `.status` — one read of a value fixed before the daemon mounted, so a mount that came up under another mode fails there, naming the mode, rather than several phases later as a permission error on a path. `resolveCfcMode` falls back to `DEFAULT_CFC_ENFORCEMENT_MODE` in packages/runner/src/cfc/types.ts, which is `disabled`, so the flag selects the mode this mount would have taken anyway and changes nothing until that constant moves.

The `cfcRenderCeiling` entry in EXPERIMENTAL_OPTIONS.md names the new option alongside the console command.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

