### PR TITLE
ci: register the pattern-tier and action-pin gates in the topology

### DIFF
--- a/tasks/test-topology/gates.ts
+++ b/tasks/test-topology/gates.ts
@@ -84,8 +84,10 @@ const CHECK_GATES: readonly Gate[] = [
     kind: "gate",
     task: "check-verb-session-sync",
   },
+  { name: "check-pattern-tiers", kind: "gate", task: "check-pattern-tiers" },
   { name: "check-unused-deps", kind: "gate", task: "check-unused-deps" },
   { name: "check-deno-pins", kind: "gate", task: "check-deno-pins" },
+  { name: "check-action-pins", kind: "gate", task: "check-action-pins" },
   {
     name: "check-single-copy-deps",
     kind: "gate",


### PR DESCRIPTION
The `Check` job runs `check-pattern-tiers` and `check-action-pins` through `run-recorded`, so each writes a record under the identity `["gate","repo","check-pattern-tiers"]` and
`["gate","repo","check-action-pins"]`. Neither name appeared in the `repo-checks` suite in `tasks/test-topology/gates.ts`, which is the list of everything else the `Check` job runs, so no suite in the topology claimed either identity.

Two things follow from that. A lane asked to run the repository's gates runs the twenty the suite enumerates and neither of these, because a lane builds its commands from the suite rather than from the workflow. And the store half of the drift guard, which fails on a recorded identity no suite claims, would have failed on both; it has not, because nothing passes it `--records` yet.

Both are whole-tree checks that take no way of running part of themselves, so each is one unit whose command is the task wrapped in the recorder, and each sits where the workflow runs it: the pattern tiers after the verb-session gate, the action pins after the Deno pins.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

