### PR TITLE
ci(dashboard): keep the publish workflow out of test records

### DIFF
--- a/.claude/rules/github-workflows.md
+++ b/.claude/rules/github-workflows.md
@@ -60,6 +60,14 @@ steps wrap their command in `deno task run-recorded <kind> <scope> <name>
 without the ship step runs fine and records nothing — which is how a new
 job silently falls out of the flake and duration history.
 
+A job whose every test another workflow already records against the same
+commit is the exception, and it records nothing: no spool directory, no
+`run-recorded` wrapper, no ship step. Recording there would file each of
+those tests twice against one commit. The Dashboard workflow's tests job
+is the one such job, and the relay does not follow that workflow. The
+exemption covers tests, not jobs, so a test that runs only in such a job
+is recorded there.
+
 ## Before splitting or rebalancing jobs
 
 `docs/development/CI_PERFORMANCE.md` says when that work is worth starting and,

--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -27,8 +27,6 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
     steps:
       # A manual run can name any ref. Publishing moves the `latest` tag that
       # the deployment follows, so a run on another ref stops here, before
@@ -50,18 +48,15 @@ jobs:
       - name: 🔍 Install dependencies
         uses: ./.github/actions/deno-install
 
+      # This runs the same task on the same commit as CI's `Test` job, which
+      # is where the dashboard's tests are recorded. Repeating that recording
+      # here would file each of those tests twice against one commit, so this
+      # job writes no test records: it sets no spool directory, wraps nothing
+      # in `run-recorded`, and ships no artifact. The relay does not follow
+      # this workflow.
       - name: 🧪 Test dashboard
         working-directory: packages/dashboard
-        run: deno task run-recorded unit dashboard test -- deno task test
-
-      # The test-records relay follows this workflow's completion and ships
-      # the artifact; this job stays free of cloud credentials.
-      - name: 📤 Ship test records
-        if: always()
-        uses: ./.github/actions/test-records-ship
-        with:
-          artifact: dashboard-tests
-          job: Tests
+        run: deno task test
 
   publish:
     name: Publish image

--- a/.github/workflows/test-records-relay.yml
+++ b/.github/workflows/test-records-relay.yml
@@ -14,7 +14,7 @@ name: Test Records Relay
 
 on:
   workflow_run:
-    workflows: ["CI", "Dashboard"]
+    workflows: ["CI"]
     types:
       - completed
   workflow_dispatch:

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -342,8 +342,10 @@ first. Test workflows start emitting the field only after that support is on
 the default branch. Otherwise the old relay drops the field before writing a
 create-only object that cannot be repaired in place.
 
-The relay workflow follows the completion of every workflow that runs tests —
-success, failure, cancellation, and timeout alike. It ships a
+The relay workflow follows the completion of every workflow that records
+tests — success, failure, cancellation, and timeout alike. A workflow whose
+tests another workflow already records against the same commit records
+nothing of its own, and the relay does not follow it. It ships a
 same-repository run unconditionally, since only write access creates
 one, and a fork run only when the run's actor — read from the trusted
 payload — is on the team member list (`TEST_RECORDS_MEMBER_ACTOR_IDS`,

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1167,6 +1167,12 @@ read CI's verdict — so its own test job is the only thing standing between a
 dashboard that fails its tests and the `latest` tag. Leave it in place even
 though it looks redundant.
 
+What that test job does not do is record what it runs. CI records the same
+task on the same commit, so a second recording here would file each of those
+tests twice against one commit. The job therefore sets no spool directory,
+wraps nothing in `run-recorded`, and ships no test-records artifact, and the
+relay does not follow this workflow.
+
 No image is built or published for a pull request.
 
 The publish job authenticates with GitHub OIDC and GCP Workload Identity

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -622,6 +622,22 @@ Deno.test("Dashboard publishes only from main, never from a pull request", async
   );
 });
 
+Deno.test("the Dashboard workflow records no tests", async () => {
+  const dashboard = withoutComments(await workflow("dashboard-image.yml"));
+  const relay = withoutComments(await workflow("test-records-relay.yml"));
+
+  // CI runs `packages/dashboard`'s test task on the same commit and records
+  // what it runs. Recording the same task again here would file each of those
+  // tests twice against one commit, so this workflow takes no part in test
+  // records at either end: it spools nothing, and the relay does not follow
+  // it. Reinstating either half alone produces a run whose records are
+  // gathered and never shipped.
+  assertEquals(dashboard.includes("CF_TEST_RECORDS_DIR"), false);
+  assertEquals(dashboard.includes("run-recorded"), false);
+  assertEquals(dashboard.includes("test-records-ship"), false);
+  assertStringIncludes(workflowTriggers(relay), '    workflows: ["CI"]\n');
+});
+
 Deno.test("One commit publishes one set of release artifacts", async () => {
   // A release artifact is named after the commit it was built from, and the
   // deploy hands the bastion a commit rather than a build. So a commit has one


### PR DESCRIPTION
The Dashboard workflow's tests job records what it runs. It sets a spool directory, wraps `packages/dashboard`'s test task in `run-recorded`, and ships a `test-records-dashboard-tests` artifact, and the relay follows this workflow to collect that artifact.

Those records duplicate CI's. The dashboard is a workspace package, so CI's `Test` job runs the same task on the same commit, and the browser pass inside it reports through the deno-web-test reporter under the `dashboard` scope. A main commit therefore already carries the dashboard's eight browser tests from CI. The publish workflow gathers those same eight identities again, plus one `unit/dashboard/test` line from the wrapper summarizing a task CI also runs. Storing them would give one execution of each test two entries in its history.

The tests job now takes no part in test records at either end: no spool directory, no wrapper, no ship step, and the relay no longer follows the workflow. Reinstating one half alone leaves a run that gathers records nothing collects, so a test in `tasks/ci-workflow.test.ts` holds the two together, and each of its four assertions was checked by mutation.

Nothing that reached the store is lost, because none of it ever reached the store. The relay's download step gives each artifact a directory of its own only when more than one matches its pattern; with a single match it extracts the files flat. The relay scans that directory for subdirectories, finds none, reports that the run produced no artifacts, and exits successfully. The Dashboard workflow ships exactly one artifact, so its records have never been stored. That defect is filed separately, and the duplication is worth removing either way.

What stays unrecorded is unchanged: `packages/dashboard`'s plain `deno test` cases appear nowhere, in CI or here, because the member's test task is a script that no `--junit-path` reaches.

The rule in `.claude/rules/github-workflows.md` held every job that runs tests to shipping records, and the specification said the relay follows every workflow that runs tests. Both now carry the exception. It is scoped to tests rather than to jobs, so a test that runs only in such a job is still recorded there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

