### PR TITLE
docs: add test-selection publisher runbook

### DIFF
--- a/.github/workflows/test-selection.yml
+++ b/.github/workflows/test-selection.yml
@@ -1,9 +1,8 @@
 # The publisher: reads the test-record store, folds what is new into a
 # rolling aggregate, scores every identity, and creates one manifest object.
-# The planned five pull-request lanes will read that manifest once CI adopts
-# them. Nothing gates on it today: when this fails, the previous manifest stays
-# newest for the dashboard and read-only tools, so selection quality decays
-# slowly rather than anything turning red.
+# Whatever reads a manifest reads the newest one. Nothing gates on this
+# workflow: when it fails, the manifest before it is still the newest, so
+# selection quality decays slowly rather than anything turning red.
 #
 # Its Google Cloud identity comes from a Workload Identity Federation
 # provider pinned to exactly this workflow file on main, so no other

--- a/.github/workflows/test-selection.yml
+++ b/.github/workflows/test-selection.yml
@@ -1,15 +1,16 @@
 # The publisher: reads the test-record store, folds what is new into a
-# rolling aggregate, scores every identity, and creates one manifest
-# object. The five pull-request lanes read that manifest to decide what to
-# run. Nothing gates on it: when this fails, the previous manifest is
-# still the newest one and lanes keep using it, so selection quality
-# decays slowly rather than anything turning red.
+# rolling aggregate, scores every identity, and creates one manifest object.
+# The planned five pull-request lanes will read that manifest once CI adopts
+# them. Nothing gates on it today: when this fails, the previous manifest stays
+# newest for the dashboard and read-only tools, so selection quality decays
+# slowly rather than anything turning red.
 #
 # Its Google Cloud identity comes from a Workload Identity Federation
 # provider pinned to exactly this workflow file on main, so no other
 # workflow, ref, or repository can mint it (infra: tofu/test-records). The
-# account holds objectCreator on the selection prefix and nothing else: it
-# cannot read, list, overwrite, or delete.
+# account's identity-specific writer grant is objectCreator on the selection
+# prefix, so it cannot overwrite or delete. The dataset's public objectViewer
+# grant separately lets it read and list objects like any public reader.
 #
 # Four-hourly rather than daily because aggregation is incremental and so
 # cheap, and a flake that appears in the morning should not wait until the

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -7,14 +7,11 @@ normative description of the contract;
 [the plan](../plans/pull-request-test-selection.md) carries the reasoning
 and the parts still to be built.
 
-## Current status
-
-The storage, keyless publisher identity, bootstrap state, and four-hourly
-publisher are live. This does not mean that test selection runs pull-request
-continuous integration. `.github/workflows/deno.yml` still runs the existing
-job matrices and does not invoke `tasks/ci-lane.ts`; the continuous-integration
-switch in parts two and three of the plan is still pending. For now, published
-manifests feed the dashboard and the read-only commands below, not test jobs.
+What reads a published manifest is the dashboard, the read-only commands
+below, and the pull-request lanes. Which of those the repository has
+turned on is a question the plan answers, under [the
+work](../plans/pull-request-test-selection.md#the-work); a manifest is
+published either way.
 
 Every local query about test selection goes through one entry point:
 
@@ -271,8 +268,10 @@ objects on top and doubles every catch in them.
 A rollup is a derived cache of one closed day rather than the full-fidelity
 record of that day, so
 [the record spec](../specs/test-records.md#trust-boundaries-for-consumers)
-asks a consumer that feeds decisions to use it on that basis. This is a
-content boundary, not weaker credential provenance. The daily compactor
+asks a consumer that feeds decisions to treat a rollup as a cache of one
+day rather than the record of it. What that rests on is the content: a
+rollup summarizes a day's raw records rather than carrying them. It does
+not rest on the credential that wrote it. The daily compactor
 authenticates without a key through Workload Identity Federation, pinned to
 `.github/workflows/test-records-compact.yml` on the default branch. There is no
 downloaded compactor key and no writing path from a workstation; a local
@@ -308,31 +307,24 @@ These checks are read-only:
 gh run list --repo commontoolsinc/labs \
   --workflow test-selection.yml --branch main --limit 10
 gh run view RUN_ID --repo commontoolsinc/labs --log
-python3 - <<'PY'
-import json
-from urllib.parse import urlencode
-from urllib.request import urlopen
+deno run --allow-net --allow-env - <<'TS'
+import { listObjectTimes } from "@commonfabric/test-support/records";
+import { storeBucket } from "./tasks/test-records-config.ts";
+import { manifestPrefix } from "./tasks/test-selection/store.ts";
 
-endpoint = "https://storage.googleapis.com/storage/v1/b/cf-ci-metadata/o"
-query = {
-    "prefix": "labs/test-selection/v1/",
-    "fields": "nextPageToken,items(name,timeCreated,size)",
-}
-while True:
-    with urlopen(f"{endpoint}?{urlencode(query)}") as response:
-        page = json.load(response)
-    for item in page.get("items", []):
-        print(item["timeCreated"], item["size"], item["name"], sep="\t")
-    token = page.get("nextPageToken")
-    if not token:
-        break
-    query["pageToken"] = token
-PY
+const prefix = `${manifestPrefix()}/`;
+const objects = await listObjectTimes({ bucket: storeBucket(), prefix });
+for (const object of objects) console.log(object.createdAt, object.name);
+console.log(`${objects.length} objects under ${prefix}`);
+TS
 ```
 
-Use the identifier at the end of the logged manifest name to find both objects.
-The loop follows every `nextPageToken`; a first page is not evidence that state
-is absent.
+Use the identifier at the end of the logged manifest name to find both
+objects. `listObjectTimes` reads the listing to its end rather than a
+first page, so a name it does not print is a name the prefix does not
+hold. The count on the last line is what separates a prefix holding
+nothing from a listing that never ran: a cold start prints the count and
+no names.
 
 The selection dashboard tile supplies the existing stale signal: it turns
 amber when the newest manifest is more than eight hours old.
@@ -344,10 +336,11 @@ Do not use bootstrap as a routine retry: it starts from an empty aggregate and
 replaces score history with only the selected window.
 
 - If the newest state is valid, rerun the ordinary workflow from `main` with
-  bootstrap off and the `days` input empty, so the landed default is used. If
-  an outage extends beyond that two-day window, keep the run incremental and
-  widen its window. Land the chosen window in reviewed workflow or publisher
-  configuration on `main` before running it; do not supply a live-only override.
+  bootstrap off. An empty `days` reads the landed two-day default, which is
+  what an ordinary catch-up needs. An outage longer than that needs a wider
+  window, and the `days` input is what widens it. Such a run is still an
+  incremental one: it folds onto the state already there rather than
+  replacing it, which is what separates it from a bootstrap.
 - If the complete paginated listing has no state objects under the intended
   prefix and schema version, this is a cold start. Dispatch the workflow from
   `main` once with bootstrap on and leave `days` empty so the landed sixty-day

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -7,7 +7,16 @@ normative description of the contract;
 [the plan](../plans/pull-request-test-selection.md) carries the reasoning
 and the parts still to be built.
 
-Everything a person types goes through one entry point:
+## Current status
+
+The storage, keyless publisher identity, bootstrap state, and four-hourly
+publisher are live. This does not mean that test selection runs pull-request
+continuous integration. `.github/workflows/deno.yml` still runs the existing
+job matrices and does not invoke `tasks/ci-lane.ts`; the continuous-integration
+switch in parts two and three of the plan is still pending. For now, published
+manifests feed the dashboard and the read-only commands below, not test jobs.
+
+Every local query about test selection goes through one entry point:
 
 ```
 deno task test-selection <mode>
@@ -259,29 +268,97 @@ manifest or aggregate. The previous manifest stays newest. Completed
 days are recorded, so no later run over a wide window folds their raw
 objects on top and doubles every catch in them.
 
-A rollup is written by the one principal here whose credential exists as
-key material, so it carries weaker provenance than the raw records it
-summarizes, and
+A rollup is a derived cache of one closed day rather than the full-fidelity
+record of that day, so
 [the record spec](../specs/test-records.md#trust-boundaries-for-consumers)
-asks a consumer that feeds decisions to treat it as a cache of a day
-rather than the record of it. Seeding catch counts from days closed a
-week or more ago is that use. The four-hourly path in its steady state
-reaches no day it could read one from: compaction leaves a partition open
-for a week, and that path reads two days. So a rollup is read by a
-bootstrap, and by a run catching up after an outage or over a window
-somebody widened.
+asks a consumer that feeds decisions to use it on that basis. This is a
+content boundary, not weaker credential provenance. The daily compactor
+authenticates without a key through Workload Identity Federation, pinned to
+`.github/workflows/test-records-compact.yml` on the default branch. There is no
+downloaded compactor key and no writing path from a workstation; a local
+`deno task test-records-compact --plan` is read-only.
 
-`deno task test-records-compact` is what writes rollups, and an operator
-runs it from a workstation with a downloaded key — nothing federated runs
-it, so there is no workflow ref to pin an identity to. A day nobody has
-compacted is folded from its raw objects, which is what a bootstrap does
-for every day until the compactor has reached one.
+The four-hourly publisher normally reaches no rollup: compaction leaves a
+partition open for a week, while the incremental publisher reads two days. A
+bootstrap, an incremental run catching up after an outage, or an incremental
+run using a deliberately widened window can reach older closed days and read
+their rollups. A day the compactor has not reached is folded from its raw
+objects.
 
-Publishing needs the workflow's own federated identity, which is pinned
-to that workflow file on the default branch and is the only principal
-that can create a manifest. A personal reporting key cannot: it is scoped
-to its holder's own submissions folder. So a person runs `--dry-run
---out` and reads what a run would have produced.
+Publishing uses the workflow's own federated identity, pinned to that workflow
+file on the default branch. It is the only workflow principal with a
+folder-scoped create grant for manifests. A personal reporting key cannot
+create one: it is scoped to its holder's own submissions folder. So a person
+runs `--dry-run --out` and reads what a run would have produced.
+
+### Verifying publication
+
+A bootstrap or recovery is accepted only after all three of these are true:
+
+1. The workflow run succeeds and its log names the manifest it created.
+2. A complete public listing contains that manifest and a state object with the
+   same trailing identifier.
+3. A later incremental run succeeds and creates another manifest and state
+   pair. Reaching that write proves that the incremental path could list, read,
+   and validate the state left by the earlier run.
+
+These checks are read-only:
+
+```bash
+gh run list --repo commontoolsinc/labs \
+  --workflow test-selection.yml --branch main --limit 10
+gh run view RUN_ID --repo commontoolsinc/labs --log
+python3 - <<'PY'
+import json
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+endpoint = "https://storage.googleapis.com/storage/v1/b/cf-ci-metadata/o"
+query = {
+    "prefix": "labs/test-selection/v1/",
+    "fields": "nextPageToken,items(name,timeCreated,size)",
+}
+while True:
+    with urlopen(f"{endpoint}?{urlencode(query)}") as response:
+        page = json.load(response)
+    for item in page.get("items", []):
+        print(item["timeCreated"], item["size"], item["name"], sep="\t")
+    token = page.get("nextPageToken")
+    if not token:
+        break
+    query["pageToken"] = token
+PY
+```
+
+Use the identifier at the end of the logged manifest name to find both objects.
+The loop follows every `nextPageToken`; a first page is not evidence that state
+is absent.
+
+The selection dashboard tile supplies the existing stale signal: it turns
+amber when the newest manifest is more than eight hours old.
+
+### Recovery
+
+Read the failed run's log and the public object listing before taking action.
+Do not use bootstrap as a routine retry: it starts from an empty aggregate and
+replaces score history with only the selected window.
+
+- If the newest state is valid, rerun the ordinary workflow from `main` with
+  bootstrap off and the `days` input empty, so the landed default is used. If
+  an outage extends beyond that two-day window, keep the run incremental and
+  widen its window. Land the chosen window in reviewed workflow or publisher
+  configuration on `main` before running it; do not supply a live-only override.
+- If the complete paginated listing has no state objects under the intended
+  prefix and schema version, this is a cold start. Dispatch the workflow from
+  `main` once with bootstrap on and leave `days` empty so the landed sixty-day
+  default applies. Then require the three acceptance checks above.
+- If listing or pagination fails, the newest state cannot be read, or its schema
+  is invalid, that is not absence. The publisher refuses to write by design.
+  Leave the append-only manifests and state objects intact: they and the raw
+  record history are the recovery sources. The current tool has no operator
+  option to select or restore an older state, so recovery requires a reviewed
+  path that reads preserved state and folds forward, landed on `main`; do not
+  improvise one with object deletion, renaming, or bootstrap.
 
 To run it by hand against the store without creating anything:
 

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1,11 +1,10 @@
 # Choosing which tests a pull request runs
 
-Status: in progress. Part one is built apart from the one-off bootstrap
-dispatch; part two is built apart from its continuous-integration
-configuration and the coverage work; part three has the reporter and
-nothing else. [The work](#the-work) carries the detail. The record store
-this plan consumes is live and holds the data the design needs; the gaps
-it does not yet hold are listed under [What the store is
+Status: in progress. Part one is built. Part two is built apart from its
+continuous-integration configuration and the coverage work; part three has
+the reporter and nothing else. [The work](#the-work) carries the detail.
+The record store this plan consumes is live and holds the data the design
+needs; the gaps it does not yet hold are listed under [What the store is
 missing](#what-the-store-is-missing) and closed by the first part of the
 work.
 
@@ -2911,10 +2910,13 @@ should have, which the full run on `main` catches. That bounds the whole
 attack surface, and it is why the manifest is allowed to be an ordinary
 public object rather than a signed artifact.
 
-Write access to the manifest prefix is one service account reachable only
-through a Workload Identity provider pinned to one workflow file on
-`main`, exactly as the relay is. Nothing else in the organization can
-write there, and the account cannot read, list, overwrite, or delete.
+The publisher is the only workflow-scoped writer to the manifest prefix. Its
+service account is reachable through a Workload Identity provider pinned to one
+workflow file on `main`, exactly as the relay is. Its identity-specific
+`objectCreator` grant cannot overwrite or delete, while the dataset's public
+`objectViewer` grant separately lets it read and list objects like any other
+public reader. Broader bucket administrators remain the infrastructure
+containment caveat rather than another publisher path.
 
 The lane runner treats the manifest as untrusted input and validates it
 whole. The only field that reaches a shell is a suite identifier, which is
@@ -3183,7 +3185,18 @@ answers somewhere people can see them.
       rollup of the shared area cannot say a day is accounted for and
       take that day's local submissions with it. Local records stay on
       their raw path until they have rollups of their own.
-- [ ] The one-off bootstrap dispatch.
+- [x] The one-off bootstrap dispatch. On 2026-09-06, [run
+      34020738350](https://github.com/commontoolsinc/labs/actions/runs/34020738350)
+      on `main` folded 12 rollup days and 67,463,235 executions, then created
+      `manifest-2026-09-06T08:02:32.080Z-01M1TWYZZV2PXG5Y5VG3MCY91Q.json.gz`
+      and the matching state object. The public listing shows both, and later
+      incremental runs succeeded from that state. As a later check, scheduled
+      [run
+      34274701451](https://github.com/commontoolsinc/labs/actions/runs/34274701451)
+      on 2026-09-08 folded 1,321,563 executions into 19,904 identities and
+      created
+      `manifest-2026-09-08T20:25:40.387Z-01M21B6E8PQV8ZPP0E21CMR4G3.json.gz`
+      with its matching state object.
 - [x] Repeat the record census after `main` emitted server-execution
       variant records, and replace the plan's projection inputs.
 - [x] Dashboard tiles: the flake list, what the newest manifest would

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -2915,8 +2915,9 @@ service account is reachable through a Workload Identity provider pinned to one
 workflow file on `main`, exactly as the relay is. Its identity-specific
 `objectCreator` grant cannot overwrite or delete, while the dataset's public
 `objectViewer` grant separately lets it read and list objects like any other
-public reader. Broader bucket administrators remain the infrastructure
-containment caveat rather than another publisher path.
+public reader. A bucket administrator can still write anywhere in the
+bucket. That is a risk the infrastructure has to contain, rather than a
+second way to publish a manifest.
 
 The lane runner treats the manifest as untrusted input and validates it
 whole. The only field that reaches a shell is a suite identifier, which is

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -243,10 +243,11 @@ the partition where their report was produced, not where it was uploaded.
 A trailing window can make late arrivals likely to be found, but cannot
 make discovery exact; what listing does and does not settle is described
 below. The whole dataset is readable by `allUsers`. Writers hold
-`roles/storage.objectCreator` pinned to their own folder, which cannot
-read, list, overwrite, or delete; nothing already stored can be modified
-by any append credential. An incompatible schema writes under `v2/` and
-readers migrate at their own pace.
+`roles/storage.objectCreator` pinned to their own folder. That
+identity-specific writer grant cannot overwrite or delete, while the public
+reader grant separately lets every principal read and list. Nothing already
+stored can be modified by any append credential. An incompatible schema writes
+under `v2/` and readers migrate at their own pace.
 
 Four writer principals exist, three of them recording. The **relay** —
 the only one that writes what CI produced — holds create on


### PR DESCRIPTION
## Summary

- record the successful one-off bootstrap and later incremental publication evidence while keeping CI adoption pending
- add read-only verification, stale-manifest, and state-preserving recovery guidance
- correct obsolete credential and permission descriptions for the keyless compactor and public-read store

## Checks

- `deno fmt --check`
- `deno lint`
- `deno task check-docs`
- `deno task check-conflict-markers`
- `deno task check-control-characters`
- `deno test -A tasks/test-selection-publish.test.ts tasks/test-selection/store.test.ts tasks/test-records-compact.test.ts`
- `deno test -A tasks/ci-workflow.test.ts`
- `git diff --check origin/main...HEAD`

Documentation and comments only; no live workflow was dispatched.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

