### PR TITLE
Drop the escape rate from test selection

### DIFF
--- a/.github/workflows/dashboard-image.yml
+++ b/.github/workflows/dashboard-image.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - "Dockerfile.dashboard"
       - "packages/dashboard/**"
+      # The image runs whatever `packages/test-support` held when it was
+      # built, and the wall's manifest reader is in there. Without this
+      # the deployed dashboard keeps reading manifests by a rule the
+      # publisher has stopped writing to.
+      - "packages/test-support/**"
       - "scripts/ci-gantt.ts"
       - "deno.jsonc"
       - "deno.lock"

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -27,11 +27,11 @@ deno task test-selection explain '["integration","patterns","counter.test.ts","s
 ```
 
 It prints the suite and the invocation unit the identity belongs to, its
-score and its cost, the catches behind that score with how many were on
-the default branch and across how many distinct sources, when the most
-recent one was, its churn and flake rate, and whether it is withheld and
-why. An identity the store has never seen is reported as mandatory, which
-is what an identity with no history is.
+score and its cost, the catches behind that score and how many distinct
+sources they came from, when the most recent one was, its churn and flake
+rate, and whether it is withheld and why. An identity the store has never
+seen is reported as mandatory, which is what an identity with no history
+is.
 
 The identity resolves through `tasks/test-identity-aliases.jsonl` first,
 so asking about a renamed test under either name finds the joined history.

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1,11 +1,11 @@
 # Choosing which tests a pull request runs
 
 Status: in progress. Part one is built apart from the one-off bootstrap
-dispatch and one dashboard tile; part two is built apart from its
-continuous-integration configuration and the coverage work; part three has
-the reporter and nothing else. [The work](#the-work) carries the detail.
-The record store this plan consumes is live and holds the data the design
-needs; the gaps it does not yet hold are listed under [What the store is
+dispatch; part two is built apart from its continuous-integration
+configuration and the coverage work; part three has the reporter and
+nothing else. [The work](#the-work) carries the detail. The record store
+this plan consumes is live and holds the data the design needs; the gaps
+it does not yet hold are listed under [What the store is
 missing](#what-the-store-is-missing) and closed by the first part of the
 work.
 
@@ -1239,8 +1239,7 @@ commit ten times counts once.
 
 A catch is always a point in the test's favor, and the place it happened
 says something further. The three places are worth keeping apart, because
-they answer different questions and one of them is the measure of whether
-this whole design is working.
+they answer different questions.
 
 A **local catch** is somebody at a workstation, part way through writing
 something, running a test and finding it red. It is the highest-quality
@@ -1277,11 +1276,6 @@ invites the mistake. The first of those is this system's job to fix, and
 it fixes it automatically, because main catches raise the score that gets
 the test selected.
 
-The aggregate of main catches across all tests is the number that says
-whether selecting a subset was a good idea: how often something reaches
-`main` that a test we already had would have caught. It goes on the wall
-as a system measure, and it is the thing to watch after the lanes go live.
-
 ### The inputs
 
 For each complete identity that the topology locates to an item, the
@@ -1289,8 +1283,6 @@ publisher computes:
 
 - `catches` — how many catches it has, over all of history, weighted by
   where each happened.
-- `mainCatches` — how many of those were on `main`, kept separately
-  because they measure escapes as well as the test.
 - `lastCatch` — when the most recent one was.
 - `sources` — how many distinct sources are among those catches. A source
   is the branch for a continuous-integration run and the reporting
@@ -2902,14 +2894,6 @@ that, a flaky-but-not-excluded item repeated three times fails three times
 as often as it would have. The net is an empirical question and the
 dashboard is where it gets answered.
 
-**Whether this was a good idea is measurable, and the measurement exists
-before the change does.** The escape rate — how often something reaches
-`main` that a test the repository already had would have caught — can be
-computed from the store today, while pull requests still run everything.
-That gives a baseline taken under the old regime to judge the new one
-against, rather than a number that only starts existing once there is
-nothing to compare it to.
-
 **Coverage stops being enforced across the repository, and stays enforced
 per package.** Nothing will fail because a change lowered the repository's
 whole coverage number. What replaces that is a weekly trend somebody has
@@ -3320,19 +3304,10 @@ answers somewhere people can see them.
 - [ ] The one-off bootstrap dispatch.
 - [x] Repeat the record census after `main` emitted server-execution
       variant records, and replace the plan's projection inputs.
-- [ ] Dashboard tiles: the coverage debt trend, the flake list, what the
-      newest manifest would select, and the escape rate — how often
-      something reaches `main` that a test we already had caught there.
-      That last one is measurable today, before any of this changes what
-      runs, which makes it the baseline everything after is judged
-      against.
-  - [x] The flake list, and what the newest manifest would select.
-  - [x] The coverage debt trend. It reads the repository-wide figure each
-        `main` run's `perf-metrics` artifact already carries, so it needed
-        nothing from the rest of this work.
-  - [ ] The escape rate. Every manifest carries each identity's `main`
-        catches, but over unbounded history, so a rate needs the state to
-        keep those per day as well as in total.
+- [x] Dashboard tiles: the flake list, what the newest manifest would
+      select, and the coverage debt trend. The trend reads the
+      repository-wide figure each `main` run's `perf-metrics` artifact
+      already carries, so it needed nothing from the rest of this work.
 - [x] The `deno task test-selection` entry point and its modes: `dials`,
       `coverage`, `explain <identity>`, and `plan` with `--dry-run` and
       `--verify`. Every mode that packs reads the topology, so the

--- a/packages/test-support/src/records/selection-testing.ts
+++ b/packages/test-support/src/records/selection-testing.ts
@@ -24,7 +24,7 @@ export function sampleEntry(
     unit: `packages/${test.s}/test/${test.s}.test.ts`,
     cost: 0.05,
     score: 0.05,
-    inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
+    inputs: { catches: 0, sources: 0, churn: 0 },
     flakeRate: 0,
     repeats: 1,
     ...fields,

--- a/packages/test-support/src/records/selection.test.ts
+++ b/packages/test-support/src/records/selection.test.ts
@@ -25,6 +25,19 @@ describe("selection", () => {
       expect(parseManifest(serializeManifest(manifest))).toEqual(manifest);
     });
 
+    it("drops a field it does not know rather than refusing the object", () => {
+      // Manifests already in the store carry fields this reader has
+      // since stopped keeping. Refusing those would leave every lane
+      // running the whole corpus for as long as one is the newest.
+      const object = JSON.parse(serializeManifest(sampleManifest()));
+      for (const entry of object.entries) entry.inputs.mainCatches = 3;
+      const parsed = parseManifest(JSON.stringify(object));
+      expect(parsed).toBeDefined();
+      expect(parsed!.entries.length).toBe(object.entries.length);
+      expect(Object.hasOwn(parsed!.entries[0]!.inputs, "mainCatches"))
+        .toBe(false);
+    });
+
     it("returns undefined for a schema version it does not know", () => {
       const ahead = {
         ...sampleManifest(),
@@ -227,7 +240,6 @@ describe("selection", () => {
         "a churn that is not a number",
         withField("inputs", {
           catches: 0,
-          mainCatches: 0,
           sources: 0,
           churn: "some",
         }, "entry"),
@@ -236,7 +248,6 @@ describe("selection", () => {
         "a last catch that is not a day",
         withField("inputs", {
           catches: 0,
-          mainCatches: 0,
           sources: 0,
           churn: 0,
           lastCatch: 7,

--- a/packages/test-support/src/records/selection.ts
+++ b/packages/test-support/src/records/selection.ts
@@ -22,9 +22,6 @@ export interface ScoreInputs {
   /** Catches, weighted by where each happened. */
   catches: number;
 
-  /** How many of those were on `main`, which measure escapes as well. */
-  mainCatches: number;
-
   /** The day of the most recent catch, absent when there are none. */
   lastCatch?: string;
 
@@ -253,8 +250,8 @@ function parseIdentity(value: unknown): TestIdentity | undefined {
 function parseInputs(value: unknown): ScoreInputs | undefined {
   if (!isRecord(value)) return undefined;
   if (
-    !isFiniteNumber(value.catches) || !isFiniteNumber(value.mainCatches) ||
-    !isFiniteNumber(value.sources) || !isFiniteNumber(value.churn)
+    !isFiniteNumber(value.catches) || !isFiniteNumber(value.sources) ||
+    !isFiniteNumber(value.churn)
   ) {
     return undefined;
   }
@@ -263,7 +260,6 @@ function parseInputs(value: unknown): ScoreInputs | undefined {
   }
   const inputs: ScoreInputs = {
     catches: value.catches,
-    mainCatches: value.mainCatches,
     sources: value.sources,
     churn: value.churn,
   };

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -78,7 +78,7 @@ function manifestOf(entries: readonly Partial<ManifestEntry>[]): Manifest {
       unit: "packages/bakery/glaze.test.ts",
       cost: 1,
       score: 0.5,
-      inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
+      inputs: { catches: 0, sources: 0, churn: 0 },
       flakeRate: 0,
       repeats: 1,
       ...entry,
@@ -888,7 +888,7 @@ describe("running a lane's work", () => {
       unit: "packages/bakery/glaze.test.ts",
       cost: 1.5,
       score: 0.5,
-      inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
+      inputs: { catches: 0, sources: 0, churn: 0 },
       flakeRate: 0,
       repeats: 1,
     };

--- a/tasks/post-main-report.test.ts
+++ b/tasks/post-main-report.test.ts
@@ -469,7 +469,7 @@ describe("post-main-report", () => {
           unit,
           flakeRate: 0.02,
           cost: 1,
-          inputs: { catches: 3, mainCatches: 1, sources: 2, churn: 0 },
+          inputs: { catches: 3, sources: 2, churn: 0 },
         }),
       ],
       withheld: [{ test: kneads, suite: "workspace-unit", reason: "flaky" }],

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -405,8 +405,11 @@ describe("publish()", () => {
     expect(manifest!.entries[0]!.unit).toBe(
       "packages/memory/test/space.test.ts",
     );
-    // The failure at c1 that c2 went on to fix is a catch on main.
-    expect(manifest!.entries[0]!.inputs.mainCatches).toBe(1);
+    // The failure at c1 that c2 went on to fix is a catch on main, and
+    // a catch there is weighted by where it happened. The 1.5 is
+    // `CATCH_WEIGHT_MAIN` written out: comparing against the dial would
+    // hold just as well for a dial of zero and a catch never counted.
+    expect(manifest!.entries[0]!.inputs.catches).toBe(1.5);
   });
 
   it("leaves out an identity no suite claims, and says how many", async () => {

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -102,14 +102,13 @@ describe("test-selection", () => {
       const held = manifest();
       held.entries[0]!.inputs = {
         catches: 3,
-        mainCatches: 1,
         sources: 2,
         churn: 0.5,
         lastCatch: "2026-08-20",
       };
       const text = explainLines(held, TEST, { selected: true }).join("\n");
       expect(text).toContain("3.0 weighted catches");
-      expect(text).toContain("1 of them on main");
+      expect(text).toContain("2 sources");
       expect(text).toContain("2026-08-20");
       expect(text).toContain("selects it");
     });

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -208,8 +208,7 @@ export function explainLines(
     `${key}`,
     `  suite ${entry.suite}, in ${entry.unit}`,
     `  score ${entry.score.toFixed(3)}, costing ${entry.cost.toFixed(3)}s`,
-    `  ${entry.inputs.catches.toFixed(1)} weighted catches, ` +
-    `${entry.inputs.mainCatches} of them on main, across ` +
+    `  ${entry.inputs.catches.toFixed(1)} weighted catches, across ` +
     `${entry.inputs.sources} sources`,
     entry.inputs.lastCatch === undefined
       ? "  it has never caught anything"

--- a/tasks/test-selection/census.test.ts
+++ b/tasks/test-selection/census.test.ts
@@ -47,7 +47,7 @@ function manifestOf(entries: readonly Partial<ManifestEntry>[]): Manifest {
       unit: "packages/bakery/glaze.test.ts",
       cost: 1,
       score: 0.5,
-      inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
+      inputs: { catches: 0, sources: 0, churn: 0 },
       flakeRate: 0,
       repeats: 1,
       ...entry,

--- a/tasks/test-selection/census.ts
+++ b/tasks/test-selection/census.ts
@@ -83,7 +83,7 @@ export function standIn(
     unit,
     cost: median(suiteCosts) ?? UNMEASURED_COST_SECONDS,
     score: VALUE_FLOOR,
-    inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
+    inputs: { catches: 0, sources: 0, churn: 0 },
     flakeRate: 0,
     repeats: 1,
   };

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -425,14 +425,12 @@ describe("score", () => {
     it("keeps an old proven test ahead of one with no record", () => {
       const proven = {
         catches: 4,
-        mainCatches: 0,
         lastCatch: "2024-08-20",
         sources: 2,
         churn: 0,
       };
       const unproven = {
         catches: 0,
-        mainCatches: 0,
         sources: 0,
         churn: 0,
       };
@@ -446,7 +444,6 @@ describe("score", () => {
         value(
           {
             catches,
-            mainCatches: 0,
             lastCatch: "2026-08-20",
             sources: 1,
             churn: 0,
@@ -461,7 +458,7 @@ describe("score", () => {
     it("decays a catch slowly and never below the freshness floor", () => {
       const at = (lastCatch: string) =>
         value(
-          { catches: 4, mainCatches: 0, lastCatch, sources: 0, churn: 0 },
+          { catches: 4, lastCatch, sources: 0, churn: 0 },
           "2026-08-20",
         );
       expect(at("2026-08-13")).toBeGreaterThan(at("2026-04-20"));

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -813,7 +813,6 @@ export function scoreInputs(
     catches: CATCH_WEIGHT_LOCAL * state.localCatches +
       CATCH_WEIGHT_PR * state.prCatches +
       CATCH_WEIGHT_MAIN * state.mainCatches,
-    mainCatches: state.mainCatches,
     sources: state.sources.length,
     churn: churn(state, today),
   };


### PR DESCRIPTION
The plan for choosing which tests a pull request runs carried one unbuilt dashboard tile: the escape rate, meaning how often something reaches the default branch that a test the repository already had would have caught. A count of catches there is in every manifest, but over unbounded history, so turning it into a rate needs the publisher's per-identity state to keep those counts per day as well as in total. That is a second time series in every identity's state, kept forever, for one number on the wall. The benefit does not carry the cost.

Remove the tile from the plan, along with the passage arguing that the escape rate is how the design judges itself, and the consequence claiming the measurement exists before the change does. The scoring rationale stays: a catch on the default branch is still a recorded escape, and still counts one and a half times.

Remove `inputs.mainCatches` from the manifest as well. It was kept apart from the weighted `catches` because it measured escapes as well as the test, and nothing else needs it: the score reads only the weighted figure, and `explain` printed it in one clause of one line. That clause was wrong anyway. A catch on the default branch is worth 1.5, so a test with two local catches and one there printed "5.5 weighted catches, 1 of them on main", where the 1 is not one of the 5.5. The publisher's own state goes on counting local, pull-request and default-branch catches apart, because the weights are what they are for.

Every manifest in the store still carries the field, so what a reader does with one it no longer knows gets a case of its own in `parseManifest()`'s table: the object parses, and the field does not survive into what comes back. Refusing those objects would leave every lane treating the newest manifest as absent, which makes the whole corpus mandatory.

The deployed dashboard is the one reader that cannot be fixed after the fact. Its image is built from the whole tree, and
`packages/test-support` is the only package outside `packages/dashboard` that the wall's own code imports: it holds the manifest reader the flake tile and the selection tile run. The workflow's path filter did not list it, so a change to how a manifest is read reached the default branch without reaching the wall, and a refused manifest throws rather than emptying a tile. Add it, so the image rebuilt at merge is deployed before the publisher's four-hourly cron writes the first manifest under the new rule.

Also stop the bootstrap case in `test-selection-publish.test.ts` asserting against the dial that computed the value it checks. `expect(inputs.catches).toBe(CATCH_WEIGHT_MAIN)` holds just as well when `CATCH_WEIGHT_MAIN` is zero and the catch on the default branch was never counted at all, which is the one thing that case exists to prove.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

