### PR TITLE
test: the S18 receipt case states its rung and reads its reason

### DIFF
--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -26,7 +26,7 @@ import {
   prepareCfcGrantWrite,
   verifyCfcGrantDocument,
 } from "../src/cfc/grants.ts";
-import type { IFCLabel } from "../src/cfc/mod.ts";
+import type { CfcEnforcementMode, IFCLabel } from "../src/cfc/mod.ts";
 import {
   buildCfcPolicySnapshot,
   type ExchangeRule,
@@ -39,7 +39,10 @@ import {
   StorageManager,
 } from "../src/storage/cache.deno.ts";
 import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
-import { isPermanentRejection } from "../src/storage/rejection.ts";
+import {
+  isCfcEnforcementRejection,
+  isPermanentRejection,
+} from "../src/storage/rejection.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-single-use-grants");
 
@@ -263,6 +266,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
     opts: {
       receipts?: boolean;
       policyEvaluation?: "off" | "observe" | "enforce";
+      enforcement?: CfcEnforcementMode;
       rules?: readonly ExchangeRule[];
     },
     body: (
@@ -285,6 +289,10 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       // The rule firings these tests assert on happen inside policy
       // evaluation.
       cfcPolicyEvaluation: opts.policyEvaluation ?? "enforce",
+      // An unstated rung is the one the runtime resolves for a construction
+      // that names none. The S18 gate case below names its own; nothing else
+      // in this file does.
+      cfcEnforcementMode: opts.enforcement,
     });
     try {
       await body(runtime, storageManager);
@@ -1234,19 +1242,43 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       });
     });
 
+    // The enforcement rung decides this case, so it names one. A reserved
+    // grant address written through the ordinary write surface is refused
+    // from `enforce-explicit` upward. Under `observe` the recorded reason
+    // stays a diagnostic and under `disabled` no gate runs, so under either
+    // of those the commit succeeds and the forged write lands.
     it("rejects an unprivileged write at the receipt address (S18 gate)", async () => {
-      await withRuntime({}, async (runtime) => {
-        const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
-        const tx = runtime.edit();
-        tx.writeOrThrow({
-          space: signer.did(),
-          id: receiptId,
-          type: "application/json",
-          path: ["value"],
-        }, { forged: true });
-        const result = await tx.commit();
-        expect(result.error).toBeDefined();
-      });
+      await withRuntime(
+        { enforcement: "enforce-explicit" },
+        async (runtime) => {
+          const receiptId = cfcGrantConsumedReceiptId(grantIdFor(runtime));
+          const tx = runtime.edit();
+          tx.writeOrThrow({
+            space: signer.did(),
+            id: receiptId,
+            type: "application/json",
+            path: ["value"],
+          }, { forged: true });
+          // Prepare, the way the runtime's own commit paths do, so the gate
+          // this case is named for is the one that decides the commit. An
+          // unprepared transaction is refused too, but for being unprepared:
+          // that arm carries no reason and would still refuse if the gate
+          // stopped recording the write.
+          tx.prepareCfc();
+          const state = tx.getCfcState().prepare;
+          expect(state.status).toBe("invalidated");
+          if (state.status === "invalidated") {
+            expect(state.reasons.join(" ")).toContain(
+              `unprivileged write to protected cfc path ${receiptId}`,
+            );
+          }
+          const result = await tx.commit();
+          // The refusal, rather than any error at all. The message prefix is
+          // what tells a CFC refusal apart from an ordinary abort or a storage
+          // failure.
+          expect(isCfcEnforcementRejection(result.error)).toBe(true);
+        },
+      );
     });
   });
 


### PR DESCRIPTION
`cfc-single-use-grants.test.ts` builds every runtime through one helper that names no CFC enforcement rung, so each case measured whichever rung the runtime's default dial table happened to carry. One case reads that rung. "rejects an unprivileged write at the receipt address (S18 gate)" writes at a reserved grant address through the ordinary write surface and expects the commit to be refused, and that refusal exists from `enforce-explicit` upward. Under `observe` the recorded reason stays a diagnostic, and under `disabled` no gate runs at all, so under either of those the forged write lands and the case fails on `expect(result.error).toBeDefined()` with "Expected actual to not be strictly equal to: undefined", which names no rung.

The case now states `enforce-explicit`, the lowest rung at which its subject exists, through a new dial on the file's runtime helper. The helper passes the option straight to the runtime rather than resolving a default of its own, so the other forty-two steps still take whatever the table says and a raise still reaches them. The neighbouring `cfc-grant-records.test.ts` names its option the same way. The two cases that forge a receipt through a bare `ExtendedStorageTransaction` are untouched: such a transaction carries no CFC state, which is the premise those cases are built on, and a dial set on one case's runtime does not reach them.

The case was also measuring a weaker gate than its name claims. It committed without preparing, so the refusal it saw was the one a relevant transaction takes for arriving at commit unprepared, which carries no reason. Dropping the S18 recording while leaving the relevance mark in place kept that refusal and the case passed. It now prepares first, the way the runtime's own commit paths do, and reads the gate's own verdict: the prepare is invalidated and its reasons name the protected path that was written. Its commit assertion asks `isCfcEnforcementRejection` rather than accepting any error, since the refusal travels under the same name as an ordinary abort and only the message prefix separates them.

Checked by running the file with the enforcement rung in `RUNTIME_CFC_DIAL_DEFAULTS` set to each of the four rungs in turn, and by deleting the `unprivilegedSystemWrites` recording from `#noteSystemWrite` while keeping its `markCfcRelevant` call. Before, the case failed at `disabled` and at `observe` and passed under the deletion. After, all forty-three steps pass at all four rungs and the case fails under the deletion.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

