### PR TITLE
ci: stop the coverage gate recording itself as a test

### DIFF
--- a/.claude/rules/github-workflows.md
+++ b/.claude/rules/github-workflows.md
@@ -68,6 +68,14 @@ is the one such job, and the relay does not follow that workflow. The
 exemption covers tests, not jobs, so a test that runs only in such a job
 is recorded there.
 
+A check that no lane can be asked to run is the other exception, and it
+records nothing either: no spool directory, no `run-recorded` wrapper, no
+ship step. `docs/specs/test-records.md` under "Recording" holds the
+criterion. The `Coverage Check` job in `deno.yml` is the one such job,
+because it reads the coverage artifacts of every test job in its own run.
+A gate comparing against a base ref is not this: `check-baselines-append-only`
+and `check-test-aliases` each resolve a merge base, and both record.
+
 ## Before splitting or rebalancing jobs
 
 `docs/development/CI_PERFORMANCE.md` says when that work is worth starting and,

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1892,8 +1892,6 @@ jobs:
     if: (github.event_name == 'pull_request') || (github.ref_name == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
-    env:
-      CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
     needs:
       - check
       - test
@@ -1935,6 +1933,9 @@ jobs:
           skip-decompress: false
           digest-mismatch: error
 
+      # The gate reads the coverage artifacts of every test job in this run, so
+      # no lane can be asked to run it and this job writes no test records.
+      # `docs/specs/test-records.md` under "Recording" holds the criterion.
       - name: 📊 Run coverage check
         timeout-minutes: *work-timeout
         env:
@@ -1943,7 +1944,6 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: >-
-          deno task run-recorded gate repo coverage-check --
           deno run --allow-net --allow-env --allow-read --allow-run
           --allow-write tasks/coverage-check.ts
 
@@ -1968,13 +1968,6 @@ jobs:
           path: perf-metrics.json
           retention-days: 90
           if-no-files-found: ignore
-
-      - name: 📤 Ship test records
-        if: always()
-        uses: ./.github/actions/test-records-ship
-        with:
-          artifact: coverage-check
-          job: Coverage Check
 
   status:
     name: "Status"

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -146,6 +146,15 @@ such a harness as a child process hands it an empty
 `CF_TEST_RECORDS_DIR`, since the child reads its own environment; an
 empty value is recording off, the same as an unset one.
 
+A check that no lane can be asked to run is not recorded. A record is one
+execution of one test, and every history built from records — flake rate,
+duration, and what a pull request selects — answers whether to run that
+test again. A check reading the artifacts of every job in its own run
+exists only as part of a whole run, so there is nothing to select and no
+suite in the test topology to claim its identity. The pull request
+coverage gate is the one such check; a gate resolving a merge base
+against a base ref is not, and records normally.
+
 A run's owner — locally `deno task test`, `deno task integration`, or
 `deno task run-recorded` when a personal key is present — creates the
 spool under the per-user spool root (`CF_TEST_RECORDS_SPOOL_ROOT`, or the

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -673,6 +673,26 @@ Deno.test("the Dashboard workflow records no tests", async () => {
   assertStringIncludes(workflowTriggers(relay), '    workflows: ["CI"]\n');
 });
 
+Deno.test("the Coverage Check job records no tests", async () => {
+  const job = jobBlock(
+    withoutComments(await workflow("deno.yml")),
+    "coverage-check",
+  );
+
+  // The gate reads the coverage artifacts of every test job in this run, so no
+  // lane can be asked to run it, and the criterion in `docs/specs/test-records.md`
+  // under "Recording" puts it outside test records: no spool directory, no
+  // wrapper, no ship step.
+  assert(!job.includes("CF_TEST_RECORDS_DIR"), "the job spools test records");
+  assert(
+    !job.includes("run-recorded"),
+    "the job wraps its command in run-recorded",
+  );
+  assert(!job.includes("test-records-ship"), "the job ships test records");
+  // The gate itself runs.
+  assertStringIncludes(job, "tasks/coverage-check.ts");
+});
+
 Deno.test("One commit publishes one set of release artifacts", async () => {
   // A release artifact is named after the commit it was built from, and the
   // deploy hands the bastion a commit rather than a build. So a commit has one


### PR DESCRIPTION
The `Coverage Check` job wraps its command in `run-recorded` and ships a `coverage-check` artifact, so every CI run files a test record under the identity `["gate","repo","coverage-check"]`.

Nothing can be asked to run that check. The gate reads the coverage artifacts of every test job in its own run, so it exists only as part of a whole run, and the test topology has no suite that claims the identity. Handed a record carrying it, `deno task check-test-topology --records` answers `no suite claims the recorded identity ["gate","repo","coverage-check"]`. Every history built from records — flake rate, duration, and what a pull request selects — answers whether to run that test again, and here there is no such question. The duration report is the only one the record ever reached: the selection publisher folds only placed identities into states, and an identity no suite claims is never placed, so it reached no manifest and no flake rate.

The job now takes no part in test records: no spool directory, no `run-recorded` wrapper, no ship step. The gate is otherwise unchanged, and the relay still follows CI for every other job's records.

The criterion goes in `docs/specs/test-records.md` under "Recording", which is where what counts as a test belongs. Somebody adding a gate to `tasks/test-topology/gates.ts`, or wrapping a new command-level check, never opens the workflow rule. `.claude/rules/github-workflows.md` held every job that runs tests to shipping records, and already carried one exception for a job whose tests another workflow records against the same commit; it now carries this one beside it and points at the specification for the criterion.

That criterion is runnability rather than the stability of the verdict. The gate also holds each changed source group against a baseline read from earlier main runs, so one commit can pass today and fail tomorrow, and on main it judges nothing at all: with no pull request number it runs informationally and publishes the baseline. But a criterion written from that would sweep in gates that record correctly. `check-baselines-append-only` and `check-test-aliases` each compare against a base ref, each resolves a merge base first, and each can be run on a commit alone.

A test in `tasks/ci-workflow.test.ts` holds the job to all four properties: no spool directory, no wrapper, no ship step, and the gate still invoked. Each assertion was checked by mutation, and each fails with a message naming the construct that came back.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

