### PR TITLE
test: drop the coverage attribution map from test selection

### DIFF
--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -432,8 +432,8 @@ items. The manifest reports it as unavailable under that suite and variant,
 with the registry's phase and reason. A step-level entry leaves the file
 item in the suite because every other step still runs. It marks only the
 skipped leaf identity unavailable, so that leaf is excluded from the
-unknown-identity and coverage-target rules while the rest of the file's
-identities behave normally.
+unknown-identity rule while the rest of the file's identities behave
+normally.
 
 Removing either kind of skip makes the file or leaf ordinary topology
 again. Until a full `main` run records it, it is unknown and therefore
@@ -822,12 +822,14 @@ So the check is one invocation per identity with every sibling skipped,
 and the answer is a flag carried in the manifest beside the score.
 
 It cannot be a sweep. One invocation per identity is around 18,000 of
-them, against the roughly 2,000 the weekly coverage attribution job
-already costs three and a half hours for. So `main` checks the identities
-in the files its own run touched, plus a rotating slice of everything else.
-The map fills in over weeks and stays current where the code is moving,
-and an identity whose file changed loses its flag until it is checked
-again.
+them, and every one pays a process start before it runs a test. At the
+rate one invocation per test file costs, which [the consequences
+below](#consequences-we-are-choosing) price at three and a half hours for
+two thousand, that is upwards of thirty hours. So `main` checks the
+identities in the files its own run touched, plus a rotating slice of
+everything else. The flags fill in over weeks and stay current where the
+code is moving, and an identity whose file changed loses its flag until it
+is checked again.
 
 #### When the flag is wrong
 
@@ -1490,10 +1492,14 @@ until a successful `main` run has produced records for it.
 
 **What the change touches must run.** A pull request that edits a test and
 does not run it is not something this repository should permit, so a
-changed test file's items are mandatory. A changed *source* file is
-handled by the coverage attribution map, which knows which test files
-execute which lines: see
-[Choosing tests by what the change touches](#choosing-tests-by-what-the-change-touches).
+changed test file's items are mandatory. A unit that is not a file, such
+as a type-check group or a binary, is one its suite maps the change onto,
+since only the suite knows what its unit covers. A changed *source* file
+forces nothing else in, apart from the whole of a covered package's
+measured set under [the per-package
+gate](#the-one-coverage-gate-that-survives). What runs for it otherwise is
+what the score chose, which is the trade named under [consequences we are
+choosing](#consequences-we-are-choosing).
 
 ### Renames, and the alias file
 
@@ -1624,14 +1630,25 @@ be counted as a catch. A test failing on `main` a dozen times a year would
 then look like one of the most valuable tests in the repository while
 being one of the least.
 
-The second rule closes it, and it is the same distinction stated as a
-question about what came next. **A failure on `main` that a change fixed
-is a catch. A failure on `main` that went away by itself is a flake.**
-Concretely: the identity failed at `main` commit C and passed at the next
-`main` run, and nothing between the two touched any code the test covers.
-The coverage attribution map is what answers "any code the test covers";
-without it the fallback is the test's own file and scope, which is
-coarser and errs toward calling things catches.
+The second rule is the same distinction stated as a question about what
+came next. **A failure on `main` is judged by the next
+`main` run that passed.** At the same commit the test disagreed with
+itself, so the failure is a flake observation. The two runs can arrive in
+separate batches, which is why this is a rule of its own rather than the
+directly observable case above. At a later commit the failure counts as a
+catch.
+
+A run of failures ended by one pass counts one catch, dated to the first
+of them, so a week of `main` being red is worth one catch and not seven.
+
+That narrows the hole rather than closing it. Nothing separates a failure
+a change fixed from one that healed itself, so a flaky test collects
+catches on `main` it did not earn. The same test runs on pull requests as
+well, where repeats and re-runs put several observations at one commit,
+and a test that disagrees with itself there is seen doing it. I would
+expect that to bound the over-crediting, because a test flaky enough on
+`main` to matter is being run far more often on pull requests, but nothing
+here measures it.
 
 `flakeRate` is the share of a test's failures that fall under either rule.
 
@@ -1770,12 +1787,12 @@ From what is left, given every item's value and cost and a budget of five
 lanes times 230 seconds each, it fills in four passes.
 
 1. **Mandatory.** Everything marked mandatory goes in first: the `always`
-   suites, the items the diff touched directly, the items the coverage
-   attribution map says execute the changed lines, every item of a
-   covered package the diff touched as described in [The one coverage gate
-   that survives](#the-one-coverage-gate-that-survives), and the items with
-   no history. An item excluded above comes back into this pass if the
-   change touches what it covers, since that is very likely a fix. Every
+   suites, the items the diff touched directly, every item of a covered
+   package the diff touched as described in [The one coverage gate that
+   survives](#the-one-coverage-gate-that-survives), and the items with no
+   history. An item excluded above comes back into this pass if the
+   change edits the test itself, or its suite maps the change onto its
+   unit, since that is very likely a fix. Every
    item taken here leaves the selectable set, so no later pass can run one
    of them again. This pass can in principle put a lane past its budget;
    when it does, the runner says in the job summary how far past, rather
@@ -2057,8 +2074,9 @@ The object carries:
 - the `unschedulable` list;
 - a count and digest of the known item-level identities, for the
   unknown-item rule;
-- the name of the newest coverage attribution map, which is published
-  beside the manifest on its own weekly cadence rather than inside it.
+- each covered workspace member's own-tests uncovered-line count, against
+  the commit it was measured at, which is what the per-package gate
+  compares a pull request against.
 
 The size is measured rather than bounded. A publisher run over one day of
 the store — 18,849 objects holding 5,487,611 executions — produced 20,091
@@ -2257,10 +2275,9 @@ alternate execution of one test.
 
 What the runner does, in order:
 
-1. Resolve the manifest from the commit's date and fetch it, then fetch
-   the attribution map that manifest names. No manifest at or before that
-   date, or a fetch failure, takes the fallback (see [Failure
-   modes](#failure-modes)).
+1. Resolve the manifest from the commit's date and fetch it. No manifest
+   at or before that date, or a fetch failure, takes the fallback (see
+   [Failure modes](#failure-modes)).
 2. Enumerate every suite against the working tree, and read the manifest
    against that enumeration. The tree decides which tests exist and the
    manifest decides what each is worth and costs, so an entry naming a
@@ -2268,9 +2285,8 @@ What the runner does, in order:
    never seen gains a stand-in. Everything after this reads the result
    rather than the manifest the store gave, which is what keeps the full
    run and a pull request working from one answer about what exists.
-3. Compute the diff against the merge base, and resolve the changed source
-   lines through the attribution map to the items that execute them. The
-   full run skips this: it has no diff.
+3. Compute the diff against the merge base, and ask each suite which of
+   its units the diff touched. The full run skips this: it has no diff.
 4. Call `plan()`, take this lane's plan. The full run calls it with the
    `everything` policy, and with the empty diff step 3 left it. Those two
    values are the whole of the difference between the two runs.
@@ -2468,9 +2484,9 @@ is no longer the same thing.
 
 What the gate was actually for is worth separating from how it worked. It
 was there so that coverage keeps going up, or at least stops going down
-quietly. That goal survives, and it is served three ways: as a trend on
-`main`, as a gate over the packages a pull request can still measure
-whole, and as information about the diff itself.
+quietly. That goal survives, and it is served two ways: as a trend on
+`main`, and as a gate over the packages a pull request can still measure
+whole.
 
 ### The repository-wide number is a trend, not a gate
 
@@ -2732,68 +2748,6 @@ which is the change the author is looking at. That is the whole of the
 argument, and it is why this gate keeps its teeth while the
 repository-wide one gives them up.
 
-### Coverage attribution, and what it unlocks
-
-Deno writes one coverage profile per pair of test file and source file. A
-test file that exercises a source file produces a profile naming that
-source and counting only what that test file reached. This was checked
-rather than assumed: two test files touching different functions of one
-module produce two separate profiles for that module, with the counts
-correctly separated, and it holds under `--parallel`.
-
-The profiles carry no marker saying which test file produced them, so
-attribution needs one coverage directory per test file, which needs one
-`deno test` invocation per test file. At 2,000 test files that is around
-three and a half hours of runner time — impossible per run, and entirely
-affordable as a weekly job sharded across the same lane machinery. Pattern
-coverage needs none of this: `cf test` already writes one coverage file
-per test.
-
-What that buys is an **attribution map**: for every source line, the test
-items that execute it. Published beside the manifest, refreshed weekly,
-and stale in exactly the way a weekly map is stale — which is fine,
-because it is used to *add* tests to a run, never to remove them.
-
-An attribution target is a suite item, not a bare file path. When the same
-file runs in default and non-default suites, the map keeps those targets
-separate. A changed line makes every configuration whose measured item
-executes it mandatory; coverage from one variant does not silently stand
-in for another. A whole file or exact leaf declared unavailable in a
-configuration is not a coverage target for that configuration. The file's
-remaining available leaves continue to participate normally.
-
-### Choosing tests by what the change touches
-
-With the map, a pull request's changed source lines resolve to the test
-items that execute them, and those items become mandatory. This is the
-thing today's continuous integration cannot do at all, and it makes a
-selected run better at its actual job than a scope-based guess would be: a
-change to one function in `packages/runner` runs the tests that execute
-that function, rather than a sample of the 655 test files in that package.
-
-Without the map — before it is first built, or for a brand-new source file
-nothing covers yet — the fallback is the scope-level boost the score
-already carries, and an uncovered new file is reported rather than
-silently passed over.
-
-### Diff coverage on a pull request, as information
-
-The same map gives a number worth showing without gating on it: of the
-lines this change adds or modifies, how many did the tests that actually
-ran execute?
-
-That number needs no baseline, which is what makes it survive selection.
-It is a floor rather than a verdict — some tests that cover those lines
-were not selected — and the comment says so. It appears as part of the
-reporter's comment, framed as what it is: here are the lines your change
-added that nothing ran, and here are the test files that cover the lines
-next to them, which is where a new test would most naturally go.
-
-This is what covers the ground the repository-wide gate used to. For a
-package that carries the per-package gate the ratchet still says no. For
-everything else the comment says where a test would go, which is more
-likely to produce a test than a failure was.
-
 ## Telling a pull request what `main` found
 
 Selection means some regressions land and `main` catches them. That is the
@@ -2823,9 +2777,10 @@ pull request's own run could not have:
   the test's score so the next change in that area runs it. Ran and
   passing is a flake or an interaction between changes, and it is a
   different conversation.
-- **A coverage debt increase above the threshold**, with the lines and
-  where a test would go. Never as a failure — the run is green — and never
-  for one line.
+- **A coverage debt increase above the threshold**, naming the source
+  groups the change touched that rose as well, which is as near as this
+  gets to saying where a test would go. Never as a failure — the run is
+  green — and never for one line.
 - **A rise in a covered package's own-tests number**, named as one the
   per-package gate exists to catch. There are three ways one reaches
   `main`: the change touched more covered packages than the cap allows, so
@@ -2891,6 +2846,28 @@ intolerable, the escape hatch is a merge queue, which restores the
 guarantee at the cost of merge latency. This plan does not propose one; it
 notes that the option exists and that nothing here forecloses it.
 
+**Outside a covered package, a change to a source file does not pull in
+the tests that execute it.** Selection knows which test files a change
+edited, and which units each suite says the change touched. Where the diff
+touches a covered package and stays under the cap, [the per-package
+gate](#the-one-coverage-gate-that-survives) makes that package's whole
+measured set mandatory, which reaches the tests executing the changed
+lines by running every test the package has. Everywhere else, selection
+does not know which tests execute a changed line, so what runs for an
+edited source file is what the score chose. The finer answer is buildable
+and is not being built. Deno writes one coverage profile per pair of test
+file and source file, which was checked rather than assumed, but the
+profiles carry no marker saying which test file produced them. So telling
+them apart takes one coverage directory per test file, which takes one
+`deno test` invocation per test file, and at around 2,000 test files that
+is about three and a half hours of runner time. A job of that size runs on
+a cadence of its own and publishes an artifact of its own, which every
+lane then has to resolve, reconcile against the tree, and fall back from
+when it is absent. What that buys is a better mandatory set, and what it
+costs is a second store to keep and a second thing to be wrong about. Such
+a map only ever adds items to a run, so building one later means adding
+the job and the rules that read it rather than redesigning the packer.
+
 **Pull requests should get *less* red, not more.** This is the opposite of
 what an early draft of this design predicted, and the difference is the
 two exclusion rules. A test that is currently failing on `main` is not
@@ -2913,8 +2890,8 @@ nothing to compare it to.
 **Coverage stops being enforced across the repository, and stays enforced
 per package.** Nothing will fail because a change lowered the repository's
 whole coverage number. What replaces that is a weekly trend somebody has
-to choose to look at, plus a comment saying where a test would go. Over
-the 31 packages that carry the [per-package
+to choose to look at, plus a comment naming the source groups where the
+debt rose. Over the 31 packages that carry the [per-package
 gate](#the-one-coverage-gate-that-survives) the ratchet still fails a pull
 request, because there both sides measure the same complete thing. The
 reduction in enforcement is real and confined to what could no longer be
@@ -2943,7 +2920,7 @@ is pinned to the commit's date. And if none of that settles it,
 | A new test surface nobody registered | `check-test-topology` fails on the next `main` run and names the unclaimed identities. |
 | A record's variant or record surface contradicts its batch | Kept as written and named in the lane summary. The identity then belongs to no suite, so the store half of the drift guard fails on the next `main` run. |
 | A suite gains a new variant with no records | Every available item in that variant is mandatory until a successful full `main` run accounts for every enumerated item under that exact variant, the store drift guard passes, and the next publisher cycle includes the run. Other variants do not stand in for it. |
-| A variant deliberately skips a file or leaf | The topology reads the existing skip registry and the manifest reports the test as unavailable with its phase and reason. It is not unknown or a coverage target. Removing the skip makes it mandatory until `main` records it. |
+| A variant deliberately skips a file or leaf | The topology reads the existing skip registry and the manifest reports the test as unavailable with its phase and reason. It is not unknown. Removing the skip makes it mandatory until `main` records it. |
 | One item is bigger than a lane's planned budget | It gets a lane to itself, up to the hard five-minute bound. Bigger than that, a mandatory item is still placed and its lane over-runs, while a discretionary one is listed as unschedulable in the manifest and reported; the 60-second ratchet is the fix. |
 | The mandatory set alone exceeds the budget | The lane runs it anyway and over-runs, past the five-minute step bound where the set demands it. The summary says by how much, which is what argues for raising the bound. |
 | A covered package has no baseline, or none from an ancestor of the merge base | The lane reports the comparison and does not fail. The next full `main` run supplies one. |
@@ -2961,7 +2938,6 @@ is pinned to the commit's date. And if none of that settles it,
 | `main` is broken and stays broken | Every test failing in the latest `main` run leaves the selectable set, so pull requests are unaffected while it is fixed. They come back on their own. |
 | The reporter cannot find the pull request behind a `main` commit | It logs the commit and posts nothing. A direct push to `main` with no pull request behind it is the ordinary case for this. |
 | The reporter would comment on a test that is known flaky | It says so in the comment rather than implying the change caused it. |
-| The attribution map is stale or missing | Changed-source selection falls back to the scope-level boost, and the diff-coverage figure says it is a floor. The map only ever adds tests to a run. |
 | Somebody games the coverage number | There is nothing to game: no gate, no per-change target, and a tile that shows a multi-week direction rather than a figure. |
 
 ## Security and trust
@@ -3021,7 +2997,7 @@ only to the suite carrying its exact variant. Separate fixtures cover both
 skip shapes from `tasks/server-execution-on-skips.ts`: a whole-file skip is
 declared unavailable and is not enumerated, while a step-level skip leaves
 the file and its other identities available but excludes the named leaf
-from the unknown and coverage rules. A CLI fixture maps step identities to
+from the unknown-identity rule. A CLI fixture maps step identities to
 items and the overlapping `integration.sh` task identity to the suite. The
 task identity is claimed by the drift guard but contributes to neither
 item score nor item cost, so it cannot double-count its steps. The same
@@ -3177,7 +3153,6 @@ derived one is editing a line that is not there.
 | `FLAKE_COMMIT_REACH` | 8 | commits | Chosen | How many of the most recently observed commits the fold keeps outcomes at, alongside the span above. Moves for the same two reasons and against the same cost. |
 | `FLAKE_WINDOW_DAYS` | 60 | days | Chosen | Up when a flake rate swings about on too little evidence; down when a test since fixed stays excluded. |
 | `COST_WINDOW_DAYS` | 7 | days | Chosen | Up when cost estimates are noisy; down when durations drift faster than the estimate follows. |
-| `ATTRIBUTION_MAP_DAYS` | 7 | days | Chosen | Up when rebuilding the map costs more than its staleness does; down when changed lines keep resolving to tests that have moved. |
 | `RENAME_SIMILARITY` | 0.7 | share of the longer name's own part | Chosen | Up when the run report offers rename pairings nobody meant; down when a rename that discarded history goes unoffered. It only decides what is suggested — nothing is written to the alias file without somebody appending it. |
 | `RENAME_MARGIN` | 0.1 | share of the longer name's own part | Chosen | Up when the run report pairs a deletion with an unrelated addition; down when a rename made alongside another rename in the same area goes unoffered. |
 | `RENAME_SUGGESTIONS` | 5 | suggestions in one comment | Chosen | Up when a change that renamed many tests has its later suggestions cut off; down when a comment carrying this many is one nobody reads. |
@@ -3364,7 +3339,7 @@ exercised on the branch on its own.
 - [x] The server-execution ON configuration consumes
       `tasks/server-execution-on-skips.ts`: whole-file entries are declared
       unavailable and omitted from enumeration, while step entries exclude
-      only the named leaf identity from unknown and coverage rules.
+      only the named leaf identity from the unknown-identity rule.
 - [x] Give `packages/cli/integration/fuse-exec.sh` fine granularity.
   - [x] Every phase records, so the suite records 25 identities rather
         than one, across the 23 phases the script goes through. Each
@@ -3417,8 +3392,6 @@ exercised on the branch on its own.
       and repeats.
 - [ ] `deno.yml`: `plan-full` and `full-tests` on push, with the build,
       attestation, coverage and deploy jobs repointed at them.
-- [ ] The weekly coverage attribution job, and the map published beside
-      the manifest.
 - [ ] Repository-wide coverage measurement moves to the full run and stops
       failing anything.
 - [ ] `tasks/write-coverage-lcov.ts` converts each workspace member's

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -51,12 +51,19 @@ A failure on the default branch cannot be judged when it happens. Every
 push there is a distinct commit with one run, so a test that is flaky
 there never contradicts itself, and counting each such failure as a catch
 would make the least valuable test in the repository look like the most
-valuable. Such a failure waits for the next run on that branch: still
-failing is the same breakage continuing and nothing new is learned;
-passing means the change between the two commits fixed it, which is what
-the test caught. Telling a fix apart from a failure that healed itself
-needs the coverage attribution map, and without one the judgement errs
-toward calling a failure a catch.
+valuable. Such a failure waits for the next run on that branch. Still
+failing is the same breakage continuing, and nothing new is learned.
+Passing at the same commit is the test disagreeing with itself, and counts
+as a flake observation. Passing at a later commit counts as a catch: the
+change between the two commits fixed what the test found. A run of
+failures ended by one pass counts one catch, dated to the first of them,
+so a week of the branch being red is worth one catch and not seven.
+
+Nothing separates a failure a change fixed from one that healed itself, so
+a test flaky on the default branch is credited for its own noise. The
+judgement errs toward crediting a test rather than away from it. An
+overstated score costs run time, and an understated one costs a test its
+place.
 
 ### Where a catch happened
 
@@ -161,8 +168,9 @@ cannot act on.
   selected.
 - An identity above `FLAKE_EXCLUSION_RATE` is not selected.
 
-Either comes back the moment the change touches what it covers, since that
-is very likely a fix and has to be allowed to prove itself.
+Either comes back the moment the change edits the test itself, or its
+suite maps the change onto its unit, since that is very likely a fix and
+has to be allowed to prove itself.
 
 Two rules force a test in.
 
@@ -173,8 +181,10 @@ Two rules force a test in.
   data and that a renamed test is an unknown identity until an alias line
   lands.
 - **What the change touches must run.** A changed test file's identities
-  are mandatory. A changed source file resolves through the coverage
-  attribution map to the identities that execute its lines.
+  are mandatory. A unit that is not a file, such as a type-check group or
+  a binary, is one its suite maps the change onto, because only the suite
+  knows what its unit covers. Nothing else about a changed source file
+  forces a test in. Which tests run for it is what the score decides.
 
 ## The manifest
 

--- a/packages/test-support/src/records/selection.test.ts
+++ b/packages/test-support/src/records/selection.test.ts
@@ -136,7 +136,6 @@ describe("selection", () => {
         "a known digest that is not one",
         withField("known", { count: 0, digest: "" }),
       ],
-      ["an attribution map that is not a name", withField("attributionMap", 7)],
       ["entries that are not a list", withField("entries", {})],
       ["withheld that is not a list", withField("withheld", {})],
       [
@@ -433,7 +432,6 @@ describe("selection", () => {
 
     it("accepts the optional fields when they are well formed", () => {
       const manifest = sampleManifest({
-        attributionMap: "labs/test-selection/v1/map-1.json",
         unavailable: [{
           suite: "s",
           unit: "u",

--- a/packages/test-support/src/records/selection.ts
+++ b/packages/test-support/src/records/selection.ts
@@ -182,9 +182,6 @@ export interface Manifest {
   /** How many item-level identities the store knows, and their digest. */
   known: { count: number; digest: string };
 
-  /** The newest coverage attribution map, published on its own cadence. */
-  attributionMap?: string;
-
   coverageBaselines: CoverageBaseline[];
 }
 
@@ -487,12 +484,6 @@ export function parseManifest(value: unknown): Manifest | undefined {
   ) {
     return undefined;
   }
-  if (
-    value.attributionMap !== undefined &&
-    !isNonEmptyString(value.attributionMap)
-  ) {
-    return undefined;
-  }
   // One identity may not appear twice: the packer removes an identity
   // from the selectable set as it takes it, and a duplicate would let a
   // later pass take it again.
@@ -502,7 +493,7 @@ export function parseManifest(value: unknown): Manifest | undefined {
     if (seen.has(key)) return undefined;
     seen.add(key);
   }
-  const manifest: Manifest = {
+  return {
     schema: MANIFEST_SCHEMA_VERSION,
     generatedAt: value.generatedAt,
     seed: value.seed,
@@ -518,10 +509,6 @@ export function parseManifest(value: unknown): Manifest | undefined {
     known: { count: value.known.count, digest: value.known.digest },
     coverageBaselines,
   };
-  if (value.attributionMap !== undefined) {
-    manifest.attributionMap = value.attributionMap;
-  }
-  return manifest;
 }
 
 /** Serializes a manifest for the store. */

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -188,10 +188,7 @@ describe("plan", () => {
       }];
       const mandatory = new Map([
         [testIdentityKey(held.test), "changed" as const],
-        [
-          testIdentityKey(manifest.entries[3]!.test),
-          "covers-changed" as const,
-        ],
+        [testIdentityKey(manifest.entries[3]!.test), "changed" as const],
       ]);
       const names = selected(run(manifest, { mandatory })).map((s) =>
         s.entry.test.n

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -31,7 +31,6 @@ import type {
 export type SelectionReason =
   | "always"
   | "changed"
-  | "covers-changed"
   | "unknown"
   | "coverage-gate"
   | "value"
@@ -124,8 +123,7 @@ export interface PlanInput {
 
   /**
    * Identities this change makes mandatory, against the reason. The lane
-   * runner fills this from the diff, from the topology's enumeration, and
-   * from the coverage attribution map.
+   * runner fills this from the diff and from the topology's enumeration.
    */
   mandatory: Map<string, SelectionReason>;
 
@@ -413,8 +411,9 @@ export function plan(input: PlanInput): Plan {
     unschedulable.push({ test: entry.test, suite: entry.suite, cost });
   }
 
-  // What must not run, unless the change touches what it covers, in which
-  // case it is very likely a fix and must be allowed to prove itself.
+  // What must not run, unless the change edits the test itself or its
+  // suite maps the change onto its unit, in which case it is very likely
+  // a fix and must be allowed to prove itself.
   const excluded = new Set<string>(
     unschedulable.map((entry) => testIdentityKey(entry.test)),
   );

--- a/tasks/test-selection/policy.ts
+++ b/tasks/test-selection/policy.ts
@@ -206,9 +206,6 @@ export const SAME_COMMIT_REACH_DAYS = 2;
  */
 export const FLAKE_COMMIT_REACH = 8;
 
-/** Days before the coverage attribution map is rebuilt. */
-export const ATTRIBUTION_MAP_DAYS = 7;
-
 /**
  * How alike two test names have to be before one is offered as the
  * other's new name, between zero and one. A rename usually keeps most of
@@ -688,15 +685,6 @@ export const DIALS: readonly Dial[] = [
     why: "Up when reruns of a commit arrive far enough behind the run they " +
       "repeat that their disagreement is being counted as a catch; down " +
       "when the fold's memory is the thing that will not fit.",
-  },
-  {
-    name: "ATTRIBUTION_MAP_DAYS",
-    value: ATTRIBUTION_MAP_DAYS,
-    unit: "days",
-    setBy: "chosen",
-    why:
-      "Up when rebuilding the map costs more than its staleness does; down " +
-      "when changed lines keep resolving to tests that have moved.",
   },
   {
     name: "RENAME_SIMILARITY",

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -331,6 +331,24 @@ describe("score", () => {
       expect(state.pendingMain).toEqual([]);
     });
 
+    it("counts one catch for a run of failures one change ended", () => {
+      // A test red across several commits on the default branch has one
+      // thing wrong with it, and the change that makes it green fixed
+      // that one thing.
+      const state = stateFrom([
+        saw("fail", { day: "2026-08-17", commit: "c0" }),
+        saw("fail", { day: "2026-08-18", commit: "c1" }),
+        saw("fail", { day: "2026-08-19", commit: "c2" }),
+        saw("pass", { commit: "c3" }),
+      ]);
+      expect(state.mainCatches).toBe(1);
+      expect(state.lastCatch).toBe("2026-08-17");
+      expect(state.pendingMain).toEqual([]);
+      // One catch and nothing else: the run resolved, so none of the
+      // failures in it is also flake evidence.
+      expect(flakeRate(state, "2026-08-20")).toBe(0);
+    });
+
     it("reads a green rerun of the same commit as a flake", () => {
       // The two runs can arrive in separate batches, so the same-commit
       // check inside one batch does not see this pair.
@@ -344,16 +362,6 @@ describe("score", () => {
       ]);
       expect(state.mainCatches).toBe(0);
       expect(flakeRate(state, "2026-08-21")).toBe(1);
-    });
-
-    it("reads a failure nothing fixed as a flake", () => {
-      const folded = foldObservations([
-        saw("fail", { day: "2026-08-19", commit: "c0" }),
-        saw("pass", { commit: "c1" }),
-      ], { coveredChanged: () => false });
-      const state = folded.states.get(KEY)!;
-      expect(state.mainCatches).toBe(0);
-      expect(flakeRate(state, "2026-08-20")).toBe(1);
     });
   });
 

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -181,28 +181,17 @@ function bump(counts: Record<string, number>, day: string): void {
 }
 
 /**
- * Whether anything a test covers changed between two `main` commits. The
- * coverage attribution map is what answers this; without one the answer
- * is yes, which errs toward calling a failure a catch.
- */
-export type CoveredChange = (
-  identity: string,
-  fromCommit: string,
-  toCommit: string,
-) => boolean;
-
-/**
  * Judges the failures on `main` that were waiting for a later `main` run.
  * A failure the next run still shows is the same breakage continuing, so
  * it keeps waiting and nothing new is learned. A failure the next run
- * does not show either went away by itself, which is a flake, or was
- * fixed by the change between the two, which is a catch.
+ * does not show is a flake when that run is at the same commit, and a
+ * catch otherwise. Nothing separates a failure a change fixed from one
+ * that healed itself, so a failure that healed itself is credited as a
+ * catch as well.
  */
 function resolvePendingMain(
   state: IdentityState,
-  key: string,
   observation: Observation,
-  coveredChanged: CoveredChange,
 ): void {
   if (state.pendingMain.length === 0) return;
   if (observation.outcome === "fail") return;
@@ -225,11 +214,7 @@ function resolvePendingMain(
     bump(state.flakesByDay, first.day);
     return;
   }
-  if (coveredChanged(key, first.commit, observation.commit)) {
-    creditCatch(state, "main", first.day, first.source);
-  } else {
-    bump(state.flakesByDay, first.day);
-  }
+  creditCatch(state, "main", first.day, first.source);
 }
 
 /** How a batch of observations was judged. */
@@ -450,9 +435,6 @@ export interface FoldOptions {
   /** The state each identity's history had reached before this batch. */
   prior?: Map<string, IdentityState>;
 
-  /** How to tell a fixed failure on `main` from one that healed itself. */
-  coveredChanged?: CoveredChange;
-
   /** What earlier batches of the same stream saw. */
   context?: FoldContext;
 }
@@ -483,7 +465,6 @@ export function foldObservations(
     );
   }
   const states = options.prior ?? new Map<string, IdentityState>();
-  const coveredChanged = options.coveredChanged ?? (() => true);
   const context = options.context ?? emptyContext();
   const stateOf = (key: string): IdentityState => {
     let state = states.get(key);
@@ -597,7 +578,7 @@ export function foldObservations(
 
     bump(state.runsByDay, day);
     if (observation.place === "main") {
-      resolvePendingMain(state, key, observation, coveredChanged);
+      resolvePendingMain(state, observation);
       state.lastMainOutcome = observation.outcome;
     }
     if (observation.outcome === "pass") continue;

--- a/tasks/test-topology/suite.ts
+++ b/tasks/test-topology/suite.ts
@@ -239,9 +239,8 @@ export interface ConfiguredSkip {
  *
  * A whole-file entry leaves the file out of the variant suite's units. A
  * step-level entry leaves the file in and names the one leaf that does
- * not run, so that leaf is excluded from the unknown-identity and
- * coverage-target rules while every other identity in the file behaves
- * normally.
+ * not run, so that leaf is excluded from the unknown-identity rule while
+ * every other identity in the file behaves normally.
  */
 export function unavailableFrom(
   skips: readonly ConfiguredSkip[],


### PR DESCRIPTION
The test-selection plan and specification described a map from every source line to the tests that execute it, rebuilt by a weekly job and published beside the manifest. Two things were to read it. A pull request that changed a source file would make the tests covering the changed lines mandatory. And the scorer would use it to tell a failure on the default branch that a change fixed from one that healed itself, so that a test flaky on that branch did not collect catches for its own noise.

Building it costs more than either is worth. The coverage profiles Deno writes carry no marker saying which test file produced them, so telling them apart takes one coverage directory per test file, which takes one `deno test` invocation per test file. At around 2,000 test files that is about three and a half hours of runner time, so it is a job on a cadence of its own publishing an artifact of its own, which every lane then has to resolve, reconcile against the tree, and fall back from when it is absent: a second store to keep and a second thing to be wrong about.

So it is not being built. This removes it from the specification and the plan, along with the code that existed only to consume it:

- `attributionMap` on the manifest, which no publisher ever wrote;
- the `ATTRIBUTION_MAP_DAYS` dial;
- the `covers-changed` selection reason, which nothing could produce;
- the `coveredChanged` hook in the fold. A failure on the default branch that a later run does not show now counts as a catch whenever that run is at a later commit, which is what the hook's default already did.

What a change to a source file runs is now what the score chose, plus the mandatory items the suites name: a changed test file, a unit that is not a file whose suite maps the change onto it, and the whole measured set of a covered package the change touched while the diff stays under the per-package gate's cap. The plan records that under the consequences it is choosing, since such a map only ever adds items to a run and building one later means adding the job and the rules that read it rather than redesigning the packer.

Both documents also had to stop claiming what the hook bought. Neither said what stops a long outage on the default branch from becoming a catch for every run it was red, and both now say it: a run of failures ended by one pass counts one catch, dated to the first of them. A test covers that rule, and pins the flake rate at zero so that crediting one failure as both a catch and flake evidence fails it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

