### PR TITLE
fix(test-records): a bdd test carries the file it was registered from

### DIFF
--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -310,12 +310,36 @@ leaves the map in the spool, and it applies `CF_TEST_SKIP_LIST`. Wrapping
 own, so a process with nothing to skip and no spool it may write leaves
 `Deno.test` alone and the report's own class names are read instead.
 
+Both of those need permissions the test task grants. Reading
+`CF_TEST_RECORDS_DIR` and `CF_TEST_SKIP_LIST` needs `--allow-env`, so a
+task naming a restricted list of variables names those two among them —
+`readEnv` swallows the refusal, so a task that leaves them out records
+nothing and skips nothing, silently.
+Writing the map needs `--allow-write` covering the directory the run
+owner put the spool in, which is a path only the environment knows: a
+task string cannot name it, because `deno task` expands `$VAR` but not
+`${VAR:-default}`, and `--allow-write=` with an unset variable ends the
+run with `Empty values are not allowed`. So a task that has to capture
+grants a write path wide enough to hold whatever spool a run hands it.
+
 A test task naming its own `--import-map` does not take the preload. That
 map governs every module of the invocation, the preload included, so a
 specifier the preload needs and the map does not carry fails the whole
 run rather than the preload alone. Such a member keeps its JUnit path and
 loses nothing by the omission: with no wrapper installed, the report
 keeps its own class names and ingestion reads the file from those.
+
+What a class name reaches is the test file that registered the test
+itself. A module of ours that registers on a file's behalf — a fixture
+runner handed a directory of cases, a harness that replaces `Deno.test`
+to give each test a clock — is the nearest frame below the runner, so
+the class names it instead. Such a module goes in two places: it calls
+`registerFrameworkModule(import.meta.url)`, so the preload's map names
+the file that asked, and its path tail goes in
+`MACHINERY_MODULE_SUFFIXES`, so ingestion declines the class name rather
+than recording the module as every test's file. Missing from the first,
+it takes the map; missing from the second, it takes the report. A
+surface that registers this way and cannot write a map records no file.
 
 A harness with per-result callbacks
 appends records through `FragmentWriter` (see the hooks in

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -95,11 +95,21 @@ places and the second overrides the first. Deno names a case's class after
 the module that registered the test, so the case a `describe` registers
 carries the file of every leaf beneath it, and the report joins itself: a
 leaf is named as its describe chain, and its file is the one whose
-registered name is the longest prefix of that chain. That source
-disappears the moment anything wraps `Deno.test`, because every class then
-names the wrapper. The registration preload is such a wrapper, and it
-replaces what it takes: it writes a name-to-file map into the spool, and
-ingestion lays that over what the report says.
+registered name is the longest prefix of that chain. What the class names
+is the nearest frame of this repository's own code below the runner, so
+that source holds only while nothing of ours sits between a test file and
+the registrar. The `describe` and `it` the import map resolves to are
+therefore the real ones wherever they would have nothing to do, and a
+module that does register on a file's behalf — a fixture runner, a clock
+harness — takes the class name with it.
+
+The registration preload is such a module, and it replaces what it takes:
+it writes a name-to-file map into the spool, and ingestion lays that over
+what the report says. The map holds each name `Deno.test` was called with
+and, for a file written with `describe` and `it`, the whole chain of each
+leaf. A suite title two files share says nothing about either and is
+dropped from the merged map; a leaf's whole chain is what usually
+survives that.
 
 The context line carries `schema` (this document describes version 1, the
 `v1` in object paths), a per-object ULID `reportId`, the canonical `repo`

--- a/packages/js-compiler/deno.jsonc
+++ b/packages/js-compiler/deno.jsonc
@@ -2,7 +2,7 @@
   "name": "@commonfabric/js-compiler",
   "tasks": {
     // --no-check: this package is type-checked by `deno task check` (tasks/check.sh).
-    "test": "deno test --no-check --allow-read --allow-write --allow-run --allow-env=UPDATE_GOLDENS,API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV test/*.test.ts"
+    "test": "deno test --no-check --allow-read --allow-write --allow-run --allow-env=UPDATE_GOLDENS,API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,CF_TEST_RECORDS_DIR,CF_TEST_SKIP_LIST test/*.test.ts"
   },
   "imports": {
     // Dependency guide: ../../docs/development/DEPENDENCIES.md

--- a/packages/schema-generator/deno.jsonc
+++ b/packages/schema-generator/deno.jsonc
@@ -14,8 +14,8 @@
     "typescript": "npm:typescript@6.0.3"
   },
   "tasks": {
-    "test": "deno test --parallel --allow-read --allow-write --allow-run --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,UPDATE_GOLDENS,FIXTURE,SKIP_INPUT_CHECK test/**/*.test.ts",
-    "test:check": "deno test --allow-read --allow-write --allow-run --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,UPDATE_GOLDENS,FIXTURE,SKIP_INPUT_CHECK test/**/*.test.ts",
+    "test": "deno test --parallel --allow-read --allow-write --allow-run --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,UPDATE_GOLDENS,FIXTURE,SKIP_INPUT_CHECK,CF_TEST_RECORDS_DIR,CF_TEST_SKIP_LIST test/**/*.test.ts",
+    "test:check": "deno test --allow-read --allow-write --allow-run --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,UPDATE_GOLDENS,FIXTURE,SKIP_INPUT_CHECK,CF_TEST_RECORDS_DIR,CF_TEST_SKIP_LIST test/**/*.test.ts",
     "check": "deno check src/**/*.ts test/*.ts test/schema/**/*.ts test/typescript/**/*.ts",
     "fmt": "deno fmt src/ test/",
     "lint": "deno lint src/ test/"

--- a/packages/static/deno.jsonc
+++ b/packages/static/deno.jsonc
@@ -12,7 +12,7 @@
     // `PATH`, which is a different binary when the shell's Deno is not the pin.
     // A task line runs the Deno running the task, so asking that Deno for its
     // own path allows exactly the one binary the tests start.
-    "deno-test": "deno test --allow-read --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV --allow-run=$(deno eval \"console.log(Deno.execPath())\") --allow-write=/tmp,/var/folders",
+    "deno-test": "deno test --allow-read --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,CF_TEST_RECORDS_DIR,CF_TEST_SKIP_LIST --allow-run=$(deno eval \"console.log(Deno.execPath())\") --allow-write=/tmp,/var/folders",
     "browser-test": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts test/*.test.ts",
     "compile-types": "./scripts/compile-type-lib.ts ../../../TypeScript/src/lib ./assets/types/es2023.d.ts",
     "gen-cfc-types": "./scripts/generate-cfc-types.ts",

--- a/packages/test-support/deno.jsonc
+++ b/packages/test-support/deno.jsonc
@@ -19,7 +19,7 @@
     // its own path allows exactly the one binary the tests start.
     // Repository tools are outside the workspace, so list their regression
     // tests here to keep them in the normal workspace test suite.
-    "test": "deno test --frozen=true --allow-env=CF_COMPILE_CACHE_FILE,CF_TEST_RECORDS_DIR --allow-read --allow-write --allow-run=$(deno eval \"console.log(Deno.execPath())\") src/*.test.ts src/records/*.test.ts test/records/*.test.ts ../../tools/write-iframe-wrapper.test.ts",
+    "test": "deno test --frozen=true --allow-env=CF_COMPILE_CACHE_FILE,CF_TEST_RECORDS_DIR,CF_TEST_SKIP_LIST --allow-read --allow-write --allow-run=$(deno eval \"console.log(Deno.execPath())\") src/*.test.ts src/records/*.test.ts test/records/*.test.ts ../../tools/write-iframe-wrapper.test.ts",
     "check": "deno check src/**/*.ts test/clock-preload.ts",
     "fmt": "deno fmt src/ test/",
     "lint": "deno lint src/ test/"

--- a/packages/test-support/src/fixture-runner.ts
+++ b/packages/test-support/src/fixture-runner.ts
@@ -1,6 +1,12 @@
 import { beforeAll, describe, it } from "@std/testing/bdd";
 import { walkSync } from "@std/fs/walk";
 import { basename, isAbsolute, relative, resolve, SEPARATOR } from "@std/path";
+import { registerFrameworkModule } from "./records/registration.ts";
+
+// A suite registered through this runner belongs to the file that asked
+// for it, not to this module, so the file attribution walks past these
+// frames on its way out to the caller.
+registerFrameworkModule(import.meta.url);
 
 export interface Fixture {
   readonly rootDir: string;

--- a/packages/test-support/src/records/bdd.ts
+++ b/packages/test-support/src/records/bdd.ts
@@ -19,6 +19,9 @@
  * it appears in the run's output and in its JUnit report as skipped and
  * the store learns it was deliberately not run instead of watching the
  * identity disappear.
+ *
+ * An invocation with no capture installed gets the real functions back
+ * whole; see `capturing`.
  */
 
 import { describe as realDescribe, it as realIt } from "@std/testing/bdd/real";
@@ -91,12 +94,8 @@ export function bodyOf(
  * untouched, so an unfamiliar overload still runs and still reports its
  * own error.
  *
- * With no capture installed there is no skip list to apply, and the
- * chain would be read by nobody. The call goes straight through, so an
- * invocation that is not recording keeps its report's own class names:
- * a frame between the test file and `describe` moves where the runner
- * thinks the test was registered, and the class name is what ingestion
- * falls back to when there is no name map to join onto.
+ * With no capture installed there is no skip list to apply and no chain
+ * for anything to read, so the call goes straight through.
  */
 export function wrapDescribe(
   through: AnyFunction,
@@ -133,10 +132,19 @@ export function wrapDescribe(
 
 /**
  * Wraps one `it` entry point so that a listed leaf is registered as
- * ignored. The leaf's identity is the enclosing chain and its own name
- * joined, which is what the store speaks in, and the file is read from
- * the registration stack the same way the preload reads it — the two
+ * ignored, and so that the leaf's own file reaches the name map. The
+ * leaf's identity is the enclosing chain and its own name joined, which
+ * is what the store speaks in, and the file is read from the
+ * registration stack the same way the preload reads it — the two
  * together, because the same test name occurs in more than one file.
+ *
+ * The preload's wrapper around `Deno.test` sees only the container the
+ * describe chain registers, so without this the map holds one entry per
+ * top-level suite title. Two files opening with the same title are then
+ * one ambiguous entry, and every leaf under either of them loses its
+ * file. Recording each leaf against its own file narrows that to two
+ * files holding the same whole identity, which is a name clash rather
+ * than a shared title.
  */
 export function wrapIt(
   through: AnyFunction,
@@ -150,6 +158,7 @@ export function wrapIt(
     if (name === undefined) return through(...args);
     const identity = [...chain, name].join(NAME_SEPARATOR);
     const file = registeringFile(new Error().stack ?? "");
+    if (file !== undefined) capture.names.set(identity, file);
     return capture.skipped(file, identity) ? ignore(...args) : through(...args);
   };
 }
@@ -169,22 +178,45 @@ function withEntryPoints(
   return wrapper;
 }
 
+/**
+ * Whether anything registered through this module has work to do, read
+ * once as this module is evaluated.
+ *
+ * Deno names a case's class after the nearest frame of the tree's own
+ * code below the runner, so a wrapper here takes that name from the test
+ * file whether or not it does anything with the call. With no capture
+ * there is nothing for it to do, and the real functions go back whole,
+ * so the report's class names name the file and ingestion reads the file
+ * from those.
+ *
+ * Reading it once is what makes that possible: the exported binding is
+ * either a wrapper or the real function, and it is fixed before the
+ * first `describe` runs. The preload installs the capture before any
+ * test module loads, and `installRegistrationCapture` reports an
+ * invocation that loaded this module ahead of it.
+ */
+const capturing = activeCapture() !== undefined;
+
 /** `describe`, tracking the chain its body registers inside. */
-export const describe = withEntryPoints(
-  wrapDescribe(realDescribe as unknown as AnyFunction),
-  realDescribe as unknown as AnyFunction,
-  wrapDescribe,
-) as typeof realDescribe;
+export const describe: typeof realDescribe = capturing
+  ? withEntryPoints(
+    wrapDescribe(realDescribe as unknown as AnyFunction),
+    realDescribe as unknown as AnyFunction,
+    wrapDescribe,
+  ) as typeof realDescribe
+  : realDescribe;
 
 const realIgnore = (realIt as unknown as Record<string, AnyFunction>).ignore ??
   (realIt as unknown as AnyFunction);
 
 /** `it`, registering a listed leaf as ignored rather than running it. */
-export const it = withEntryPoints(
-  wrapIt(realIt as unknown as AnyFunction, realIgnore),
-  realIt as unknown as AnyFunction,
-  (through) => wrapIt(through, realIgnore),
-) as typeof realIt;
+export const it: typeof realIt = capturing
+  ? withEntryPoints(
+    wrapIt(realIt as unknown as AnyFunction, realIgnore),
+    realIt as unknown as AnyFunction,
+    (through) => wrapIt(through, realIgnore),
+  ) as typeof realIt
+  : realIt;
 
 /** The alias `@std/testing/bdd` gives `it`. */
 export const test: typeof realIt = it;

--- a/packages/test-support/src/records/bdd.ts
+++ b/packages/test-support/src/records/bdd.ts
@@ -94,15 +94,14 @@ export function bodyOf(
  * untouched, so an unfamiliar overload still runs and still reports its
  * own error.
  *
- * With no capture installed there is no skip list to apply and no chain
- * for anything to read, so the call goes straight through.
+ * The capture is handed in rather than looked up, because a wrapper is
+ * only built where one is installed.
  */
 export function wrapDescribe(
   through: AnyFunction,
-  capture: () => RegistrationCapture | undefined = activeCapture,
+  capture: () => RegistrationCapture,
 ): AnyFunction {
   return (...args: unknown[]): unknown => {
-    if (capture() === undefined) return through(...args);
     const name = nameOf(args);
     const found = bodyOf(args);
     if (name === undefined || found === undefined) return through(...args);
@@ -149,11 +148,10 @@ export function wrapDescribe(
 export function wrapIt(
   through: AnyFunction,
   ignore: AnyFunction,
-  active: () => RegistrationCapture | undefined = activeCapture,
+  active: () => RegistrationCapture,
 ): AnyFunction {
   return (...args: unknown[]): unknown => {
     const capture = active();
-    if (capture === undefined) return through(...args);
     const name = nameOf(args);
     if (name === undefined) return through(...args);
     const identity = [...chain, name].join(NAME_SEPARATOR);
@@ -179,8 +177,7 @@ function withEntryPoints(
 }
 
 /**
- * Whether anything registered through this module has work to do, read
- * once as this module is evaluated.
+ * The capture installed before this module was evaluated, read once.
  *
  * Deno names a case's class after the nearest frame of the tree's own
  * code below the runner, so a wrapper here takes that name from the test
@@ -193,30 +190,31 @@ function withEntryPoints(
  * either a wrapper or the real function, and it is fixed before the
  * first `describe` runs. The preload installs the capture before any
  * test module loads, and `installRegistrationCapture` reports an
- * invocation that loaded this module ahead of it.
+ * invocation that loaded this module ahead of it. Nothing uninstalls a
+ * capture, so a wrapper built here has one for as long as it lives.
  */
-const capturing = activeCapture() !== undefined;
+const capture = activeCapture();
 
 /** `describe`, tracking the chain its body registers inside. */
-export const describe: typeof realDescribe = capturing
-  ? withEntryPoints(
-    wrapDescribe(realDescribe as unknown as AnyFunction),
+export const describe: typeof realDescribe = capture === undefined
+  ? realDescribe
+  : withEntryPoints(
+    wrapDescribe(realDescribe as unknown as AnyFunction, () => capture),
     realDescribe as unknown as AnyFunction,
-    wrapDescribe,
-  ) as typeof realDescribe
-  : realDescribe;
+    (through) => wrapDescribe(through, () => capture),
+  ) as typeof realDescribe;
 
 const realIgnore = (realIt as unknown as Record<string, AnyFunction>).ignore ??
   (realIt as unknown as AnyFunction);
 
 /** `it`, registering a listed leaf as ignored rather than running it. */
-export const it: typeof realIt = capturing
-  ? withEntryPoints(
-    wrapIt(realIt as unknown as AnyFunction, realIgnore),
+export const it: typeof realIt = capture === undefined
+  ? realIt
+  : withEntryPoints(
+    wrapIt(realIt as unknown as AnyFunction, realIgnore, () => capture),
     realIt as unknown as AnyFunction,
-    (through) => wrapIt(through, realIgnore),
-  ) as typeof realIt
-  : realIt;
+    (through) => wrapIt(through, realIgnore, () => capture),
+  ) as typeof realIt;
 
 /** The alias `@std/testing/bdd` gives `it`. */
 export const test: typeof realIt = it;

--- a/packages/test-support/src/records/bdd.ts
+++ b/packages/test-support/src/records/bdd.ts
@@ -94,13 +94,10 @@ export function bodyOf(
  * untouched, so an unfamiliar overload still runs and still reports its
  * own error.
  *
- * The capture is handed in rather than looked up, because a wrapper is
- * only built where one is installed.
+ * Takes no capture: a wrapper is built only where one is installed, and
+ * tracking the chain is the whole of what this does with it.
  */
-export function wrapDescribe(
-  through: AnyFunction,
-  capture: () => RegistrationCapture,
-): AnyFunction {
+export function wrapDescribe(through: AnyFunction): AnyFunction {
   return (...args: unknown[]): unknown => {
     const name = nameOf(args);
     const found = bodyOf(args);
@@ -199,9 +196,9 @@ const capture = activeCapture();
 export const describe: typeof realDescribe = capture === undefined
   ? realDescribe
   : withEntryPoints(
-    wrapDescribe(realDescribe as unknown as AnyFunction, () => capture),
+    wrapDescribe(realDescribe as unknown as AnyFunction),
     realDescribe as unknown as AnyFunction,
-    (through) => wrapDescribe(through, () => capture),
+    wrapDescribe,
   ) as typeof realDescribe;
 
 const realIgnore = (realIt as unknown as Record<string, AnyFunction>).ignore ??

--- a/packages/test-support/src/records/registration.test.ts
+++ b/packages/test-support/src/records/registration.test.ts
@@ -7,6 +7,7 @@ import {
   asDefinition,
   buildCapture,
   fileForName,
+  MACHINERY_MODULE_SUFFIXES,
   NAME_MAP_PREFIX,
   NAME_MAP_SUFFIX,
   parseSkipList,
@@ -17,9 +18,16 @@ import {
   repositoryRootOf,
   serializeSkipList,
 } from "./registration.ts";
+// Imported for what loading it declares: the shared fixture runner calls
+// `describe` on behalf of the file that asked for a suite, so it declares
+// itself machinery and the attribution walks past its frames.
+import "../fixture-runner.ts";
 
 // The wrapper's own frame, as it appears in a real registration stack.
 const WRAPPER = new URL("./registration.ts", import.meta.url).href;
+
+// The fixture runner's frame, as it appears in the same stack.
+const FIXTURE_RUNNER = new URL("../fixture-runner.ts", import.meta.url).href;
 
 async function writeNameMap(
   dir: string,
@@ -62,6 +70,28 @@ describe("registration", () => {
       expect(registeringModule(stack)).toBe(
         "file:///repo/packages/runner/test/scheduler.test.ts",
       );
+    });
+
+    it("passes over the shared fixture runner", () => {
+      const stack = [
+        "Error",
+        `    at Object.test (${WRAPPER}:3:17)`,
+        `    at defineFixtureSuite (${FIXTURE_RUNNER}:224:3)`,
+        "    at file:///repo/packages/ts-transformers/test/" +
+        "fixture-based.test.ts:27:3",
+      ].join("\n");
+      expect(registeringModule(stack)).toBe(
+        "file:///repo/packages/ts-transformers/test/fixture-based.test.ts",
+      );
+    });
+
+    it("names the shared fixture runner as machinery for ingestion too", () => {
+      // The two lists cover one module from two sides. Declaring it
+      // walks the map past its frames; naming its path tail stops
+      // ingestion reading it as the file every fixture case came from.
+      expect(
+        MACHINERY_MODULE_SUFFIXES.some((tail) => FIXTURE_RUNNER.endsWith(tail)),
+      ).toBe(true);
     });
 
     it("returns undefined when no frame names a file", () => {

--- a/packages/test-support/src/records/registration.ts
+++ b/packages/test-support/src/records/registration.ts
@@ -25,19 +25,31 @@ export const NAME_MAP_SUFFIX = ".json";
 /** Variable naming the file holding this invocation's skip list. */
 export const SKIP_LIST_VARIABLE = "CF_TEST_SKIP_LIST";
 
+/** The tail of the bdd re-export's path, wherever the tree is checked out. */
+const BDD_MODULE_SUFFIX = "src/records/bdd.ts";
+
 /**
- * The tails of the test machinery's own paths. Deno names a JUnit case's
- * class after the module that registered the test, so a case registered
- * through one of these names that module rather than the test file:
- * `registration.ts` while the `Deno.test` wrapper is installed, and
- * `bdd.ts` for anything registered through the `describe` and `it` this
- * repository's import map resolves to. Ingestion rejects a classname
- * ending in either rather than reading it as a test file, and the
- * preload's name map is what supplies the file instead.
+ * The tails of the paths of modules that register a test on another
+ * file's behalf. Deno names a JUnit case's class after the module that
+ * registered the test, so a case registered through one of these names
+ * that module rather than the test file: `registration.ts` is the
+ * `Deno.test` wrapper the preload installs, `bdd.ts` the `describe` and
+ * `it` this repository's import map resolves to, `fixture-runner.ts`
+ * builds a suite over a directory of fixtures, and `clock-preload.ts`
+ * replaces `Deno.test` to give each test a clock. Ingestion rejects a
+ * classname ending in one of these rather than reading it as a test
+ * file, and the preload's name map supplies the file instead.
+ *
+ * Every module named here calls `registerFrameworkModule`, so that the
+ * map names the file that asked for the test rather than the module
+ * that registered it. The two lists cover one thing from two sides, and
+ * a module missing from either loses a file its own way.
  */
 export const MACHINERY_MODULE_SUFFIXES: readonly string[] = [
   "src/records/registration.ts",
-  "src/records/bdd.ts",
+  BDD_MODULE_SUFFIX,
+  "src/fixture-runner.ts",
+  "test/clock-preload.ts",
 ];
 
 /**
@@ -48,8 +60,11 @@ export const MACHINERY_MODULE_SUFFIXES: readonly string[] = [
 export const NAME_SEPARATOR = " > ";
 
 /**
- * A name map as it travels: the name each `Deno.test` was registered
- * under, against the repository-relative file that registered it.
+ * A name map as it travels: a registered name against the
+ * repository-relative file it came from. The names are what `Deno.test`
+ * was called with, and, for a file written with `describe` and `it`, the
+ * whole chain of each leaf as well — a title two files share says
+ * nothing about either, where a leaf's whole chain usually does.
  */
 export type NameMap = Record<string, string>;
 
@@ -327,6 +342,21 @@ export function installRegistrationCapture(
   // write the replacement map into. With neither, the report is the
   // better source and nothing is wrapped.
   if (skips === undefined && !writableSpool(spool)) return undefined;
+  // The bdd re-export decides whether to wrap as it is evaluated, and
+  // declares itself machinery in the same breath. Finding it declared
+  // here means it decided before this ran and handed back the real
+  // `describe` and `it`, so nothing of ours sits inside a describe chain
+  // any more: no leaf reaches the name map, and no leaf is checked
+  // against the skip list. A skip list says what this invocation is not
+  // to run, so an invocation that cannot apply one stops rather than
+  // running what it was told to leave alone. A name map is metadata, and
+  // losing it is said out loud and carried.
+  if ([...frameworkModules].some((url) => url.endsWith(BDD_MODULE_SUFFIX))) {
+    const detail = "the bdd re-export loaded before this preload, so no " +
+      "leaf reaches the name map or the skip list";
+    if (skips !== undefined) throw new Error(`test records: ${detail}`);
+    console.warn(`test records: ${detail}`);
+  }
 
   const built = buildCapture({
     registrar: Deno.test,

--- a/packages/test-support/test/records/bdd.test.ts
+++ b/packages/test-support/test/records/bdd.test.ts
@@ -105,7 +105,7 @@ describe("what the wrappers do once a capture is installed", () => {
     // recognize it.
     const seen: unknown[][] = [];
     const through = (...args: unknown[]) => seen.push(args);
-    wrapDescribe(through, capturing())("a name with no body");
+    wrapDescribe(through)("a name with no body");
     wrapIt(through, () => {}, capturing())({ no: "name" });
     expect(seen).toEqual([["a name with no body"], [{ no: "name" }]]);
   });
@@ -121,7 +121,7 @@ describe("what the wrappers do once a capture is installed", () => {
       definition.fn();
     };
     const it_ = wrapIt(() => {}, () => {}, inner);
-    wrapDescribe(through, capturing())({
+    wrapDescribe(through)({
       name: "outer",
       fn: () => it_("leaf", () => {}),
     });

--- a/packages/test-support/test/records/preload.test.ts
+++ b/packages/test-support/test/records/preload.test.ts
@@ -33,6 +33,10 @@ const FIXTURE_CONFIG = {
       .href,
     "@std/testing/bdd/real": "jsr:@std/testing@^1.0.19/bdd",
     "@std/ulid": "jsr:@std/ulid@^1.0.0",
+    "@records/registration": new URL(
+      "../../src/records/registration.ts",
+      import.meta.url,
+    ).href,
   },
 };
 
@@ -131,6 +135,36 @@ describe("elsewhere", () => {
 });
 `;
 
+// A second file opening with the same suite title as BDD_FILE. Nothing
+// stops two files sharing one, and several packages have a title every
+// one of their files opens with.
+const SHARED_TITLE_FILE = `import { describe, it } from "@std/testing/bdd";
+describe("outer", () => {
+  it("elsewhere", () => {});
+});
+`;
+
+// Two modules that register a suite for whoever calls them, one
+// declaring itself machinery and one not. What each leaf's file comes
+// out as is the whole of what the declaration does.
+const DECLARED_REGISTRAR = `import { describe, it } from "@std/testing/bdd";
+import { registerFrameworkModule } from "@records/registration";
+registerFrameworkModule(import.meta.url);
+export function suite(title: string): void {
+  describe(title, () => {
+    it("leaf", () => {});
+  });
+}
+`;
+
+const BARE_REGISTRAR = `import { describe, it } from "@std/testing/bdd";
+export function suite(title: string): void {
+  describe(title, () => {
+    it("leaf", () => {});
+  });
+}
+`;
+
 const BARE_FILE = `Deno.test("bare kept", () => {});
 Deno.test("bare dropped", () => {});
 `;
@@ -171,6 +205,139 @@ describe("preload", () => {
       const byName = new Map(records.map((r) => [r.test.n, r.file]));
       expect(byName.get("outer > kept")).toEqual("bdd.test.ts");
       expect(byName.get("bare kept")).toEqual("bare.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("keeps each leaf's own file where two files share a suite title", async () => {
+    const fixture = await makeFixture({
+      "bdd.test.ts": BDD_FILE,
+      "shared.test.ts": SHARED_TITLE_FILE,
+    });
+    try {
+      const run = await runFixture(fixture, ["bdd.test.ts", "shared.test.ts"]);
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const names = await readNameMaps(fixture.spool);
+      // The title both files register under says nothing about either,
+      // so it carries no file; each leaf carries its own.
+      expect(names.get("outer")).toBeUndefined();
+      expect(names.get("outer > kept")).toEqual("bdd.test.ts");
+      expect(names.get("outer > elsewhere")).toEqual("shared.test.ts");
+
+      const records = ingestJUnit(await Deno.readTextFile(fixture.junit), {
+        kind: "unit",
+        scope: "fixture",
+        fileByName: names,
+      });
+      const byName = new Map(records.map((r) => [r.test.n, r.file]));
+      expect(byName.get("outer > kept")).toEqual("bdd.test.ts");
+      expect(byName.get("outer > elsewhere")).toEqual("shared.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("says so when the bdd re-export loaded before it", async () => {
+    // Loading the re-export first is what makes it hand back the real
+    // `describe` and `it`, and every leaf then reaches the report
+    // without reaching the name map. A preload that pulls the re-export
+    // in ahead of this one is the way that happens.
+    const fixture = await makeFixture({
+      "bdd.test.ts": BDD_FILE,
+      "early.ts": `import "@std/testing/bdd";\n`,
+    });
+    try {
+      // Without `--quiet`, which folds what a preload writes into a
+      // section of its own and shows it.
+      const run = await new Deno.Command(Deno.execPath(), {
+        args: [
+          "test",
+          "--allow-read",
+          "--allow-write",
+          "--allow-env",
+          "--preload=./early.ts",
+          `--preload=${preloadModulePath()}`,
+          `--junit-path=${fixture.junit}`,
+          "bdd.test.ts",
+        ],
+        cwd: fixture.dir,
+        env: { CF_TEST_RECORDS_DIR: fixture.spool },
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      const output = new TextDecoder().decode(run.stdout) +
+        new TextDecoder().decode(run.stderr);
+      assert(run.success, output);
+      expect(output).toContain("the bdd re-export loaded before this preload");
+      // What the warning names: the wrapper around `Deno.test` still
+      // sees the suite the describe chain registers, and nothing sees
+      // the leaves inside it.
+      const names = await readNameMaps(fixture.spool);
+      expect(names.get("outer")).toEqual("bdd.test.ts");
+      expect(names.get("outer > kept")).toBeUndefined();
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("attributes a suite a declared registrar built to its caller", async () => {
+    const fixture = await makeFixture({
+      "declared.ts": DECLARED_REGISTRAR,
+      "bare.ts": BARE_REGISTRAR,
+      "declared.test.ts":
+        `import { suite } from "./declared.ts";\nsuite("declared");\n`,
+      "bare.test.ts": `import { suite } from "./bare.ts";\nsuite("bare");\n`,
+    });
+    try {
+      const run = await runFixture(fixture, [
+        "declared.test.ts",
+        "bare.test.ts",
+      ]);
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const names = await readNameMaps(fixture.spool);
+      expect(names.get("declared > leaf")).toEqual("declared.test.ts");
+      // Undeclared, so the map names the module that called `describe`
+      // rather than the file that asked it to.
+      expect(names.get("bare > leaf")).toEqual("bare.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("stops a run that loaded the re-export early and holds a skip list", async () => {
+    const fixture = await makeFixture({
+      "bdd.test.ts": BDD_FILE,
+      "early.ts": `import "@std/testing/bdd";\n`,
+    });
+    try {
+      const skips = join(fixture.dir, "skips.json");
+      await Deno.writeTextFile(
+        skips,
+        serializeSkipList({ "bdd.test.ts": ["outer > dropped"] }),
+      );
+      const run = await new Deno.Command(Deno.execPath(), {
+        args: [
+          "test",
+          "--allow-read",
+          "--allow-write",
+          "--allow-env",
+          "--preload=./early.ts",
+          `--preload=${preloadModulePath()}`,
+          "bdd.test.ts",
+        ],
+        cwd: fixture.dir,
+        env: { CF_TEST_RECORDS_DIR: fixture.spool, CF_TEST_SKIP_LIST: skips },
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      // A skip list says what this invocation is not to run, and nothing
+      // reaches inside a describe chain to apply it, so the run ends
+      // rather than running the leaf it was told to leave alone.
+      expect(run.success).toBe(false);
+      const output = new TextDecoder().decode(run.stdout) +
+        new TextDecoder().decode(run.stderr);
+      expect(output).toContain("the bdd re-export loaded before this preload");
     } finally {
       await Deno.remove(fixture.dir, { recursive: true });
     }
@@ -363,11 +530,10 @@ describe("preload", () => {
     });
     try {
       // No write permission and no skip list, so `Deno.test` is left
-      // alone and a bare test keeps its own class name. A bdd file's
-      // class name is the module its `describe` came from, which is the
-      // repository's own re-export, so ingestion declines it and the
-      // leaf has no file: the preload's name map is what supplies one,
-      // and this run wrote none.
+      // alone and the report keeps its own class names. The bdd
+      // re-export hands back the real `describe` and `it` where there is
+      // no capture, so a bdd file's class name is the file too, and both
+      // kinds of leaf carry one without a name map to join onto.
       const run = await new Deno.Command(Deno.execPath(), {
         args: [
           "test",
@@ -392,7 +558,7 @@ describe("preload", () => {
         filePrefix: "",
       });
       const byName = new Map(records.map((r) => [r.test.n, r.file]));
-      expect(byName.get("outer > kept")).toBeUndefined();
+      expect(byName.get("outer > kept")).toEqual("bdd.test.ts");
       expect(byName.get("bare kept")).toEqual("bare.test.ts");
     } finally {
       await Deno.remove(fixture.dir, { recursive: true });


### PR DESCRIPTION
PROBLEM

The test-selection publisher leaves out every identity the topology cannot place on a suite and a unit. Placement joins a record to a unit by the source file it carries. Almost none of them carry one. Reproducing the publisher over two days of the store: of the 3,660 identities it could not claim, 3,648 have no file at all. The integration suites are nearly empty. The whole manifest holds two pattern integration entries:

    pattern-integration           0.013s
    pattern-integration-opposite  0.012s

Both carry the identity "parseCaptureSeriesCount clamps invalid capture env values". That is a plain `Deno.test` sitting among browser-driven ones. It is all those two suites report.

SOLUTION

Four things were removing the file.

The `describe` and `it` the import map resolves to are wrappers. A wrapper with nothing to do still stands between the test file and the registrar. Deno names a case's class after the nearest frame of this repository's own code. That frame took the name. They now hand back the real functions where no capture is installed. That is decided once, as the module is evaluated, so the preload refuses a run that loaded the re-export ahead of it while holding a skip list.

A module registering a test for another file takes the attribution through both paths. The fixture runner and the clock harness are now named in both lists.

The name map held one entry per suite title, so two files sharing a title lost every leaf. Each leaf is now recorded against its own file.

Four test tasks now name `CF_TEST_RECORDS_DIR` and `CF_TEST_SKIP_LIST` in their restricted `--allow-env` lists.

DESIGN DISCUSSION

A record's file comes from one of two places. Deno names a case's class after the module that registered the test, so the case a `describe` registers carries the file of every leaf beneath it, and the report joins itself. The registration preload writes a name-to-file map into the run's spool, and ingestion lays that map over what the report says.

The first cause took both at once. The class named the re-export module, which ingestion declines twice over: the path matches the machinery list, and from any package other than the one holding it the path climbs out of the working directory. The map that would have replaced the class name is written only where the preload can read `CF_TEST_RECORDS_DIR` and write the spool. The jobs that build their own test flags pass no preload, and several test tasks withhold one of those two permissions. Running the tests of `packages/utils` the way the workspace runner runs them produces 742 records and a report holding three class names, none of which is a test file:

    ext:cli/40_test.js
    https://jsr.io/@std/testing/1.0.19/_test_suite.ts
    ../test-support/src/records/bdd.ts

Deciding once is what lets the real functions go back whole: the exported binding is either a wrapper or the real function, and it is fixed before the first `describe` runs. That rests on the preload installing its capture first, which is what `--preload` gives for every test module. A preload that pulls the re-export in ahead of the registration one breaks the order. Nothing of this repository's code then sits inside a describe chain, so no leaf reaches the name map and no leaf is checked against the skip list. A leaf the skip list names runs. A skip list says what an invocation is not to run, so an invocation holding one stops; with no skip list only the map is lost, and the preload says so and carries on.

Two lists cover a module that registers for another file, from opposite sides. `frameworkModules` says whose frames the map walks past. `MACHINERY_MODULE_SUFFIXES` says whose paths ingestion refuses to read as a test file. The fixture runner and the clock harness were in neither. What that costs is a wrong file rather than a missing one, because a class name naming a registrar is a relative source path like any other. Both registrars sit in `packages/test-support`, and every other package reaches them by a path that climbs out of itself, which the relative-path rule rejects. The tree is therefore correct by where its files sit rather than by anything the code does. A fixture in this change registers two suites through two registrars, one declaring itself machinery and one not, and the undeclared one is recorded as the file of the leaf it built.

Twenty-two files across six packages open with a suite title another file in the same package also opens with. Recording each leaf narrows the ambiguity to two files holding the same whole identity, which is a name clash rather than a shared title.

`readEnv` swallows a refused environment read, so a task leaving those two variables out of a restricted list records nothing and skips nothing without saying anything. `schema-generator`, `js-compiler` and `static` named neither variable, and `test-support` named only the first.

Each package's test task was run the way the workspace runner runs it, and the report it wrote was ingested. Records carrying no file fall as follows: utils 742 to 0, runtime-client 509 to 0, ts-transformers 379 to 0, schema-generator 314 to 0, js-compiler 153 to 0, leb128 64 to 0, llm 45 to 0, navigation 23 to 0, home-schemas 6 to 0. A pattern integration file was run both ways. Run as its job runs it, with no preload and the class name as the only source, it names its own file; run with the preload, the map names the same file.

Three sources of a missing file remain, and this change does not reach them. `packages/html` and `packages/runner` install a clock harness that replaces `Deno.test`, so their class names name the harness, and neither test task grants write permission where the run's spool sits. A task string cannot name that path: `deno task` expands `$VAR` but not `${VAR:-default}`, and `--allow-write=` with an unset variable ends the run. Several `packages/toolshed` files declare their hooks outside any `describe`, which makes the bdd runner enclose them in a root suite of its own named `global`; the reported identity carries that root and the chain this code can see does not. And `packages/test-support` reaches a test file two directories above itself, which is outside the path its own name maps are read within.

Nothing here repairs the records already written. They carry no file, and nothing can give them one, because the store keeps identities rather than reports. Those identities stay unplaced until the same test runs again and records a file. For anything that still exists in the tree, that is the next run on the default branch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

