### PR TITLE
test: a CFC verdict through editWithRetry runs the action once

### DIFF
--- a/packages/runner/test/edit-with-retry-classification.test.ts
+++ b/packages/runner/test/edit-with-retry-classification.test.ts
@@ -30,6 +30,7 @@ import {
   type SessionFactory,
   StorageManager as V2StorageManager,
 } from "../src/storage/v2.ts";
+import { CFC_GRANT_ID_PREFIX } from "../src/cfc/grants.ts";
 import { DEFAULT_MAX_RETRIES, Runtime } from "../src/runtime.ts";
 import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
 import type { FabricValue } from "../src/builder/types.ts";
@@ -236,6 +237,46 @@ describe("editWithRetry rejection classification", () => {
       expect(ok).toBe("done");
     });
   }
+
+  it("returns a `CfcCommitRefusalError` after one run of the action", async () => {
+    // A real CFC refusal rather than the stubs above: which shape a boundary
+    // refusal takes is settled before the classifier sees it. The transaction
+    // write chokepoint records an unprivileged write at a reserved CFC grant
+    // address, prepare refuses it with a verdict, and a refusal whose reasons
+    // are all verdicts is the terminal name.
+    //
+    // The rung decides this case, so it names one: the refusal exists from
+    // `enforce-explicit` upward, and under `observe` the reason stays a
+    // diagnostic while under `disabled` no gate runs at all.
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    let actions = 0;
+    try {
+      const result = await runtime.editWithRetry((tx) => {
+        actions++;
+        tx.writeOrThrow({
+          space: signer.did(),
+          id: `${CFC_GRANT_ID_PREFIX}forged` as URI,
+          type: "application/json",
+          path: ["value"],
+        }, { forged: true });
+        return "written";
+      });
+      expect(actions).toBe(1);
+      expect(result.error?.name).toBe("CfcCommitRefusalError");
+      expect(result.error?.message).toContain(
+        "unprivileged write to protected cfc path",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
 });
 
 // The classification above is only reachable if the wire name survives


### PR DESCRIPTION
The CFC commit boundary refuses a relevant transaction that did not come out of prepare in a prepared state, and whether that refusal is terminal or retryable turns on the reasons prepare recorded. Every reason a verdict and the rejection is a `CfcCommitRefusalError`, which `editWithRetry` returns on the first attempt. Anything else and it is a `StorageTransactionAborted`, which `editWithRetry` retries.

Nothing checked that a deterministic policy refusal reaches the classifier tagged. Dropping the `verdictReason(...)` wrapper from the unprivileged system-write reason in `cfc/prepare.ts` leaves cfc-privileged-system-write, cfc-verdict-reason, cfc-grant-records, cfc-single-use-grants, runtime-edit-with-retry and runtime-prepare-tx-for-commit all green, while turning one run of the action into six. That is the doomed loop the allow-list in storage/rejection.ts exists to prevent, reintroduced by a producer with no gate on it.

The case names `enforce-explicit`, the lowest rung at which its subject exists: under `observe` the recorded reason stays a diagnostic and the commit succeeds, and under `disabled` no gate runs at all. Checked by running it at `observe`, where it fails on the error name being `undefined`.

The test writes at a reserved CFC grant address through `editWithRetry`, which the transaction write chokepoint records and prepare refuses with a verdict. The action runs once and the result is a `CfcCommitRefusalError`. It is the only thing in the runner package that fails when that reason is left untagged.

What it does not cover, and why it need not: the boundary's other refusal shape is a relevant transaction reaching commit with nothing prepared, which records no reasons at all and so takes the retryable name. `editWithRetry` does not produce that shape, because it prepares before every commit attempt. Instrumenting that arm and running the runner suite records 44 such refusals, every one of them from test code calling `tx.commit()` directly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

