### PR TITLE
ci: let every gate earn its place in a lane

### DIFF
--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -264,9 +264,6 @@ interface Suite {
   /** Environment variables its commands run with. */
   env?: Record<string, string>;
 
-  /** Whether a subset of this suite is always run, and on what basis. */
-  mandatory?: "always" | "changed";
-
   /** Every available item and every configured unavailability. */
   enumerate(): Promise<{
     items: Item[];
@@ -359,15 +356,12 @@ suite supplies the variant shared by all of them. Direct records already
 carry their kind, scope, and name; the runner checks their record surface
 against the suite before applying that same variant.
 
-`mandatory` is the policy escape hatch. `"always"` means every item runs
-on every pull request, with no exceptions of any kind — it outranks the
-score, the budget, and both exclusion rules, and
-[Two rules that keep a test out](#two-rules-that-keep-a-test-out) explains
-why that has to be literal. `"changed"` means an item runs when the pull
-request touches a file the item covers; the per-package type check is the
-natural user, because the store already records one `typecheck` identity
-per package group and the mapping from a changed file to a package is
-direct.
+No suite exempts itself from selection. An item runs because the change
+touches what it covers, because nothing has a record of it, or because it
+is worth what running it costs, and a repository gate is held to those
+rules the way a unit test is. `deno fmt --check` earns its place from the
+failures it has caught; a suite that could declare itself exempt would be
+a suite whose worth nothing measures.
 
 Answering "what does this item cover" belongs to the suite, because a
 unit that is not a path is one only its suite can map a diff onto. A
@@ -375,13 +369,7 @@ suite whose units are files needs to say nothing: the diff naming the
 file is the whole of the question. A suite whose units are type-check
 groups or binaries maps the diff itself, and a suite that maps it wrongly
 runs too much or too little rather than reporting anything, so the answer
-errs toward running. Absent the field, the suite is selected purely on value.
-
-The `always` set is deliberately tiny, and every member of it is a gate
-whose failure means the tree is broken rather than that one test is
-unhappy: `deno fmt --check`, `deno lint`, and the topology drift guard.
-Together they cost seconds. Nothing expensive belongs there, and adding to
-the set is a decision to spend part of every lane's budget forever.
+errs toward running.
 
 ### Today's jobs as suites
 
@@ -391,6 +379,7 @@ table is the migration's checklist.
 | Suite | Today's jobs | Record variant | Capabilities |
 | --- | --- | --- | --- |
 | `repo-gates` | `Check` (all but the type check) | — | `deno` |
+| `repo-history-gates` | the two append-only gates in `Pattern Update State and Baseline Integrity` | — | `deno`, `git-history` |
 | `typecheck` | `Check` (the type check) | — | `deno` |
 | `workspace-unit` | `Test (1..8)` | — | `deno`, `fuse`, `browser` |
 | `runner-unit` | `Runner Tests (1..8)` | — | `deno` |
@@ -735,7 +724,7 @@ build's 17,999 executions.
 | A pattern file run by `cf test` | `pattern-unit` | One. The runner writes one record per pattern file | Nothing to reach: the file is the identity. |
 | A pattern file checked by the compatibility gate | `pattern-compat` | One, named `pattern-compat <key>`, which the task appends itself as each file's verdict is known | Nothing to reach. The task already takes `--only` to restrict which files it reads. |
 | A single-step arm of `integration.sh` | `cli-core` | One, named for its step | Nothing to reach. The script's own whole-invocation record is suite-level and belongs to no invocation unit at all. |
-| One gate command | `repo-gates` | One, named for the gate that ran | Nothing to reach. |
+| One gate command | `repo-gates`, `repo-history-gates` | One, named for the gate that ran | Nothing to reach. |
 | One `deno check` invocation | `typecheck` | One, named for the path group it checked, which the task records itself | Nothing to reach. |
 | A whole task carrying one record | `cfcheck`, `pattern-vintage` | One, for everything the task did | Nothing to reach, and nothing finer exists: the suite is its own identity. |
 | A section of `fuse-exec.sh` | `cli-fuse` | The phases that section alone selects. The phases more than one section runs record against the suite instead, since they name no single section | Nothing to reach below the section. A mount comes up for the section, not for the phase, so its phases run or are skipped together. |
@@ -969,18 +958,19 @@ far worse failure than the workflow edit it replaced.
 `deno task check-test-topology` closes that, in two halves that catch the
 two different ways a surface goes missing.
 
-The **tree half** needs no store and runs on every pull request, in the
-`repo-gates` suite marked `mandatory: "always"`. It walks the tree for
-things that look like tests — `*.test.ts`, `*.test.tsx`, the integration
-directories, the shell scripts under `packages/cli/integration/` — and
-fails if any of them is claimed by no suite's `enumerate()`, or more than
-once under the same record surface and variant. A default suite and a
-non-default suite may claim the same source item because they are distinct
-execution surfaces. This is the half that catches a pull request adding a
-test surface nobody registered, at the moment it is added, and it is cheap
-enough to be unconditional. An entry in a configuration's declared skip
-registry accounts for its unavailable file or leaf without pretending it
-ran.
+The **tree half** needs no store, and is a unit of the `repo-gates` suite.
+It walks the tree for things that look like tests — `*.test.ts`,
+`*.test.tsx`, the integration directories, the shell scripts under
+`packages/cli/integration/` — and fails if any of them is claimed by no
+suite's `enumerate()`, or more than once under the same record surface and
+variant. A default suite and a non-default suite may claim the same source
+item because they are distinct execution surfaces. This is the half that
+catches a pull request adding a test surface nobody registered, and it is
+selected the way everything else is: a pull request that does not draw it
+leaves the unregistered surface to the full run on `main`, which is where
+the record of what this guard catches comes from. An entry in a
+configuration's declared skip registry accounts for its unavailable file or
+leaf without pretending it ran.
 
 The **store half** runs on `main`. It reads the most recent successful
 `main` build's records and fails if any recorded identity is one that no
@@ -1440,31 +1430,25 @@ from measurement rather than from somebody's judgement at one moment, it
 needs no owner or expiry to stop it rotting, and it reverses on its own
 the moment the test is fixed.
 
-**Neither rule touches an `always` item.** Both exclusions exist to stop a
-pull request failing for something its author cannot act on, and both
-reason about *tests*, whose individual absence costs one signal. An
-`always` item is not that. It is a gate the repository has decided must be
-green, and the moment it is red the exclusion would remove it from every
-pull request — including the pull requests that are about to make it
-worse, and including, in the drift guard's case, the very pull request
-that added the unregistered test surface it exists to catch. A guard that
-switches itself off exactly when it starts firing is not a guard.
+**Both rules reach a repository gate as well.** Formatting, linting and
+the drift guard are tests of the tree, and neither rule says anything
+about one of them that it does not say about a unit test. A gate failing
+in the latest `main` run leaves the selectable set, because a pull request
+red on it is red for something its author cannot act on. A gate above the
+flake threshold leaves the set too, and appears on the wall as the defect
+in the gate that it is.
 
-So `always` means always. Two consequences follow and both are intended.
-An `always` item red on `main` blocks every pull request until it is
-fixed. That is correct: with `deno fmt`, `deno lint`, and the topology
-guard, a red one means the tree is broken, the fix is usually a minute's
-work, and letting changes pile on top of it is how a minute becomes an
-afternoon. And an `always` item above the flake threshold keeps running
-rather than being hidden; a gate that is flaky is a defect in the gate,
-reported as one on the wall, and concealing it would be worse than the
-noise.
+The exception both rules carry cannot fire for a gate. A gate's unit is
+the name of a gate rather than a path, and its suite maps no change onto
+its units, so nothing a pull request touches reaches one. A gate red on
+`main` therefore stays out of pull requests until `main` is green, and
+`main`, which runs the whole corpus, is where it goes on failing until
+somebody fixes it.
 
 What the lane owes people in exchange is clarity about whose problem it
-is. A failing `always` item that was already failing in the latest `main`
-run is labelled in the job summary as pre-existing, with a link to the
-`main` run that first showed it, so nobody spends time looking for it in
-their own diff.
+is. The job summary names what was withheld and why, and says of each
+whether it ran anyway because the change reaches it, so nobody spends time
+looking for a pre-existing failure in their own diff.
 
 ### Two rules that force a test in
 
@@ -1778,9 +1762,9 @@ quietly absent.
 From what is left, given every item's value and cost and a budget of five
 lanes times 230 seconds each, it fills in four passes.
 
-1. **Mandatory.** Everything marked mandatory goes in first: the `always`
-   suites, the items the diff touched directly, every item of a covered
-   package the diff touched as described in [The one coverage gate that
+1. **Mandatory.** Everything mandatory goes in first: the items the diff
+   touched directly, every item of a covered package the diff touched as
+   described in [The one coverage gate that
    survives](#the-one-coverage-gate-that-survives), and the items with no
    history. An item excluded above comes back into this pass if the
    change edits the test itself, or its suite maps the change onto its
@@ -2918,7 +2902,6 @@ is pinned to the commit's date. And if none of that settles it,
 | A fork pull request | Works unchanged. The manifest is world-readable, and the existing member gate decides whether the fork's records ship. |
 | A re-run of one failed lane | Runs the same set, because the manifest is resolved by the commit's date, which no attempt changes. |
 | Both `pr-tests` and `full-tests` skip | `Status` fails. Its second clause requires one of them to have succeeded, so a pull request that ran no tests can never report green. |
-| An `always` item is red on `main` | Every pull request fails on it, deliberately, and the job summary says it was already red and links the `main` run. See [Two rules that keep a test out](#two-rules-that-keep-a-test-out). |
 | `main` is broken and stays broken | Every test failing in the latest `main` run leaves the selectable set, so pull requests are unaffected while it is fixed. They come back on their own. |
 | The reporter cannot find the pull request behind a `main` commit | It logs the commit and posts nothing. A direct push to `main` with no pull request behind it is the ordinary case for this. |
 | The reporter would comment on a test that is known flaky | It says so in the comment rather than implying the change caused it. |
@@ -3307,10 +3290,10 @@ exercised on the branch on its own.
       measurements, and returns at most one item for an identity that
       several arms or entry points can run. Add `tasks/ci-capabilities.ts`.
       Twenty-one suites currently hold 2,396 units. The repository gates are two
-      suites rather than one, because `mandatory` belongs to a suite and
-      the `always` set has to stay tiny: `repo-gates` holds formatting,
-      linting and the drift guard, and `repo-checks` holds the rest of
-      what the `Check` job runs, selected on value like anything else.
+      suites rather than one, because a lane opens what a suite needs
+      before it runs any of it: `repo-gates` holds every gate that reads
+      the working tree alone, and `repo-history-gates` the two append-only
+      gates that read the revision the change is measured against.
 - [x] The server-execution ON configuration consumes
       `tasks/server-execution-on-skips.ts`: whole-file entries are declared
       unavailable and omitted from enumeration, while step entries exclude

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -1505,9 +1505,10 @@ describe("what a lane records about itself", () => {
         {
           manifest: () =>
             Promise.resolve({
-              // A gate the change did not touch, costing most of a lane:
-              // `always` outranks the budget, so the lane takes it and
-              // reports what that cost rather than dropping it.
+              // A manifest that knows one gate, which leaves every
+              // other unit in the tree unknown and therefore mandatory.
+              // The lane takes them all and says what that cost rather
+              // than dropping work.
               manifest: manifestOf([{
                 test: { k: "format", s: "repo", n: "deno-fmt" },
                 suite: "repo-gates",

--- a/tasks/test-selection/census.test.ts
+++ b/tasks/test-selection/census.test.ts
@@ -121,7 +121,6 @@ describe("what a lane must run whatever the score says", () => {
     // than the diff being matched against the unit's name.
     const binaries = suite({
       id: "binaries",
-      mandatory: "changed",
       recordSurfaces: [{ kind: "gate", scope: "repo" }],
       units: ["toolshed", "cf"],
       unitsForChange: (changed) =>
@@ -156,10 +155,12 @@ describe("what a lane must run whatever the score says", () => {
     ).toBeUndefined();
   });
 
-  it("runs every unit of a suite marked always", () => {
+  it("leaves a gate the corpus already knows to the score", () => {
+    // A gate is a test of the tree like any other: what it is worth is
+    // what decides, so a gate that catches nothing stops being paid for.
+
     const gates = suite({
       id: "repo-gates",
-      mandatory: "always",
       recordSurfaces: [{ kind: "gate", scope: "repo" }],
       units: ["deno-fmt"],
     });
@@ -168,8 +169,13 @@ describe("what a lane must run whatever the score says", () => {
       suite: "repo-gates",
       unit: "deno-fmt",
     }]);
-    const { mandatory } = census([gates], manifest, new Set());
-    expect([...mandatory.values()]).toEqual(["always"]);
+    expect(census([gates], manifest, new Set()).mandatory.size).toBe(0);
+    // A gate's unit is a name rather than a path and its suite maps no
+    // change onto its units, so the rule that reaches it is the corpus
+    // having no record of it.
+    expect([
+      ...census([gates], undefined, new Set()).mandatory.values(),
+    ]).toEqual(["unknown"]);
   });
 
   it("says nothing about a unit a configuration declares unavailable", () => {

--- a/tasks/test-selection/census.ts
+++ b/tasks/test-selection/census.ts
@@ -119,12 +119,11 @@ export interface Census {
 /**
  * Reads the working tree against a manifest.
  *
- * Three rules make a unit mandatory: its suite is marked `always`, the
- * change touched what it covers, or no manifest has ever seen it. The
- * last of those is the rule the test-record spec requires of any consumer
- * that selects which tests run. A selector that never runs the unselected
- * starves its own data, and a renamed test is an unknown identity until
- * an alias lands.
+ * Two rules make a unit mandatory: the change touched what it covers, or
+ * no manifest has ever seen it. The second is the rule the test-record
+ * spec requires of any consumer that selects which tests run. A selector
+ * that never runs the unselected starves its own data, and a renamed test
+ * is an unknown identity until an alias lands.
  */
 export function census(
   suites: readonly Suite[],
@@ -173,9 +172,7 @@ export function census(
     );
     for (const unit of suite.units) {
       if (unavailable.has(unit)) continue;
-      const reason: SelectionReason | undefined = suite.mandatory === "always"
-        ? "always"
-        : touched.has(unit)
+      const reason: SelectionReason | undefined = touched.has(unit)
         ? "changed"
         : undefined;
       const recorded = inUnit.get(`${suite.id}\t${unit}`);

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -29,7 +29,6 @@ import type {
 
 /** Why one identity is in the run. */
 export type SelectionReason =
-  | "always"
   | "changed"
   | "unknown"
   | "coverage-gate"

--- a/tasks/test-topology.test.ts
+++ b/tasks/test-topology.test.ts
@@ -80,6 +80,7 @@ describe("the test topology", () => {
     const records = [
       { test: { k: "format", s: "repo", n: "deno-fmt" } },
       { test: { k: "gate", s: "repo", n: "check-deno-pins" } },
+      { test: { k: "gate", s: "repo", n: "check-test-aliases" } },
       { test: { k: "gate", s: "repo", n: "pattern-compat annotation.tsx" } },
       { test: { k: "gate", s: "repo", n: "pattern-vintage a b c" } },
       { test: { k: "typecheck", s: "repo", n: "cfcheck a.tsx" } },
@@ -114,16 +115,6 @@ describe("the test topology", () => {
     });
     expect(claims.map((claim) => [claim.suite.id, claim.level])).toEqual([
       ["cli-core", "suite"],
-    ]);
-  });
-
-  it("marks only the three gates that mean the tree is broken", () => {
-    const always = suites.filter((suite) => suite.mandatory === "always");
-    expect(always.map((suite) => suite.id)).toEqual(["repo-gates"]);
-    expect(always[0]!.units).toEqual([
-      "deno-fmt",
-      "deno-lint",
-      "check-test-topology",
     ]);
   });
 });

--- a/tasks/test-topology/binaries.test.ts
+++ b/tasks/test-topology/binaries.test.ts
@@ -46,7 +46,6 @@ describe("the binary build suites", () => {
     // once. After that a build earns its place the way every other test
     // does, and a compile that breaks on `main` is what lifts it.
     for (const suite of suites) {
-      expect([suite.id, suite.mandatory]).toEqual([suite.id, undefined]);
       expect([suite.id, suite.unitsForChange]).toEqual([suite.id, undefined]);
     }
   });

--- a/tasks/test-topology/gates.test.ts
+++ b/tasks/test-topology/gates.test.ts
@@ -10,10 +10,30 @@ const byId = (id: string): Suite => suites.find((s) => s.id === id)!;
 const context = { root: "/repo", outputDir: "/out" };
 
 describe("the repository's gate suites", () => {
-  it("marks only the gates whose failure means the tree is broken", () => {
-    expect(
-      suites.filter((s) => s.mandatory === "always").map((s) => s.id),
-    ).toEqual(["repo-gates"]);
+  it("gives the base revision to the gates whose suite asks for history", async () => {
+    // A lane opens what a suite needs before it runs any of it, so which
+    // suite a gate sits in decides whether the lane it runs in has
+    // history to read. Both lists are built over every gate of both
+    // suites, so a gate that reaches for the base revision from the suite
+    // that asks for no history fails this.
+
+    const reading: string[] = [];
+    const declared: string[] = [];
+    for (const suite of [byId("repo-gates"), byId("repo-history-gates")]) {
+      for (const unit of suite.units) {
+        const [invocation] = await suite.command([{ unit, skip: [] }], {
+          ...context,
+          baseRef: "origin/release",
+        });
+        if (invocation!.command.includes("origin/release")) reading.push(unit);
+        if (suite.needs.includes("git-history")) declared.push(unit);
+      }
+    }
+    expect(reading.toSorted()).toEqual([
+      "check-baselines-append-only",
+      "check-test-aliases",
+    ]);
+    expect(declared.toSorted()).toEqual(reading.toSorted());
   });
 
   it("runs a gate through the recorder that names its identity", async () => {
@@ -31,7 +51,7 @@ describe("the repository's gate suites", () => {
   });
 
   it("gives a gate that compares against a base the base to use", async () => {
-    const [invocation] = await byId("repo-checks").command(
+    const [invocation] = await byId("repo-history-gates").command(
       [{ unit: "check-test-aliases", skip: [] }],
       { ...context, baseRef: "origin/release" },
     );
@@ -39,7 +59,7 @@ describe("the repository's gate suites", () => {
   });
 
   it("compares against main where the lane names no base", async () => {
-    const [invocation] = await byId("repo-checks").command(
+    const [invocation] = await byId("repo-history-gates").command(
       [{ unit: "check-baselines-append-only", skip: [] }],
       context,
     );
@@ -47,7 +67,7 @@ describe("the repository's gate suites", () => {
   });
 
   it("runs a gate that belongs to a package in that package", async () => {
-    const [invocation] = await byId("repo-checks").command(
+    const [invocation] = await byId("repo-gates").command(
       [{ unit: "check-cfc-types", skip: [] }],
       context,
     );
@@ -55,14 +75,21 @@ describe("the repository's gate suites", () => {
   });
 
   it("locates a gate by the name its record carries", () => {
+    // Both gate suites record under the `gate` kind and the `repo` scope,
+    // so the name is what separates one's records from the other's.
     expect(
       byId("repo-gates").locate({
         test: { k: "format", s: "repo", n: "deno-fmt" },
       }),
     ).toEqual({ level: "unit", unit: "deno-fmt" });
     expect(
+      byId("repo-history-gates").locate({
+        test: { k: "gate", s: "repo", n: "check-test-aliases" },
+      }),
+    ).toEqual({ level: "unit", unit: "check-test-aliases" });
+    expect(
       byId("repo-gates").locate({
-        test: { k: "gate", s: "repo", n: "check-deno-pins" },
+        test: { k: "gate", s: "repo", n: "check-test-aliases" },
       }),
     ).toBeUndefined();
   });

--- a/tasks/test-topology/gates.ts
+++ b/tasks/test-topology/gates.ts
@@ -3,12 +3,12 @@
  * pattern type check, the pattern update gates, and the checks that hold
  * a file or a document to a shape.
  *
- * Two of them are suites rather than one because of what `mandatory`
- * means. A gate marked `always` outranks the score, the budget, and both
- * exclusion rules, so the set of them is deliberately tiny and every
- * member is a gate whose failure means the tree is broken rather than
- * that one test is unhappy. `repo-gates` holds those three; everything
- * else the `Check` job runs is an ordinary selectable gate.
+ * The gates are two suites rather than one because a lane opens what a
+ * suite needs before it runs any of it. Two of them read the revision the
+ * change is measured against, which takes a checkout carrying history;
+ * the rest read the working tree and need nothing but the toolchain. A
+ * gate reaches a lane the way a test does: on what it is worth, or
+ * because nothing has a record of it.
  */
 
 import { collectPathsByScope, scopeOfPath } from "../typecheck.ts";
@@ -46,20 +46,11 @@ interface Gate {
   cwd?: string;
 }
 
-/**
- * The gates that run on every pull request whatever else does. A red one
- * means the tree is broken, the fix is usually a minute's work, and
- * letting changes pile on top of it is how a minute becomes an
- * afternoon.
- */
-const ALWAYS_GATES: readonly Gate[] = [
+/** The gates that read nothing but the working tree. */
+const WORKING_TREE_GATES: readonly Gate[] = [
   { name: "deno-fmt", kind: "format", task: "fmt", args: () => ["--check"] },
   { name: "deno-lint", kind: "lint", task: "lint" },
   { name: "check-test-topology", kind: "gate", task: "check-test-topology" },
-];
-
-/** Everything else the repository checks about itself. */
-const CHECK_GATES: readonly Gate[] = [
   { name: "check-skill-facts", kind: "gate", task: "check-skill-facts" },
   { name: "check-tripwires", kind: "gate", task: "check-tripwires" },
   { name: "check-docs", kind: "gate", task: "check-docs" },
@@ -119,6 +110,14 @@ const CHECK_GATES: readonly Gate[] = [
     task: "check-withheld-globals",
     cwd: "packages/static",
   },
+];
+
+/**
+ * The gates that hold a file to being appended to. Each reads the file as
+ * it stood at the merge base with the revision the change is measured
+ * against, which takes a checkout carrying history.
+ */
+const HISTORY_GATES: readonly Gate[] = [
   {
     name: "check-baselines-append-only",
     kind: "gate",
@@ -142,7 +141,6 @@ function gateSuite(
   id: string,
   gates: readonly Gate[],
   needs: readonly CapabilityId[],
-  mandatory?: "always",
 ): Suite {
   const byName = new Map(gates.map((gate) => [gate.name, gate]));
   const recordSurfaces: RecordSurface[] = [
@@ -152,7 +150,6 @@ function gateSuite(
     id,
     recordSurfaces,
     needs,
-    ...(mandatory === undefined ? {} : { mandatory }),
     units: gates.map((gate) => gate.name),
     unavailable: [],
     locate(record): Location | undefined {
@@ -192,11 +189,9 @@ function gateSuite(
 }
 
 /**
- * The type check, one unit per package group. It is `mandatory:
- * "changed"` rather than selected on value: the store records one
+ * The type check, one unit per package group. The store records one
  * identity per group and the mapping from a changed file to its group is
- * direct, so a change can always be checked against exactly the groups it
- * touches.
+ * direct, so `unitsForChange` names exactly the groups a change touches.
  */
 async function typecheckSuite(root: string): Promise<Suite> {
   const byScope = await collectPathsByScope(root);
@@ -207,7 +202,6 @@ async function typecheckSuite(root: string): Promise<Suite> {
     id: "typecheck",
     recordSurfaces,
     needs: ["deno"],
-    mandatory: "changed",
     units: scopes,
     unavailable: [],
     // A group's unit is the scope it checks rather than a path, so the
@@ -393,8 +387,8 @@ function patternVintageSuite(): Suite {
 /** Every gate suite, read from the working tree. */
 export async function loadGateSuites(root: string): Promise<Suite[]> {
   return [
-    gateSuite("repo-gates", ALWAYS_GATES, ["deno"], "always"),
-    gateSuite("repo-checks", CHECK_GATES, ["deno", "git-history"]),
+    gateSuite("repo-gates", WORKING_TREE_GATES, ["deno"]),
+    gateSuite("repo-history-gates", HISTORY_GATES, ["deno", "git-history"]),
     await typecheckSuite(root),
     cfcheckSuite(),
     await patternCompatSuite(root),

--- a/tasks/test-topology/suite.ts
+++ b/tasks/test-topology/suite.ts
@@ -132,9 +132,6 @@ export interface Suite {
   /** Setup this suite needs before it can run. */
   needs: readonly CapabilityId[];
 
-  /** Whether a subset of it always runs, and on what basis. */
-  mandatory?: "always" | "changed";
-
   /**
    * Every unit available in this working tree. Read when the topology is
    * loaded rather than on demand, because `locate` answers from the same
@@ -313,7 +310,6 @@ export interface FileSuiteOptions {
   id: string;
   variant?: string;
   needs: readonly CapabilityId[];
-  mandatory?: "always" | "changed";
 
   /**
    * The packages it spans. One runner does not imply one scope: the
@@ -350,9 +346,6 @@ export function fileSuite(options: FileSuiteOptions): Suite {
     recordSurfaces,
     ...(options.variant === undefined ? {} : { variant: options.variant }),
     needs: options.needs,
-    ...(options.mandatory === undefined
-      ? {}
-      : { mandatory: options.mandatory }),
     units,
     unavailable,
 


### PR DESCRIPTION
`tasks/test-topology/gates.ts` marked three gates as `mandatory: "always"`: `deno fmt --check`, `deno lint`, and the topology drift guard. A suite marked that way outranks the score, the budget, and both exclusion rules, so those three ran on every pull request whatever the records said about them.

That is the one thing a corpus measured by what it catches cannot afford. A test's worth here comes from the failures it has caught; a suite that declares itself exempt is a suite whose worth nothing measures, and its share of every lane's budget is spent forever on the strength of a decision nobody revisits. `docs/specs/test-selection.md` names two rules that force a test in — an identity with no records, and a change touching what the test covers — and "the suite said so" is not one of them.

So the exemption goes, and the three gates become ordinary units of the gate suite.

What reaches a gate afterwards is worth stating exactly, because one of those two rules cannot. A gate's unit is the name of a gate, `deno-fmt` or `check-docs`, while the changed set a unit is matched against holds repository-relative paths, and `gateSuite` supplies no `unitsForChange` to map one onto the other. So nothing a pull request touches makes a gate mandatory: a gate runs because the corpus has no record of it, or because it is worth what running it costs. A gate red on `main` stays out of pull requests until `main` is green, and `main` runs the whole corpus, so that is where it goes on failing. The section on the two rules that keep a test out says so, in place of the argument it used to make for the exemption.

With `always` gone the `mandatory` field had one value left, and that value never decided anything: the census maps the diff onto every suite's units whether or not the suite carries `"changed"`, so the type check behaves identically without it. The field therefore goes too, along with the `always` selection reason, which leaves one set of rules with nothing able to opt out of them.

The gates stay two suites, because a lane opens what a suite needs before it runs any of it, and the split is now that rather than the exemption. `repo-gates` holds every gate that reads nothing but the working tree, and `repo-history-gates` the two that hold a file to being appended to by reading it at the merge base, which is what `git-history` provides. The 20 gates that were declared as needing an unshallowed checkout because they shared a suite with those two now ask for nothing but the toolchain.

Which suite a gate belongs to is part of how a manifest entry is matched to a unit, so the gates that move between the two arrive as units with no records. They run once each, the way any unknown identity does, and the next published manifest carries them again.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

