### PR TITLE
docs(test-selection): hold the dial table and `DIALS` to each other

### DIFF
--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -39,21 +39,8 @@ so asking about a renamed test under either name finds the joined history.
 ### `dials`
 
 Every number selection can be tuned by, with the unit its value counts,
-whether somebody chose it or the publisher measures it, and which way you
-would move it. `tasks/test-selection/policy.ts` is where they live and the
-only place any of them lives.
-
-The units are worth reading. Several dials are bare fractions that do not
-mean the same thing — a share of a test's score and a share of a run's
-budget read identically — and naming the unit is what keeps them from
-being compared to each other.
-
-A **measured** dial is not yours to edit. The publisher overwrites it from
-the lanes' own timing records, and the number in the file is only the seed
-used before anything has been measured. `setupCost` per capability, and
-the overhead and correction per suite, are measured too, and are not in
-`policy.ts` at all: they are published in each manifest, which is where to
-read them.
+where the value comes from, and which way you would move it.
+[Every dial](#every-dial) lists them.
 
 ### `coverage`
 
@@ -103,6 +90,90 @@ tree instead — the larger of the number of suites with anything to run
 and what packing the stand-ins asks for — and says on the error stream
 that it did so, since a projection from costs nobody has measured would
 be arithmetic over an invented figure.
+
+## Every dial
+
+`tasks/test-selection/policy.ts` defines every one of these, and nothing
+else defines any of them. `dials` prints the same content as the table
+below, and `tasks/test-selection/policy.test.ts` holds the two to each
+other: a dial added, removed, or reworded in `policy.ts` without the
+matching edit here fails `deno task test`.
+
+The **Units** column says what each number counts. Several of the dials
+are bare fractions that do not mean the same thing, and the table holds
+two different `0.25` values as it stands: `WEIGHT_BREADTH` is a share of a
+test's score and `FILL_DENSITY_SHARE` is a share of the run's budget. A
+share of an item's runs reads the same way again. Naming the unit is what
+keeps them from being compared to each other.
+
+The **Set by** column separates three kinds. A **chosen** value is a
+decision somebody made, and editing it is how the decision changes. A
+**measured** value is worked out from the data and written back by the
+publisher, so the number in the file is only the seed used before there is
+anything to measure, and editing it changes nothing after the first
+publisher run. A **derived** value is computed from other dials and has no
+expression of its own to edit: each lane budget is its run's bound less
+the prologue and the safety margin, so a budget that does not fit inside
+its own bound cannot be written down. The distinction matters because all
+three look identical in a source file, and somebody who tunes a measured
+value is arguing with a tape measure while somebody who tries to tune a
+derived one is editing a line that is not there.
+
+Three more numbers are measured, and they are not in the table because
+they are not in `policy.ts`: `setupCost` for each capability, and
+`suiteOverhead` and `correction` for each suite. They are fitted from the
+lanes' own timing records and published in the manifest, one set per
+publisher run, which is where to read them. Nothing hand-edits them, and a
+manifest carrying a strange one is a measurement to look at rather than a
+setting to fix.
+
+| Dial | Default | Units | Set by | Why you would move it, and which way |
+| --- | --- | --- | --- | --- |
+| `LANES` | 5 | lanes | chosen | Up when pull-request feedback is too thin and runner capacity allows more; down when the wave crowds other workflows off the shared runners. |
+| `LANE_BOUND_SECONDS` | 300 | seconds | chosen | Up when more should fit in a lane; down when five minutes is longer than anybody will wait for a first answer. The lane jobs that this bounds do not exist yet; when they do, their work-step and job timeouts in `deno.yml` have to move with it, and nothing checks that until they are written. |
+| `LANE_PROLOGUE_SECONDS` | 40 | seconds | measured | Never. The publisher overwrites it from the lanes' own timing records, and the checked-in figure is only what the first lane uses before any lane has reported one. |
+| `LANE_SAFETY_SECONDS` | 30 | seconds | chosen | Up when lanes overrun their bound on slow runners; down when they finish early every time and the headroom is buying nothing. |
+| `LANE_BUDGET_SECONDS` | 230 | seconds | derived | Nothing edits this. It is the bound less the prologue and the safety margin, so a budget that does not fit inside its own bound cannot be written down. |
+| `FULL_LANE_BOUND_SECONDS` | 600 | seconds | chosen | Up when the run on `main` uses more jobs than it needs; down when `main` takes too long to say something broke. |
+| `FULL_LANE_BUDGET_SECONDS` | 530 | seconds | derived | Nothing edits this. It is the full run's bound less the same prologue and safety margin a pull request's lane pays, since a lane of either run is the same job doing the same setup on the same runner. |
+| `FULL_RUN_LABEL` | ci: full | a label | chosen | Not a quantity. Change it only if the label collides with one the repository already uses for something else. |
+| `UNMEASURED_COST_SECONDS` | 1 | seconds | chosen | Up when a lane holding new tests runs long; down when it finishes early. It is reached for only by a suite with no measured test at all, since a suite that has any charges an unmeasured one what its middle test costs. |
+| `VALUE_FLOOR` | 0.05 | score | chosen | Up when the cheap tail is not being swept up; down when it crowds out tests with a record of catching things. |
+| `WEIGHT_PROVEN` | 0.55 | share of the score | chosen | Up when a record of catching things should count for more. The three weights are shares of one score, so what this gains the other two lose. |
+| `WEIGHT_BREADTH` | 0.25 | share of the score | chosen | Up when a test that several distinct sources have hit should count for more; down when breadth is mostly telling you about the environment rather than the test. |
+| `WEIGHT_CHURN` | 0.15 | share of the score | chosen | Up when something going wrong right now should jump the queue faster; down when the queue keeps being jumped by noise. |
+| `PROVEN_SATURATION` | 2 | catches | chosen | Where the `proven` term reaches half its ceiling. Up when the term should go on telling eight catches from four; down when one catch should already be worth nearly everything a test can earn. |
+| `FRESHNESS_HALF_LIFE_DAYS` | 120 | days | chosen | Up when old catches should keep more of their value; down when a test that caught something a year ago crowds out one that caught something last week. |
+| `FRESHNESS_FLOOR` | 0.3 | multiplier | chosen | Up when a very old catch should keep more of its worth; down when age should be allowed to retire one almost completely. |
+| `CATCH_WEIGHT_LOCAL` | 2 | multiplier | chosen | Up when evidence from a workstation should count for more; down if local records ever arrive in volume and stop being the scarce signal they are today. |
+| `CATCH_WEIGHT_PR` | 1 | multiplier | chosen | Neither. It is the unit the other two are expressed against, so move those instead. |
+| `CATCH_WEIGHT_MAIN` | 1.5 | multiplier | chosen | Up when an escape should pull harder on what gets selected next; down when the failures on `main` are mostly environmental rather than real. |
+| `BREADTH_SATURATION` | 2 | sources | chosen | Where the `breadth` term reaches half its ceiling. Up when the term should go on telling eight sources from four; down when one source should already be worth nearly all it can give. |
+| `ENVIRONMENTAL_MIN_SOURCES` | 5 | sources | chosen | How many distinct sources a failure must span inside `CATCH_BREADTH_WINDOW_DAYS` before it reads as the environment. Up when a genuinely broad regression is written off; down when a broken runner's failures still count as catches. |
+| `CHURN_HALF_LIFE_DAYS` | 14 | days | chosen | Up when recent trouble should stay relevant for longer; down when a problem already fixed keeps its tests selected for weeks afterwards. |
+| `CHURN_WINDOW_DAYS` | 60 | days | chosen | How far back the decayed counts are read. Past this the weight is under one part in sixteen, so moving it is a performance decision rather than a policy one. |
+| `FLAKE_WINDOW_DAYS` | 60 | days | chosen | Up when a flake rate swings about on too little evidence; down when a test that has since been fixed stays excluded. |
+| `COST_WINDOW_DAYS` | 7 | days | chosen | Up when cost estimates are noisy; down when durations drift with the code or the runner image faster than the estimate follows. |
+| `FILL_VALUE_SHARE` | 0.6 | share of the run's budget | chosen | Up when expensive high-value tests are crowded out by cheap ones; down when a lane spends its budget on a few slow tests and runs little else. The three shares sum to one. |
+| `FILL_DENSITY_SHARE` | 0.25 | share of the run's budget | chosen | Up when more of the cheap tail should run; down when the tail is displacing tests with a record. |
+| `FILL_EXPLORATION_SHARE` | 0.15 | share of the run's budget | chosen | Up when the unselected corpus is going stale; down when lanes spend the share on tests that never find anything. |
+| `FLAKE_EXCLUSION_RATE` | 0.05 | share of runs | chosen | Up when fewer tests should be held back from pull requests; down when flakes are still blocking people. |
+| `FLAKE_REPEAT_RATES` | 0.01, 0.03 | share of runs | chosen | Up when repeats cost more lane time than the intermittent failures they catch are worth; down when intermittent failures are still slipping through. Every band stays under `FLAKE_EXCLUSION_RATE`, or an item is excluded before it reaches the band and the band never fires. |
+| `MAX_REPEATS` | 3 | runs of one item | chosen | Up when intermittent regressions still get through; down when repeats are crowding a lane. |
+| `SUITE_FLAKE_PRIOR_RATE` | 0.02 | share of runs | chosen | Up when too many suites count as flake-prone and their new items are repeated needlessly; down when new tests in a noisy suite land unrepeated and then flake. |
+| `COVERAGE_COMMENT_LINES` | 25 | lines | chosen | Up when coverage comments are too noisy; down when debt is climbing unnoticed. |
+| `LOCAL_COVERAGE_MAX_SECONDS` | 30 | seconds | chosen | Up when too many packages are reported as expensive for the report to be worth reading; down when one is quietly eating a lane. Nothing is excluded either way; it only decides what the summary mentions. |
+| `LOCAL_COVERAGE_MAX_PACKAGES` | 2 | packages | chosen | Up when broader changes should still be gated and the run can afford their packages' whole test sets; down when sweeping changes are crowding lanes. |
+| `EXCLUDED_FROM_COVERAGE_GATE` | 9 | workspace members | chosen | Not a quantity. A line comes off when a package fits the run's budget or gains a Deno-only half, which turns its gate on. A line goes on when a package's own tests stop being what covers it. |
+| `LOCAL_COVERAGE_BASELINE_DAYS` | 7 | days | chosen | Up when branches based further back are being reported for want of an ancestor baseline; down when the manifest carries more history than anybody reads. |
+| `COVERAGE_TREND_WEEKS` | 3 | weeks | chosen | Up when the tile goes amber too readily; down when debt climbs for a month before anybody is told. |
+| `CATCH_BREADTH_WINDOW_DAYS` | 2 | days | chosen | Up when a broken runner's failures are being counted as catches; down when genuine breadth is being written off as environmental. |
+| `SAME_COMMIT_REACH_DAYS` | 2 | days | chosen | How far back the fold remembers a commit's outcomes, so that a rerun landing in a later batch than the run it repeats is still read as the test disagreeing with itself. Up when reruns land far enough behind that their disagreement is being counted as a catch; down when the fold's memory is the thing that will not fit. It costs the number of identities that have failed times the number of commits, so it is the dial to check first when a run runs out of memory. |
+| `FLAKE_COMMIT_REACH` | 8 | commits | chosen | How many of the most recently observed commits the fold keeps every identity's outcomes at. Past that a commit keeps only the identities that have already failed, so this bounds a test's first failure: up when one lands more commits after the pass it disagrees with than this and is counted as a catch; down when the fold's memory is the thing that will not fit. |
+| `RENAME_SIMILARITY` | 0.7 | share of the longer name's own part | chosen | Up when the run report offers rename pairings nobody meant; down when a rename that discarded history goes unoffered. It only decides what is suggested — nothing is written to the alias file without somebody appending it. |
+| `RENAME_MARGIN` | 0.1 | share of the longer name's own part | chosen | Up when the run report pairs a deletion with an unrelated addition; down when a rename made alongside another rename in the same area goes unoffered. |
+| `RENAME_SUGGESTIONS` | 5 | suggestions in one comment | chosen | Up when a change that renamed many tests has its later suggestions cut off; down when a comment carrying this many is one nobody reads. |
+| `ALIAS_GATE_MIN_CATCHES` | off | catches | chosen | Off by default. Turn it on at a catch count to fail a pull request that discards that much history in a rename without an alias line, and lower the count as the alias file becomes routine. |
 
 ## The publisher
 

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -3052,9 +3052,10 @@ test-selection`. Its modes are also how the system is tested by hand.
   is the question this system will be asked most often and the one it
   would otherwise answer badly.
 - `dials` prints every dial with its comment, its current value and the
-  unit that value is in, saying of each whether it is chosen or measured,
-  and for a measured one whether the figure shown is still the checked-in
-  seed or one the publisher has since written back.
+  unit that value is in, saying of each whether somebody chose it, the
+  publisher measures it, or it is computed from other dials, and for a
+  measured one whether the figure shown is still the checked-in seed or
+  one the publisher has since written back.
 - `coverage` prints every workspace member, whether it carries the
   per-package coverage gate, the reason beside it when it does not, the
   task the gate measures, and the baseline the newest manifest holds for
@@ -3076,81 +3077,9 @@ those comments, and every manifest records the values it was built with,
 so a manifest is self-describing and a change in behavior can always be
 traced to a change in a dial.
 
-The **Units** column says what each number counts. Several of the dials
-are bare fractions that do not mean the same thing, and the table holds
-two different `0.25` values as it stands: `WEIGHT_BREADTH` is a share of a
-test's score and `FILL_DENSITY_SHARE` is a share of a lane's budget. A
-share of an item's runs reads the same way again. Naming the unit is what
-keeps them from being compared to each other.
-
-The **Set by** column separates three kinds. A **chosen** value is a
-decision somebody made, and editing it is how the decision changes. A
-**measured** value is worked out from the data and written back by the
-publisher, so the number in the file is only the seed used before there is
-anything to measure, and editing it changes nothing after the first
-publisher run. A **derived** value is computed from other dials and has no
-expression of its own to edit: each lane budget is its run's bound less
-the prologue and the safety margin, so a budget that does not fit inside
-its own bound cannot be written down. The distinction matters because all
-three look identical in a source file, and somebody who tunes a measured
-value is arguing with a tape measure while somebody who tries to tune a
-derived one is editing a line that is not there.
-
-| Dial | Default | Units | Set by | Why you would move it, and which way |
-| --- | --- | --- | --- | --- |
-| `LANES` | 5 | lanes | Chosen | Up when pull-request feedback is too thin and runner capacity allows more; down when the wave crowds other workflows off the shared runners. |
-| `LANE_BOUND_SECONDS` | 300 | seconds | Chosen | Up when more should fit in a lane; down when five minutes is longer than anybody will wait for a first answer. Either way `LANE_WORK_TIMEOUT_MINUTES` and `LANE_JOB_TIMEOUT_MINUTES` in `deno.yml` move with it. |
-| `LANE_PROLOGUE_SECONDS` | 40 | seconds | Measured | Never. The publisher overwrites it from the lanes' own timing records, and the checked-in figure is only what the first lane uses before any lane has reported one. |
-| `LANE_SAFETY_SECONDS` | 30 | seconds | Chosen | Up when lanes overrun their bound on slow runners; down when they finish early every time and the headroom is buying nothing. |
-| `FULL_LANE_BOUND_SECONDS` | 600 | seconds | Chosen | Up when `main`'s run uses more jobs than it needs; down when `main` takes too long to say something broke. |
-| `FULL_LANE_BUDGET_SECONDS` | 530 | seconds | Derived | Nothing edits this. It is the full run's bound less the same prologue and safety margin a pull request's lane pays, since a lane of either run is the same job doing the same setup on the same runner. |
-| `FULL_RUN_LABEL` | `ci: full` | a label | Chosen | Not a quantity. Change it only if the label collides with one the repository already uses for something else. |
-| `VALUE_FLOOR` | 0.05 | score | Chosen | Up when the cheap tail is not being swept up; down when it crowds out tests with a record of catching things. |
-| `WEIGHT_PROVEN` | 0.55 | share of the score | Chosen | Up when a record of catching things should count for more. The three weights are shares of one score, so what this gains the other two lose. |
-| `WEIGHT_BREADTH` | 0.25 | share of the score | Chosen | Up when a test that several distinct sources have hit should count for more; down when breadth is mostly telling you about the environment rather than the test. |
-| `WEIGHT_CHURN` | 0.15 | share of the score | Chosen | Up when something going wrong right now should jump the queue faster; down when the queue keeps being jumped by noise. |
-| `PROVEN_SATURATION` | 2 | catches | Chosen | Up when four catches should outrank one by more; down when one catch should already be worth nearly everything a test can earn. |
-| `FRESHNESS_HALF_LIFE_DAYS` | 120 | days | Chosen | Up when old catches should keep more of their value; down when a test that caught something a year ago crowds out one that caught something last week. |
-| `FRESHNESS_FLOOR` | 0.3 | multiplier | Chosen | Up when a very old catch should keep more of its worth; down when age should be allowed to retire one almost completely. |
-| `CATCH_WEIGHT_LOCAL` | 2.0 | multiplier | Chosen | Up when evidence from a workstation should count for more; down if local records ever arrive in volume and stop being the scarce signal they are today. |
-| `CATCH_WEIGHT_PR` | 1.0 | multiplier | Chosen | Neither. It is the unit the other two are expressed against, so move those instead. |
-| `CATCH_WEIGHT_MAIN` | 1.5 | multiplier | Chosen | Up when an escape should pull harder on what gets selected next; down when `main`'s failures are mostly environmental rather than real. |
-| `CHURN_HALF_LIFE_DAYS` | 14 | days | Chosen | Up when recent trouble should stay relevant for longer; down when a problem already fixed keeps its tests selected for weeks afterwards. |
-| `FILL_VALUE_SHARE` | 0.60 | share of the budget | Chosen | Up when expensive high-value tests are crowded out by cheap ones; down when a lane spends its budget on a few slow tests and runs little else. The three shares sum to one. |
-| `FILL_DENSITY_SHARE` | 0.25 | share of the budget | Chosen | Up when more of the cheap tail should run; down when the tail is displacing tests with a record. |
-| `FILL_EXPLORATION_SHARE` | 0.15 | share of the budget | Chosen | Up when the unselected corpus is going stale; down when lanes spend the share on tests that never find anything. |
-| `FLAKE_EXCLUSION_RATE` | 0.05 | share of runs | Chosen | Up when fewer tests should be held back from pull requests; down when flakes are still blocking people. |
-| `FLAKE_REPEAT_RATES` | 0.01, 0.03 | share of runs | Chosen | Up when repeats cost more lane time than the intermittent failures they catch are worth; down when intermittent failures are still slipping through. Every band stays under `FLAKE_EXCLUSION_RATE`, or an item is excluded before it reaches the band and the band never fires. |
-| `MAX_REPEATS` | 3 | runs of one item | Chosen | Up when intermittent regressions still get through; down when repeats are crowding a lane. |
-| `SUITE_FLAKE_PRIOR_RATE` | 0.02 | share of runs | Chosen | Up when too many suites count as flake-prone and their new items are repeated needlessly; down when new tests in a noisy suite land unrepeated and then flake. |
-| `COVERAGE_COMMENT_LINES` | 25 | lines | Chosen | Up when coverage comments are too noisy; down when debt is climbing unnoticed. |
-| `LOCAL_COVERAGE_MAX_SECONDS` | 30 | seconds | Chosen | Up when too many packages are reported as expensive for the report to be worth reading; down when one is quietly eating a lane. Nothing is excluded either way; it only decides what the summary mentions. |
-| `LOCAL_COVERAGE_MAX_PACKAGES` | 2 | packages | Chosen | Up when broader changes should still be gated and the run can afford their packages' whole test sets; down when sweeping changes are crowding lanes. |
-| `EXCLUDED_FROM_COVERAGE_GATE` | nine | workspace members | Chosen | Not a quantity. A line comes off when a package fits the run's budget or gains a Deno-only half, which turns its gate on. A line goes on when a package's own tests stop being what covers it. |
-| `LOCAL_COVERAGE_BASELINE_DAYS` | 7 | days | Chosen | Up when branches based further back are being reported for want of an ancestor baseline; down when the manifest carries more history than anybody reads. |
-| `COVERAGE_TREND_WEEKS` | 3 | weeks | Chosen | Up when the tile goes amber too readily; down when debt climbs for a month before anybody is told. |
-| `CATCH_BREADTH_WINDOW_DAYS` | 2 | days | Chosen | Up when a broken runner's failures are being counted as catches; down when genuine breadth is being written off as environmental. |
-| `ENVIRONMENTAL_MIN_SOURCES` | 5 | sources | Chosen | How many distinct sources a failure spans inside that window before it reads as the environment. Up when a genuinely broad regression is written off; down when a broken runner's failures still count as catches. |
-| `BREADTH_SATURATION` | 2 | sources | Chosen | Where the breadth term reaches half its ceiling. Up when four sources should outrank one by more; down when one source should already be worth nearly all of it. |
-| `CHURN_WINDOW_DAYS` | 60 | days | Chosen | How far back the decayed counts are read. Past this the weight is under one part in sixteen, so this is a performance decision rather than a policy one. |
-| `SAME_COMMIT_REACH_DAYS` | 2 | days | Chosen | How far back the fold remembers a commit's outcomes, so that a re-run landing in a later batch than the run it repeats is still read as the test disagreeing with itself. Up when re-runs land far enough behind that their disagreement is counted as a catch; down when the fold's memory is what will not fit. It costs the number of identities that have failed times the number of commits, so it is the first dial to look at when a publisher run runs out of memory. |
-| `FLAKE_COMMIT_REACH` | 8 | commits | Chosen | How many of the most recently observed commits the fold keeps outcomes at, alongside the span above. Moves for the same two reasons and against the same cost. |
-| `FLAKE_WINDOW_DAYS` | 60 | days | Chosen | Up when a flake rate swings about on too little evidence; down when a test since fixed stays excluded. |
-| `COST_WINDOW_DAYS` | 7 | days | Chosen | Up when cost estimates are noisy; down when durations drift faster than the estimate follows. |
-| `RENAME_SIMILARITY` | 0.7 | share of the longer name's own part | Chosen | Up when the run report offers rename pairings nobody meant; down when a rename that discarded history goes unoffered. It only decides what is suggested — nothing is written to the alias file without somebody appending it. |
-| `RENAME_MARGIN` | 0.1 | share of the longer name's own part | Chosen | Up when the run report pairs a deletion with an unrelated addition; down when a rename made alongside another rename in the same area goes unoffered. |
-| `RENAME_SUGGESTIONS` | 5 | suggestions in one comment | Chosen | Up when a change that renamed many tests has its later suggestions cut off; down when a comment carrying this many is one nobody reads. |
-| `ALIAS_GATE_MIN_CATCHES` | off | catches | Chosen | Off by default. Turn it on at a catch count to fail a pull request that discards that much history in a rename without an alias line, and lower the count as the alias file becomes routine. |
-
-Three more numbers are measured, and they are not in the table because
-they are not in `policy.ts`: `setupCost` for each capability, and
-`suiteOverhead` and `correction` for each suite. They are fitted from the
-lanes' own timing records and published in the manifest, one set per
-publisher run, which is where to read them. Nothing hand-edits them, and a
-manifest carrying a strange one is a measurement to look at rather than a
-setting to fix. They are listed here so that the answer to "what numbers
-decide what runs" is complete rather than only complete for the ones a
-person owns.
+[Every dial](../development/test-selection.md#every-dial) in the
+test-selection guide tabulates them, one row each with its default, its
+unit, where its value comes from, and the reason to move it.
 
 Of the chosen dials, three are worth revisiting first, because their right
 values are empirical rather than structural. They stay chosen — nothing

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -24,6 +24,7 @@ import type { ManifestEntry } from "./test-selection/manifest.ts";
 import type { Suite } from "./test-topology/suite.ts";
 import {
   DIALS,
+  dialValue,
   EXCLUDED_FROM_COVERAGE_GATE,
   LANES,
 } from "./test-selection/policy.ts";
@@ -154,11 +155,18 @@ describe("test-selection", () => {
   });
 
   describe("dialLines()", () => {
-    it("prints every dial with its unit and how it is set", () => {
-      const text = dialLines().join("\n");
-      for (const dial of DIALS) expect(text).toContain(dial.name);
-      expect(text).toContain("(chosen)");
-      expect(text).toContain("(measured)");
+    it("prints every dial with its value, unit, source, and reason", () => {
+      // Three lines per dial, in `DIALS` order: the name with its value,
+      // the reason to move it, and a blank line.
+
+      const lines = dialLines();
+      DIALS.forEach((dial, index) => {
+        expect(lines[index * 3]).toContain(dial.name);
+        expect(lines[index * 3]).toContain(
+          `${dialValue(dial)} ${dial.unit} (${dial.setBy})`,
+        );
+        expect(lines[index * 3 + 1]).toContain(dial.why);
+      });
     });
 
     it("says a dial that is off is off rather than printing nothing", () => {

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -24,6 +24,7 @@ import {
 } from "@commonfabric/test-support/records";
 import {
   DIALS,
+  dialValue,
   EXCLUDED_FROM_COVERAGE_GATE,
   LANE_BUDGET_SECONDS,
   LANES,
@@ -94,13 +95,9 @@ export function dialLines(): string[] {
   const lines: string[] = [];
   const width = Math.max(...DIALS.map((dial) => dial.name.length));
   for (const dial of DIALS) {
-    const shown = Array.isArray(dial.value)
-      ? dial.value.join(", ")
-      : dial.value === undefined
-      ? "off"
-      : String(dial.value);
     lines.push(
-      `${pad(dial.name, width)}  ${shown} ${dial.unit} (${dial.setBy})`,
+      `${pad(dial.name, width)}  ${dialValue(dial)} ${dial.unit} ` +
+        `(${dial.setBy})`,
     );
     lines.push(`${" ".repeat(width)}  ${dial.why}`);
     lines.push("");

--- a/tasks/test-selection/policy.test.ts
+++ b/tasks/test-selection/policy.test.ts
@@ -11,6 +11,62 @@ const EXPORTED_DIALS = Object.keys(policy).filter((name) =>
   /^[A-Z][A-Z0-9_]*$/.test(name) && name !== "DIALS"
 );
 
+/** The live document the dial table lives in, from the repository root. */
+const DIAL_TABLE_PATH = "docs/development/test-selection.md";
+
+/** The dial table's header row, which is how the table is found. */
+const DIAL_TABLE_HEADER =
+  "| Dial | Default | Units | Set by | Why you would move it, and which way |";
+
+/** One line of a cell, unwrapped and with its pipes unescaped. */
+function flatten(text: string): string {
+  return text.replace(/\\\|/g, "|").replace(/\s+/g, " ").trim();
+}
+
+/** The same, without the backticks a cell puts around a name. */
+function unquoted(text: string): string {
+  return flatten(text).replace(/`/g, "");
+}
+
+/** A table row's cells. A cell escapes any `|` it holds. */
+function tableCells(line: string): string[] {
+  const inner = line.trim().replace(/^\|/, "").replace(/(?<!\\)\|$/, "");
+  return inner.split(/(?<!\\)\|/).map(flatten);
+}
+
+/** The dial table's columns after the first, which names the dial. */
+const DIAL_TABLE_COLUMNS = tableCells(DIAL_TABLE_HEADER).slice(1);
+
+/**
+ * The dial table's rows, each one its cells with the dial's name first.
+ * `policy.ts` wraps its strings at 72 columns and the table writes each
+ * row on one line, so both sides are flattened before anything is
+ * compared.
+ */
+function dialTable(): string[][] {
+  const lines = Deno.readTextFileSync(
+    new URL(`../../${DIAL_TABLE_PATH}`, import.meta.url),
+  ).split("\n");
+  const headers = lines.flatMap((line, at) =>
+    flatten(line) === flatten(DIAL_TABLE_HEADER) ? [at] : []
+  );
+  if (headers.length !== 1) {
+    throw new Error(
+      `${DIAL_TABLE_PATH} holds ${headers.length} dial tables and takes ` +
+        "exactly one. It is the documented copy of `DIALS` in " +
+        "`tasks/test-selection/policy.ts`, and it belongs in a live " +
+        "document, which an archived one is not. Point `DIAL_TABLE_PATH` " +
+        "at the live document holding it.",
+    );
+  }
+  const rows: string[][] = [];
+  for (const line of lines.slice(headers[0]! + 2)) {
+    if (!line.trimStart().startsWith("|")) break;
+    rows.push(tableCells(line));
+  }
+  return rows;
+}
+
 describe("policy", () => {
   describe("the dial table", () => {
     it("names every exported dial", () => {
@@ -37,6 +93,49 @@ describe("policy", () => {
 
     it("lists each dial once", () => {
       expect(NAMED_IN_TABLE.size).toBe(DIALS.length);
+    });
+  });
+
+  describe("the dial table in the guide", () => {
+    // `DIALS` and the table in the documentation are two copies of one
+    // set of decisions, and a reader reaches for whichever is nearer.
+    // Each cell is compared on its own, so a mismatch names the dial and
+    // the column it is in.
+
+    it("holds one row per dial and no row without one", () => {
+      expect(dialTable().map((row) => unquoted(row[0]!)))
+        .toEqual(DIALS.map((dial) => dial.name));
+    });
+
+    it("gives every dial the value, unit, source, and reason `policy.ts` gives it", () => {
+      const rows = dialTable();
+      const disagreements: string[] = [];
+      for (const dial of DIALS) {
+        const row = rows.find((cells) => unquoted(cells[0]!) === dial.name);
+        if (row === undefined) {
+          disagreements.push(
+            `${dial.name}: ${DIAL_TABLE_PATH} carries no row for it`,
+          );
+          continue;
+        }
+        const inCode = [
+          policy.dialValue(dial),
+          dial.unit,
+          dial.setBy,
+          dial.why,
+        ];
+        DIAL_TABLE_COLUMNS.forEach((column, index) => {
+          const documented = row[index + 1] ?? "";
+          const code = flatten(inCode[index]!);
+          if (documented !== code) {
+            disagreements.push(
+              `${dial.name} ${column}: ${DIAL_TABLE_PATH} says ` +
+                `"${documented}", \`policy.ts\` says "${code}"`,
+            );
+          }
+        });
+      }
+      expect(disagreements).toEqual([]);
     });
   });
 

--- a/tasks/test-selection/policy.ts
+++ b/tasks/test-selection/policy.ts
@@ -8,9 +8,10 @@
  * A **chosen** dial is a decision somebody made, and editing it is how the
  * decision changes. A **measured** dial is worked out from the data and
  * written back by the publisher, so the value here is only the seed used
- * before there is anything to measure. The two look identical in a source
- * file, which is why `DIALS` says which each one is: somebody who tunes a
- * measured value is arguing with a tape measure.
+ * before there is anything to measure. A **derived** dial is computed from
+ * other dials, and editing it means editing those. The three look
+ * identical in a source file, which is why `DIALS` says which each one is:
+ * somebody who tunes a measured value is arguing with a tape measure.
  */
 
 /** How many jobs a pull request's tests are packed into. */
@@ -117,7 +118,7 @@ export const FLAKE_WINDOW_DAYS = 60;
 /** Days of durations an item's cost estimate reads. */
 export const COST_WINDOW_DAYS = 7;
 
-/** The share of a lane's budget spent in descending value. */
+/** The share of the run's budget spent in descending value. */
 export const FILL_VALUE_SHARE = 0.60;
 
 /** The share spent in descending value per second. */
@@ -284,7 +285,7 @@ export const EXCLUDED_FROM_COVERAGE_GATE: ReadonlyMap<string, string> = new Map(
   ],
 );
 
-/** Whether a dial is a decision or a measurement. */
+/** Whether a dial is a decision, a measurement, or computed. */
 export type DialSource = "chosen" | "measured" | "derived";
 
 /** One dial, as `deno task test-selection dials` prints it. */
@@ -298,11 +299,20 @@ export interface Dial {
   why: string;
 }
 
+/** Returns `dial`'s value as one line of text. */
+export function dialValue(dial: Dial): string {
+  return Array.isArray(dial.value)
+    ? dial.value.join(", ")
+    : dial.value === undefined
+    ? "off"
+    : String(dial.value);
+}
+
 /**
  * Every dial, with the unit its value counts and the reason to move it.
  * The units matter because several dials are bare fractions that do not
  * mean the same thing: `WEIGHT_BREADTH` is a share of a test's score and
- * `FILL_DENSITY_SHARE` is a share of a lane's budget, and naming the unit
+ * `FILL_DENSITY_SHARE` is a share of the run's budget, and naming the unit
  * is what keeps them from being compared to each other.
  */
 export const DIALS: readonly Dial[] = [
@@ -324,8 +334,8 @@ export const DIALS: readonly Dial[] = [
       "Up when more should fit in a lane; down when five minutes is longer " +
       "than anybody will wait for a first answer. The lane jobs that this " +
       "bounds do not exist yet; when they do, their work-step and job " +
-      "timeouts in deno.yml have to move with it, and nothing checks that " +
-      "until they are written.",
+      "timeouts in `deno.yml` have to move with it, and nothing checks " +
+      "that until they are written.",
   },
   {
     name: "LANE_PROLOGUE_SECONDS",
@@ -368,9 +378,9 @@ export const DIALS: readonly Dial[] = [
     unit: "seconds",
     setBy: "derived",
     why: "Nothing edits this. It is the full run's bound less the same " +
-      "prologue and safety margin a pull request's lane pays, so a lane of " +
-      "either run is packed against what is left after the parts the " +
-      "packer does not control.",
+      "prologue and safety margin a pull request's lane pays, since a lane " +
+      "of either run is the same job doing the same setup on the same " +
+      "runner.",
   },
   {
     name: "FULL_RUN_LABEL",
@@ -431,9 +441,9 @@ export const DIALS: readonly Dial[] = [
     value: PROVEN_SATURATION,
     unit: "catches",
     setBy: "chosen",
-    why:
-      "Up when four catches should outrank one by more; down when one catch " +
-      "should already be worth nearly everything a test can earn.",
+    why: "Where the `proven` term reaches half its ceiling. Up when the " +
+      "term should go on telling eight catches from four; down when one " +
+      "catch should already be worth nearly everything a test can earn.",
   },
   {
     name: "FRESHNESS_HALF_LIFE_DAYS",
@@ -486,18 +496,19 @@ export const DIALS: readonly Dial[] = [
     value: BREADTH_SATURATION,
     unit: "sources",
     setBy: "chosen",
-    why:
-      "Up when four sources should outrank one by more; down when one source " +
-      "should already be worth nearly all the breadth term can give.",
+    why: "Where the `breadth` term reaches half its ceiling. Up when the " +
+      "term should go on telling eight sources from four; down when one " +
+      "source should already be worth nearly all it can give.",
   },
   {
     name: "ENVIRONMENTAL_MIN_SOURCES",
     value: ENVIRONMENTAL_MIN_SOURCES,
     unit: "sources",
     setBy: "chosen",
-    why: "Up when a genuinely broad regression is being written off as the " +
-      "environment; down when a broken runner's failures are still being " +
-      "counted as catches.",
+    why: "How many distinct sources a failure must span inside " +
+      "`CATCH_BREADTH_WINDOW_DAYS` before it reads as the environment. Up " +
+      "when a genuinely broad regression is written off; down when a " +
+      "broken runner's failures still count as catches.",
   },
   {
     name: "CHURN_HALF_LIFE_DAYS",
@@ -538,7 +549,7 @@ export const DIALS: readonly Dial[] = [
   {
     name: "FILL_VALUE_SHARE",
     value: FILL_VALUE_SHARE,
-    unit: "share of the budget",
+    unit: "share of the run's budget",
     setBy: "chosen",
     why: "Up when expensive high-value tests are crowded out by cheap ones; " +
       "down when a lane spends its budget on a few slow tests and runs " +
@@ -547,7 +558,7 @@ export const DIALS: readonly Dial[] = [
   {
     name: "FILL_DENSITY_SHARE",
     value: FILL_DENSITY_SHARE,
-    unit: "share of the budget",
+    unit: "share of the run's budget",
     setBy: "chosen",
     why: "Up when more of the cheap tail should run; down when the tail is " +
       "displacing tests with a record.",
@@ -555,7 +566,7 @@ export const DIALS: readonly Dial[] = [
   {
     name: "FILL_EXPLORATION_SHARE",
     value: FILL_EXPLORATION_SHARE,
-    unit: "share of the budget",
+    unit: "share of the run's budget",
     setBy: "chosen",
     why:
       "Up when the unselected corpus is going stale; down when lanes spend " +
@@ -577,8 +588,9 @@ export const DIALS: readonly Dial[] = [
     setBy: "chosen",
     why: "Up when repeats cost more lane time than the intermittent failures " +
       "they catch are worth; down when intermittent failures are still " +
-      "slipping through. Every band stays under FLAKE_EXCLUSION_RATE, so " +
-      "raising one past that rate means raising the rate too.",
+      "slipping through. Every band stays under `FLAKE_EXCLUSION_RATE`, or " +
+      "an item is excluded before it reaches the band and the band never " +
+      "fires.",
   },
   {
     name: "MAX_REPEATS",
@@ -671,20 +683,25 @@ export const DIALS: readonly Dial[] = [
     value: SAME_COMMIT_REACH_DAYS,
     unit: "days",
     setBy: "chosen",
-    why: "Up when reruns are landing far enough behind the run they repeat " +
-      "that their disagreement is being counted as a catch; down when the " +
-      "fold's memory is the thing that will not fit. It costs the number " +
-      "of identities that have failed times the number of commits, so it " +
-      "is the dial to check first when a run runs out of memory.",
+    why: "How far back the fold remembers a commit's outcomes, so that a " +
+      "rerun landing in a later batch than the run it repeats is still read " +
+      "as the test disagreeing with itself. Up when reruns land far enough " +
+      "behind that their disagreement is being counted as a catch; down " +
+      "when the fold's memory is the thing that will not fit. It costs the " +
+      "number of identities that have failed times the number of commits, " +
+      "so it is the dial to check first when a run runs out of memory.",
   },
   {
     name: "FLAKE_COMMIT_REACH",
     value: FLAKE_COMMIT_REACH,
     unit: "commits",
     setBy: "chosen",
-    why: "Up when reruns of a commit arrive far enough behind the run they " +
-      "repeat that their disagreement is being counted as a catch; down " +
-      "when the fold's memory is the thing that will not fit.",
+    why: "How many of the most recently observed commits the fold keeps " +
+      "every identity's outcomes at. Past that a commit keeps only the " +
+      "identities that have already failed, so this bounds a test's first " +
+      "failure: up when one lands more commits after the pass it disagrees " +
+      "with than this and is counted as a catch; down when the fold's " +
+      "memory is the thing that will not fit.",
   },
   {
     name: "RENAME_SIMILARITY",


### PR DESCRIPTION
Every test-selection dial was written down twice: once in `DIALS` in `tasks/test-selection/policy.ts`, which is what `deno task test-selection dials` prints, and once in a table in the plan document. Nothing compared them, and they had drifted. Most of that was rewording, but three entries carried real differences, one dial had no row at all, and reviewing the reconciliation turned up two defects in what the dials say about themselves.

## The reconciliation

`FLAKE_COMMIT_REACH`'s reason to move it was a copy of `SAME_COMMIT_REACH_DAYS`'s. It described how far back the fold remembers a commit's outcomes, where this dial is a count of the most recently observed commits the fold keeps outcomes at, so anybody running `dials` to decide whether to move it was reading about a different dial. It now describes itself, and says what it bounds: a commit that slides out of the reach keeps every identity the failure witness names, so a test that has already failed stays exact until `SAME_COMMIT_REACH_DAYS` drops the commit, and what the reach bounds is a test's first failure.

`FLAKE_REPEAT_RATES` disagreed with the table about what happens when a band is raised past `FLAKE_EXCLUSION_RATE`. The document was right: `repeatsFor()` returns one repeat for any rate above the exclusion rate before it consults the bands at all, and the planner drops those items from the selectable set, so a band at or above that rate can never fire. The code said "raising one past that rate means raising the rate too", which is advice; the mechanism is what a reader needs, and it is what the dial's own declaration comment already said.

`SAME_COMMIT_REACH_DAYS` says what the dial is before saying when to move it, which the table did and the code did not. `dials` prints the reason and never the declaration comment, so for a dial whose name does not carry its meaning the reason is the only prose a reader gets. `BREADTH_SATURATION` and `ENVIRONMENTAL_MIN_SOURCES` gain the same shape. The table's version of the second said "inside that window", which resolved only because the table happened to place it after `CATCH_BREADTH_WINDOW_DAYS`; `dials` orders by `DIALS` and puts something else there, so the window is now named outright.

The rest were settled one at a time rather than by preferring a side. `LANE_BOUND_SECONDS` keeps the code's wording because the table named `LANE_WORK_TIMEOUT_MINUTES` and `LANE_JOB_TIMEOUT_MINUTES`, which exist only in the plan. `COST_WINDOW_DAYS` and `FLAKE_WINDOW_DAYS` keep the code's fuller phrasing. `EXCLUDED_FROM_COVERAGE_GATE`'s default becomes a numeral rather than the word for it, so that it matches what `dials` prints.

## Two dials pointed the wrong way

`PROVEN_SATURATION` and `BREADTH_SATURATION` both said "up when four should outrank one by more". The terms they saturate enter the score by addition, so what decides rank against another test is the difference, not the ratio. With `1 - 0.5 ** (n / saturation)`, the gap between four and one is 0.457 at a saturation of 2, 0.397 at 3, and 0.341 at 4. It peaks at about 1.5, so from where both dials sit, raising them narrows the gap the sentence says raising them widens. Both now say where the term reaches half its ceiling and what moving it does to eight against four, which is monotonic in the direction stated.

The three fill shares are shares of the whole run's budget, not of a lane's: the planner sets its budget to the lane budget times the lane count, and each pass spends its share of what is left of that. Their unit said "share of the budget", which is the ambiguity the unit column exists to remove, and one declaration comment and the `DIALS` header both said "a lane's budget". The unit is now "share of the run's budget".

## Where the table lives

It moves to a section of its own in
`docs/development/test-selection.md`, taking the plan's prose about the two columns with it, and the plan points at it. A plan is archived to `docs/history/plans/` once its work lands, and an archived document is never edited, so a table kept there would either freeze or take the check with it. The guide is the live document somebody already edits when a dial changes. The plan keeps the reasoning that is a plan's to keep, including which dials are worth revisiting first.

## The check

`tasks/test-selection/policy.test.ts` reads the table out of that document and compares it to `DIALS` column by column: the same rows in the same order, and for each row the value, the unit, the source, and the reason. A mismatch names the dial and the column and quotes both sides. It sits beside the tests already holding `DIALS` to this module's exports.

Rows are compared as a list rather than keyed by dial name, so a second row for a dial cannot hide behind the first. The document must hold exactly one dial table, so a second copy elsewhere in it is not invisible. A row's delimiters are stripped before it is split, so a row written without its trailing pipe — which renders the same in GitHub Markdown — does not lose its last cell and fail by accusing the content. Whitespace is collapsed and escaped pipes are unescaped, since the code wraps its strings at 72 columns and each table row is one long line, but backticks are compared: `dials` prints the reason as it stands, so backticks lost on one side are a visible regression in what the command prints. Only the cell naming the dial is compared without them.

When the header row cannot be found, the failure says the table is the documented copy of `DIALS`, that it belongs in a live document, and that the fix is to point `DIAL_TABLE_PATH` at wherever it went.

`dialValue()` moves to `policy.ts` beside the `Dial` interface it formats and is what both the table and `dials` render a value through, so there is one answer to what a dial's value looks like written down. The `dialLines()` test, which asserted only that every dial's name appeared somewhere in the output, now checks each dial's line for its value, unit, and source, and the line under it for its reason.

The prose in both documents and in `policy.ts` now names the `derived` kind alongside `chosen` and `measured`, which `DialSource` has had all along and no description mentioned.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

