### PR TITLE
fix(cf-harness): read the session's enforcement rung from its preset

### DIFF
--- a/packages/cf-harness/src/cfc-posture.ts
+++ b/packages/cf-harness/src/cfc-posture.ts
@@ -19,7 +19,10 @@ import {
 } from "@commonfabric/runner/cfc";
 import { presetCfcOptions } from "@commonfabric/runner";
 
-import type { HarnessFabricSessionConfig } from "./config.ts";
+import {
+  fabricSessionPresetCfcDials,
+  type HarnessFabricSessionConfig,
+} from "./config.ts";
 
 /**
  * The posture the session's runtime will run at, as the shared record.
@@ -40,20 +43,10 @@ import type { HarnessFabricSessionConfig } from "./config.ts";
  */
 export const harnessFabricSessionPosture = (
   config: HarnessFabricSessionConfig,
-): CfcPostureReport => {
-  const options = presetCfcOptions({
-    ...(config.cfcPosture !== undefined
-      ? { cfcPosture: config.cfcPosture }
-      : {}),
-    ...(config.cfcEnforcementMode !== undefined
-      ? { cfcEnforcementMode: config.cfcEnforcementMode }
-      : {}),
-    ...(config.cfcFlowLabels !== undefined
-      ? { cfcFlowLabels: config.cfcFlowLabels }
-      : {}),
-  });
-  return projectedCfcPostureReport(options);
-};
+): CfcPostureReport =>
+  projectedCfcPostureReport(
+    presetCfcOptions(fabricSessionPresetCfcDials(config)),
+  );
 
 const dialLine = (
   name: string,

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -7,8 +7,9 @@ import {
   clausesEqual,
   isCfcEnforcementMode,
   meetCfcObservationCeilings,
+  resolveCfcDials,
 } from "@commonfabric/runner/cfc";
-import type { CfcPosture } from "@commonfabric/runner";
+import { type CfcPosture, presetCfcOptions } from "@commonfabric/runner";
 import type { HarnessCfcEnforcementModeSource } from "./contracts/cfc-policy-snapshot.ts";
 import {
   type HarnessCredentialOwnerRef,
@@ -318,14 +319,48 @@ export const parseHarnessGatewayAuthMode = (
   isHarnessGatewayAuthMode(input) ? input : undefined;
 
 /**
- * The mode a fabric session enforces at, whether or not it named one: the
- * session's preset pins `enforce-explicit`, and `--fabric-cfc-enforcement-mode`
- * raises from there.
+ * The CFC dials a fabric session config states that the session's runtime
+ * preset takes. The read ceiling reaches the controller by another route.
+ */
+export type HarnessFabricSessionPresetCfcDials = Pick<
+  HarnessFabricSessionConfig,
+  "cfcEnforcementMode" | "cfcFlowLabels" | "cfcPosture"
+>;
+
+/**
+ * The dials this config states, in the shape the session's runtime preset
+ * takes them. A dial the config does not carry is absent here, and the preset
+ * decides it.
+ */
+export const fabricSessionPresetCfcDials = (
+  fabricSession: HarnessFabricSessionConfig,
+): HarnessFabricSessionPresetCfcDials => ({
+  ...(fabricSession.cfcPosture !== undefined
+    ? { cfcPosture: fabricSession.cfcPosture }
+    : {}),
+  ...(fabricSession.cfcEnforcementMode !== undefined
+    ? { cfcEnforcementMode: fabricSession.cfcEnforcementMode }
+    : {}),
+  ...(fabricSession.cfcFlowLabels !== undefined
+    ? { cfcFlowLabels: fabricSession.cfcFlowLabels }
+    : {}),
+});
+
+/**
+ * The mode a fabric session enforces at, whether or not it named one.
+ *
+ * `presetCfcOptions` resolves the dials the config states, and the runtime's
+ * own dial defaults resolve whatever the preset leaves unset. A session's
+ * runtime is constructed through those same two steps over the same dials, so
+ * the rung this returns is the rung it runs at. That is a rung of the whole
+ * enforcement ladder, wider than the {@link HarnessFabricCfcEnforcementMode}
+ * an operator may state.
  */
 export const fabricSessionCfcEnforcementMode = (
   fabricSession: HarnessFabricSessionConfig,
-): HarnessFabricCfcEnforcementMode =>
-  fabricSession.cfcEnforcementMode ?? "enforce-explicit";
+): CfcEnforcementMode =>
+  resolveCfcDials(presetCfcOptions(fabricSessionPresetCfcDials(fabricSession)))
+    .cfcEnforcementMode;
 
 /** What the operator stated the harness's own dial to be, if anything. */
 const statedCfcEnforcementMode = (

--- a/packages/cf-harness/src/fabric-session.ts
+++ b/packages/cf-harness/src/fabric-session.ts
@@ -8,7 +8,11 @@
 
 import { Identity } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
-import type { HarnessFabricSessionConfig } from "./config.ts";
+import {
+  fabricSessionPresetCfcDials,
+  type HarnessFabricSessionConfig,
+  type HarnessFabricSessionPresetCfcDials,
+} from "./config.ts";
 import {
   createFabricInstantiationRecorder,
   type FabricPatternInstantiations,
@@ -54,12 +58,9 @@ export type HarnessFabricSessionFactory = () => Promise<HarnessFabricSession>;
  */
 export const harnessFabricSessionControllerOptions = (
   config: HarnessFabricSessionConfig,
-): {
+): HarnessFabricSessionPresetCfcDials & {
   apiUrl: URL;
   space: string;
-  cfcEnforcementMode?: HarnessFabricSessionConfig["cfcEnforcementMode"];
-  cfcFlowLabels?: HarnessFabricSessionConfig["cfcFlowLabels"];
-  cfcPosture?: HarnessFabricSessionConfig["cfcPosture"];
   cfcReadMaxConfidentiality?: HarnessFabricSessionConfig[
     "cfcReadMaxConfidentiality"
   ];
@@ -67,13 +68,7 @@ export const harnessFabricSessionControllerOptions = (
 } => ({
   apiUrl: new URL(config.apiUrl),
   space: config.space,
-  ...(config.cfcEnforcementMode !== undefined
-    ? { cfcEnforcementMode: config.cfcEnforcementMode }
-    : {}),
-  ...(config.cfcFlowLabels !== undefined
-    ? { cfcFlowLabels: config.cfcFlowLabels }
-    : {}),
-  ...(config.cfcPosture !== undefined ? { cfcPosture: config.cfcPosture } : {}),
+  ...fabricSessionPresetCfcDials(config),
   ...(config.cfcReadMaxConfidentiality !== undefined
     ? { cfcReadMaxConfidentiality: config.cfcReadMaxConfidentiality }
     : {}),

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -82,7 +82,8 @@ export const isTerminalHarnessRunStatus = (
  * session factory directly, whose runtime's posture the harness never saw.
  */
 export interface HarnessFabricSessionCfcPosture {
-  enforcementMode: "enforce-explicit" | "enforce-strict";
+  /** The rung the session's runtime resolves to, from the whole ladder. */
+  enforcementMode: CfcEnforcementMode;
 
   /** `configured` when the operator set the dial; `preset-pin` otherwise. */
   enforcementModeSource: "configured" | "preset-pin";

--- a/packages/cf-harness/test/cfc-posture.test.ts
+++ b/packages/cf-harness/test/cfc-posture.test.ts
@@ -6,16 +6,21 @@
  * renderer is pinned because it is the only form most operators ever see the
  * record in — an ungated sink that did not reach the output is a gap nobody
  * reads about.
+ *
+ * The itemized enforcement dial belongs here too. A run records it beside the
+ * record, from the same configuration, and an audit reads both.
  */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { presetCfcOptions } from "@commonfabric/runner";
 
 import {
   harnessFabricSessionPosture,
   harnessFabricSessionPostureBanner,
   renderCfcPostureReport,
 } from "../src/cfc-posture.ts";
+import { fabricSessionCfcEnforcementMode } from "../src/config.ts";
 
 const SESSION = {
   apiUrl: "https://toolshed.example/",
@@ -70,6 +75,44 @@ describe("cfc-posture", () => {
       });
       expect(record.deviations.map((deviation) => deviation.owner.length > 0))
         .toEqual([true, true, true, true]);
+    });
+  });
+
+  describe("fabricSessionCfcEnforcementMode()", () => {
+    it("leaves the dial on the pin under the named bundle", () => {
+      // The bundle sets every other staged enforcement dial and this one it
+      // leaves alone.
+      expect(
+        fabricSessionCfcEnforcementMode({
+          ...SESSION,
+          cfcPosture: "max-enforcement",
+        }),
+      ).toBe(presetCfcOptions({}).cfcEnforcementMode);
+    });
+
+    it("names the rung the session states", () => {
+      expect(
+        fabricSessionCfcEnforcementMode({
+          ...SESSION,
+          cfcEnforcementMode: "enforce-strict",
+        }),
+      ).toBe("enforce-strict");
+    });
+
+    it("agrees with the record the same configuration projects", () => {
+      // A run records both from the same config: the itemized dial an audit
+      // compares against, and the whole record beside it. Each rung below is
+      // the one both sides of the assertion read back.
+      for (
+        const session of [
+          SESSION,
+          { ...SESSION, cfcEnforcementMode: "enforce-strict" as const },
+        ]
+      ) {
+        expect(fabricSessionCfcEnforcementMode(session)).toBe(
+          harnessFabricSessionPosture(session).enforcementMode.rung,
+        );
+      }
     });
   });
 

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -248,7 +248,7 @@ Deno.test("the harness loop's own default matches the rung an unstated fabric se
   assertEquals(
     fabricSessionCfcEnforcementMode(unstatedSession),
     pinned,
-    "`fabricSessionCfcEnforcementMode` restates the rung `presetCfcOptions` pins, and the two have parted; move the fallback in `config.ts` to the rung the preset now pins",
+    "`fabricSessionCfcEnforcementMode` no longer reads the rung `presetCfcOptions` resolves; take it back to that resolution rather than naming a rung in `config.ts`",
   );
 
   assert(


### PR DESCRIPTION
`fabricSessionCfcEnforcementMode` answers what CFC enforcement rung a fabric session's runtime runs at. For a session that stated no dial it answered with a literal `"enforce-explicit"`, which is a hand-copy of a value another package owns.

The rung an unstated session actually runs at is decided elsewhere. `harnessFabricSessionControllerOptions` forwards `cfcEnforcementMode` only when an operator stated one, so an unstated dial reaches the `remoteClient` preset absent, and `presetCfcOptions` supplies the pin. Whatever that preset leaves unset then resolves through the runtime's own dial defaults. Neither of those two sources was connected to the copy in cf-harness, so moving the pin would leave the copy behind.

What a stale copy costs is a run that records a posture it did not run under. The single caller writes this value into the run's `fabricSessionCfc.enforcementMode`, while the same record's `record` field comes from `harnessFabricSessionPosture`, which resolves properly through `presetCfcOptions`. One record would carry two different answers for one dial. The AUD-15 audit check compares a run's own mode against the recorded claim, so it would pass runs it should fail.

The repair reads the same source `harnessFabricSessionPosture` reads: `presetCfcOptions` for the preset's resolution, then `resolveCfcDials` for the runtime's default table behind it. That is the resolution the session's runtime performs, so the itemized dial and the record now agree by construction rather than by two authors matching.

Two things fall out of doing it that way.

The function declared the two-rung type that describes what an operator may state on `--fabric-cfc-enforcement-mode`, which is a different set from what the preset resolves: the preset answers with a rung of the whole four-rung ladder. Returning the narrow type would need a runtime check on the way out and a throw for anything outside the pair, and that throw answers the case wrongly — a fleet posture moved off the pair, a rollback to `observe` say, is a rung the session would genuinely run at, and refusing to record it stops every run rather than recording the truth. The return type, and the
`HarnessFabricSessionCfcPosture.enforcementMode` field it is written into, are a rung of the whole ladder instead, which needs no check and no cast. The narrow type keeps its own job, which is the flag's admissible set. Every reader already treated the value this way: `cfcEnforcementStrictness` takes a full-ladder rung, the resume comparison is an inequality, and AUD-15 compares through strictness.

The second is that the dials reaching the preset were themselves stated twice. `harnessFabricSessionControllerOptions` decides which of the config's CFC dials the session's runtime ever sees, and the projection that reads that preset back hand-wrote the same conditional spreads, so a dial added to one could go missing from the other. Both now derive from `fabricSessionPresetCfcDials`. The read ceiling reaches the controller without passing through the preset, so it stays beside that spread rather than joining it.

Three cases in `cfc-posture.test.ts`, whose subject they are and which is already written in the BDD form: the named bundle leaving this dial on the pin, a stated raise, and the itemized dial against the record's rung. "the harness loop's own default matches the rung an unstated fabric session enforces at" in `config.test.ts` already covers the unstated rung, so nothing here restates it; its first assertion is now trivially true, and its failure message told a reader to move a fallback that no longer exists, so it now says to take the function back to the preset's resolution.

Values are unchanged today, since the preset still pins `enforce-explicit`. What changes is that the rung follows the pin when the pin moves.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

