### PR TITLE
fix(memory): preserve CFC schema closure across query crossings

### DIFF
--- a/docs/specs/memory-v2/05-queries.md
+++ b/docs/specs/memory-v2/05-queries.md
@@ -278,19 +278,19 @@ document's ROLE in the query:
   full family.
 
 - A document the evaluation merely reaches — loaded mid-walk through a link
-  crossing — is owed its computed surface, not its whole family. The server
-  MUST resolve and load its `result` metadata link, and MUST register every
-  internal manifest link's target in the watch tracking state WITHOUT
-  loading or delivering it: the subscription stays reactive to each
-  registered document, and the next commit that leaves one with a live,
-  deliverable snapshot PROMOTES it — delivered whole with that refresh's
-  updates, tracked from then on, its own internal manifest links
-  registered in turn. A deletion does not promote: the registration
-  stays, and the recreation promotes it. The `pattern`,
-  `argument`, and `cfc` links of a crossing-reached document are not
-  chased. A refresh that re-evaluates a crossing-reached document applies
-  these same rules, so a subscription's delivered shape does not depend on
-  the order in which documents changed.
+  crossing — is owed its computed surface and policy closure, not its whole
+  execution family. The server MUST resolve and load its `result` metadata
+  link and the schema document named by `cfc.schemaHash`, and MUST register
+  every internal manifest link's target in the watch tracking state WITHOUT
+  loading or delivering it: the subscription stays reactive to each registered
+  document, and the next commit that leaves one with a live, deliverable
+  snapshot PROMOTES it — delivered whole with that refresh's updates, tracked
+  from then on, its own internal manifest links registered in turn. A deletion
+  does not promote: the registration stays, and the recreation promotes it.
+  The `pattern` and `argument` links of a crossing-reached document are not
+  chased. A refresh that re-evaluates a crossing-reached document applies these
+  same rules, so a subscription's delivered shape does not depend on the order
+  in which documents changed.
 
 A metadata family is a same-space structure: a metadata or manifest link
 that resolves to another space selects nothing — the evaluating space's

--- a/packages/memory/test/v2-query.test.ts
+++ b/packages/memory/test/v2-query.test.ts
@@ -2327,10 +2327,20 @@ Deno.test("memory v2 extendTrackedGraph attributes the roots it adds", async () 
   }
 });
 
-Deno.test("memory v2 query chases metadata for named roots, not crossings", async () => {
+Deno.test("memory v2 query chases CFC metadata for crossings", async () => {
   const { engine, path } = await createEngine();
   const space = "did:key:z6Mk-memory-v2-query-meta-roots";
   const link = (id: string) => ({ "/": { "link@1": { id, path: [], space } } });
+  const crossingSchema = {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        ifc: { confidentiality: ["crossing-policy"] },
+      },
+    },
+  } as const;
+  const crossingSchemaHash = internSchemaAsTaggedHashString(crossingSchema);
 
   try {
     applyCommit(engine, {
@@ -2358,9 +2368,18 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
           value: { value: { derived: "target cell" } },
         }, {
           op: "set",
+          id: `cid:${crossingSchemaHash}`,
+          value: { value: crossingSchema },
+        }, {
+          op: "set",
           id: "of:crossing-target",
           value: {
             value: { name: "target" },
+            cfc: {
+              version: 1,
+              schemaHash: crossingSchemaHash,
+              labelMap: { version: 1, entries: [] },
+            },
             pattern: link("of:target-family"),
             result: link("of:target-result"),
             internal: [{ link: link("of:target-cell") }, {
@@ -2431,6 +2450,7 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
     assert(ids.has("of:crossing-target"));
     assert(ids.has("of:root-family"));
     assert(ids.has("of:target-result"));
+    assert(ids.has(`cid:${crossingSchemaHash}`));
     assert(!ids.has("of:target-family"));
     // The crossed piece's derived cell is registered, not delivered: its
     // bytes ride its next commit rather than every subscription that can
@@ -2626,6 +2646,19 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
     // document re-walks it WITHOUT promoting it to a named root's
     // family, so what a subscriber holds does not depend on update
     // history.
+    const refreshedSchema = {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          ifc: { confidentiality: ["crossing-policy"] },
+        },
+        revision: { type: "number" },
+      },
+    } as const;
+    const refreshedSchemaHash = internSchemaAsTaggedHashString(
+      refreshedSchema,
+    );
     applyCommit(engine, {
       sessionId: "session:writer",
       invocation: invocationFor(3),
@@ -2635,9 +2668,18 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
         reads: { confirmed: [], pending: [] },
         operations: [{
           op: "set",
+          id: `cid:${refreshedSchemaHash}`,
+          value: { value: refreshedSchema },
+        }, {
+          op: "set",
           id: "of:crossing-target",
           value: {
-            value: { name: "target, renamed" },
+            value: { name: "target, renamed", revision: 2 },
+            cfc: {
+              version: 1,
+              schemaHash: refreshedSchemaHash,
+              labelMap: { version: 1, entries: [] },
+            },
             pattern: link("of:target-family"),
             result: link("of:target-result"),
             internal: [{ link: link("of:target-cell") }],
@@ -2652,6 +2694,11 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
       new Set([toDirtyKey("of:crossing-target")]),
     );
     assertExists(crossingRefreshed);
+    assert(
+      crossingRefreshed.updates.has(
+        `${space}/space/cid:${refreshedSchemaHash}`,
+      ),
+    );
     assert(
       !lazyTracked.state.tracker.has(`${space}/space/of:target-family`),
     );

--- a/packages/runner/src/graph-query.ts
+++ b/packages/runner/src/graph-query.ts
@@ -73,13 +73,18 @@ export type GraphQueryWalkStats = {
 
 /**
  * The rails a crossing-reached document still chases: the ones computed
- * values are supplied through. A plain subscriber whose walk crosses into
- * a piece reads what the piece computes off `result`, and `internal`
- * carries the sub-piece manifests those computations hang off. The
- * remaining rails — pattern, argument, cfc — serve loading and running a
+ * values and their policy closure are supplied through. A plain subscriber
+ * whose walk crosses into a piece reads what the piece computes off `result`,
+ * `internal` carries the sub-piece manifests those computations hang off, and
+ * `cfc` keeps every delivered document's schema policy available with it. The
+ * remaining rails — `pattern` and `argument` — serve loading and running a
  * piece, which is the intent of naming one, not of reaching one.
  */
-const CROSSING_META_RAILS: readonly MetaRail[] = ["result", "internal"];
+const CROSSING_META_RAILS: readonly MetaRail[] = [
+  "cfc",
+  "result",
+  "internal",
+];
 
 export const createGraphQueryWalkStats = (): GraphQueryWalkStats => ({
   coveredSelectorSkips: 0,
@@ -220,16 +225,16 @@ export class GraphQueryWalk {
       },
       undefined,
       undefined,
-      // A document this walk loads through a link crossing chases only the
-      // rails computed values arrive through — `result` and `internal` —
-      // so a subscriber reading THROUGH a piece still receives and stays
-      // subscribed to what the piece computes. The full family belongs to
-      // the documents a query names: `visit()` chases every rail for its
-      // named document, which is what a caller that intends to load and
-      // run one — a piece resume, a setsrc staging read — relies on.
-      // Chasing every rail at every crossing instead multiplies a wide
-      // walk by each visited piece's whole doc set (pattern, argument,
-      // cfc and their recursion) for documents nothing asked to run.
+      // A document this walk loads through a link crossing chases the rails
+      // computed values arrive through — `result` and `internal` — plus the
+      // `cfc` policy closure that accompanies its value. A subscriber reading
+      // THROUGH a piece therefore receives what the piece computes with the
+      // schema needed to interpret its restrictions. The execution family
+      // belongs to documents a query names: `visit()` additionally chases
+      // `pattern` and `argument` for a named document, which is what a caller
+      // that intends to load and run one — a piece resume, a setsrc staging
+      // read — relies on. Chasing those rails at every crossing would multiply
+      // a wide walk by each visited piece's executable inputs.
       CROSSING_META_RAILS,
       // With a sink, the internal rail is registered rather than loaded:
       // a crossed piece's derived cells stay subscribed without shipping
@@ -246,7 +251,8 @@ export class GraphQueryWalk {
    * reaches in the walk's schema tracker. The named document's own metadata
    * family — pattern, source, cfc, and the rest — is recorded with it;
    * documents the walk merely reaches through link crossings are recorded
-   * under the selectors that reached them, without their families.
+   * under the selectors that reached them, with their policy and computed
+   * metadata but without their execution family.
    *
    * The document records under `schemaTrackerKey` over the walk's identity
    * unless the caller passes `docKey`: a caller that named an explicit


### PR DESCRIPTION
## Summary

- follow cfc.schemaHash for every graph-query crossing while keeping pattern and argument root-only
- preserve the same-round-trip policy-schema closure promised by the content-addressed schema spec
- cover initial query delivery and dirty crossing refreshes whose schema hash changes
- update the memory query spec to distinguish policy metadata from execution metadata

## Why

PR #6726 grouped cfc with execution-only metadata and stopped chasing it for crossing-reached documents. The document inline CFC label map still arrived, but the schema document used to interpret its policy arrived only through an asynchronous client repair pull. This restores schema closure as part of the graph query itself.

The new initial-delivery assertion fails before the implementation change and passes afterward.

## Testing

- deno task just-test test/v2-query.test.ts (packages/memory): 32 passed
- deno task test (packages/memory): 602 passed
- deno task test (packages/runner): 1,389 passed / 8,400 steps
- deno task check
- deno fmt --check
- deno lint
- deno task check-docs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

