### PR TITLE
Two index atoms that know how a connector store spells "deleted" (CT-2189)

### DIFF
--- a/docs/common/patterns/primitives.md
+++ b/docs/common/patterns/primitives.md
@@ -7,7 +7,7 @@ rendering to the host. They live under `packages/patterns/primitives/` and
 form the `primitive` tier in
 [`packages/patterns/index.md`](../../../packages/patterns/index.md).
 
-**Status: six occupants, all adopted by the pattern index** — see
+**Status: eight occupants, all adopted by the pattern index** — see
 [`packages/patterns/index.md`](../../../packages/patterns/index.md). An earlier
 candidate (`EditableList`) was built, proven against real callers, and retired —
 see [Lessons](#lessons-from-the-first-primitive) below, which is required
@@ -24,8 +24,8 @@ Do not build a primitive from a duplication census alone. Before any code:
    this" is the orphaned-`suggestable/` failure mode; it doesn't count.
    A published pattern index counts as an adopter only on the same evidence: a
    shape sessions have actually built for themselves, read off the corpus, not
-   a shape one might plausibly want. The six current primitives were each
-   chosen against an entry already in the index that rebuilt it from scratch.
+   a shape one might plausibly want. The primitives here were each chosen
+   against an entry already in the index that rebuilt it from scratch.
 2. **Two callers from different families** before the primitive is considered
    proven (one caller just reproduces that caller's needs with the serial
    numbers filed off).
@@ -44,6 +44,23 @@ In priority order:
 2. **An optional default `[UI]`.** A static `VNode` giving a caller who just
    wants the thing a working experience for free. A caller who wants custom
    rendering simply does not render it.
+
+### A primitive over an injected handle
+
+A primitive whose input is a capability handle rather than a caller's cell —
+`SqliteDb` is the one in use — exposes the same surface minus the mutation
+half: it reads through the handle, and returns typed rows, counts, the pending
+flag and the failure text as cells. What it owns is the query, and the query is
+the whole reason it exists. A store's column semantics are not in the handle a
+session is given: `describe_handle` discloses the tables and columns and says
+nothing about which value means "deleted", so a session writing its own query
+guesses, and a wrong guess returns zero rows over a full table rather than an
+error. The primitive is where that knowledge is written down once, in code that
+is tested against both spellings.
+
+Such a primitive cannot run standalone — only whoever wires the input can
+supply a handle — so it is left out of the `demo/` host, and its tests go where
+a handle can be minted rather than beside the pattern.
 
 That's the whole surface. In particular, do **not** add string-addressed
 ("ByText"/"ByTitle") mutation layers "for agents": LLM tool-calls round-trip

--- a/docs/common/patterns/primitives.md
+++ b/docs/common/patterns/primitives.md
@@ -58,9 +58,15 @@ guesses, and a wrong guess returns zero rows over a full table rather than an
 error. The primitive is where that knowledge is written down once, in code that
 is tested against both spellings.
 
-Such a primitive cannot run standalone — only whoever wires the input can
-supply a handle — so it is left out of the `demo/` host, and its tests go where
-a handle can be minted rather than beside the pattern.
+Such a primitive is left out of the `demo/` host, since a host that embeds one
+has to hand it a database. Its pattern test builds one with `sqliteDatabase()`
+and seeds it through a handler. Two things about that test are worth knowing
+before writing another. A query the primitive declares no `reactOn` for does
+not re-run after the seed, so the test drives one of the primitive's own
+reactive inputs — the month — and that is what reads the seeded rows. And
+reading `[UI]` stores links to the session-scoped query results in the vnode
+tree, which the runtime warns about; the test carries
+`allowConsoleWarnings: true` and says why.
 
 That's the whole surface. In particular, do **not** add string-addressed
 ("ByText"/"ByTitle") mutation layers "for agents": LLM tool-calls round-trip

--- a/packages/cf-harness/test/primitives-connector-reads.test.ts
+++ b/packages/cf-harness/test/primitives-connector-reads.test.ts
@@ -1,14 +1,21 @@
 /**
  * The two index atoms that read a loom connector store —
  * `packages/patterns/primitives/ledger-month-transactions.tsx` and
- * `mailbox-month-headers.tsx` — against databases carrying both tombstone
- * spellings the two stores use.
+ * `mailbox-month-headers.tsx` — reached the way a harness session reaches
+ * them: through `run_pattern` over an injected `SqliteDb` handle.
  *
- * The atoms are pattern sources, but their input is a `SqliteDb` handle and a
- * pattern test has no way to mint one: a database reaches a pattern only from
- * whoever wired the input. So they are exercised the way a harness session
- * reaches them, through `run_pattern` over a handle cell this file seeds, and
- * the test lives beside that machinery rather than beside the atoms.
+ * What is stated here is what only this route can state. A pattern test builds
+ * its database with `sqliteDatabase()`, which is a cell-derived database in
+ * the pattern's own space; a session is instead handed a handle cell naming a
+ * store it did not create, and the query it issues is bound to that. The
+ * tombstone rule, the month window, the row ceiling and the views are stated
+ * in the pattern tests beside each atom, which is also where they earn
+ * authored-pattern coverage.
+ *
+ * A database with rows already in it is the other thing this route has: the
+ * handle is seeded before the atom is built, so the read that settles is the
+ * atom's first one, and the month it resolves for a caller that names none is
+ * whatever month the clock is in.
  */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
@@ -327,31 +334,6 @@ describe("connector-reading primitives", () => {
       >;
       expect(headers[0].subject).toBe("Your bill is ready");
       expect(headers[0].sender).toBe("Pacific Gas");
-    });
-
-    it("returns no more headers than `limit` asks for", async () => {
-      const mail = await seedDatabase(MAILBOX_TABLES, [
-        {
-          sql: PARTICIPANT_INSERT,
-          params: [1, "Pacific Gas", "billing@pge.example"],
-        },
-        messageRow(1, "First", "2026-03-01T09:00:00Z", null),
-        messageRow(2, "Second", "2026-03-02T09:00:00Z", null),
-        messageRow(3, "Third", "2026-03-03T09:00:00Z", null),
-      ]);
-
-      const result = await runAtom(
-        await atomSource("mailbox-month-headers.tsx"),
-        { mail, month: "2026-03", limit: 2 },
-      );
-
-      expect(result.errorMessage).toBe("");
-      expect(result.headerCount).toBe(2);
-      const headers = result.headers as Array<{ subject: string }>;
-      expect(headers.map((header) => header.subject)).toEqual([
-        "Third",
-        "Second",
-      ]);
     });
   });
 });

--- a/packages/cf-harness/test/primitives-connector-reads.test.ts
+++ b/packages/cf-harness/test/primitives-connector-reads.test.ts
@@ -1,0 +1,357 @@
+/**
+ * The two index atoms that read a loom connector store —
+ * `packages/patterns/primitives/ledger-month-transactions.tsx` and
+ * `mailbox-month-headers.tsx` — against databases carrying both tombstone
+ * spellings the two stores use.
+ *
+ * The atoms are pattern sources, but their input is a `SqliteDb` handle and a
+ * pattern test has no way to mint one: a database reaches a pattern only from
+ * whoever wired the input. So they are exercised the way a harness session
+ * reaches them, through `run_pattern` over a handle cell this file seeds, and
+ * the test lives beside that machinery rather than beside the atoms.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { fromFileUrl } from "@std/path";
+import { createSession, Identity } from "@commonfabric/identity";
+import { table } from "@commonfabric/memory/sqlite/schema";
+import type { SqliteDbRef } from "@commonfabric/memory/v2";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { Runtime } from "@commonfabric/runner";
+import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { CfHarnessEngine } from "../src/engine.ts";
+import type { RunPatternToolSuccessOutput } from "../src/tools/run-pattern.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+
+const signer = await Identity.fromPassphrase("cf-harness connector atoms");
+
+/** Where the atoms live, relative to this file. */
+const atomSource = (name: string): Promise<string> =>
+  Deno.readTextFile(
+    fromFileUrl(new URL(`../../patterns/primitives/${name}`, import.meta.url)),
+  );
+
+/** One SQLite write, as a seed run records it onto a transaction. */
+interface SeedWrite {
+  sql: string;
+  params: (string | number | null)[];
+}
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
+  resolvePath(path: string): string {
+    return path;
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path.startsWith("/workspace");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(_request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+}
+
+/** The columns of `rows_plaid_transaction` the ledger atom projects. */
+const LEDGER_TABLES = {
+  rows_plaid_transaction: table({
+    record_id: "text primary key",
+    transaction_id: "text",
+    account_id: "text",
+    date: "text",
+    amount: "real",
+    signed_amount: "real",
+    merchant_name: "text",
+    name: "text",
+    pending: "integer",
+    category_primary: "text",
+    iso_currency_code: "text",
+    deleted: "integer",
+    deleted_at: "text",
+  }),
+};
+
+/** The mail tables the mailbox atom reads and joins. */
+const MAILBOX_TABLES = {
+  messages: table({
+    id: "integer primary key",
+    subject: "text",
+    snippet: "text",
+    received_at: "text",
+    sent_at: "text",
+    internal_date: "text",
+    sender_id: "integer",
+    deleted_at: "text",
+  }),
+  participants: table({
+    id: "integer primary key",
+    display_name: "text",
+    email_address: "text",
+  }),
+};
+
+const LEDGER_INSERT = "INSERT INTO rows_plaid_transaction (record_id, " +
+  "transaction_id, account_id, date, amount, signed_amount, merchant_name, " +
+  "name, pending, category_primary, iso_currency_code, deleted, deleted_at) " +
+  "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+const MESSAGE_INSERT = "INSERT INTO messages (id, subject, snippet, " +
+  "received_at, sent_at, internal_date, sender_id, deleted_at) " +
+  "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+
+const PARTICIPANT_INSERT =
+  "INSERT INTO participants (id, display_name, email_address) VALUES (?, ?, ?)";
+
+/**
+ * A ledger row as the connector store writes one: text columns never NULL, a
+ * tombstone marked by the integer flag rather than by `deleted_at`.
+ */
+const ledgerRow = (
+  recordId: string,
+  date: string,
+  merchant: string,
+  amount: number,
+  deleted: number,
+): SeedWrite => ({
+  sql: LEDGER_INSERT,
+  params: [
+    recordId,
+    `txn-${recordId}`,
+    "acct-1",
+    date,
+    amount,
+    -amount,
+    merchant,
+    `${merchant} purchase`,
+    0,
+    "GENERAL_SERVICES",
+    "USD",
+    deleted,
+    deleted === 1 ? `${date}T12:00:00Z` : "",
+  ],
+});
+
+/** A message as the mail store writes one: a live row leaves `deleted_at` NULL. */
+const messageRow = (
+  id: number,
+  subject: string,
+  receivedAt: string,
+  deletedAt: string | null,
+): SeedWrite => ({
+  sql: MESSAGE_INSERT,
+  params: [
+    id,
+    subject,
+    `${subject} snippet`,
+    receivedAt,
+    null,
+    null,
+    1,
+    deletedAt,
+  ],
+});
+
+describe("connector-reading primitives", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `connector-atoms-${crypto.randomUUID()}`,
+      }),
+      runtime,
+    );
+    await pieces.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /** Seeds a database holding `writes` and answers the link naming its handle. */
+  async function seedDatabase(
+    tables: Record<string, unknown>,
+    writes: readonly SeedWrite[],
+  ): Promise<string> {
+    const space = pieces.getSpace();
+    const dbRef = {
+      id: `connector-atoms-${crypto.randomUUID()}`,
+      tables,
+    } as SqliteDbRef;
+    const tx = runtime.edit();
+    const handle = runtime.getCell<SqliteDbRef>(
+      space,
+      `connector-atoms-handle-${crypto.randomUUID()}`,
+      undefined,
+      tx,
+    );
+    handle.set(dbRef);
+    for (const write of writes) {
+      tx.recordSqliteWrite!(space, {
+        op: "sqlite",
+        db: dbRef,
+        sql: write.sql,
+        params: write.params,
+      });
+    }
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+    return createLLMFriendlyLink(handle.getAsNormalizedFullLink(), space);
+  }
+
+  /** Runs `source` over `inputs` and answers the piece's settled result. */
+  async function runAtom(
+    source: string,
+    inputs: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const engine = new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: `connector-atoms-${crypto.randomUUID()}`,
+      cfcEnforcementMode: "disabled",
+      fabricSessionFactory: () => Promise.resolve({ pieces }),
+    });
+    const result = await engine.invokeBuiltinTool("run_pattern", {
+      sourceText: source,
+      inputs,
+    });
+    const output = result.output as RunPatternToolSuccessOutput;
+    expect(output.status).toBe("ok");
+
+    // The query is a server round-trip, so the run returns while it is still
+    // in flight; the piece's own result is where it lands.
+    const piece = await pieces.get(output.pieceId);
+    await runtime.idle();
+    await pieces.synced();
+    await runtime.idle();
+    return (await piece.result.get()) as Record<string, unknown>;
+  }
+
+  describe("ledger-month-transactions", () => {
+    it("returns the month's live rows and leaves out the tombstoned ones", async () => {
+      const bank = await seedDatabase(LEDGER_TABLES, [
+        ledgerRow("live", "2026-03-04", "Pacific Gas", 84.2, 0),
+        ledgerRow("gone", "2026-03-06", "Refunded Co", 12, 1),
+        ledgerRow("later", "2026-04-02", "Next Month", 9, 0),
+      ]);
+
+      const result = await runAtom(
+        await atomSource(
+          "ledger-month-transactions.tsx",
+        ),
+        { bank, month: "2026-03" },
+      );
+
+      expect(result.errorMessage).toBe("");
+      expect(result.month).toBe("2026-03");
+      expect(result.rowCount).toBe(1);
+      expect((result.rows as Array<{ merchant_name: string }>)[0].merchant_name)
+        .toBe("Pacific Gas");
+    });
+
+    it("reads the current month when the caller names none", async () => {
+      const thisMonth = new Date().toISOString().slice(0, 7);
+      const bank = await seedDatabase(LEDGER_TABLES, [
+        ledgerRow("now", `${thisMonth}-01`, "Current Month Co", 10, 0),
+        ledgerRow("old", "2020-01-01", "Long Ago Co", 10, 0),
+      ]);
+
+      const result = await runAtom(
+        await atomSource("ledger-month-transactions.tsx"),
+        { bank },
+      );
+
+      expect(result.errorMessage).toBe("");
+      expect(result.month).toBe(thisMonth);
+      expect(result.rowCount).toBe(1);
+    });
+  });
+
+  describe("mailbox-month-headers", () => {
+    it("returns the month's live headers with their sender, and leaves out the deleted ones", async () => {
+      const mail = await seedDatabase(MAILBOX_TABLES, [
+        {
+          sql: PARTICIPANT_INSERT,
+          params: [1, "Pacific Gas", "billing@pge.example"],
+        },
+        messageRow(1, "Your bill is ready", "2026-03-04T09:00:00Z", null),
+        messageRow(2, "Deleted notice", "2026-03-05T09:00:00Z", "2026-03-06"),
+        messageRow(3, "Next month", "2026-04-01T09:00:00Z", null),
+      ]);
+
+      const result = await runAtom(
+        await atomSource("mailbox-month-headers.tsx"),
+        { mail, month: "2026-03" },
+      );
+
+      expect(result.errorMessage).toBe("");
+      expect(result.month).toBe("2026-03");
+      expect(result.headerCount).toBe(1);
+      const headers = result.headers as Array<
+        { subject: string; sender: string }
+      >;
+      expect(headers[0].subject).toBe("Your bill is ready");
+      expect(headers[0].sender).toBe("Pacific Gas");
+    });
+
+    it("returns no more headers than `limit` asks for", async () => {
+      const mail = await seedDatabase(MAILBOX_TABLES, [
+        {
+          sql: PARTICIPANT_INSERT,
+          params: [1, "Pacific Gas", "billing@pge.example"],
+        },
+        messageRow(1, "First", "2026-03-01T09:00:00Z", null),
+        messageRow(2, "Second", "2026-03-02T09:00:00Z", null),
+        messageRow(3, "Third", "2026-03-03T09:00:00Z", null),
+      ]);
+
+      const result = await runAtom(
+        await atomSource("mailbox-month-headers.tsx"),
+        { mail, month: "2026-03", limit: 2 },
+      );
+
+      expect(result.errorMessage).toBe("");
+      expect(result.headerCount).toBe(2);
+      const headers = result.headers as Array<{ subject: string }>;
+      expect(headers.map((header) => header.subject)).toEqual([
+        "Third",
+        "Second",
+      ]);
+    });
+  });
+});

--- a/packages/cf-harness/test/seed-pattern-index.test.ts
+++ b/packages/cf-harness/test/seed-pattern-index.test.ts
@@ -172,6 +172,8 @@ describe("seed-pattern-index", () => {
         "check-list.tsx",
         "counter.tsx",
         "dice-roller.tsx",
+        "ledger-month-transactions.tsx",
+        "mailbox-month-headers.tsx",
         "option-picker.tsx",
         "sortable-table.tsx",
       ]);
@@ -337,16 +339,16 @@ describe("seed-pattern-index", () => {
         r.deps,
       );
       expect(code).toBe(0);
-      expect(r.published.length).toBe(6);
+      expect(r.published.length).toBe(8);
       expect(r.recorded).toEqual(r.published);
-      expect(r.lines.at(-1)).toContain("6 published, 0 already held");
+      expect(r.lines.at(-1)).toContain("8 published, 0 already held");
     });
 
     it("publishes nothing in a dry run, having compiled everything", async () => {
       const r = recorder();
       const code = await runSeed({ dryRun: true, only: [], directory }, r.deps);
       expect(code).toBe(0);
-      expect(r.compiled.length).toBe(6);
+      expect(r.compiled.length).toBe(8);
       expect(r.published).toEqual([]);
       expect(r.recorded).toEqual([]);
       expect(r.lines.at(-1)).toContain("nothing published");
@@ -382,7 +384,7 @@ describe("seed-pattern-index", () => {
       );
       expect(code).toBe(0);
       expect(r.recorded).toEqual([]);
-      expect(r.lines.at(-1)).toContain("0 published, 6 already held");
+      expect(r.lines.at(-1)).toContain("0 published, 8 already held");
     });
 
     it("publishes nothing when an atom compiles to no durable identity", async () => {
@@ -554,7 +556,7 @@ describe("seed-pattern-index", () => {
     it("seeds every atom and answers success", async () => {
       const h = io();
       expect(await main([], h.io)).toBe(0);
-      expect(h.published.length).toBe(6);
+      expect(h.published.length).toBe(8);
     });
 
     it("publishes nothing on a dry run", async () => {

--- a/packages/patterns/baselines/primitives/ledger-month-transactions.tsx/20260909T014432Z-iSMcioBHjdZAnJrO.json
+++ b/packages/patterns/baselines/primitives/ledger-month-transactions.tsx/20260909T014432Z-iSMcioBHjdZAnJrO.json
@@ -1,0 +1,130 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "SqliteDatabase": {
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rev": {
+            "type": "number"
+          },
+          "tables": {
+            "additionalProperties": true,
+            "type": "object"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "bank": {
+        "$ref": "#/$defs/SqliteDatabase",
+        "asCell": [
+          "sqlite"
+        ],
+        "description": "The connector ledger to read. Whoever wired the input chose which."
+      },
+      "month": {
+        "default": "",
+        "description": "The month to read, as `YYYY-MM`. Empty means the current month.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "bank"
+    ],
+    "type": "object"
+  },
+  "pattern": "primitives/ledger-month-transactions.tsx",
+  "resultSchema": {
+    "$defs": {
+      "LedgerTransaction": {
+        "properties": {
+          "account_id": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "category_primary": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "iso_currency_code": {
+            "type": "string"
+          },
+          "merchant_name": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pending": {
+            "type": "number"
+          },
+          "signed_amount": {
+            "type": "number"
+          },
+          "transaction_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "transaction_id",
+          "date",
+          "amount",
+          "signed_amount",
+          "merchant_name",
+          "name",
+          "account_id",
+          "pending",
+          "category_primary",
+          "iso_currency_code"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "errorMessage": {
+        "description": "Why the read failed, empty while it has not.",
+        "type": "string"
+      },
+      "month": {
+        "description": "The month the rows were read from, as `YYYY-MM`.",
+        "type": "string"
+      },
+      "pending": {
+        "type": "boolean"
+      },
+      "rowCount": {
+        "type": "number"
+      },
+      "rows": {
+        "items": {
+          "$ref": "#/$defs/LedgerTransaction"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "month",
+      "rows",
+      "rowCount",
+      "pending",
+      "errorMessage",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/primitives/mailbox-month-headers.tsx/20260909T014432Z-V9qXRW0W82CabbOA.json
+++ b/packages/patterns/baselines/primitives/mailbox-month-headers.tsx/20260909T014432Z-V9qXRW0W82CabbOA.json
@@ -1,0 +1,115 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "SqliteDatabase": {
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rev": {
+            "type": "number"
+          },
+          "tables": {
+            "additionalProperties": true,
+            "type": "object"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "limit": {
+        "default": 200,
+        "description": "How many headers to return, newest first.",
+        "type": "number"
+      },
+      "mail": {
+        "$ref": "#/$defs/SqliteDatabase",
+        "asCell": [
+          "sqlite"
+        ],
+        "description": "The mail store to read. Whoever wired the input chose which."
+      },
+      "month": {
+        "default": "",
+        "description": "The month to read, as `YYYY-MM`. Empty means the current month.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "mail"
+    ],
+    "type": "object"
+  },
+  "pattern": "primitives/mailbox-month-headers.tsx",
+  "resultSchema": {
+    "$defs": {
+      "MailboxHeader": {
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "received_at": {
+            "type": "string"
+          },
+          "sender": {
+            "type": "string"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "subject",
+          "snippet",
+          "sender",
+          "received_at"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "errorMessage": {
+        "description": "Why the read failed, empty while it has not.",
+        "type": "string"
+      },
+      "headerCount": {
+        "type": "number"
+      },
+      "headers": {
+        "items": {
+          "$ref": "#/$defs/MailboxHeader"
+        },
+        "type": "array"
+      },
+      "month": {
+        "description": "The month the headers were read from, as `YYYY-MM`.",
+        "type": "string"
+      },
+      "pending": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "month",
+      "headers",
+      "headerCount",
+      "pending",
+      "errorMessage",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/primitives/mailbox-month-headers.tsx/20260909T021450Z-zP78IvNYwY5W2kjb.json
+++ b/packages/patterns/baselines/primitives/mailbox-month-headers.tsx/20260909T021450Z-zP78IvNYwY5W2kjb.json
@@ -1,0 +1,115 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "SqliteDatabase": {
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rev": {
+            "type": "number"
+          },
+          "tables": {
+            "additionalProperties": true,
+            "type": "object"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "limit": {
+        "default": 200,
+        "description": "How many headers to return, newest first. Held between 1 and 500, so a\ncaller cannot widen the read past what the atom will answer for.",
+        "type": "number"
+      },
+      "mail": {
+        "$ref": "#/$defs/SqliteDatabase",
+        "asCell": [
+          "sqlite"
+        ],
+        "description": "The mail store to read. Whoever wired the input chose which."
+      },
+      "month": {
+        "default": "",
+        "description": "The month to read, as `YYYY-MM`. Empty means the current month.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "mail"
+    ],
+    "type": "object"
+  },
+  "pattern": "primitives/mailbox-month-headers.tsx",
+  "resultSchema": {
+    "$defs": {
+      "MailboxHeader": {
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "received_at": {
+            "type": "string"
+          },
+          "sender": {
+            "type": "string"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "subject",
+          "snippet",
+          "sender",
+          "received_at"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "errorMessage": {
+        "description": "Why the read failed, empty while it has not.",
+        "type": "string"
+      },
+      "headerCount": {
+        "type": "number"
+      },
+      "headers": {
+        "items": {
+          "$ref": "#/$defs/MailboxHeader"
+        },
+        "type": "array"
+      },
+      "month": {
+        "description": "The month the headers were read from, as `YYYY-MM`.",
+        "type": "string"
+      },
+      "pending": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "month",
+      "headers",
+      "headerCount",
+      "pending",
+      "errorMessage",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -62,10 +62,20 @@ Composable building blocks designed for embedding in other patterns
 adopter-first entry bar.
 
 `amount-ledger.tsx`, `check-list.tsx`, `counter.tsx`, `dice-roller.tsx`,
-`option-picker.tsx`, `sortable-table.tsx`, and the `demo/` host that embeds all
-six. Each is a single self-contained file taking real, optional inputs, with an
-embeddable `[UI]` — a fragment rather than a `cf-screen` — so a host can drop it
-in as a JSX tag or run it standalone.
+`option-picker.tsx`, `sortable-table.tsx`, and the `demo/` host that embeds
+those six. Each is a single self-contained file taking real, optional inputs,
+with an embeddable `[UI]` — a fragment rather than a `cf-screen` — so a host can
+drop it in as a JSX tag or run it standalone.
+
+`ledger-month-transactions.tsx` and `mailbox-month-headers.tsx` read a loom
+connector store instead of a caller's own cell. Their input is a `SqliteDb`
+handle, which only whoever wires the input can supply, so neither runs
+standalone and neither is in the `demo/` host; their tests are Deno tests at
+`packages/cf-harness/test/primitives-connector-reads.test.ts`, where a handle
+can be minted. Between them they carry the two tombstone conventions a connector
+store uses — the integer `deleted = 0` flag on a connector ledger,
+`deleted_at IS NULL` on the mail store — which is the thing a session reading
+one of these databases has no other way to learn.
 
 Their adopter is the pattern index: they are published to it as composable
 parts, and their descriptions are derived from their doc comments by

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -69,13 +69,14 @@ drop it in as a JSX tag or run it standalone.
 
 `ledger-month-transactions.tsx` and `mailbox-month-headers.tsx` read a loom
 connector store instead of a caller's own cell. Their input is a `SqliteDb`
-handle, which only whoever wires the input can supply, so neither runs
-standalone and neither is in the `demo/` host; their tests are Deno tests at
-`packages/cf-harness/test/primitives-connector-reads.test.ts`, where a handle
-can be minted. Between them they carry the two tombstone conventions a connector
-store uses — the integer `deleted = 0` flag on a connector ledger,
-`deleted_at IS NULL` on the mail store — which is the thing a session reading
-one of these databases has no other way to learn.
+handle, so neither is in the `demo/` host: a host that embeds one has to hand it
+a database. Their pattern tests build one with `sqliteDatabase()` and drive the
+atom's reactive `month` input, which is what re-runs a query the atom declares
+no `reactOn` for; `packages/cf-harness/test/primitives-connector-reads.test.ts`
+states what only an injected handle can. Between them they carry the two
+tombstone conventions a connector store uses — the integer `deleted = 0` flag on
+a connector ledger, `deleted_at IS NULL` on the mail store — which is the thing
+a session reading one of these databases has no other way to learn.
 
 Their adopter is the pattern index: they are published to it as composable
 parts, and their descriptions are derived from their doc comments by

--- a/packages/patterns/primitives/ledger-month-transactions.test.tsx
+++ b/packages/patterns/primitives/ledger-month-transactions.test.tsx
@@ -22,6 +22,7 @@ import {
   Writable,
 } from "commonfabric";
 import {
+  findElement,
   findElementByText,
   findNodeByProp,
   textContent,
@@ -167,6 +168,9 @@ export default pattern(() => {
       // A store of another shape reports why rather than an empty month, and
       // the view says so.
       { assertion: assert(() => broken.errorMessage !== "") },
+      {
+        assertion: assert(() => broken.errorMessage.includes("no such column")),
+      },
       { assertion: assert(() => broken.rowCount === 0) },
       {
         assertion: assert(() =>
@@ -188,6 +192,15 @@ export default pattern(() => {
       { assertion: assert(() => ledger.month === "2026-03") },
       { assertion: assert(() => ledger.errorMessage === "") },
       { assertion: assert(() => ledger[NAME] === "Transactions 2026-03 (1)") },
+
+      // A read that did not fail renders no alert, which is the other half of
+      // the failing-store case: without this, an alert shown over empty text
+      // would satisfy that one.
+      {
+        assertion: assert(() =>
+          findElement(ledger[UI], "cf-alert") === undefined
+        ),
+      },
 
       // The rendered list states the same row: its merchant, and the amount
       // formatted under the row's own currency.

--- a/packages/patterns/primitives/ledger-month-transactions.test.tsx
+++ b/packages/patterns/primitives/ledger-month-transactions.test.tsx
@@ -106,6 +106,21 @@ const seedLedger = handler<void, { db: SqliteDb }>((_, { db }) => {
   ]);
 });
 
+/**
+ * A ledger table missing the columns the atom projects, which is what a handle
+ * wired to a store of another shape looks like from inside the query.
+ */
+const narrowLedgerTable = () =>
+  table({ record_id: "text primary key", date: "text" });
+
+/** One row, so the query over the narrow table has a reason to run. */
+const seedNarrow = handler<void, { db: SqliteDb }>((_, { db }) => {
+  db.exec(
+    "INSERT INTO rows_plaid_transaction (record_id, date) VALUES (?, ?)",
+    ["narrow", "2026-03-04"],
+  );
+});
+
 export default pattern(() => {
   const db = sqliteDatabase({
     tables: { rows_plaid_transaction: ledgerTable() },
@@ -123,6 +138,16 @@ export default pattern(() => {
     month,
   });
 
+  // A store whose ledger table does not carry the columns the atom projects,
+  // which is what a handle wired to a store of another shape looks like from
+  // inside the query.
+  const narrow = sqliteDatabase({
+    tables: { rows_plaid_transaction: narrowLedgerTable() },
+  });
+  const seedNarrowRow = seedNarrow({ db: narrow });
+  const brokenMonth = new Writable("1970-01");
+  const broken = LedgerMonthTransactions({ bank: narrow, month: brokenMonth });
+
   return {
     // The one warning this allows is normalizeAndDiff's "Storing a
     // session-scoped link in space-scoped data", raised when reading `[UI]`
@@ -133,8 +158,22 @@ export default pattern(() => {
     allowConsoleWarnings: true,
     [TESTS]: [
       { assertion: assert(() => ledger.rowCount === 0) },
+      { assertion: assert(() => broken.rowCount === 0) },
 
       { action: action(() => seed.send()) },
+      { action: action(() => seedNarrowRow.send()) },
+      { action: action(() => brokenMonth.set("2026-03")) },
+
+      // A store of another shape reports why rather than an empty month, and
+      // the view says so.
+      { assertion: assert(() => broken.errorMessage !== "") },
+      { assertion: assert(() => broken.rowCount === 0) },
+      {
+        assertion: assert(() =>
+          findElementByText(broken[UI], "cf-alert", broken.errorMessage) !==
+            undefined
+        ),
+      },
       { action: action(() => month.set("2026-03")) },
 
       // The live row survives; the tombstone does not, and neither does the

--- a/packages/patterns/primitives/ledger-month-transactions.test.tsx
+++ b/packages/patterns/primitives/ledger-month-transactions.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Tests LedgerMonthTransactions: the tombstone rule, the month window, the
+ * default month, the rendered list and empty state, and the failure text.
+ *
+ * The atom takes no `reactOn`, because a database it only reads has nothing to
+ * react to. Its `month` input is reactive, so a test seeds the rows and then
+ * names the month, which is what re-runs the query over them.
+ *
+ * Run: deno task cf test packages/patterns/primitives/ledger-month-transactions.test.tsx
+ */
+import {
+  action,
+  assert,
+  handler,
+  NAME,
+  pattern,
+  sqliteDatabase,
+  type SqliteDb,
+  table,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
+import {
+  findElementByText,
+  findNodeByProp,
+  textContent,
+} from "../test/vnode-helpers.ts";
+import LedgerMonthTransactions from "./ledger-month-transactions.tsx";
+
+/** The ledger columns the atom projects, as the connector store declares them. */
+const ledgerTable = () =>
+  table({
+    record_id: "text primary key",
+    transaction_id: "text",
+    account_id: "text",
+    date: "text",
+    amount: "real",
+    signed_amount: "real",
+    merchant_name: "text",
+    name: "text",
+    pending: "integer",
+    category_primary: "text",
+    iso_currency_code: "text",
+    deleted: "integer",
+    deleted_at: "text",
+  });
+
+const insertSql = (): string =>
+  "INSERT INTO rows_plaid_transaction (record_id, transaction_id, " +
+  "account_id, date, amount, signed_amount, merchant_name, name, pending, " +
+  "category_primary, iso_currency_code, deleted, deleted_at) " +
+  "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+/**
+ * Seeds one live row, one tombstone and one row in the next month. The
+ * tombstone carries `deleted = 1` with `deleted_at` set and the live row
+ * carries `deleted = 0` with `deleted_at` the empty string, which is how the
+ * connector store writes both: the text column is never NULL either way.
+ */
+const seedLedger = handler<void, { db: SqliteDb }>((_, { db }) => {
+  db.exec(insertSql(), [
+    "live",
+    "txn-live",
+    "acct-1",
+    "2026-03-04",
+    84.2,
+    -84.2,
+    "Pacific Gas",
+    "Pacific Gas autopay",
+    0,
+    "GENERAL_SERVICES",
+    "USD",
+    0,
+    "",
+  ]);
+  db.exec(insertSql(), [
+    "gone",
+    "txn-gone",
+    "acct-1",
+    "2026-03-06",
+    12,
+    -12,
+    "Refunded Co",
+    "Refunded Co charge",
+    0,
+    "GENERAL_MERCHANDISE",
+    "USD",
+    1,
+    "2026-03-07T12:00:00Z",
+  ]);
+  db.exec(insertSql(), [
+    "later",
+    "txn-later",
+    "acct-1",
+    "2026-04-02",
+    9,
+    -9,
+    "Next Month Co",
+    "Next Month Co charge",
+    0,
+    "GENERAL_SERVICES",
+    "USD",
+    0,
+    "",
+  ]);
+});
+
+export default pattern(() => {
+  const db = sqliteDatabase({
+    tables: { rows_plaid_transaction: ledgerTable() },
+  });
+  const seed = seedLedger({ db });
+
+  // Both months start on one the seed puts nothing in. `month` is the atom's
+  // one reactive input, so naming a month is what re-runs the query over rows
+  // seeded after the atom was built.
+  const month = new Writable("1970-01");
+  // Session-scoped, because the atom's rows come from session-scoped queries
+  // and a space-scoped slot holding a link to one resolves per reader.
+  const ledger = LedgerMonthTransactions.asScope("session")({
+    bank: db,
+    month,
+  });
+
+  return {
+    // The one warning this allows is normalizeAndDiff's "Storing a
+    // session-scoped link in space-scoped data", raised when reading `[UI]`
+    // puts a link to the atom's session-scoped query result into the vnode
+    // tree. Per-reader resolution is what a session-scoped result is for, and
+    // the slot holding the link is a view-node child the atom does not
+    // declare. The flag is a boolean, so it cannot be pinned to that text.
+    allowConsoleWarnings: true,
+    [TESTS]: [
+      { assertion: assert(() => ledger.rowCount === 0) },
+
+      { action: action(() => seed.send()) },
+      { action: action(() => month.set("2026-03")) },
+
+      // The live row survives; the tombstone does not, and neither does the
+      // row a month later.
+      { assertion: assert(() => ledger.rowCount === 1) },
+      {
+        assertion: assert(() => ledger.rows[0].merchant_name === "Pacific Gas"),
+      },
+      { assertion: assert(() => ledger.rows[0].date === "2026-03-04") },
+      { assertion: assert(() => ledger.rows[0].signed_amount === -84.2) },
+      { assertion: assert(() => ledger.rows[0].pending === 0) },
+      { assertion: assert(() => ledger.month === "2026-03") },
+      { assertion: assert(() => ledger.errorMessage === "") },
+      { assertion: assert(() => ledger[NAME] === "Transactions 2026-03 (1)") },
+
+      // The rendered list states the same row: its merchant, and the amount
+      // formatted under the row's own currency.
+      {
+        assertion: assert(() =>
+          findElementByText(ledger[UI], "cf-text", "Pacific Gas") !== undefined
+        ),
+      },
+      {
+        assertion: assert(() => textContent(ledger[UI]).includes("-84.20 USD")),
+      },
+      {
+        assertion: assert(() =>
+          !textContent(ledger[UI]).includes("Refunded Co")
+        ),
+      },
+      {
+        assertion: assert(() =>
+          findNodeByProp(
+            ledger[UI],
+            "message",
+            "No transactions this month.",
+          ) === undefined
+        ),
+      },
+
+      // A month the seed left empty reads back empty rather than stale, and
+      // the view says so.
+      { action: action(() => month.set("2026-05")) },
+      { assertion: assert(() => ledger.rowCount === 0) },
+      { assertion: assert(() => ledger.month === "2026-05") },
+      { assertion: assert(() => ledger.pending === false) },
+      {
+        assertion: assert(() =>
+          findNodeByProp(
+            ledger[UI],
+            "message",
+            "No transactions this month.",
+          ) !== undefined
+        ),
+      },
+
+      // Naming no month resolves one from the database's own clock rather
+      // than leaving the window unbounded.
+      { action: action(() => month.set("")) },
+      { assertion: assert(() => ledger.month.length === 7) },
+      { assertion: assert(() => ledger.month.charAt(4) === "-") },
+      { assertion: assert(() => ledger.errorMessage === "") },
+    ],
+  };
+});

--- a/packages/patterns/primitives/ledger-month-transactions.tsx
+++ b/packages/patterns/primitives/ledger-month-transactions.tsx
@@ -92,13 +92,18 @@ const rowsSql = (): string =>
     "LIMIT 500",
   ].join("\n");
 
-/** What a query reports about a failure, empty when it has not failed. */
-const errorText = (error: unknown): string => {
-  if (error === undefined || error === null) return "";
-  if (typeof error === "string") return error;
-  const message = (error as { message?: unknown }).message;
-  return typeof message === "string" ? message : "The query failed.";
-};
+/**
+ * What a query reports about a failure, empty when it has not failed.
+ *
+ * The same narrowing the sqlite builtin applies before it writes one, so a
+ * value that reaches here already a message passes through unchanged.
+ */
+const errorText = (error: unknown): string =>
+  error === undefined || error === null
+    ? ""
+    : error instanceof Error
+    ? error.message
+    : String(error);
 
 /** `amount` as a signed figure in `code`, to the cent. */
 const money = (amount: number, code: string): string =>

--- a/packages/patterns/primitives/ledger-month-transactions.tsx
+++ b/packages/patterns/primitives/ledger-month-transactions.tsx
@@ -127,14 +127,9 @@ export const LedgerMonthTransactions = pattern<
   const rowCount = computed(() => (rowsRead.result ?? []).length);
   const pending = computed(() => rowsRead.pending === true);
   const errorMessage = computed(() => errorText(rowsRead.error));
-  // Each of these reads the envelope rather than the cells above it: `!` and
-  // `!==` applied to a computed act on the cell object, which is always
-  // truthy and never equal to a string, so a view gated on one would be
-  // gated on nothing.
-  const hasError = computed(() => errorText(rowsRead.error) !== "");
+  const hasError = computed(() => errorMessage !== "");
   const isEmpty = computed(() =>
-    rowsRead.pending !== true && errorText(rowsRead.error) === "" &&
-    (rowsRead.result ?? []).length === 0
+    !pending && !hasError && (rowsRead.result ?? []).length === 0
   );
 
   const listRows = rows.map((row: LedgerTransaction) => (

--- a/packages/patterns/primitives/ledger-month-transactions.tsx
+++ b/packages/patterns/primitives/ledger-month-transactions.tsx
@@ -122,9 +122,14 @@ export const LedgerMonthTransactions = pattern<
   const rowCount = computed(() => (rowsRead.result ?? []).length);
   const pending = computed(() => rowsRead.pending === true);
   const errorMessage = computed(() => errorText(rowsRead.error));
-  const hasError = computed(() => errorMessage !== "");
+  // Each of these reads the envelope rather than the cells above it: `!` and
+  // `!==` applied to a computed act on the cell object, which is always
+  // truthy and never equal to a string, so a view gated on one would be
+  // gated on nothing.
+  const hasError = computed(() => errorText(rowsRead.error) !== "");
   const isEmpty = computed(() =>
-    !pending && !hasError && (rowsRead.result ?? []).length === 0
+    rowsRead.pending !== true && errorText(rowsRead.error) === "" &&
+    (rowsRead.result ?? []).length === 0
   );
 
   const listRows = rows.map((row: LedgerTransaction) => (

--- a/packages/patterns/primitives/ledger-month-transactions.tsx
+++ b/packages/patterns/primitives/ledger-month-transactions.tsx
@@ -1,0 +1,180 @@
+/**
+ * Reads one month of bank transactions out of a loom connector ledger — the
+ * Plaid `rows_plaid_transaction` table a finance connector writes — newest
+ * first, bounded to the month and to 500 rows, with a list `[UI]` over them.
+ * Live rows are `deleted = 0`: the shared connector store writes its text
+ * columns never-NULL and marks a tombstone with that integer flag, so a
+ * `deleted_at IS NULL` filter matches no row at all and reports an empty
+ * ledger over a full table. `month` picks the window as `YYYY-MM`, and
+ * defaults to the calendar month the database's own clock is in.
+ *
+ * @hashtags plaid, bank, transactions, ledger, finance, month, connector
+ * @keywords bank transactions, plaid ledger, this month's transactions,
+ * bill payments, spending, deleted flag, tombstone, connector store,
+ * SqliteDb handle
+ */
+import {
+  computed,
+  Default,
+  ifElse,
+  NAME,
+  pattern,
+  type SqliteDb,
+  UI,
+  type VNode,
+} from "commonfabric";
+
+/** One row of `rows_plaid_transaction`, under the column names it carries. */
+export interface LedgerTransaction {
+  transaction_id: string;
+  date: string;
+  amount: number;
+  signed_amount: number;
+  merchant_name: string;
+  name: string;
+  account_id: string;
+  pending: number;
+  category_primary: string;
+  iso_currency_code: string;
+}
+
+export interface LedgerMonthTransactionsInput {
+  /** The connector ledger to read. Whoever wired the input chose which. */
+  bank: SqliteDb;
+
+  /** The month to read, as `YYYY-MM`. Empty means the current month. */
+  month?: string | Default<"">;
+}
+
+export interface LedgerMonthTransactionsOutput {
+  [NAME]: string;
+  [UI]: VNode;
+
+  /** The month the rows were read from, as `YYYY-MM`. */
+  month: string;
+
+  rows: LedgerTransaction[];
+  rowCount: number;
+  pending: boolean;
+
+  /** Why the read failed, empty while it has not. */
+  errorMessage: string;
+}
+
+/**
+ * The month the caller asked for, else the one the database's clock is in.
+ *
+ * The clock is read in SQL rather than in the pattern because a pattern body
+ * and a `computed` are both denied the clock inside the sandbox.
+ */
+const resolvedMonthSql = (): string =>
+  "COALESCE(NULLIF(?, ''), strftime('%Y-%m', 'now', 'localtime'))";
+
+/** One row naming the month the rows below were read from. */
+const monthSql = (): string => `SELECT ${resolvedMonthSql()} AS month`;
+
+/**
+ * The month as a half-open range over `date` rather than a `substr` of it, so
+ * an index on the column can be walked to the bound instead of scanned past
+ * it.
+ */
+const rowsSql = (): string =>
+  [
+    `WITH bounds AS (SELECT ${resolvedMonthSql()} || '-01' AS start)`,
+    "SELECT t.transaction_id, t.date, t.amount, t.signed_amount,",
+    "  t.merchant_name, t.name, t.account_id, t.pending,",
+    "  t.category_primary, t.iso_currency_code",
+    "FROM bounds, rows_plaid_transaction t",
+    "WHERE t.deleted = 0",
+    "  AND t.date >= bounds.start",
+    "  AND t.date < date(bounds.start, '+1 month')",
+    "ORDER BY t.date DESC",
+    "LIMIT 500",
+  ].join("\n");
+
+/** What a query reports about a failure, empty when it has not failed. */
+const errorText = (error: unknown): string => {
+  if (error === undefined || error === null) return "";
+  if (typeof error === "string") return error;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === "string" ? message : "The query failed.";
+};
+
+/** `amount` as a signed figure in `code`, to the cent. */
+const money = (amount: number, code: string): string =>
+  `${(amount || 0).toFixed(2)} ${code || "USD"}`;
+
+export const LedgerMonthTransactions = pattern<
+  LedgerMonthTransactionsInput,
+  LedgerMonthTransactionsOutput
+>(({ bank, month }) => {
+  const monthRead = bank.query<{ month: string }>(monthSql(), {
+    params: [month],
+    scope: "session",
+  });
+  const rowsRead = bank.query<LedgerTransaction>(rowsSql(), {
+    params: [month],
+    scope: "session",
+  });
+
+  const resolvedMonth = computed(() => monthRead.result?.[0]?.month ?? "");
+  const rows = computed(() => rowsRead.result ?? []);
+  const rowCount = computed(() => (rowsRead.result ?? []).length);
+  const pending = computed(() => rowsRead.pending === true);
+  const errorMessage = computed(() => errorText(rowsRead.error));
+  const hasError = computed(() => errorMessage !== "");
+  const isEmpty = computed(() =>
+    !pending && !hasError && (rowsRead.result ?? []).length === 0
+  );
+
+  const listRows = rows.map((row: LedgerTransaction) => (
+    <cf-hstack gap="2" align="center" justify="between">
+      <cf-text style="flex: 1;">
+        {computed(() =>
+          row.merchant_name || row.name || "Unnamed"
+        )}
+      </cf-text>
+      <cf-text tone="muted">{row.date}</cf-text>
+      <cf-text style="font-variant-numeric: tabular-nums;">
+        {computed(() =>
+          money(row.signed_amount, row.iso_currency_code)
+        )}
+      </cf-text>
+    </cf-hstack>
+  ));
+
+  return {
+    [NAME]: computed(() => `Transactions ${resolvedMonth} (${rowCount})`),
+    [UI]: (
+      <cf-vstack gap="3" padding="3">
+        <cf-hstack justify="between" align="center">
+          <cf-heading level={5}>Bank transactions</cf-heading>
+          <cf-text tone="muted">{resolvedMonth}</cf-text>
+        </cf-hstack>
+
+        {ifElse(
+          hasError,
+          <cf-alert status="error">{errorMessage}</cf-alert>,
+          null,
+        )}
+
+        <cf-vstack gap="2">
+          {listRows}
+        </cf-vstack>
+
+        {ifElse(
+          isEmpty,
+          <cf-empty-state message="No transactions this month." />,
+          null,
+        )}
+      </cf-vstack>
+    ),
+    month: resolvedMonth,
+    rows,
+    rowCount,
+    pending,
+    errorMessage,
+  };
+});
+
+export default LedgerMonthTransactions;

--- a/packages/patterns/primitives/mailbox-month-headers-ceiling.test.tsx
+++ b/packages/patterns/primitives/mailbox-month-headers-ceiling.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Tests MailboxMonthHeaders' row ceiling against a month that holds more rows
+ * than the ceiling admits, which is the only way to tell a clamped limit from
+ * an unclamped one: over a handful of rows the two answer the same.
+ *
+ * It reads counts and subjects and never `[UI]`. A rendered 500-row result is
+ * a load still in flight when the runtime is disposed, which reports a
+ * sync-load failure at teardown; the view is stated in the atom's other test,
+ * over a month small enough to settle.
+ *
+ * Run: deno task cf test packages/patterns/primitives/mailbox-month-headers-ceiling.test.tsx
+ */
+import {
+  action,
+  assert,
+  handler,
+  pattern,
+  sqliteDatabase,
+  type SqliteDb,
+  table,
+  TESTS,
+  Writable,
+} from "commonfabric";
+import MailboxMonthHeaders from "./mailbox-month-headers.tsx";
+
+const messagesTable = () =>
+  table({
+    id: "integer primary key",
+    subject: "text",
+    snippet: "text",
+    received_at: "text",
+    sent_at: "text",
+    internal_date: "text",
+    sender_id: "integer",
+    deleted_at: "text",
+  });
+
+const participantsTable = () =>
+  table({
+    id: "integer primary key",
+    display_name: "text",
+    email_address: "text",
+  });
+
+/**
+ * Seeds 600 live messages in June through one recursive-CTE insert, so the
+ * ceiling has a hundred more rows to refuse than it admits. `received_at`
+ * encodes the row number, so lexicographic order is row order and the newest
+ * row is `Bulk 1599`.
+ */
+const seedBulk = handler<void, { db: SqliteDb }>((_, { db }) => {
+  db.exec(
+    "INSERT INTO messages (id, subject, snippet, received_at, sender_id, " +
+      "deleted_at) WITH RECURSIVE c(n) AS (SELECT 1000 UNION ALL " +
+      "SELECT n + 1 FROM c WHERE n < 1599) " +
+      "SELECT n, 'Bulk ' || n, '', " +
+      "'2026-06-01T00:00:00.' || printf('%04d', n) || 'Z', 1, NULL FROM c",
+  );
+});
+
+export default pattern(() => {
+  const db = sqliteDatabase({
+    tables: { messages: messagesTable(), participants: participantsTable() },
+  });
+  const seed = seedBulk({ db });
+
+  // Both inputs are reactive, so naming a month is what re-runs the query over
+  // rows seeded after the atom was built, and naming a limit re-runs it again.
+  const month = new Writable("1970-01");
+  const limit = new Writable(100000);
+  const mailbox = MailboxMonthHeaders({ mail: db, month, limit });
+
+  return {
+    [TESTS]: [
+      { assertion: assert(() => mailbox.headerCount === 0) },
+
+      { action: action(() => seed.send()) },
+      { action: action(() => month.set("2026-06")) },
+
+      // A limit past the ceiling reads to the ceiling rather than refusing.
+      // The 500th row being `Bulk 1100` is the same statement as the 501st
+      // being absent: the rows run from 1599 down.
+      { assertion: assert(() => mailbox.errorMessage === "") },
+      { assertion: assert(() => mailbox.headerCount === 500) },
+      { assertion: assert(() => mailbox.headers[0].subject === "Bulk 1599") },
+      { assertion: assert(() => mailbox.headers[499].subject === "Bulk 1100") },
+
+      // The ceiling named exactly reads the same 500, so the clamp neither
+      // narrows a limit that already sits on it nor lets one past.
+      { action: action(() => limit.set(500)) },
+      { assertion: assert(() => mailbox.headerCount === 500) },
+      { assertion: assert(() => mailbox.headers[0].subject === "Bulk 1599") },
+      { assertion: assert(() => mailbox.headers[499].subject === "Bulk 1100") },
+
+      // A limit below the ceiling is the caller's, still newest first.
+      { action: action(() => limit.set(3)) },
+      { assertion: assert(() => mailbox.headerCount === 3) },
+      { assertion: assert(() => mailbox.headers[0].subject === "Bulk 1599") },
+      { assertion: assert(() => mailbox.headers[2].subject === "Bulk 1597") },
+
+      // Ends on a month holding nothing, so the last read this run issues is
+      // one that settles empty rather than a large one still in flight when
+      // the runtime is disposed.
+      { action: action(() => month.set("2026-07")) },
+      { assertion: assert(() => mailbox.headerCount === 0) },
+    ],
+  };
+});

--- a/packages/patterns/primitives/mailbox-month-headers.test.tsx
+++ b/packages/patterns/primitives/mailbox-month-headers.test.tsx
@@ -1,6 +1,8 @@
 /**
  * Tests MailboxMonthHeaders: the tombstone rule, the month window, the sender
- * join, the row ceiling against a hostile limit, and the rendered list.
+ * join, a hostile limit, the failure text, and the rendered list. The row
+ * ceiling needs a month with more rows than it admits, so it is stated in
+ * mailbox-month-headers-ceiling.test.tsx instead.
  *
  * The atom takes no `reactOn`, because a database it only reads has nothing to
  * react to. Its `month` and `limit` inputs are reactive, so a test seeds the
@@ -22,6 +24,7 @@ import {
   Writable,
 } from "commonfabric";
 import {
+  findElement,
   findElementByText,
   findNodeByProp,
   textContent,
@@ -106,11 +109,21 @@ const seedMailbox = handler<void, { db: SqliteDb }>((_, { db }) => {
 });
 
 /**
- * A messages table missing the columns the atom projects, which is what a
- * handle wired to a store of another shape looks like from inside the query.
+ * A messages table carrying every column the join, the filter and the ordering
+ * need, and missing one the atom projects. That is what makes the diagnostic
+ * name the projected column rather than a table the query could not find, so a
+ * later unrelated missing-table failure cannot satisfy the assertion.
  */
 const narrowMessagesTable = () =>
-  table({ id: "integer primary key", received_at: "text" });
+  table({
+    id: "integer primary key",
+    snippet: "text",
+    received_at: "text",
+    sent_at: "text",
+    internal_date: "text",
+    sender_id: "integer",
+    deleted_at: "text",
+  });
 
 /** One row, so the query over the narrow table has a reason to run. */
 const seedNarrow = handler<void, { db: SqliteDb }>((_, { db }) => {
@@ -118,21 +131,6 @@ const seedNarrow = handler<void, { db: SqliteDb }>((_, { db }) => {
     1,
     "2026-03-01T09:00:00Z",
   ]);
-});
-
-/**
- * Seeds 600 live messages in June through one recursive-CTE insert, so the
- * 500-row ceiling has more rows to refuse than it admits. `received_at`
- * encodes the row number, so lexicographic order is row order.
- */
-const seedBulk = handler<void, { db: SqliteDb }>((_, { db }) => {
-  db.exec(
-    "INSERT INTO messages (id, subject, snippet, received_at, sender_id, " +
-      "deleted_at) WITH RECURSIVE c(n) AS (SELECT 1000 UNION ALL " +
-      "SELECT n + 1 FROM c WHERE n < 1599) " +
-      "SELECT n, 'Bulk ' || n, '', " +
-      "'2026-06-01T00:00:00.' || printf('%04d', n) || 'Z', 1, NULL FROM c",
-  );
 });
 
 export default pattern(() => {
@@ -147,12 +145,14 @@ export default pattern(() => {
   const limit = new Writable(200);
   const mailbox = MailboxMonthHeaders({ mail: db, month, limit });
 
-  // A store whose messages table does not carry the columns the atom
-  // projects, and which has no participants table to join.
+  // A store whose messages table is missing a column the atom projects,
+  // everything the join and the window need being present.
   const narrow = sqliteDatabase({
-    tables: { messages: narrowMessagesTable() },
+    tables: {
+      messages: narrowMessagesTable(),
+      participants: participantsTable(),
+    },
   });
-  const seedBulkRows = seedBulk({ db });
   const seedNarrowRow = seedNarrow({ db: narrow });
   const brokenMonth = new Writable("1970-01");
   const broken = MailboxMonthHeaders({ mail: narrow, month: brokenMonth });
@@ -177,6 +177,11 @@ export default pattern(() => {
       // A store of another shape reports why rather than an empty month, and
       // the view says so.
       { assertion: assert(() => broken.errorMessage !== "") },
+      {
+        assertion: assert(() =>
+          broken.errorMessage.includes("no such column: m.subject")
+        ),
+      },
       { assertion: assert(() => broken.headerCount === 0) },
       {
         assertion: assert(() =>
@@ -193,6 +198,15 @@ export default pattern(() => {
       { assertion: assert(() => mailbox.month === "2026-03") },
       { assertion: assert(() => mailbox.errorMessage === "") },
       { assertion: assert(() => mailbox[NAME] === "Mail 2026-03 (3)") },
+
+      // A read that did not fail renders no alert, which is the other half of
+      // the failing-store case: without this, an alert shown over empty text
+      // would satisfy that one.
+      {
+        assertion: assert(() =>
+          findElement(mailbox[UI], "cf-alert") === undefined
+        ),
+      },
 
       // The sender comes from the joined participant, and the snippet from
       // the message; no body column is projected to carry one.
@@ -237,23 +251,9 @@ export default pattern(() => {
       { assertion: assert(() => mailbox.headerCount === 1) },
       { assertion: assert(() => mailbox.errorMessage === "") },
 
-      // A limit past the ceiling reads to the ceiling rather than refusing.
-      // June holds 600 live messages, so 500 is a bound the rows can reach:
-      // the newest 500 come back, and the 501st is not among them.
-      { action: action(() => seedBulkRows.send()) },
-      { action: action(() => limit.set(100000)) },
-      { action: action(() => month.set("2026-06")) },
-      { assertion: assert(() => mailbox.errorMessage === "") },
-      { assertion: assert(() => mailbox.headerCount === 500) },
-      { assertion: assert(() => mailbox.headers[0].subject === "Bulk 1599") },
-      { assertion: assert(() => mailbox.headers[499].subject === "Bulk 1100") },
-
-      // The ceiling named exactly reads the same 500, so the clamp neither
-      // narrows a limit that already sits on it nor lets one past.
-      { action: action(() => limit.set(500)) },
-      { assertion: assert(() => mailbox.headerCount === 500) },
-      { assertion: assert(() => mailbox.headers[0].subject === "Bulk 1599") },
-      { assertion: assert(() => mailbox.headers[499].subject === "Bulk 1100") },
+      // The ceiling a limit past it reads to is stated in
+      // mailbox-month-headers-ceiling.test.tsx, where the month holds more
+      // rows than the ceiling admits.
 
       // A month the seed left empty reads back empty rather than stale, and
       // the view says so.

--- a/packages/patterns/primitives/mailbox-month-headers.test.tsx
+++ b/packages/patterns/primitives/mailbox-month-headers.test.tsx
@@ -105,6 +105,36 @@ const seedMailbox = handler<void, { db: SqliteDb }>((_, { db }) => {
   ]);
 });
 
+/**
+ * A messages table missing the columns the atom projects, which is what a
+ * handle wired to a store of another shape looks like from inside the query.
+ */
+const narrowMessagesTable = () =>
+  table({ id: "integer primary key", received_at: "text" });
+
+/** One row, so the query over the narrow table has a reason to run. */
+const seedNarrow = handler<void, { db: SqliteDb }>((_, { db }) => {
+  db.exec("INSERT INTO messages (id, received_at) VALUES (?, ?)", [
+    1,
+    "2026-03-01T09:00:00Z",
+  ]);
+});
+
+/**
+ * Seeds 600 live messages in June through one recursive-CTE insert, so the
+ * 500-row ceiling has more rows to refuse than it admits. `received_at`
+ * encodes the row number, so lexicographic order is row order.
+ */
+const seedBulk = handler<void, { db: SqliteDb }>((_, { db }) => {
+  db.exec(
+    "INSERT INTO messages (id, subject, snippet, received_at, sender_id, " +
+      "deleted_at) WITH RECURSIVE c(n) AS (SELECT 1000 UNION ALL " +
+      "SELECT n + 1 FROM c WHERE n < 1599) " +
+      "SELECT n, 'Bulk ' || n, '', " +
+      "'2026-06-01T00:00:00.' || printf('%04d', n) || 'Z', 1, NULL FROM c",
+  );
+});
+
 export default pattern(() => {
   const db = sqliteDatabase({
     tables: { messages: messagesTable(), participants: participantsTable() },
@@ -117,6 +147,16 @@ export default pattern(() => {
   const limit = new Writable(200);
   const mailbox = MailboxMonthHeaders({ mail: db, month, limit });
 
+  // A store whose messages table does not carry the columns the atom
+  // projects, and which has no participants table to join.
+  const narrow = sqliteDatabase({
+    tables: { messages: narrowMessagesTable() },
+  });
+  const seedBulkRows = seedBulk({ db });
+  const seedNarrowRow = seedNarrow({ db: narrow });
+  const brokenMonth = new Writable("1970-01");
+  const broken = MailboxMonthHeaders({ mail: narrow, month: brokenMonth });
+
   return {
     // The one warning this allows is normalizeAndDiff's "Storing a
     // session-scoped link in space-scoped data", raised when reading `[UI]`
@@ -127,9 +167,23 @@ export default pattern(() => {
     allowConsoleWarnings: true,
     [TESTS]: [
       { assertion: assert(() => mailbox.headerCount === 0) },
+      { assertion: assert(() => broken.headerCount === 0) },
 
       { action: action(() => seed.send()) },
+      { action: action(() => seedNarrowRow.send()) },
       { action: action(() => month.set("2026-03")) },
+      { action: action(() => brokenMonth.set("2026-03")) },
+
+      // A store of another shape reports why rather than an empty month, and
+      // the view says so.
+      { assertion: assert(() => broken.errorMessage !== "") },
+      { assertion: assert(() => broken.headerCount === 0) },
+      {
+        assertion: assert(() =>
+          findElementByText(broken[UI], "cf-alert", broken.errorMessage) !==
+            undefined
+        ),
+      },
 
       // The three live March messages, newest first. The deleted one is gone
       // and so is the one in April.
@@ -170,10 +224,12 @@ export default pattern(() => {
         ),
       },
 
-      // A limit the caller names bounds the rows.
+      // A limit the caller names bounds the rows, and takes the newest ones
+      // in order rather than any two of them.
       { action: action(() => limit.set(2)) },
       { assertion: assert(() => mailbox.headerCount === 2) },
       { assertion: assert(() => mailbox.headers[0].subject === "Third") },
+      { assertion: assert(() => mailbox.headers[1].subject === "Second") },
 
       // A negative limit is SQLite's spelling for "no limit at all", so the
       // atom's own floor is what the query gets instead.
@@ -181,11 +237,23 @@ export default pattern(() => {
       { assertion: assert(() => mailbox.headerCount === 1) },
       { assertion: assert(() => mailbox.errorMessage === "") },
 
-      // A limit past the ceiling reads to the ceiling rather than refusing,
-      // and this mailbox holds fewer rows than either.
+      // A limit past the ceiling reads to the ceiling rather than refusing.
+      // June holds 600 live messages, so 500 is a bound the rows can reach:
+      // the newest 500 come back, and the 501st is not among them.
+      { action: action(() => seedBulkRows.send()) },
       { action: action(() => limit.set(100000)) },
-      { assertion: assert(() => mailbox.headerCount === 3) },
+      { action: action(() => month.set("2026-06")) },
       { assertion: assert(() => mailbox.errorMessage === "") },
+      { assertion: assert(() => mailbox.headerCount === 500) },
+      { assertion: assert(() => mailbox.headers[0].subject === "Bulk 1599") },
+      { assertion: assert(() => mailbox.headers[499].subject === "Bulk 1100") },
+
+      // The ceiling named exactly reads the same 500, so the clamp neither
+      // narrows a limit that already sits on it nor lets one past.
+      { action: action(() => limit.set(500)) },
+      { assertion: assert(() => mailbox.headerCount === 500) },
+      { assertion: assert(() => mailbox.headers[0].subject === "Bulk 1599") },
+      { assertion: assert(() => mailbox.headers[499].subject === "Bulk 1100") },
 
       // A month the seed left empty reads back empty rather than stale, and
       // the view says so.

--- a/packages/patterns/primitives/mailbox-month-headers.test.tsx
+++ b/packages/patterns/primitives/mailbox-month-headers.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Tests MailboxMonthHeaders: the tombstone rule, the month window, the sender
+ * join, the row ceiling against a hostile limit, and the rendered list.
+ *
+ * The atom takes no `reactOn`, because a database it only reads has nothing to
+ * react to. Its `month` and `limit` inputs are reactive, so a test seeds the
+ * rows and then names a month, which is what re-runs the query over them.
+ *
+ * Run: deno task cf test packages/patterns/primitives/mailbox-month-headers.test.tsx
+ */
+import {
+  action,
+  assert,
+  handler,
+  NAME,
+  pattern,
+  sqliteDatabase,
+  type SqliteDb,
+  table,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
+import {
+  findElementByText,
+  findNodeByProp,
+  textContent,
+} from "../test/vnode-helpers.ts";
+import MailboxMonthHeaders from "./mailbox-month-headers.tsx";
+
+/** The message columns the atom projects, plus the sender it joins on. */
+const messagesTable = () =>
+  table({
+    id: "integer primary key",
+    subject: "text",
+    snippet: "text",
+    received_at: "text",
+    sent_at: "text",
+    internal_date: "text",
+    sender_id: "integer",
+    deleted_at: "text",
+  });
+
+const participantsTable = () =>
+  table({
+    id: "integer primary key",
+    display_name: "text",
+    email_address: "text",
+  });
+
+const messageSql = (): string =>
+  "INSERT INTO messages (id, subject, snippet, received_at, sender_id, " +
+  "deleted_at) VALUES (?, ?, ?, ?, ?, ?)";
+
+/**
+ * Seeds a sender, three live messages in March, one deleted message in the
+ * same month, and one in April. A live message leaves `deleted_at` NULL, which
+ * is how this store marks one, and a deleted message carries a stamp.
+ */
+const seedMailbox = handler<void, { db: SqliteDb }>((_, { db }) => {
+  db.exec(
+    "INSERT INTO participants (id, display_name, email_address) " +
+      "VALUES (?, ?, ?)",
+    [1, "Pacific Gas", "billing@pge.example"],
+  );
+  db.exec(messageSql(), [
+    1,
+    "First",
+    "First snippet",
+    "2026-03-01T09:00:00Z",
+    1,
+    null,
+  ]);
+  db.exec(messageSql(), [
+    2,
+    "Second",
+    "Second snippet",
+    "2026-03-02T09:00:00Z",
+    1,
+    null,
+  ]);
+  db.exec(messageSql(), [
+    3,
+    "Third",
+    "Third snippet",
+    "2026-03-03T09:00:00Z",
+    1,
+    null,
+  ]);
+  db.exec(messageSql(), [
+    4,
+    "Deleted notice",
+    "Deleted snippet",
+    "2026-03-04T09:00:00Z",
+    1,
+    "2026-03-05T09:00:00Z",
+  ]);
+  db.exec(messageSql(), [
+    5,
+    "Next month",
+    "Next snippet",
+    "2026-04-01T09:00:00Z",
+    1,
+    null,
+  ]);
+});
+
+export default pattern(() => {
+  const db = sqliteDatabase({
+    tables: { messages: messagesTable(), participants: participantsTable() },
+  });
+  const seed = seedMailbox({ db });
+
+  // Both inputs are reactive, so naming a month is what re-runs the query over
+  // rows seeded after the atom was built, and naming a limit re-runs it again.
+  const month = new Writable("1970-01");
+  const limit = new Writable(200);
+  const mailbox = MailboxMonthHeaders({ mail: db, month, limit });
+
+  return {
+    // The one warning this allows is normalizeAndDiff's "Storing a
+    // session-scoped link in space-scoped data", raised when reading `[UI]`
+    // puts a link to the atom's session-scoped query result into the vnode
+    // tree. Per-reader resolution is what a session-scoped result is for, and
+    // the slot holding the link is a view-node child the atom does not
+    // declare. The flag is a boolean, so it cannot be pinned to that text.
+    allowConsoleWarnings: true,
+    [TESTS]: [
+      { assertion: assert(() => mailbox.headerCount === 0) },
+
+      { action: action(() => seed.send()) },
+      { action: action(() => month.set("2026-03")) },
+
+      // The three live March messages, newest first. The deleted one is gone
+      // and so is the one in April.
+      { assertion: assert(() => mailbox.headerCount === 3) },
+      { assertion: assert(() => mailbox.headers[0].subject === "Third") },
+      { assertion: assert(() => mailbox.headers[2].subject === "First") },
+      { assertion: assert(() => mailbox.month === "2026-03") },
+      { assertion: assert(() => mailbox.errorMessage === "") },
+      { assertion: assert(() => mailbox[NAME] === "Mail 2026-03 (3)") },
+
+      // The sender comes from the joined participant, and the snippet from
+      // the message; no body column is projected to carry one.
+      { assertion: assert(() => mailbox.headers[0].sender === "Pacific Gas") },
+      {
+        assertion: assert(() => mailbox.headers[0].snippet === "Third snippet"),
+      },
+
+      // The rendered list states the newest subject and its sender, and
+      // carries neither the deleted message nor April's.
+      {
+        assertion: assert(() =>
+          findElementByText(mailbox[UI], "cf-text", "Third") !== undefined
+        ),
+      },
+      {
+        assertion: assert(() =>
+          textContent(mailbox[UI]).includes("Pacific Gas")
+        ),
+      },
+      {
+        assertion: assert(() =>
+          !textContent(mailbox[UI]).includes("Deleted notice")
+        ),
+      },
+      {
+        assertion: assert(() =>
+          !textContent(mailbox[UI]).includes("Next month")
+        ),
+      },
+
+      // A limit the caller names bounds the rows.
+      { action: action(() => limit.set(2)) },
+      { assertion: assert(() => mailbox.headerCount === 2) },
+      { assertion: assert(() => mailbox.headers[0].subject === "Third") },
+
+      // A negative limit is SQLite's spelling for "no limit at all", so the
+      // atom's own floor is what the query gets instead.
+      { action: action(() => limit.set(-1)) },
+      { assertion: assert(() => mailbox.headerCount === 1) },
+      { assertion: assert(() => mailbox.errorMessage === "") },
+
+      // A limit past the ceiling reads to the ceiling rather than refusing,
+      // and this mailbox holds fewer rows than either.
+      { action: action(() => limit.set(100000)) },
+      { assertion: assert(() => mailbox.headerCount === 3) },
+      { assertion: assert(() => mailbox.errorMessage === "") },
+
+      // A month the seed left empty reads back empty rather than stale, and
+      // the view says so.
+      { action: action(() => month.set("2026-05")) },
+      { assertion: assert(() => mailbox.headerCount === 0) },
+      {
+        assertion: assert(() =>
+          findNodeByProp(mailbox[UI], "message", "No mail this month.") !==
+            undefined
+        ),
+      },
+
+      // Naming no month resolves one from the database's own clock rather
+      // than leaving the window unbounded.
+      { action: action(() => month.set("")) },
+      { assertion: assert(() => mailbox.month.length === 7) },
+      { assertion: assert(() => mailbox.month.charAt(4) === "-") },
+      { assertion: assert(() => mailbox.errorMessage === "") },
+    ],
+  };
+});

--- a/packages/patterns/primitives/mailbox-month-headers.tsx
+++ b/packages/patterns/primitives/mailbox-month-headers.tsx
@@ -142,14 +142,9 @@ export const MailboxMonthHeaders = pattern<
   const headerCount = computed(() => (headersRead.result ?? []).length);
   const pending = computed(() => headersRead.pending === true);
   const errorMessage = computed(() => errorText(headersRead.error));
-  // Each of these reads the envelope rather than the cells above it: `!` and
-  // `!==` applied to a computed act on the cell object, which is always
-  // truthy and never equal to a string, so a view gated on one would be
-  // gated on nothing.
-  const hasError = computed(() => errorText(headersRead.error) !== "");
+  const hasError = computed(() => errorMessage !== "");
   const isEmpty = computed(() =>
-    headersRead.pending !== true && errorText(headersRead.error) === "" &&
-    (headersRead.result ?? []).length === 0
+    !pending && !hasError && (headersRead.result ?? []).length === 0
   );
 
   const listRows = headers.map((header: MailboxHeader) => (

--- a/packages/patterns/primitives/mailbox-month-headers.tsx
+++ b/packages/patterns/primitives/mailbox-month-headers.tsx
@@ -1,0 +1,175 @@
+/**
+ * Reads this month's newest email headers out of a mail connector's
+ * `messages` table — id, subject, snippet, sender and received date, and no
+ * body column at all — with a list `[UI]` over them. A live message is
+ * `deleted_at IS NULL` here: this store marks a deleted message by stamping
+ * that column, which is the opposite spelling to the `deleted = 0` integer
+ * flag a connector ledger such as Plaid's uses, so the two cannot be filtered
+ * the same way. `month` picks the window as `YYYY-MM` and defaults to the
+ * calendar month the database's own clock is in; `limit` caps the rows at 200
+ * unless the caller says otherwise.
+ *
+ * @hashtags gmail, email, mail, messages, headers, inbox, month
+ * @keywords email headers, subject line, sender, this month's mail, bills in
+ * email, newest messages, no bodies, SqliteDb handle
+ */
+import {
+  computed,
+  Default,
+  ifElse,
+  NAME,
+  pattern,
+  type SqliteDb,
+  UI,
+  type VNode,
+} from "commonfabric";
+
+/** One message header, under the names the projection gives its columns. */
+export interface MailboxHeader {
+  id: number;
+  subject: string;
+  snippet: string;
+  sender: string;
+  received_at: string;
+}
+
+export interface MailboxMonthHeadersInput {
+  /** The mail store to read. Whoever wired the input chose which. */
+  mail: SqliteDb;
+
+  /** The month to read, as `YYYY-MM`. Empty means the current month. */
+  month?: string | Default<"">;
+
+  /** How many headers to return, newest first. */
+  limit?: number | Default<200>;
+}
+
+export interface MailboxMonthHeadersOutput {
+  [NAME]: string;
+  [UI]: VNode;
+
+  /** The month the headers were read from, as `YYYY-MM`. */
+  month: string;
+
+  headers: MailboxHeader[];
+  headerCount: number;
+  pending: boolean;
+
+  /** Why the read failed, empty while it has not. */
+  errorMessage: string;
+}
+
+/**
+ * The month the caller asked for, else the one the database's clock is in.
+ *
+ * The clock is read in SQL rather than in the pattern because a pattern body
+ * and a `computed` are both denied the clock inside the sandbox.
+ */
+const resolvedMonthSql = (): string =>
+  "COALESCE(NULLIF(?, ''), strftime('%Y-%m', 'now', 'localtime'))";
+
+/** One row naming the month the headers below were read from. */
+const monthSql = (): string => `SELECT ${resolvedMonthSql()} AS month`;
+
+/**
+ * A message dates from whichever of the three timestamps it carries, so the
+ * same expression bounds the window and orders the result; the store fills
+ * them unevenly and a message missing `received_at` still belongs to a month.
+ */
+const receivedSql = (): string =>
+  "COALESCE(m.received_at, m.sent_at, m.internal_date)";
+
+/** Headers only: no body column is projected, and none is joined for. */
+const headersSql = (): string =>
+  [
+    `WITH bounds AS (SELECT ${resolvedMonthSql()} || '-01' AS start)`,
+    "SELECT m.id, m.subject, m.snippet,",
+    `  ${receivedSql()} AS received_at,`,
+    "  COALESCE(p.display_name, p.email_address, '') AS sender",
+    "FROM bounds, messages m",
+    "LEFT JOIN participants p ON p.id = m.sender_id",
+    "WHERE m.deleted_at IS NULL",
+    `  AND ${receivedSql()} >= bounds.start`,
+    `  AND ${receivedSql()} < date(bounds.start, '+1 month')`,
+    "ORDER BY received_at DESC",
+    "LIMIT ?",
+  ].join("\n");
+
+/** What a query reports about a failure, empty when it has not failed. */
+const errorText = (error: unknown): string => {
+  if (error === undefined || error === null) return "";
+  if (typeof error === "string") return error;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === "string" ? message : "The query failed.";
+};
+
+export const MailboxMonthHeaders = pattern<
+  MailboxMonthHeadersInput,
+  MailboxMonthHeadersOutput
+>(({ mail, month, limit }) => {
+  const monthRead = mail.query<{ month: string }>(monthSql(), {
+    params: [month],
+    scope: "session",
+  });
+  const headersRead = mail.query<MailboxHeader>(headersSql(), {
+    params: [month, limit],
+    scope: "session",
+  });
+
+  const resolvedMonth = computed(() => monthRead.result?.[0]?.month ?? "");
+  const headers = computed(() => headersRead.result ?? []);
+  const headerCount = computed(() => (headersRead.result ?? []).length);
+  const pending = computed(() => headersRead.pending === true);
+  const errorMessage = computed(() => errorText(headersRead.error));
+  const hasError = computed(() => errorMessage !== "");
+  const isEmpty = computed(() =>
+    !pending && !hasError && (headersRead.result ?? []).length === 0
+  );
+
+  const listRows = headers.map((header: MailboxHeader) => (
+    <cf-vstack gap="1">
+      <cf-hstack gap="2" align="center" justify="between">
+        <cf-text style="flex: 1;">
+          {computed(() => header.subject || "(No subject)")}
+        </cf-text>
+        <cf-text tone="muted">{header.received_at}</cf-text>
+      </cf-hstack>
+      <cf-text tone="muted">{header.sender}</cf-text>
+    </cf-vstack>
+  ));
+
+  return {
+    [NAME]: computed(() => `Mail ${resolvedMonth} (${headerCount})`),
+    [UI]: (
+      <cf-vstack gap="3" padding="3">
+        <cf-hstack justify="between" align="center">
+          <cf-heading level={5}>Email headers</cf-heading>
+          <cf-text tone="muted">{resolvedMonth}</cf-text>
+        </cf-hstack>
+
+        {ifElse(
+          hasError,
+          <cf-alert status="error">{errorMessage}</cf-alert>,
+          null,
+        )}
+
+        <cf-vstack gap="2">
+          {listRows}
+        </cf-vstack>
+
+        {ifElse(
+          isEmpty,
+          <cf-empty-state message="No mail this month." />,
+          null,
+        )}
+      </cf-vstack>
+    ),
+    month: resolvedMonth,
+    headers,
+    headerCount,
+    pending,
+    errorMessage,
+  };
+});
+
+export default MailboxMonthHeaders;

--- a/packages/patterns/primitives/mailbox-month-headers.tsx
+++ b/packages/patterns/primitives/mailbox-month-headers.tsx
@@ -7,7 +7,7 @@
  * flag a connector ledger such as Plaid's uses, so the two cannot be filtered
  * the same way. `month` picks the window as `YYYY-MM` and defaults to the
  * calendar month the database's own clock is in; `limit` caps the rows at 200
- * unless the caller says otherwise.
+ * unless the caller says otherwise, and never above 500 whatever it says.
  *
  * @hashtags gmail, email, mail, messages, headers, inbox, month
  * @keywords email headers, subject line, sender, this month's mail, bills in
@@ -40,7 +40,10 @@ export interface MailboxMonthHeadersInput {
   /** The month to read, as `YYYY-MM`. Empty means the current month. */
   month?: string | Default<"">;
 
-  /** How many headers to return, newest first. */
+  /**
+   * How many headers to return, newest first. Held between 1 and 500, so a
+   * caller cannot widen the read past what the atom will answer for.
+   */
   limit?: number | Default<200>;
 }
 
@@ -58,6 +61,12 @@ export interface MailboxMonthHeadersOutput {
   /** Why the read failed, empty while it has not. */
   errorMessage: string;
 }
+
+/** Headers returned for a caller that names no limit. */
+const DEFAULT_LIMIT = 200;
+
+/** The most headers one read may return, whatever the caller asks for. */
+const MAX_LIMIT = 500;
 
 /**
  * The month the caller asked for, else the one the database's clock is in.
@@ -79,7 +88,14 @@ const monthSql = (): string => `SELECT ${resolvedMonthSql()} AS month`;
 const receivedSql = (): string =>
   "COALESCE(m.received_at, m.sent_at, m.internal_date)";
 
-/** Headers only: no body column is projected, and none is joined for. */
+/**
+ * Headers only: no body column is projected, and none is joined for.
+ *
+ * The ceiling is the atom's, not the caller's. `LIMIT ?` alone would be no
+ * bound at all — SQLite reads a negative limit as unlimited and accepts any
+ * positive one — and a query that writes a row document per result row is one
+ * a caller must not be able to widen without bound.
+ */
 const headersSql = (): string =>
   [
     `WITH bounds AS (SELECT ${resolvedMonthSql()} || '-01' AS start)`,
@@ -92,7 +108,7 @@ const headersSql = (): string =>
     `  AND ${receivedSql()} >= bounds.start`,
     `  AND ${receivedSql()} < date(bounds.start, '+1 month')`,
     "ORDER BY received_at DESC",
-    "LIMIT ?",
+    `LIMIT max(1, min(COALESCE(?, ${DEFAULT_LIMIT}), ${MAX_LIMIT}))`,
   ].join("\n");
 
 /** What a query reports about a failure, empty when it has not failed. */
@@ -121,9 +137,14 @@ export const MailboxMonthHeaders = pattern<
   const headerCount = computed(() => (headersRead.result ?? []).length);
   const pending = computed(() => headersRead.pending === true);
   const errorMessage = computed(() => errorText(headersRead.error));
-  const hasError = computed(() => errorMessage !== "");
+  // Each of these reads the envelope rather than the cells above it: `!` and
+  // `!==` applied to a computed act on the cell object, which is always
+  // truthy and never equal to a string, so a view gated on one would be
+  // gated on nothing.
+  const hasError = computed(() => errorText(headersRead.error) !== "");
   const isEmpty = computed(() =>
-    !pending && !hasError && (headersRead.result ?? []).length === 0
+    headersRead.pending !== true && errorText(headersRead.error) === "" &&
+    (headersRead.result ?? []).length === 0
   );
 
   const listRows = headers.map((header: MailboxHeader) => (

--- a/packages/patterns/primitives/mailbox-month-headers.tsx
+++ b/packages/patterns/primitives/mailbox-month-headers.tsx
@@ -111,13 +111,18 @@ const headersSql = (): string =>
     `LIMIT max(1, min(COALESCE(?, ${DEFAULT_LIMIT}), ${MAX_LIMIT}))`,
   ].join("\n");
 
-/** What a query reports about a failure, empty when it has not failed. */
-const errorText = (error: unknown): string => {
-  if (error === undefined || error === null) return "";
-  if (typeof error === "string") return error;
-  const message = (error as { message?: unknown }).message;
-  return typeof message === "string" ? message : "The query failed.";
-};
+/**
+ * What a query reports about a failure, empty when it has not failed.
+ *
+ * The same narrowing the sqlite builtin applies before it writes one, so a
+ * value that reaches here already a message passes through unchanged.
+ */
+const errorText = (error: unknown): string =>
+  error === undefined || error === null
+    ? ""
+    : error instanceof Error
+    ? error.message
+    : String(error);
 
 export const MailboxMonthHeaders = pattern<
   MailboxMonthHeadersInput,


### PR DESCRIPTION
## Why

A session handed a loom connector handle writes its own query, and the one
thing `describe_handle` cannot tell it is what a column *means*. Run
`fa6aca5e` built a two-source bills dashboard over a Gmail handle and a
simulated Plaid handle. The machinery held; zero bank rows flowed. The model
had written `AND deleted_at IS NULL` on the Plaid ledger, whose rows carry
`deleted_at = ''` — the shared connector store writes its text columns
never-NULL and marks a tombstone with the integer flag `deleted = 1`. So the
filter matched no row at all, and the dashboard reported an empty month over a
full table rather than an error. The mail store spells it the other way:
`messages.deleted_at` is NULL on a live message. Nothing in the disclosed
schema distinguishes them.

The fix is a standard-library part in the index, so the next session finds a
part that already knows how to read the handle instead of rebuilding one and
getting the tombstone wrong.

## What the atoms read

`packages/patterns/primitives/ledger-month-transactions.tsx` — input
`{ bank: SqliteDb; month?: string }`. One session-scoped query over
`rows_plaid_transaction`, bounded to the month as a half-open range over
`date` and to `LIMIT 500`, projecting only the columns it renders
(`transaction_id`, `date`, `amount`, `signed_amount`, `merchant_name`, `name`,
`account_id`, `pending`, `category_primary`, `iso_currency_code`).

`packages/patterns/primitives/mailbox-month-headers.tsx` — input
`{ mail: SqliteDb; month?: string; limit?: number }`. One session-scoped query
over `messages`, left-joined to `participants` for the sender, projecting
`id`, `subject`, `snippet`, `received_at` and `sender`. No body column is
projected and `message_bodies` is never joined. The row ceiling is the atom's,
not the caller's: `LIMIT max(1, min(COALESCE(?, 200), 500))`, because
`LIMIT ?` alone is no bound — SQLite reads a negative limit as unlimited and
accepts any positive one.

Both resolve `month` in SQL (`strftime('%Y-%m', 'now', 'localtime')` when the
caller names none), because a pattern body and a `computed` are both denied the
clock inside the sandbox. Both return typed rows, a count, the pending flag and
the failure text, plus a small embeddable `[UI]`. Labeled columns flow through
untouched.

## The tombstone rule

- Connector ledger (Plaid): a live row is `deleted = 0`. `deleted_at` is text
  and never NULL, so `deleted_at IS NULL` selects nothing.
- Mail store: a live message is `deleted_at IS NULL`.

Each atom's doc comment states its own rule in the first paragraph, which is
what the index ranks on, and each names the other convention so a reader who
found one learns that the two differ.

## Published

An entry identity is a content hash of the source bytes, and review moved the
source three times, so each atom has published four times. The identity below
is the one `deno task seed-pattern-index --dry-run` computes for the branch as
it stands, checked against what is published rather than assumed. The current ids are what a session
composing today resolves; the superseded ones remain in the index.

| atom | current patternId | superseded |
| --- | --- | --- |
| `ledger-month-transactions` | `ss-2w4nQ8sd648sX-wyShStxRYHekQkGIaFXYPBMKXc` | `x471NgvH…`, `NqBCYia-…`, `yQKkhYez…` |
| `mailbox-month-headers` | `Uw9QukQ-2o6fgV4aREqrscYPtzG0xVOYTgA7tQcalvw` | `fu-0yBUq…`, `YuELB-T0…`, `a8fsFdzi…` |

Each seeded against `ben-loom-dev-6` after the commit that carries its source,
so a published content hash is one a commit contains.

## How it was verified

**Search rank, against the live index after re-seeding.** Before any of this
was published, `searchPatterns` for "bank transactions this month" returned
*nothing at all*, and "email headers this month" returned a sortable table and
a monthly-expenses app. Now, on all four phrasings, the current id ranks first
and its superseded sibling ranks immediately below it, never above:

| query | 1st | below it |
| --- | --- | --- |
| bank transactions this month | ledger current, 3/3 terms | its three superseded generations |
| email headers this month | mailbox current, 3/3 | its three superseded generations |
| this month's transactions from the bank ledger | ledger current, 4/4 | its three superseded generations |
| newest email subject lines this month | mailbox current, 5/5 | its three superseded generations |

Both classify as `part`, since the handle is a required argument, which is what
puts them in front of a session looking for something to compose. The
superseded entries stay discoverable — the seed publishes `discoverable: true`
and nothing here retracts one — and for the ledger the two descriptions are
byte-identical, so nothing about the ranking distinguishes them on merit.
Whether a superseded entry should be withdrawn is a question for the index, not
for this change.

**Pattern tests.** Three files under `packages/patterns/primitives/`, run by
`cf test`,
which is the lane that measures authored-pattern coverage. Each builds a
database with `sqliteDatabase()`, seeds it through a handler with both
tombstone spellings, and then drives the atom's own reactive `month` input —
the atom declares no `reactOn`, because a database it only reads has nothing to
react to, so naming a month is what re-runs the query over rows seeded after
the atom was built. Between them they state the tombstone rule, the month
window in both directions, the default month, the sender join, the failure
text and the alert that shows it, the rendered list, and the empty state. A read that
did not fail has to render no alert, which is what an always-rendering one
would break.

The row ceiling needs a month with more rows than it admits, so it has a file
of its own: June holds 600 live messages seeded through one recursive CTE, and
`limit` of `100000` and of `500` each return exactly 500, newest first, with
the 500th `Bulk 1100` — the same statement as "the 501st is absent". That file
reads counts and never `[UI]`, and ends on an empty month, because a rendered
500-row result is a load still in flight when the runtime is disposed and
reports a sync-load failure at teardown.

**Harness test.** `packages/cf-harness/test/primitives-connector-reads.test.ts`
states what only an injected handle can: a pattern test's database is
cell-derived in its own space, while a session is handed a handle naming a
store it did not create, already holding rows. The atom's first read is the one
that settles there, so this is where the default month is stated against rows
dated in it.

**Proven able to fail.** Flipping the ledger predicate to `deleted_at IS NULL`
took its pattern test to 11 passed / 11 failed; flipping the mailbox predicate
to `deleted = 0` took its test to 7 / 19; replacing the clamped limit with a
bare `LIMIT ?` failed the negative-limit case and the 500-row count; making
`errorText` answer `""` failed the failure-text assertions in both files. All
restored green. Reverting `hasError` or `isEmpty` fails nothing, which is what
says neither was a defect.

**Gates.** `deno fmt --check`, `deno lint`, `deno task check`,
`deno task cfcheck`, `check-docs`, `check-skill-facts`, `check-pattern-tiers`,
`check-baselines-append-only` — all green. `deno task test` green in
`packages/patterns` and `packages/cf-harness`, run outside a sandbox.
`deno task pattern-compat --update` recorded a contract for each atom.

## Findings

**`cf-empty-state` carries its text in a prop, so `textContent` cannot see
it.** An assertion reading `textContent(instance[UI])` for the empty-state
message fails against a view that is rendering it perfectly well, because the
text is a `message` prop rather than a child. That misread cost a round of
this branch: it was taken for a runtime defect in how a `computed` reads
another `computed`, and working code was rewritten around it before the claim
was tested. It was not a defect — restoring both expressions in full leaves
every assertion in all three test files passing — and the rewrite is withdrawn.
`findNodeByProp(root, "message", …)` is what states the empty state.

**A query's `error` is always a string.** The sqlite builtin narrows a thrown
value with `error instanceof Error ? error.message : String(error)` before it
writes one, so the branches an atom might write to read `.message` off a
structured error cannot run. That is what the last six uncovered lines were.
`errorText` is now the same narrowing in one expression.

**Runtime observation.** Reading `[UI]` raises normalizeAndDiff's "Storing a
session-scoped link in space-scoped data" warning, because the vnode tree holds
a link to the atom's session-scoped query result and the view-node child that
holds it is a slot the atom cannot declare a scope on; per-reader resolution is
the designed use of a session-scoped result, so this is a candidate runner-side
finding rather than an atom defect, and it is not filed. Both pattern tests
carry `allowConsoleWarnings: true` with a comment naming that warning — the
flag is a boolean, so it cannot be pinned to one message — and nothing asserts
on the warning's absence.

## Also in here

`packages/patterns/index.md` and `docs/common/patterns/primitives.md` gain the
two occupants and a paragraph on the flavour they introduce: a primitive whose
input is a capability handle rather than a caller's cell is not in the `demo/`
host, and its pattern test has to build a database and drive a reactive input
to read what it seeded. `packages/cf-harness/test/seed-pattern-index.test.ts`
names the atoms the seed publishes, so its list and counts move with the
directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
