### PR TITLE
fix(memory): a crossing-reached document loads the schema its labels are checked against

### DIFF
--- a/docs/specs/memory-v2/05-queries.md
+++ b/docs/specs/memory-v2/05-queries.md
@@ -280,13 +280,16 @@ document's ROLE in the query:
   the new target.
 
 - A document the evaluation merely reaches — loaded mid-walk through a link
-  crossing — is owed nothing beyond what the selector that reached it
-  selects. The server MUST NOT chase its metadata links or its internal
-  manifest links: none of that family is loaded, delivered, or tracked. A
-  subscriber that wants a document's family names the document. A refresh
-  that re-evaluates a crossing-reached document applies the same rule, so
-  a subscription's delivered shape does not depend on the order in which
-  documents changed.
+  crossing — is owed what the selector that reached it selects, and the
+  schema document its `cfc` metadata names: a reader of a labeled document
+  checks what it may read against that schema, so the server MUST resolve
+  and load it, and track it so an absent one arrives when it is written.
+  The server MUST NOT chase the document's other metadata links or its
+  internal manifest links: none of that family is loaded, delivered, or
+  tracked. A subscriber that wants a document's family names the document.
+  A refresh that re-evaluates a crossing-reached document applies the same
+  rule, so a subscription's delivered shape does not depend on the order in
+  which documents changed.
 
 A metadata family is a same-space structure: a metadata or manifest link
 that resolves to another space selects nothing — the evaluating space's

--- a/packages/memory/test/v2-query.test.ts
+++ b/packages/memory/test/v2-query.test.ts
@@ -2374,6 +2374,22 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
   };
   const idsOf = (result: { entities: { id: string }[] }) =>
     new Set(result.entities.map((entity) => entity.id));
+  // The schema the crossing document's labels are stated against, held as
+  // a content-addressed document its `cfc` envelope names by hash.
+  const labelSchema = {
+    type: "object",
+    properties: { name: { type: "string" } },
+  } as const;
+  const labelSchemaId = `cid:${internSchemaAsTaggedHashString(labelSchema)}`;
+  // The schema a later version of the crossing document restates its
+  // labels against.
+  const relabeledSchema = {
+    type: "object",
+    properties: { name: { type: "string" }, renamed: { type: "boolean" } },
+  } as const;
+  const relabeledSchemaId = `cid:${
+    internSchemaAsTaggedHashString(relabeledSchema)
+  }`;
 
   try {
     applyCommit(engine, {
@@ -2384,6 +2400,10 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
         localSeq: 1,
         reads: { confirmed: [], pending: [] },
         operations: [{
+          op: "set",
+          id: labelSchemaId,
+          value: { value: labelSchema },
+        }, {
           op: "set",
           id: "of:root-family",
           value: { value: { kind: "root pattern" } },
@@ -2404,6 +2424,11 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
           id: "of:crossing-target",
           value: {
             value: { name: "target" },
+            cfc: {
+              version: 1,
+              schemaHash: labelSchemaId.slice("cid:".length),
+              labelMap: { version: 1, entries: [] },
+            },
             pattern: link("of:target-family"),
             result: link("of:target-result"),
             internal: [{ link: link("of:target-cell") }, {
@@ -2426,13 +2451,15 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
     // the walk reaches through the `child` crossing arrives under the
     // selector that reached it and with none of its family — not the
     // pattern that serves loading it, not the result and derived cell its
-    // computations write.
+    // computations write — beyond the schema document its labels are
+    // checked against.
     const rooted = idsOf(
       queryGraph(space, engine, rootQuery, undefined, identity),
     );
     assert(rooted.has("of:meta-root"));
     assert(rooted.has("of:crossing-target"));
     assert(rooted.has("of:root-family"));
+    assert(rooted.has(labelSchemaId));
     assert(!rooted.has("of:target-family"));
     assert(!rooted.has("of:target-result"));
     assert(!rooted.has("of:target-cell"));
@@ -2443,6 +2470,7 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
       queryGraph(space, engine, targetQuery, undefined, identity),
     );
     assert(targetRooted.has("of:crossing-target"));
+    assert(targetRooted.has(labelSchemaId));
     assert(targetRooted.has("of:target-family"));
     assert(targetRooted.has("of:target-result"));
     assert(targetRooted.has("of:target-cell"));
@@ -2517,7 +2545,9 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
     // A dirty crossing keeps its crossing shape: updating the crossed
     // document re-walks it WITHOUT promoting it to a named root's
     // family, so what a subscriber holds does not depend on update
-    // history.
+    // history — and the re-walk delivers the schema document the new
+    // version's labels are checked against, exactly as the first reach
+    // delivered the old one.
     applyCommit(engine, {
       sessionId: "session:writer",
       invocation: invocationFor(3),
@@ -2527,9 +2557,18 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
         reads: { confirmed: [], pending: [] },
         operations: [{
           op: "set",
+          id: relabeledSchemaId,
+          value: { value: relabeledSchema },
+        }, {
+          op: "set",
           id: "of:crossing-target",
           value: {
             value: { name: "target, renamed" },
+            cfc: {
+              version: 1,
+              schemaHash: relabeledSchemaId.slice("cid:".length),
+              labelMap: { version: 1, entries: [] },
+            },
             pattern: link("of:target-family"),
             result: link("of:target-result"),
             internal: [{ link: link("of:target-cell") }],
@@ -2546,6 +2585,12 @@ Deno.test("memory v2 query chases metadata for named roots, not crossings", asyn
     assertExists(crossingRefreshed);
     assertExists(
       crossingRefreshed.updates.get(`${space}/space/of:crossing-target`),
+    );
+    assertExists(
+      crossingRefreshed.updates.get(`${space}/space/${relabeledSchemaId}`),
+    );
+    assert(
+      crossingTracked.state.entities.has(`${space}/space/${relabeledSchemaId}`),
     );
     for (
       const id of ["of:target-family", "of:target-result", "of:target-cell"]

--- a/packages/runner/src/graph-query.ts
+++ b/packages/runner/src/graph-query.ts
@@ -29,6 +29,7 @@ import {
   getAtPath,
   type IAttestation,
   type IMemorySpaceValueAttestation,
+  loadLabelSchemaDoc,
   loadMetaLinkedDocs,
   ManagedStorageTransaction,
   MapSetStringToPathSelectors,
@@ -197,14 +198,15 @@ export class GraphQueryWalk {
       undefined,
       undefined,
       // A document this walk loads through a link crossing is delivered
-      // under the selector that reached it, without its metadata family.
-      // The family belongs to the documents a query names: `visit()`
-      // chases every rail for its named document, which is what a caller
-      // that intends to load and run one — a piece resume, a setsrc
-      // staging read — relies on. Chasing it at every crossing instead
-      // multiplies a wide walk by each visited piece's whole doc set
-      // (pattern, argument, internal, cfc and their recursion) for
-      // documents nothing asked to run.
+      // under the selector that reached it, without its metadata family
+      // beyond the schema document its `cfc` envelope names, which a
+      // reader of a labeled document checks its reads against. The family
+      // belongs to the documents a query names: `visit()` chases every
+      // rail for its named document, which is what a caller that intends
+      // to load and run one — a piece resume, a setsrc staging read —
+      // relies on. Chasing it at every crossing instead multiplies a wide
+      // walk by each visited piece's whole doc set (pattern, argument,
+      // internal and their recursion) for documents nothing asked to run.
       false,
     );
     this.#memo = options.memo ?? createSchemaMemo();
@@ -321,16 +323,16 @@ export class GraphQueryWalk {
     // covered this document before a root named it, and coverage proves
     // reach, not family. What a caller names, it may intend to load; what
     // a walk merely reaches, it does not, so a crossing-role visit chases
-    // nothing. The chase dedupes through `metaDocsVisited`.
+    // nothing beyond the schema document its `cfc` envelope names. The
+    // family chase dedupes through `metaDocsVisited`.
+    const loaded = {
+      address: { ...document.address, space: this.#space },
+      value: document.value,
+    };
     if (role === "root") {
-      loadMetaLinkedDocs(
-        tx,
-        {
-          address: { ...document.address, space: this.#space },
-          value: document.value,
-        },
-        this.#context,
-      );
+      loadMetaLinkedDocs(tx, loaded, this.#context);
+    } else {
+      loadLabelSchemaDoc(tx, loaded, this.#context);
     }
   }
 

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1294,8 +1294,10 @@ export type TraversalContext = {
    * default: a runtime traversal that loads a document generally intends
    * to interpret it. The memory server's graph-query walk turns it off,
    * because a document reached through a crossing is owed only what the
-   * selector that reached it selects; a family belongs to the documents a
-   * query names, and the walk chases it for each named root itself.
+   * selector that reached it selects, plus the schema document its `cfc`
+   * envelope names (`loadLabelSchemaDoc`), which a reader of a labeled
+   * document checks its reads against; a family belongs to the documents
+   * a query names, and the walk chases it for each named root itself.
    * Consulted only where `includeMeta` already gates the chase; it does
    * not affect `traverseCells`, which `includeMeta` also carries.
    */
@@ -2612,23 +2614,25 @@ function trackVisitedDoc(
     );
   }
   // Load the metadata-linked docs recursively unless the address holds no
-  // value, where the context grants a mid-walk load its family
-  // (`chaseLoadedMeta`).
-  if (context.includeMeta && context.chaseLoadedMeta) {
+  // value: the whole family where the context grants a mid-walk load one
+  // (`chaseLoadedMeta`), and otherwise only the schema document the
+  // loaded document's `cfc` envelope names.
+  if (context.includeMeta) {
     // Loading metadata requires the full doc. Ignore this read for scheduling.
     const { ok: fullDoc } = tx.read(
       { ...target, path: [] },
       { meta: ignoreReadForScheduling },
     );
     if (fullDoc) {
-      loadMetaLinkedDocs(
-        tx,
-        {
-          address: { ...fullDoc.address, space: target.space },
-          value: fullDoc.value,
-        },
-        context,
-      );
+      const loaded = {
+        address: { ...fullDoc.address, space: target.space },
+        value: fullDoc.value,
+      };
+      if (context.chaseLoadedMeta) {
+        loadMetaLinkedDocs(tx, loaded, context);
+      } else {
+        loadLabelSchemaDoc(tx, loaded, context);
+      }
     }
   }
 }
@@ -2932,6 +2936,29 @@ export function loadMetaLinkedDocs(
       }
     }
   }
+}
+
+/**
+ * Loads the schema document a document's `cfc` envelope names, and nothing
+ * else of its metadata family, into the traversal. A reader of a labeled
+ * document checks what it may read against that schema, so the document
+ * is owed it wherever a walk reaches it, named or not. The target enters
+ * the schema tracker exactly as a named root's `cfc` rail enters it, so an
+ * absent one arrives when it is written. A document without an envelope
+ * loads nothing.
+ */
+export function loadLabelSchemaDoc(
+  tx: IExtendedStorageTransaction,
+  valueEntry: IMemorySpaceAttestation,
+  context: TraversalContext,
+): void {
+  loadMetaLinkedDoc(
+    tx,
+    valueEntry,
+    "cfc",
+    context.schemaTracker,
+    context.scopeKeyIdentity,
+  );
 }
 
 // With unified traversal code, we don't need to worry about the server


### PR DESCRIPTION
Stacked on #7132: the base is that PR's branch, and this diff is one commit on top of its head. Lands after it.

## Why

#7132 makes a crossing-reached document owe nothing beyond what its selector selects, and its list of reasons a crossing might have owed its family does not cover label verification. Two read paths need the schema document a document's `cfc` envelope names:

- `packages/runner/src/cell.ts` reads `cid:<schemaHash>` from the local replica to resolve a document's stored schema, and serves the document schemaless when that read finds nothing.
- `loadSchemaDocument` in `packages/runner/src/cfc/prepare.ts` throws `stored schemaHash … is missing or unreadable` unless the replica holds the document or the registry was already fed it.

A subscriber that crosses into a labeled piece receives the piece's document with its `cfc` envelope, and under #7132 alone never receives the schema document the envelope names, so its reads of that piece are checked against nothing. The document is owed wherever a walk reaches it, named or not.

## What changed

- `packages/runner/src/traverse.ts` gains `loadLabelSchemaDoc()`, which follows only the `cfc` rail of a document through the single-rail loader a named root's family chase already uses. The mid-walk gate reads the loaded document whether or not the context grants it a family, and either chases the family or loads just the label schema. The target enters the schema tracker exactly as a root's `cfc` rail does, so an absent one arrives when written.
- `packages/runner/src/graph-query.ts` calls it for a crossing-role visit, the path a refresh takes to re-walk a tracked crossing, so a relabeled document delivers its new schema document too.
- `docs/specs/memory-v2/05-queries.md`: a crossing is owed its selector's selection plus the `cfc` schema document, and the server MUST NOT chase the rest of the family.
- `packages/memory/test/v2-query.test.ts`: the named-roots-versus-crossings test's crossing carries a `cfc` envelope naming a real content-addressed schema document. It asserts the schema document arrives at first reach while pattern, result, and the derived cell still do not, and that a rewrite of the crossing with a new `cfc` hash delivers the new schema document on refresh while the family still stays out. With the loader stubbed to a no-op the first assertion fails.

## Measured

On a local clone of the Estuary topics space (202 topics), a shaped three-scalar read of the board's `topics` root delivers 916 documents with this change, because no Topic document carries `cfc` metadata. The change lands on walks that cross into labeled pieces; the board width win is untouched.

## Gates

memory 602/0, runner 1388/0, `deno task check`, `deno fmt --check`, `deno lint`, and `deno task check-docs`, all under the pinned Deno 2.9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RERGEn11PmaRxCFBoj6d9g
