### PR TITLE
cf-harness console: pages address the console relative to their mount

### DIFF
--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -295,6 +295,19 @@ level of a view, never framed.
 `?turn=<turnId>` narrows the pane to one turn. Without it the pane shows the
 session's activity in order, however many turns it has taken.
 
+`GET /live/<sessionId>/` — the trailing-slash form — answers `308` to
+`../<sessionId>`, query and all. The pane's stylesheet and script are written
+relative to `/live/<sessionId>` (see below), so the slashed form would resolve
+them one level too deep; the `Location` is relative so it lands under whatever
+prefix a host fronts the console at, with no rewriting on the host's side.
+
+Both pages address the console RELATIVE to where they were opened — assets,
+`/api` fetches and the event stream all go under the mount `src/mount.ts` reads
+off the page's own address — so a host may serve the console under a prefix on
+its own origin (loom's daemon fronts it at `/harness-console`, satisfying the
+`Host` gate and carrying the token cookie itself). At the console's own root the
+mount is empty and every path is what it always was.
+
 `?piecesBase=<url-prefix>` says where the host renders a piece. A piece's own
 address is the one `assign_slug` recorded, which is the Fabric API's; a host
 that shows pieces somewhere else — a pane of its own, say, where the API's

--- a/packages/cf-harness/console/public/index.html
+++ b/packages/cf-harness/console/public/index.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>cf-harness console</title>
-    <link rel="stylesheet" href="/styles/console.css" />
+    <link rel="stylesheet" href="./styles/console.css" />
   </head>
   <body>
     <console-app></console-app>
-    <script type="module" src="/scripts/index.js"></script>
+    <script type="module" src="./scripts/index.js"></script>
   </body>
 </html>

--- a/packages/cf-harness/console/public/live.html
+++ b/packages/cf-harness/console/public/live.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>cf-harness live session</title>
-    <link rel="stylesheet" href="/styles/console.css" />
-    <link rel="stylesheet" href="/styles/live.css" />
+    <link rel="stylesheet" href="../styles/console.css" />
+    <link rel="stylesheet" href="../styles/live.css" />
   </head>
   <body class="live">
     <console-live></console-live>
-    <script type="module" src="/scripts/live.js"></script>
+    <script type="module" src="../scripts/live.js"></script>
   </body>
 </html>

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -1002,8 +1002,9 @@ export class ConsoleServer {
     // (`./src/mount.ts`), so the trailing-slash form is sent to the
     // canonical one rather than served with a stylesheet that cannot load.
     // Relative `Location`: it resolves under any host prefix on the client.
+    // The query rides along: `?turn=` and `?piecesBase=` are the address.
     const canonical = request.method === "GET"
-      ? liveCanonicalRedirect(url.pathname)
+      ? liveCanonicalRedirect(url.pathname, url.search)
       : undefined;
     if (canonical !== undefined) {
       return new Response(null, {

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -110,6 +110,7 @@ import {
 import type { CreateHarnessPromptLoopOptions } from "../src/prompt-loop.ts";
 import type { HarnessChatSessionStore } from "../src/session-store.ts";
 import { type ConsolePolicyReport, consolePolicyReport } from "./policy.ts";
+import { liveCanonicalRedirect } from "./src/mount.ts";
 import {
   listConsoleRuns,
   readConsoleRun,
@@ -996,6 +997,19 @@ export class ConsoleServer {
     const refusal = this.#refuse(request, url);
     if (refusal !== undefined) {
       return refusal;
+    }
+    // The live pane's assets are written relative to `/live/<sessionId>`
+    // (`./src/mount.ts`), so the trailing-slash form is sent to the
+    // canonical one rather than served with a stylesheet that cannot load.
+    // Relative `Location`: it resolves under any host prefix on the client.
+    const canonical = request.method === "GET"
+      ? liveCanonicalRedirect(url.pathname)
+      : undefined;
+    if (canonical !== undefined) {
+      return new Response(null, {
+        status: 308,
+        headers: { location: canonical },
+      });
     }
     if (request.method === "GET" && url.pathname === "/api/health") {
       return Response.json({

--- a/packages/cf-harness/console/src/api.ts
+++ b/packages/cf-harness/console/src/api.ts
@@ -5,6 +5,7 @@
  */
 
 import type { HarnessChatEventEnvelope } from "../../src/contracts/interactive-chat.ts";
+import { consolePath, pageMount } from "./mount.ts";
 import type {
   PatternIndexEvent,
   PatternIndexListEventsRequest,
@@ -48,6 +49,13 @@ export type {
   PatternIndexSearchResponse,
 };
 
+/**
+ * A server path as THIS page addresses it: under the mount the page was
+ * opened at (`./mount.ts`). Written once here so no route is fetched from
+ * the origin's root by habit.
+ */
+const api = (path: string): string => consolePath(pageMount(), path);
+
 /** A started turn, and the session it runs in. */
 export interface StartedTask {
   sessionId: string;
@@ -84,7 +92,7 @@ export const startTask = async (
   sessionId?: string,
 ): Promise<StartedTask> =>
   await json<StartedTask>(
-    await fetch("/api/task", {
+    await fetch(api("/api/task"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(
@@ -103,7 +111,7 @@ export const cancelTurn = async (
   turnId?: string,
 ): Promise<void> => {
   await json<unknown>(
-    await fetch("/api/cancel", {
+    await fetch(api("/api/cancel"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ sessionId, turnId }),
@@ -115,12 +123,12 @@ export const listSessions = async (): Promise<
   readonly ConsoleSessionSummary[]
 > =>
   (await json<{ sessions: readonly ConsoleSessionSummary[] }>(
-    await fetch("/api/sessions"),
+    await fetch(api("/api/sessions")),
   )).sessions;
 
 export const listRuns = async (): Promise<readonly ConsoleRunSummary[]> =>
   (await json<{ runs: readonly ConsoleRunSummary[] }>(
-    await fetch("/api/runs"),
+    await fetch(api("/api/runs")),
   )).runs;
 
 /** The durable external result of one completed turn. */
@@ -128,12 +136,12 @@ export const readTurnResult = async (
   turnId: string,
 ): Promise<ConsoleTurnResult> =>
   await json<ConsoleTurnResult>(
-    await fetch(`/api/turns/${encodeURIComponent(turnId)}/result`),
+    await fetch(api(`/api/turns/${encodeURIComponent(turnId)}/result`)),
   );
 
 export const readRun = async (runId: string): Promise<ConsoleRunDetail> =>
   await json<ConsoleRunDetail>(
-    await fetch(`/api/runs/${encodeURIComponent(runId)}`),
+    await fetch(api(`/api/runs/${encodeURIComponent(runId)}`)),
   );
 
 /**
@@ -143,13 +151,13 @@ export const readRun = async (runId: string): Promise<ConsoleRunDetail> =>
  */
 export const readRunGraph = async (runId: string): Promise<ConsoleGraph> =>
   await json<ConsoleGraph>(
-    await fetch(`/api/runs/${encodeURIComponent(runId)}/graph`),
+    await fetch(api(`/api/runs/${encodeURIComponent(runId)}/graph`)),
   );
 
 /** The conversation map of a run and the children beneath it. */
 export const readRunFlow = async (runId: string): Promise<ConsoleFlow> =>
   await json<ConsoleFlow>(
-    await fetch(`/api/runs/${encodeURIComponent(runId)}/flow`),
+    await fetch(api(`/api/runs/${encodeURIComponent(runId)}/flow`)),
   );
 
 /**
@@ -162,7 +170,7 @@ const callIndex = async <Value>(
   body?: Record<string, unknown>,
 ): Promise<Value> =>
   await json<Value>(
-    await fetch("/api/index/call", {
+    await fetch(api("/api/index/call"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body === undefined ? { fn } : { fn, body }),
@@ -206,9 +214,11 @@ export const readRunFile = async (
   name: string,
 ): Promise<string> => {
   const response = await fetch(
-    `/api/runs/${encodeURIComponent(runId)}/${kind}/${
-      encodeURIComponent(name)
-    }`,
+    api(
+      `/api/runs/${encodeURIComponent(runId)}/${kind}/${
+        encodeURIComponent(name)
+      }`,
+    ),
   );
   if (!response.ok) {
     throw new Error(`${name} is not readable`);

--- a/packages/cf-harness/console/src/app.ts
+++ b/packages/cf-harness/console/src/app.ts
@@ -9,6 +9,7 @@
  * its own.
  */
 
+import { consolePath, pageMount } from "./mount.ts";
 import { html, LitElement, nothing, type TemplateResult } from "lit";
 import {
   cancelTurn,
@@ -250,9 +251,12 @@ export class ConsoleApp extends LitElement {
   #subscribe(): void {
     this.#stream?.close();
     const stream = new EventSource(
-      `/api/events?sessionId=${
-        encodeURIComponent(this.sessionId ?? "")
-      }&afterSequence=${this.#lastSequence}`,
+      consolePath(
+        pageMount(),
+        `/api/events?sessionId=${
+          encodeURIComponent(this.sessionId ?? "")
+        }&afterSequence=${this.#lastSequence}`,
+      ),
     );
     this.#stream = stream;
     stream.addEventListener("chat", (message) => {

--- a/packages/cf-harness/console/src/app.ts
+++ b/packages/cf-harness/console/src/app.ts
@@ -9,7 +9,6 @@
  * its own.
  */
 
-import { consolePath, pageMount } from "./mount.ts";
 import { html, LitElement, nothing, type TemplateResult } from "lit";
 import {
   cancelTurn,
@@ -20,6 +19,7 @@ import {
   readRunFlow,
   startTask,
 } from "./api.ts";
+import { consolePath, pageMount } from "./mount.ts";
 import "./index-view.ts";
 import "./flow-view.ts";
 import "./run-view.ts";

--- a/packages/cf-harness/console/src/live-view.ts
+++ b/packages/cf-harness/console/src/live-view.ts
@@ -19,6 +19,7 @@
  * otherwise a feed.
  */
 
+import { consolePath, pageMount } from "./mount.ts";
 import { html, LitElement, nothing, type TemplateResult } from "lit";
 import {
   type ConsoleChatEventEnvelope,
@@ -178,7 +179,9 @@ export const consoleLiveAddress = (
 ): ConsoleLiveAddress => {
   // The segment holds at least one character and decoding never gives back
   // fewer, so a match always names a session.
-  const match = /^\/live\/([^/]+)\/?$/.exec(pathname);
+  // Anchored at the end and not the start: a host may front the console
+  // under a prefix (`./mount.ts`), and the session is still the last segment.
+  const match = /\/live\/([^/]+)\/?$/.exec(pathname);
   let sessionId: string | undefined;
   if (match !== null) {
     try {
@@ -626,9 +629,12 @@ export class ConsoleLive extends LitElement {
   #subscribe(sessionId: string): void {
     this.#stream?.close();
     const stream = new EventSource(
-      `/api/events?sessionId=${
-        encodeURIComponent(sessionId)
-      }&afterSequence=${this.#lastSequence}`,
+      consolePath(
+        pageMount(),
+        `/api/events?sessionId=${
+          encodeURIComponent(sessionId)
+        }&afterSequence=${this.#lastSequence}`,
+      ),
     );
     this.#stream = stream;
     stream.addEventListener("chat", (message) => {

--- a/packages/cf-harness/console/src/live-view.ts
+++ b/packages/cf-harness/console/src/live-view.ts
@@ -19,13 +19,13 @@
  * otherwise a feed.
  */
 
-import { consolePath, pageMount } from "./mount.ts";
 import { html, LitElement, nothing, type TemplateResult } from "lit";
 import {
   type ConsoleChatEventEnvelope,
   type ConsoleRunDetail,
   readRun,
 } from "./api.ts";
+import { consolePath, pageMount } from "./mount.ts";
 import { stepPolicyView, withheldView } from "./steps-view.ts";
 import type { ConsoleStep } from "../steps.ts";
 import type { ConsoleTurnResultPiece } from "../turn-result.ts";

--- a/packages/cf-harness/console/src/mount.ts
+++ b/packages/cf-harness/console/src/mount.ts
@@ -42,12 +42,24 @@ export const pageMount = (): string =>
  * script are `../styles/...` and `../scripts/...`, one level up from
  * `/live/<sessionId>`, so a trailing slash would resolve them one level too
  * deep. Rather than serve a page whose assets cannot load, the server sends
- * the trailing-slash form to the canonical one. The `Location` is RELATIVE
- * on purpose: from `<mount>/live/<sessionId>/` it resolves to
+ * the trailing-slash form to the canonical one, query and all — `?turn=` and
+ * `?piecesBase=` are what the address carries, and a redirect that lost them
+ * would open the pane on the wrong thing. The `Location` is RELATIVE on
+ * purpose: from `<mount>/live/<sessionId>/` it resolves to
  * `<mount>/live/<sessionId>` on the client, whatever the mount, so a host
  * fronting the console under a prefix needs no `Location` rewriting.
+ *
+ * The operator's page has the mirror-image case, and it is the HOST's: at a
+ * bare prefix (`/harness-console`, no slash) `./styles/...` would resolve
+ * beside the prefix rather than under it. The console itself is never asked
+ * for that address — at its own root the page is `/` — so the host that
+ * fronts it under a prefix owns that redirect (loom's daemon answers 308 to
+ * the slashed form).
  */
-export const liveCanonicalRedirect = (pathname: string): string | undefined => {
+export const liveCanonicalRedirect = (
+  pathname: string,
+  search = "",
+): string | undefined => {
   const match = /^\/live\/([^/]+)\/$/.exec(pathname);
-  return match === null ? undefined : `../${match[1]}`;
+  return match === null ? undefined : `../${match[1]}${search}`;
 };

--- a/packages/cf-harness/console/src/mount.ts
+++ b/packages/cf-harness/console/src/mount.ts
@@ -19,7 +19,12 @@
 export const consoleMount = (pathname: string): string => {
   const trimmed = pathname.replace(/\/+$/, "");
   const live = /^(.*)\/live\/[^/]+$/.exec(trimmed);
-  return live === null ? trimmed : live[1];
+  // Strip any trailing slash off the mount itself: for a doubled path like
+  // `/a//live/x` the capture keeps the extra slash, and `consolePath` would
+  // then build `/a//api` — a redundant slash that some hosts route
+  // differently. The real `/harness-console` mount never hits this, but the
+  // mount is the base every path hangs off, so it should be canonical.
+  return (live === null ? trimmed : live[1]).replace(/\/+$/, "");
 };
 
 /**

--- a/packages/cf-harness/console/src/mount.ts
+++ b/packages/cf-harness/console/src/mount.ts
@@ -1,0 +1,53 @@
+/**
+ * Where this console is mounted, read from the address a page was opened at.
+ *
+ * The console serves its pages and `/api` at the root of its own origin — the
+ * loopback address on the loom host. A host can also front it under a prefix
+ * on an origin of its own: loom's daemon serves it at `/harness-console` so a
+ * Weaver on another device reaches it through the same tailnet front as every
+ * other loom route. A page must work at both, so nothing it fetches, streams
+ * or links is written from the origin's root; every path goes under the
+ * mount, and the mount is whatever precedes the page's own address.
+ */
+
+/**
+ * The prefix a page's address sits under: `""` at the console's own root, or
+ * the host's prefix, without a trailing slash. The operator's page is served
+ * at the mount itself (`/` or `/harness-console/`); the live pane is served
+ * at `<mount>/live/<sessionId>`, with or without a trailing slash.
+ */
+export const consoleMount = (pathname: string): string => {
+  const trimmed = pathname.replace(/\/+$/, "");
+  const live = /^(.*)\/live\/[^/]+$/.exec(trimmed);
+  return live === null ? trimmed : live[1];
+};
+
+/**
+ * A console path — `/api/...`, `/live/...` — as this page should address it:
+ * under the mount the page was opened at.
+ */
+export const consolePath = (mount: string, path: string): string =>
+  `${mount}${path}`;
+
+/**
+ * The mount of the page this script runs in. Outside a page (a test, a
+ * server-side import) there is no address, and the console's own root is the
+ * answer, which is what every path was before mounts existed.
+ */
+export const pageMount = (): string =>
+  consoleMount(globalThis.location?.pathname ?? "/");
+
+/**
+ * The live pane's canonical address has no trailing slash: its stylesheet and
+ * script are `../styles/...` and `../scripts/...`, one level up from
+ * `/live/<sessionId>`, so a trailing slash would resolve them one level too
+ * deep. Rather than serve a page whose assets cannot load, the server sends
+ * the trailing-slash form to the canonical one. The `Location` is RELATIVE
+ * on purpose: from `<mount>/live/<sessionId>/` it resolves to
+ * `<mount>/live/<sessionId>` on the client, whatever the mount, so a host
+ * fronting the console under a prefix needs no `Location` rewriting.
+ */
+export const liveCanonicalRedirect = (pathname: string): string | undefined => {
+  const match = /^\/live\/([^/]+)\/$/.exec(pathname);
+  return match === null ? undefined : `../${match[1]}`;
+};

--- a/packages/cf-harness/test/console/felt.config.test.ts
+++ b/packages/cf-harness/test/console/felt.config.test.ts
@@ -6,11 +6,21 @@ import config from "../../console/felt.config.ts";
 describe("felt.config", () => {
   const consoleRoot = fromFileUrl(new URL("../../console", import.meta.url));
 
-  /** Every script a served page asks the browser to load. */
+  /**
+   * Where each page is served, so its script paths — written RELATIVE to the
+   * page (`console/src/mount.ts`: the console may be fronted under a host's
+   * prefix) — resolve to what the server is asked for.
+   */
+  const servedAt: Readonly<Record<string, string>> = {
+    "index.html": "/",
+    "live.html": "/live/session",
+  };
+
+  /** Every script a served page asks the browser to load, as a server path. */
   const scriptsNamedBy = (page: string): readonly string[] => {
     const markup = Deno.readTextFileSync(join(consoleRoot, "public", page));
     return [...markup.matchAll(/<script[^>]+src="([^"]+)"/g)].map((match) =>
-      match[1]
+      new URL(match[1], `http://console${servedAt[page]}`).pathname
     );
   };
 
@@ -24,6 +34,23 @@ describe("felt.config", () => {
     for (const page of ["index.html", "live.html"]) {
       for (const script of scriptsNamedBy(page)) {
         expect(emitted).toContain(script);
+      }
+    }
+  });
+
+  it("names every asset relative to the page, never from the origin's root", () => {
+    // A root-absolute `/scripts/...` or `/styles/...` works only when the
+    // console is the whole origin. Fronted under a host's prefix (loom's
+    // /harness-console) it resolves against the host instead and the page
+    // loads nothing; the CSP's `base-uri 'none'` rules out a <base> fix.
+    for (const page of ["index.html", "live.html"]) {
+      const markup = Deno.readTextFileSync(join(consoleRoot, "public", page));
+      const references = [...markup.matchAll(/(?:src|href)="([^"]+)"/g)].map((
+        match,
+      ) => match[1]);
+      expect(references.length).toBeGreaterThan(0);
+      for (const reference of references) {
+        expect(reference.startsWith("/")).toBe(false);
       }
     }
   });

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -1696,6 +1696,28 @@ describe("console/server", () => {
       expect(response.status).toBe(404);
       expect(response.headers.get("set-cookie")).toBeNull();
     });
+
+    it("sends the trailing-slash live address to its canonical form, relatively", async () => {
+      // The pane's stylesheet and script are `../styles/...` and
+      // `../scripts/...`; from `/live/session-1/` they would resolve one level
+      // too deep. The Location is relative so it lands under whatever prefix
+      // a host fronts the console at, with no rewriting on the host's side.
+      const response = await server.handle(getRequest("/live/session-1/"));
+      await response.body?.cancel();
+
+      expect(response.status).toBe(308);
+      expect(response.headers.get("location")).toBe("../session-1");
+      expect(response.headers.get("set-cookie")).toBeNull();
+    });
+
+    it("still refuses the trailing-slash live address naming another host", async () => {
+      const response = await server.handle(
+        getRequest("/live/session-1/", { host: "evil.test:8100" }),
+      );
+      await response.body?.cancel();
+
+      expect(response.status).toBe(403);
+    });
   });
 
   describe("request authorization", () => {

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -1710,6 +1710,21 @@ describe("console/server", () => {
       expect(response.headers.get("set-cookie")).toBeNull();
     });
 
+    it("keeps the turn and pieces base a trailing-slash live address carries", async () => {
+      // `?turn=` narrows the pane and `?piecesBase=` says where a piece
+      // renders; a redirect that dropped them would open the pane on the
+      // wrong thing.
+      const response = await server.handle(getRequest(
+        "/live/session-1/?turn=turn-1&piecesBase=http%3A%2F%2Fh%2Fpattern-pane",
+      ));
+      await response.body?.cancel();
+
+      expect(response.status).toBe(308);
+      expect(response.headers.get("location")).toBe(
+        "../session-1?turn=turn-1&piecesBase=http%3A%2F%2Fh%2Fpattern-pane",
+      );
+    });
+
     it("still refuses the trailing-slash live address naming another host", async () => {
       const response = await server.handle(
         getRequest("/live/session-1/", { host: "evil.test:8100" }),

--- a/packages/cf-harness/test/console/src/api.test.ts
+++ b/packages/cf-harness/test/console/src/api.test.ts
@@ -5,10 +5,19 @@ import { cancelTurn } from "../../../console/src/api.ts";
 const realFetch = globalThis.fetch;
 
 /** Answers every request with one response, and remembers what was asked. */
-const answerWith = (response: Response): { calls: number } => {
-  const record = { calls: 0 };
-  globalThis.fetch = () => {
+const answerWith = (
+  response: Response,
+): { calls: number; paths: string[] } => {
+  const record = { calls: 0, paths: [] as string[] };
+  globalThis.fetch = (input) => {
     record.calls += 1;
+    if (typeof input === "string") {
+      record.paths.push(input);
+    } else if (input instanceof Request) {
+      record.paths.push(new URL(input.url).pathname);
+    } else {
+      record.paths.push(input.pathname);
+    }
     return Promise.resolve(response);
   };
   return record;
@@ -26,6 +35,16 @@ describe("console/src/api", () => {
       await cancelTurn("session-a", "turn-a");
 
       expect(asked.calls).toBe(1);
+    });
+
+    it("asks under the page's mount, which is the root outside a page", () => {
+      // Every path goes through console/src/mount.ts; with no location (a
+      // test), the mount is the console's own root and the path is as it was.
+      const asked = answerWith(Response.json({ sessionId: "session-a" }));
+
+      return cancelTurn("session-a", "turn-a").then(() => {
+        expect(asked.paths).toEqual(["/api/cancel"]);
+      });
     });
 
     it("rejects with the reason a refused cancel reported", async () => {

--- a/packages/cf-harness/test/console/src/api.test.ts
+++ b/packages/cf-harness/test/console/src/api.test.ts
@@ -37,14 +37,14 @@ describe("console/src/api", () => {
       expect(asked.calls).toBe(1);
     });
 
-    it("asks under the page's mount, which is the root outside a page", () => {
+    it("asks under the page's mount, which is the root outside a page", async () => {
       // Every path goes through console/src/mount.ts; with no location (a
       // test), the mount is the console's own root and the path is as it was.
       const asked = answerWith(Response.json({ sessionId: "session-a" }));
 
-      return cancelTurn("session-a", "turn-a").then(() => {
-        expect(asked.paths).toEqual(["/api/cancel"]);
-      });
+      await cancelTurn("session-a", "turn-a");
+
+      expect(asked.paths).toEqual(["/api/cancel"]);
     });
 
     it("rejects with the reason a refused cancel reported", async () => {

--- a/packages/cf-harness/test/console/src/live-view.test.ts
+++ b/packages/cf-harness/test/console/src/live-view.test.ts
@@ -144,6 +144,14 @@ describe("console/src/live-view", () => {
       });
     });
 
+    it("returns the session behind the prefix a host fronts the console at", () => {
+      // loom's daemon serves the console at /harness-console on its origin;
+      // the session is still the last segment.
+      expect(consoleLiveAddress("/harness-console/live/session-1")).toEqual({
+        sessionId: "session-1",
+      });
+    });
+
     it("returns the session named with a trailing slash", () => {
       expect(consoleLiveAddress("/live/session-1/").sessionId).toBe(
         "session-1",

--- a/packages/cf-harness/test/console/src/mount.test.ts
+++ b/packages/cf-harness/test/console/src/mount.test.ts
@@ -37,6 +37,15 @@ describe("console/src/mount", () => {
       expect(consoleMount("/a/b/live/session-1")).toBe("/a/b");
       expect(consoleMount("/a/b/")).toBe("/a/b");
     });
+
+    it("returns a canonical mount with no trailing slash from a doubled path", () => {
+      // `consolePath` hangs every route off the mount, so a mount ending in
+      // a slash would build `/a//api`. The mount is canonicalized instead.
+      expect(consoleMount("/a//live/session-1")).toBe("/a");
+      expect(consolePath(consoleMount("/a//live/session-1"), "/api/x")).toBe(
+        "/a/api/x",
+      );
+    });
   });
 
   describe("consolePath()", () => {
@@ -55,6 +64,30 @@ describe("console/src/mount", () => {
       // Deno runs these tests without a location; every path stays as it was
       // before mounts existed.
       expect(pageMount()).toBe("");
+    });
+
+    it("reads the mount off the page's own address when there is one", () => {
+      // The real path the browser is on — a page served under a host prefix
+      // sees its prefix here, which is what prepends to every fetch/stream.
+      const original = Reflect.getOwnPropertyDescriptor(globalThis, "location");
+      try {
+        for (
+          const [path, mount] of [
+            ["/", ""],
+            ["/harness-console/", "/harness-console"],
+            ["/harness-console/live/session-1", "/harness-console"],
+          ] as const
+        ) {
+          Object.defineProperty(globalThis, "location", {
+            value: { pathname: path },
+            configurable: true,
+          });
+          expect(pageMount()).toBe(mount);
+        }
+      } finally {
+        if (original) Object.defineProperty(globalThis, "location", original);
+        else Reflect.deleteProperty(globalThis, "location");
+      }
     });
   });
 

--- a/packages/cf-harness/test/console/src/mount.test.ts
+++ b/packages/cf-harness/test/console/src/mount.test.ts
@@ -68,6 +68,21 @@ describe("console/src/mount", () => {
       );
     });
 
+    it("carries the address's query through the redirect", () => {
+      expect(liveCanonicalRedirect("/live/session-1/", "?turn=t1")).toBe(
+        "../session-1?turn=t1",
+      );
+      expect(
+        liveCanonicalRedirect(
+          "/live/session-1/",
+          "?turn=t1&piecesBase=http%3A%2F%2Fh%2Fpattern-pane",
+        ),
+      ).toBe("../session-1?turn=t1&piecesBase=http%3A%2F%2Fh%2Fpattern-pane");
+      expect(liveCanonicalRedirect("/live/session-1/", "")).toBe(
+        "../session-1",
+      );
+    });
+
     it("leaves every other address alone", () => {
       expect(liveCanonicalRedirect("/live/session-1")).toBeUndefined();
       expect(liveCanonicalRedirect("/live/")).toBeUndefined();

--- a/packages/cf-harness/test/console/src/mount.test.ts
+++ b/packages/cf-harness/test/console/src/mount.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  consoleMount,
+  consolePath,
+  liveCanonicalRedirect,
+  pageMount,
+} from "../../../console/src/mount.ts";
+
+describe("console/src/mount", () => {
+  describe("consoleMount()", () => {
+    it("is the root for the console's own page at its own origin", () => {
+      expect(consoleMount("/")).toBe("");
+    });
+
+    it("is the root for a live pane at the console's own origin", () => {
+      expect(consoleMount("/live/session-1")).toBe("");
+      expect(consoleMount("/live/session-1/")).toBe("");
+    });
+
+    it("is the host's prefix for the console's page served under one", () => {
+      // loom's daemon fronts the console at /harness-console on its origin.
+      expect(consoleMount("/harness-console/")).toBe("/harness-console");
+      expect(consoleMount("/harness-console")).toBe("/harness-console");
+    });
+
+    it("is the host's prefix for a live pane served under one", () => {
+      expect(consoleMount("/harness-console/live/session-1")).toBe(
+        "/harness-console",
+      );
+      expect(consoleMount("/harness-console/live/session%2F1/")).toBe(
+        "/harness-console",
+      );
+    });
+
+    it("keeps a deeper prefix whole", () => {
+      expect(consoleMount("/a/b/live/session-1")).toBe("/a/b");
+      expect(consoleMount("/a/b/")).toBe("/a/b");
+    });
+  });
+
+  describe("consolePath()", () => {
+    it("addresses a console path under the mount", () => {
+      expect(consolePath("", "/api/events?sessionId=s")).toBe(
+        "/api/events?sessionId=s",
+      );
+      expect(consolePath("/harness-console", "/api/task")).toBe(
+        "/harness-console/api/task",
+      );
+    });
+  });
+
+  describe("pageMount()", () => {
+    it("is the root outside a page, where there is no address", () => {
+      // Deno runs these tests without a location; every path stays as it was
+      // before mounts existed.
+      expect(pageMount()).toBe("");
+    });
+  });
+
+  describe("liveCanonicalRedirect()", () => {
+    it("sends the trailing-slash live address one level up, relatively", () => {
+      // Relative so it resolves under any mount on the client: from
+      // <mount>/live/session-1/ to <mount>/live/session-1.
+      expect(liveCanonicalRedirect("/live/session-1/")).toBe("../session-1");
+      expect(liveCanonicalRedirect("/live/session%2F1/")).toBe(
+        "../session%2F1",
+      );
+    });
+
+    it("leaves every other address alone", () => {
+      expect(liveCanonicalRedirect("/live/session-1")).toBeUndefined();
+      expect(liveCanonicalRedirect("/live/")).toBeUndefined();
+      expect(liveCanonicalRedirect("/")).toBeUndefined();
+      expect(liveCanonicalRedirect("/live/session-1/turn-1")).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Why

**The console is about to be served under a prefix, on another origin, and its pages assume they are the whole origin.** The Weaver reaches loom over one `tailscale serve` front — `https://<host>.saga-castor.ts.net/` → the loom daemon — and that is the primary way Dan and Tony run it: the Weaver on a Mac that is not the loom host (Tony's loom host is macOS 15; the Weaver's floor is 26). Every pill verb already travels that origin. Two companion PRs make `/cf-harness` travel it too: **commontoolsinc/loom#5703** fronts this console at `/harness-console/*` on the daemon (Host rewritten to the loopback the console insists on, token cookie passed through with its Path rewritten, `/api/events` streamed), and **commontoolsinc/commonfabric-weaver#275** points the pill's client there when the loom it resolved is remote.

The native client is fine behind the prefix — it string-joins base + path. The **pages** are not. `index.html` and `live.html` load `/styles/...` and `/scripts/...` from the origin's root; `api.ts` fetches `/api/...` from the root; both `EventSource`s open `/api/events` at the root; and `consoleLiveAddress` anchors `/live/<sessionId>` at the start of the path. Under `/harness-console/` all of that resolves against the loom daemon and 404s — the live pane the Weaver places in the loom while a turn runs (`GET <console>/live/<sessionId>?turn=…`) comes up blank. The CSP's `base-uri 'none'` rules out a `<base>` fix, correctly. So the pages become **mount-relative**: nothing is written from the origin's root; every path goes under whatever precedes the page's own address.

Nothing changes for the console at its own root — `""` is the mount there and every path is byte-for-byte what it was. The console's own trust model (loopback bind, Host allowlist, per-process token cookie) is untouched; the host that fronts it satisfies those gates itself (loom#5703).

## What Changed

- **`console/src/mount.ts`** (new) — `consoleMount(pathname)`: `""` at the root, or the prefix a host serves the console under, for both the operator's page (`/`, `/harness-console/`) and the live pane (`<mount>/live/<id>`, trailing slash or not). `consolePath`, `pageMount()` (the running page's mount; the root outside a page). `liveCanonicalRedirect`: the trailing-slash live form → `../<id>`.
- **`console/src/api.ts`** — every `fetch` goes through one `api(path)` under the page's mount.
- **`console/src/app.ts`, `console/src/live-view.ts`** — the two `EventSource`s open under the mount; `consoleLiveAddress` matches `/live/<id>` at the END of the path, so a prefixed address still names its session.
- **`console/public/index.html`, `live.html`** — `./styles/…`, `./scripts/…` and `../styles/…`, `../scripts/…` (relative to where each page is served; felt copies the markup verbatim).
- **`console/server.ts`** — `GET /live/<id>/` answers **308** with a *relative* `Location: ../<id>`, after the Host gate. The pane's assets are `../…` from `/live/<id>`, so the trailing-slash form would resolve them one level too deep; relative so it lands under any host prefix with no `Location` rewriting on the host's side.
- **Tests** — `test/console/src/mount.test.ts` (new); `live-view.test.ts` (session behind a prefix); `api.test.ts` (the path asked for, root outside a page); `felt.config.test.ts` (script paths resolved against where each page is served, and a new check that no page asset is root-absolute); `server.test.ts` (the 308 and its relative Location; the Host gate still refuses the trailing-slash form).

## Test plan

- `deno fmt --check`, `deno lint`, `deno check` on the console — with Deno 2.9.4 (the `mise.toml` pin).
- `deno test test/console` — 21 suites, 547 steps, 0 failures. Whole-package `deno task test` result in the PR comments.
- `deno task console:build` — `dist/index.html` and `dist/live.html` carry the relative paths.
- Live, once loom#5703 is deployed on Tony's daemon and this lands in the labs tag loom pins: from the Weaver on Tony's bench, `/cf-harness <task>` places the live pane at `https://<host>/harness-console/live/<id>?turn=…` and it streams; recorded on weaver#275.

Not changed: the console still defaults to port 8100 when started bare; the Weaver pairing procedure (`docs/WEAVER.md`) pins 8135, and loom#5703 proxies to 8135 by default (configurable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeoKMjz4dBrSSWaJnLdVgV


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Coverage

ACCEPT_COVERAGE_DEBT: packages/cf-harness +5 lines

_Every line this PR adds is covered — `deno coverage --lcov` reports 0 uncovered lines in `console/src/mount.ts` and in the `server.ts` 308 block and import this PR touches (the other console files report 100%). The +5 `packages/cf-harness` figure the ratchet reports is a baseline artifact against the cf-harness PRs that merged concurrently tonight, not a coverable line in this diff. Accepting the small delta per the ratchet's own mechanism._
