### PR TITLE
feat(cf-harness): author durable Looms through explicit host tools

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -112,6 +112,8 @@ What works today:
   from the sibling `gvisor` repo:
   - `us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest`
   - override per run with `--sandbox-image` or `CF_HARNESS_SANDBOX_IMAGE`
+- durable Loom collections through an explicitly configured host transport; see
+  [Durable Loom authoring](docs/LOOM_AUTHORING.md);
 - built-in tools:
   - `bash`
   - `browser` (structured host browser control for the browser subagent profile
@@ -144,6 +146,9 @@ What works today:
     registry and a Fabric session are configured; resolves a discovery id to a
     full GitHub commit, checks the complete recursive tree, and returns a handle
     or a first-class refusal, never skill text)
+  - `loom_compose`, `loom_inspect`, and `loom_authoring_context` (present only
+    with `--loom-authoring-config`; collections and verified commit receipts,
+    separate from Pattern Instance deployment)
   - `query_docs` (present when the run resolves a documentation corpus; asks one
     question of operator-provisioned reference material and returns a bounded
     answer plus inert citations, never the documents; see

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -231,10 +231,16 @@ receipts, replay flags, and current versions, and is empty when the run composed
 none. Optional `originLoomId` is the turn's submitted origin. Enable the tools
 with `--loom-authoring-config` or `CF_HARNESS_LOOM_AUTHORING_CONFIG`; the
 complete contract is [Durable Loom authoring](../docs/LOOM_AUTHORING.md). Each
-entry copies only `slug` and `url` from the model-facing `assign_slug` output
-recorded in the run transcript; the console neither reconstructs the URL nor
-derives pattern metadata. `spaceName` identifies the space this console is
-configured against.
+entry copies `slug` and `url` from the successful `assign_slug` observation.
+When that same held token also appeared in a verified successful composition,
+optional `loomComponents: [{loomId, componentId}]` identifies its saved
+membership. The correlation uses unique matching current-turn tool calls and
+request-order receipt IDs, never the human slug or assistant prose. Clients
+suppress duplicate placement only after verifying that pair in a freshly opened
+manifest. Missing or ambiguous correlation keeps the ordinary placement path;
+different tokens for the same Pattern are not inferred equivalent. No cell
+address or token is added to the result. `spaceName` identifies this console's
+configured space.
 
 The route never holds a request open; it answers with where the turn stands, and
 the status code says whether asking again can change the answer:

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -235,12 +235,13 @@ entry copies `slug` and `url` from the successful `assign_slug` observation.
 When that same held token also appeared in a verified successful composition,
 optional `loomComponents: [{loomId, componentId}]` identifies its saved
 membership. The correlation uses unique matching current-turn tool calls and
-request-order receipt IDs, never the human slug or assistant prose. Clients
-suppress duplicate placement only after verifying that pair in a freshly opened
-manifest. Missing or ambiguous correlation keeps the ordinary placement path;
-different tokens for the same Pattern are not inferred equivalent. No cell
-address or token is added to the result. `spaceName` identifies this console's
-configured space.
+request-order receipt IDs, never the human slug or assistant prose. When using
+this metadata, clients suppress duplicate placement only after verifying the
+pair in a freshly opened manifest. Weaver also retains a legacy exact-reference
+membership check; absent either proof it keeps ordinary placement. Different
+tokens for the same Pattern are not inferred equivalent. No cell address or
+token is added to the result. `spaceName` identifies this console's configured
+space.
 
 The route never holds a request open; it answers with where the turn stands, and
 the status code says whether asking again can change the answer:

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -164,8 +164,9 @@ provider turn or make a Fabric round trip. A caller needing proven substrate
 liveness must perform a separate probe.
 
 A task body carries the text, optionally the session to continue, and optionally
-the cells the task is to be computed over and the published patterns it is to be
-given:
+the cells the task is to be computed over, published patterns, and the
+originating durable Loom. Optional `loomId` is captured per turn, persisted, and
+returned as `originLoomId`; it never changes with later UI focus:
 
 ```json
 {
@@ -212,6 +213,7 @@ The completed-turn result is:
 
 ```json
 {
+  "looms": [],
   "pieces": [
     {
       "slug": "reading-list",
@@ -224,9 +226,14 @@ The completed-turn result is:
 ```
 
 `pieces` is always present, including as `[]` when the run assigned no slug.
-Each entry copies only `slug` and `url` from the model-facing `assign_slug`
-output recorded in the run transcript; the console neither reconstructs the URL
-nor derives pattern metadata. `spaceName` identifies the space this console is
+`looms` is also always present: it contains verified current-turn composition
+receipts, replay flags, and current versions, and is empty when the run composed
+none. Optional `originLoomId` is the turn's submitted origin. Enable the tools
+with `--loom-authoring-config` or `CF_HARNESS_LOOM_AUTHORING_CONFIG`; the
+complete contract is [Durable Loom authoring](../docs/LOOM_AUTHORING.md). Each
+entry copies only `slug` and `url` from the model-facing `assign_slug` output
+recorded in the run transcript; the console neither reconstructs the URL nor
+derives pattern metadata. `spaceName` identifies the space this console is
 configured against.
 
 The route never holds a request open; it answers with where the turn stands, and

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -31,6 +31,7 @@
  * with a link rather than a transcript is what this surface is for.
  */
 
+import { readLoomAuthoringConfig } from "../src/loom-authoring.ts";
 import { parseArgs } from "@std/cli/parse-args";
 import {
   dirname,
@@ -500,6 +501,7 @@ export const resolveConsoleConfig = async (
       "workspace",
       "artifact-root",
       "model",
+      "loom-authoring-config",
       "fabric-api-url",
       "fabric-identity",
       "fabric-space",
@@ -525,6 +527,10 @@ export const resolveConsoleConfig = async (
   const flag = (name: string): string | undefined =>
     typeof parsed[name] === "string" ? nonEmpty(parsed[name]) : undefined;
 
+  const loomAuthoring = await readLoomAuthoringConfig(
+    flag("loom-authoring-config") ??
+      nonEmpty(env.CF_HARNESS_LOOM_AUTHORING_CONFIG),
+  );
   const systemPromptFile = flag("system-prompt-file") ??
     nonEmpty(env.CF_HARNESS_CONSOLE_SYSTEM_PROMPT_FILE);
 
@@ -670,6 +676,7 @@ export const resolveConsoleConfig = async (
     ),
     model: flag("model") ?? nonEmpty(env.CF_HARNESS_MODEL) ?? DEFAULT_MODEL,
     fabricSession,
+    ...(loomAuthoring !== undefined ? { loomAuthoring } : {}),
     ...(spaceDbPath !== undefined ? { spaceDbPath } : {}),
     ...(patternIndexUrl !== undefined
       ? {
@@ -942,6 +949,7 @@ export class ConsoleServer {
       envelope.event.turnId,
     ) ?? {
       pieces: [],
+      looms: [],
       spaceName: this.#config.fabricSession.space,
       finalText: envelope.event.finalText ?? "",
     };
@@ -960,7 +968,12 @@ export class ConsoleServer {
     turnId: string,
   ): Promise<ConsoleTurnResult | undefined> {
     const [session] = this.#service.status(sessionId).sessions;
+    const turns = await this.#service.listTurnsForReplay({ sessionId });
+    const originLoomId = turns.turns.find((entry) =>
+      entry.turn.turnId === turnId
+    )?.input.loomId;
     return await readConsoleTurnResult({
+      ...(originLoomId !== undefined ? { originLoomId } : {}),
       artifactRoot: session?.artifactRoot ?? this.#config.artifactRoot,
       turnId,
       spaceName: this.#config.fabricSession.space,
@@ -1315,7 +1328,17 @@ export class ConsoleServer {
       sessionId?: unknown;
       inputCells?: unknown;
       patternRefs?: unknown;
+      loomId?: unknown;
     } = typeof parsed === "object" && parsed !== null ? parsed : {};
+    if (
+      body.loomId !== undefined &&
+      (typeof body.loomId !== "string" ||
+        !/^loom-[a-f0-9]{16}$/.test(body.loomId))
+    ) {
+      return Response.json({
+        error: "loomId must be a canonical Loom identifier",
+      }, { status: 400 });
+    }
     const text = body.text;
     if (typeof text !== "string" || text.trim() === "") {
       return Response.json({ error: "text is required" }, { status: 400 });
@@ -1350,7 +1373,10 @@ export class ConsoleServer {
     }
     const turn = await this.#service.startTurn(crypto.randomUUID(), {
       sessionId,
-      input: { text },
+      input: {
+        text,
+        ...(typeof body.loomId === "string" ? { loomId: body.loomId } : {}),
+      },
       ...(inputCells.length > 0 ? { inputCells } : {}),
       ...(patternRefs.length > 0 ? { patternRefs } : {}),
     });

--- a/packages/cf-harness/console/turn-result.ts
+++ b/packages/cf-harness/console/turn-result.ts
@@ -25,6 +25,9 @@ export interface ConsoleTurnResultPiece {
 
   /** Openable URL returned beside the slug. */
   url: string;
+
+  /** Verified composition membership for the same held token. No cell address. */
+  loomComponents?: readonly { loomId: string; componentId: string }[];
 }
 
 /** The stable result an external console caller reads for a completed turn. */
@@ -113,6 +116,36 @@ interface TurnRunArtifacts {
   currentTranscriptIndexes: ReadonlySet<number>;
   finalText: string;
 }
+
+/**
+ * Pairs only this turn's unique, preceding assistant call with its tool result.
+ * Historical calls and malformed/duplicate pairs cannot prove membership.
+ */
+const callArguments = (
+  artifacts: TurnRunArtifacts,
+  resultIndex: number,
+): Record<string, unknown> | undefined => {
+  const result = artifacts.transcript[resultIndex];
+  if (result.role !== "tool") return undefined;
+  const matches = artifacts.transcript.flatMap((message, index) => {
+    if (
+      index >= resultIndex || !artifacts.currentTranscriptIndexes.has(index) ||
+      message.role !== "assistant" || !Array.isArray(message.toolCalls)
+    ) return [];
+    return message.toolCalls.filter((call) => call?.id === result.toolCallId);
+  });
+  if (matches.length !== 1 || matches[0].function?.name !== result.toolName) {
+    return undefined;
+  }
+  try {
+    const value: unknown = JSON.parse(matches[0].function.arguments);
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 /**
  * Returns a generated message's index, `malformed` for an invalid generated
@@ -239,34 +272,64 @@ export const readConsoleTurnResult = async (
   if (artifacts === undefined) {
     return undefined;
   }
+  const membership = new Map<
+    string,
+    { loomId: string; componentId: string }[]
+  >();
+  const looms = artifacts.transcript.flatMap((message, index) => {
+    if (
+      !artifacts.currentTranscriptIndexes.has(index) ||
+      message.role !== "tool" || message.toolName !== "loom_compose"
+    ) return [];
+    try {
+      const output: unknown = JSON.parse(message.content);
+      if (!isLoomAuthoredObservation(output)) return [];
+      const args = callArguments(artifacts, index);
+      const ids = output.receipt.component_ids as string[];
+      // compose preserves request order in component_ids. This correlation
+      // needs both the matching successful call and its exact receipt; it is
+      // not inferred from a human slug or copied out of model prose.
+      if (
+        args?.request_id === output.receipt.request_id &&
+        Array.isArray(args.components) && args.components.length === ids.length
+      ) {
+        args.components.forEach((component, position) => {
+          const token = component?.pattern_token;
+          if (typeof token !== "string" || token.length === 0) return;
+          membership.set(token, [...membership.get(token) ?? [], {
+            loomId: output.receipt.loom_id,
+            componentId: ids[position],
+          }]);
+        });
+      }
+      return [{
+        receipt: output.receipt,
+        replayed: output.replayed,
+        current_version: output.current_version,
+      }];
+    } catch {
+      return [];
+    }
+  });
   return {
     ...(options.originLoomId !== undefined
       ? { originLoomId: options.originLoomId }
       : {}),
-    looms: artifacts.transcript.flatMap((message, index) => {
-      if (
-        !artifacts.currentTranscriptIndexes.has(index) ||
-        message.role !== "tool" || message.toolName !== "loom_compose"
-      ) return [];
-      try {
-        const output: unknown = JSON.parse(message.content);
-        return isLoomAuthoredObservation(output)
-          ? [{
-            receipt: output.receipt,
-            replayed: output.replayed,
-            current_version: output.current_version,
-          }]
-          : [];
-      } catch {
-        return [];
-      }
-    }),
+    looms,
     pieces: artifacts.transcript.flatMap((message, index) => {
       if (!artifacts.currentTranscriptIndexes.has(index)) {
         return [];
       }
       const piece = pieceFromAssignSlug(message);
-      return piece === undefined ? [] : [piece];
+      if (piece === undefined) return [];
+      const args = callArguments(artifacts, index);
+      const coverage = typeof args?.token === "string"
+        ? membership.get(args.token)
+        : undefined;
+      return [{
+        ...piece,
+        ...(coverage === undefined ? {} : { loomComponents: coverage }),
+      }];
     }),
     spaceName: options.spaceName,
     finalText: artifacts.finalText,

--- a/packages/cf-harness/console/turn-result.ts
+++ b/packages/cf-harness/console/turn-result.ts
@@ -6,6 +6,10 @@
  * mistaken for a completed contract.
  */
 
+import {
+  isLoomAuthoredObservation,
+  type LoomAuthoredObservation,
+} from "../src/loom-authoring.ts";
 import { join } from "@std/path";
 
 import type {
@@ -25,6 +29,15 @@ export interface ConsoleTurnResultPiece {
 
 /** The stable result an external console caller reads for a completed turn. */
 export interface ConsoleTurnResult {
+  /** Verified compositions from this turn only, including explicit replays. */
+  looms: readonly Pick<
+    LoomAuthoredObservation,
+    "receipt" | "replayed" | "current_version"
+  >[];
+
+  /** Originating Loom captured at submission, independent of later UI focus. */
+  originLoomId?: string;
+
   /** Successful named-piece outputs, in transcript order. */
   pieces: readonly ConsoleTurnResultPiece[];
 
@@ -58,6 +71,9 @@ export type ConsoleChatEventEnvelope =
 
 /** Inputs which identify one turn's durable result. */
 export interface ReadConsoleTurnResultOptions {
+  /** Originating Loom from the durable turn input. */
+  originLoomId?: string;
+
   /** Root holding one artifact directory per turn. */
   artifactRoot: string;
 
@@ -224,6 +240,27 @@ export const readConsoleTurnResult = async (
     return undefined;
   }
   return {
+    ...(options.originLoomId !== undefined
+      ? { originLoomId: options.originLoomId }
+      : {}),
+    looms: artifacts.transcript.flatMap((message, index) => {
+      if (
+        !artifacts.currentTranscriptIndexes.has(index) ||
+        message.role !== "tool" || message.toolName !== "loom_compose"
+      ) return [];
+      try {
+        const output: unknown = JSON.parse(message.content);
+        return isLoomAuthoredObservation(output)
+          ? [{
+            receipt: output.receipt,
+            replayed: output.replayed,
+            current_version: output.current_version,
+          }]
+          : [];
+      } catch {
+        return [];
+      }
+    }),
     pieces: artifacts.transcript.flatMap((message, index) => {
       if (!artifacts.currentTranscriptIndexes.has(index)) {
         return [];

--- a/packages/cf-harness/console/turn-result.ts
+++ b/packages/cf-harness/console/turn-result.ts
@@ -17,6 +17,7 @@ import type {
   HarnessChatStructuredEvent,
 } from "../src/contracts/interactive-chat.ts";
 import type {
+  HarnessToolCall,
   HarnessToolTranscriptMessage,
   HarnessTranscriptMessage,
 } from "../src/contracts/transcript.ts";
@@ -120,27 +121,51 @@ interface TurnRunArtifacts {
   finalText: string;
 }
 
+/** The first two occurrences suffice to establish uniqueness at any prefix. */
+interface IndexedCall {
+  index: number;
+  call: HarnessToolCall;
+  secondIndex?: number;
+}
+
+const indexCalls = (
+  artifacts: TurnRunArtifacts,
+): ReadonlyMap<string, IndexedCall> => {
+  const calls = new Map<string, IndexedCall>();
+  artifacts.transcript.forEach((message, index) => {
+    if (
+      !artifacts.currentTranscriptIndexes.has(index) ||
+      message.role !== "assistant" || !Array.isArray(message.toolCalls)
+    ) return;
+    for (const call of message.toolCalls) {
+      if (typeof call?.id !== "string") continue;
+      const prior = calls.get(call.id);
+      if (prior === undefined) calls.set(call.id, { index, call });
+      else if (prior.secondIndex === undefined) prior.secondIndex = index;
+    }
+  });
+  return calls;
+};
+
 /**
  * Pairs only this turn's unique, preceding assistant call with its tool result.
  * Historical calls and malformed/duplicate pairs cannot prove membership.
  */
 const callArguments = (
-  artifacts: TurnRunArtifacts,
+  calls: ReadonlyMap<string, IndexedCall>,
   resultIndex: number,
   result: HarnessToolTranscriptMessage,
 ): Record<string, unknown> | undefined => {
-  const matches = artifacts.transcript.flatMap((message, index) => {
-    if (
-      index >= resultIndex || !artifacts.currentTranscriptIndexes.has(index) ||
-      message.role !== "assistant" || !Array.isArray(message.toolCalls)
-    ) return [];
-    return message.toolCalls.filter((call) => call?.id === result.toolCallId);
-  });
-  if (matches.length !== 1 || matches[0].function?.name !== result.toolName) {
+  const match = calls.get(result.toolCallId);
+  if (
+    match === undefined || match.index >= resultIndex ||
+    (match.secondIndex !== undefined && match.secondIndex < resultIndex) ||
+    match.call.function?.name !== result.toolName
+  ) {
     return undefined;
   }
   try {
-    const value: unknown = JSON.parse(matches[0].function.arguments);
+    const value: unknown = JSON.parse(match.call.function.arguments);
     return typeof value === "object" && value !== null && !Array.isArray(value)
       ? value as Record<string, unknown>
       : undefined;
@@ -274,6 +299,7 @@ export const readConsoleTurnResult = async (
   if (artifacts === undefined) {
     return undefined;
   }
+  const calls = indexCalls(artifacts);
   const membership = new Map<
     string,
     { loomId: string; componentId: string }[]
@@ -286,7 +312,7 @@ export const readConsoleTurnResult = async (
     try {
       const output: unknown = JSON.parse(message.content);
       if (!isLoomAuthoredObservation(output)) return [];
-      const args = callArguments(artifacts, index, message);
+      const args = callArguments(calls, index, message);
       const ids = output.receipt.component_ids as string[];
       // compose preserves request order in component_ids. This correlation
       // needs both the matching successful call and its exact receipt; it is
@@ -327,7 +353,7 @@ export const readConsoleTurnResult = async (
       }
       const piece = pieceFromAssignSlug(message);
       if (piece === undefined) return [];
-      const args = callArguments(artifacts, index, message);
+      const args = callArguments(calls, index, message);
       const coverage = typeof args?.token === "string"
         ? membership.get(args.token)
         : undefined;

--- a/packages/cf-harness/console/turn-result.ts
+++ b/packages/cf-harness/console/turn-result.ts
@@ -16,7 +16,10 @@ import type {
   HarnessChatEventEnvelope,
   HarnessChatStructuredEvent,
 } from "../src/contracts/interactive-chat.ts";
-import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
+import type {
+  HarnessToolTranscriptMessage,
+  HarnessTranscriptMessage,
+} from "../src/contracts/transcript.ts";
 
 /** A named piece a completed console turn made openable. */
 export interface ConsoleTurnResultPiece {
@@ -124,9 +127,8 @@ interface TurnRunArtifacts {
 const callArguments = (
   artifacts: TurnRunArtifacts,
   resultIndex: number,
+  result: HarnessToolTranscriptMessage,
 ): Record<string, unknown> | undefined => {
-  const result = artifacts.transcript[resultIndex];
-  if (result.role !== "tool") return undefined;
   const matches = artifacts.transcript.flatMap((message, index) => {
     if (
       index >= resultIndex || !artifacts.currentTranscriptIndexes.has(index) ||
@@ -284,7 +286,7 @@ export const readConsoleTurnResult = async (
     try {
       const output: unknown = JSON.parse(message.content);
       if (!isLoomAuthoredObservation(output)) return [];
-      const args = callArguments(artifacts, index);
+      const args = callArguments(artifacts, index, message);
       const ids = output.receipt.component_ids as string[];
       // compose preserves request order in component_ids. This correlation
       // needs both the matching successful call and its exact receipt; it is
@@ -317,12 +319,15 @@ export const readConsoleTurnResult = async (
       : {}),
     looms,
     pieces: artifacts.transcript.flatMap((message, index) => {
-      if (!artifacts.currentTranscriptIndexes.has(index)) {
+      if (
+        !artifacts.currentTranscriptIndexes.has(index) ||
+        message.role !== "tool"
+      ) {
         return [];
       }
       const piece = pieceFromAssignSlug(message);
       if (piece === undefined) return [];
-      const args = callArguments(artifacts, index);
+      const args = callArguments(artifacts, index, message);
       const coverage = typeof args?.token === "string"
         ? membership.get(args.token)
         : undefined;

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -44,6 +44,11 @@ the model to make policy decisions.
 
 The current package provides:
 
+- durable Loom composition, exact inspection, and bounded receipt recovery over
+  an explicitly configured host command transport; current-turn console results
+  include verified authored Loom receipts and the submitted origin. See
+  [Durable Loom authoring](LOOM_AUTHORING.md) for authority, custody, and retry
+  contracts;
 - batch CLI execution with bounded model turns and optional streamed events;
 - machine-readable capability discovery with `--describe-capabilities`;
 - persistent provider configuration and structured config/auth control, with

--- a/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md
@@ -130,7 +130,7 @@ readiness.
 - CFC authority: Common Fabric runner/runtime evidence and trusted sandbox
   sidecars. Harness-local policy logic is conservative transport/enforcement,
   not the source of label meaning.
-- Host execution: no parent-run shell reaches the host. Two bounded host-side
+- Host execution: no parent-run shell reaches the host. Bounded host-side
   surfaces exist beside the sandbox: the browser child profile's typed `browser`
   tool and allowlisted skill scripts, bound to an explicit local CDP lease the
   harness attaches itself, and the `run_pattern` tool, which compiles
@@ -140,7 +140,10 @@ readiness.
   `assign_slug` tool registers a piece the run holds a handle to in that space's
   piece list under a caller-chosen slug. Neither surface admits arbitrary host
   commands, and both fabric-session tools are present only when a fabric session
-  is configured.
+  is configured. Dedicated Loom tools additionally invoke three fixed command
+  ids through an operator-configured host CLI, using argv and stdin with pinned
+  routing and attribution. This is an authority-only host boundary, not a new
+  flow-aware store commit gate; see [LOOM_AUTHORING.md](LOOM_AUTHORING.md).
 - Network: explicit in configuration but still provisional. Sandboxed `bash`
   applies a direct-`curl` destination guard; `web_fetch` and web child profiles
   have their own bounded request policies.
@@ -164,13 +167,15 @@ Current selectable parent tools are `bash`, `read_file`, `view_image`,
 `web_fetch`, `read_skill_resource`, `run_skill_script`, `edit_file`,
 `write_file`, `delegate_task`, `describe_handle`, `run_pattern`, `assign_slug`,
 `search_patterns`, `record_feedback`, `search_skills`, `acquire_skill`, and
-`query_docs`. Individual runs receive only their configured subset; `web_fetch`
-and `run_skill_script` are not in the ordinary default surface. The last seven
-are gated on the backing a run can supply — a fabric session for `run_pattern`,
+`query_docs`, `loom_compose`, `loom_inspect`, and `loom_authoring_context`.
+Individual runs receive only their configured subset; `web_fetch` and
+`run_skill_script` are not in the ordinary default surface. Optional tools are
+gated on the backing a run can supply — a fabric session for `run_pattern`,
 `assign_slug`, and `acquire_skill`, the pattern index for `search_patterns` and
 `record_feedback`, configured skills.sh discovery for `search_skills`, and a
-resolved documentation corpus for `query_docs` — and a tool the run cannot back
-is absent from the surface rather than present and failing, so an explicit
+resolved documentation corpus for `query_docs`, and explicit host Loom
+configuration for the three Loom tools — and a tool the run cannot back is
+absent from the surface rather than present and failing, so an explicit
 allowlist naming it does not conjure it. `run_pattern` additionally requires the
 three `--fabric-*` session flags. `browser` exists only as a built-in used by
 the authorized browser child profile and cannot be selected as a parent CLI

--- a/packages/cf-harness/docs/LOOM_AUTHORING.md
+++ b/packages/cf-harness/docs/LOOM_AUTHORING.md
@@ -1,0 +1,149 @@
+# Durable Loom authoring
+
+Status: current implementation reference
+
+## Why
+
+A Pattern Instance and a Loom are different objects. `run_pattern` instantiates
+a pattern in a Fabric space; `assign_slug` names that instance. A Loom is a
+durable collection with components, stage placement, and focus, owned by the
+Loom command host. A harness caller needs commit evidence to open that
+collection, and a continuing agent needs the original receipt to avoid
+duplicating it after an interruption.
+
+## Host configuration
+
+The CLI and console accept `--loom-authoring-config /absolute/host-config.json`
+or `CF_HARNESS_LOOM_AUTHORING_CONFIG`. The file is supplied by the operator,
+read on the host, and never passed into the sandbox. Without it the three Loom
+tools are absent, including when an allowlist names them.
+
+A broker-backed configuration pins the existing scoped queue:
+
+```json
+{
+  "cliPath": "/opt/loom/src/bin/loom",
+  "transport": {
+    "kind": "broker",
+    "queuePath": "/private/loom/run/command-queue"
+  }
+}
+```
+
+A direct configuration pins an instance and agent attribution:
+
+```json
+{
+  "cliPath": "/opt/loom/src/bin/loom",
+  "transport": {
+    "kind": "direct",
+    "instanceDir": "/private/loom/instances/dev",
+    "runId": "weaver-console",
+    "actor": "agent:cf-harness"
+  }
+}
+```
+
+Paths must be absolute. A direct run identity is nonempty, canonically trimmed,
+and at most 128 characters. The optional `boundLoomId` binds context reads for a
+batch run, never an implicit composition target. Interactive turns bind their
+own `input.loomId` and clear this configuration target when none is supplied.
+
+The command process runs with a cleared environment, the host's executable
+search path, and only the configured routing variables. It receives structured
+arguments on stdin. The model cannot change the executable, queue, instance,
+actor, or run identity. A disappeared broker queue does not permit fallback to
+direct access. Direct calls pass `command run --transport direct` before the
+command id so filesystem queue discovery cannot replace the configured instance.
+An older CLI rejects this flag before dispatch. The host must run a Loom version
+supporting that routing flag, `loom.compose`, `loom.inspect`, and
+`loom.authoring-context` and must grant those commands to the configured broker.
+
+## Tools and authority
+
+- `loom_compose` creates or extends a collection from 1–100 components. A
+  component supplies exactly one `ref` (`page:`, `artifact:`, or `url:`) or
+  `pattern_token`, plus optional title, stage, and focus. An existing target is
+  named by `loom_id` and may carry an `expected_version` guard.
+- `loom_inspect` reads the current version, component metadata, and layout of
+  one exact target. It does not grant handles to the referenced cells or return
+  renderer internals.
+- `loom_authoring_context` returns at most 32 historical receipts in this run's
+  actor namespace, plus a separately bound target. History never selects a write
+  target and does not count as work newly completed in a turn. A missing
+  implicit origin is reported as unavailable beside the remaining historical
+  receipts; an explicitly requested missing target remains an error.
+
+Pattern Instance tokens are resolved inside the dedicated tool, without generic
+inbound token substitution. They must be held general address handles to whole
+Pattern Instances in the configured Fabric session's own space and `space`
+scope. Restricted skill handles, subpaths, foreign spaces, and plain cells are
+refused before a host write. The host converts the accepted token into the
+canonical `pattern:<space>/<instance-id>` Loom reference. That reference stays
+outside model-visible output. Legacy `piece:` references read from a Loom are
+reported with reference kind `pattern`.
+
+Composition is a write for the harness's existing prompt-slot policy: enforcing
+modes still require direct-command authority. The two inspection tools are
+reads. This is an authority check, not a new CFC flow-aware commit gate for
+Loom's store; host command execution, collection metadata, and titles remain
+trusted host responsibilities. Reading a receipt does not attest successful
+rendering.
+
+Comment threads retain their ordinary read-only policy unless the host
+configuration explicitly sets `allowCommentThreads: true`. With that grant, only
+the dedicated Loom tools already named in the session policy survive the
+comment-thread restriction. Shell commands, file writes, and delegation remain
+unavailable. The grant does not manufacture direct-command prompt-slot
+authority. Delegated children do not inherit host Loom configuration
+automatically.
+
+## Receipts and recovery
+
+Choose one `request_id` for one logical composition and retain its exact
+arguments on retry. The host atomically commits components, operations, and a
+receipt. A successful tool observation has `kind: "loom-authored"`, its
+historical `receipt`, `replayed`, `current_version`, and current `displaced`
+component ids. The receipt includes the Loom id, logical request id, commit
+version, created flag, component ids, operation ids, and historical displaced
+component ids.
+
+An identical retry returns the original receipt. Its commit version may be older
+than `current_version`; a replay's current `displaced` is empty even when the
+old receipt recorded an eviction. Report only current effects as actions
+performed by this invocation.
+
+Verified host refusals retain an allowlisted code and bounded recovery guidance.
+A version conflict requires inspection and reconsideration. A request conflict
+means the key already names different committed arguments: recover the original
+receipt before deciding whether any new work is needed. Raw host errors are not
+relayed to the model. An unreadable or malformed composition response remains an
+uncertain outcome; retry the identical request with the same key. Cancellation
+before invocation prevents a command. A started host command settles even if the
+model turn is cancelled, and cancellation does not roll back a commit.
+
+## Interactive and console delivery
+
+Direct interactive calls derive their receipt namespace from the configured run
+identity and stable session id, using the shared SHA-256 implementation. Each
+turn retains its own run id for artifacts. Broker-backed calls retain the
+broker's attribution and namespace.
+
+`POST /api/task` accepts optional `loomId`, validated before a turn starts. It
+is persisted as `input.loomId`, delivered to that turn's host configuration and
+context message, and returned as `originLoomId`. A later turn or a change of UI
+focus does not replace an earlier origin. The originating Loom is context: an
+explicit request for a separate collection can still create one.
+
+Completed console results retain `pieces` and add an always-present `looms`
+array. Entries contain `receipt`, `replayed`, and `current_version`. Only
+verified successful `loom_compose` observations generated in that turn qualify.
+Earlier transcript history, inspections, history lookups, prose, and malformed
+receipts produce no authored entries. An explicit replay in the current turn is
+included as a replay. Callers open a returned Loom by its receipt id through
+their Loom host; they never infer success from assistant text.
+
+Existing durable sessions retain their recorded tool policy. An adapter enabling
+new tools must create a session with the updated policy or explicitly refresh
+its policy; merely restarting a console does not expand an existing session's
+grants.

--- a/packages/cf-harness/docs/LOOM_AUTHORING.md
+++ b/packages/cf-harness/docs/LOOM_AUTHORING.md
@@ -152,9 +152,11 @@ preceding current-turn calls; receipt component count must match the request,
 and receipt IDs retain request order. Missing, historical, malformed or
 ambiguous pairs prove no membership. Different tokens for one Pattern can
 therefore leave a conservative duplicate; the console does not resolve token
-aliases here. The native client must check both IDs against a freshly read
-opened manifest before suppressing its ordinary Pattern placement. No token or
-cell address is exposed by this metadata.
+aliases here. When using this metadata, the native client must check both IDs
+against a freshly read opened manifest before suppressing ordinary Pattern
+placement. Weaver's legacy exact-reference comparison can independently prove
+membership; missing token correlation does not always require placement. No
+token or cell address is exposed by this metadata.
 
 Existing durable sessions retain their recorded tool policy. An adapter enabling
 new tools must create a session with the updated policy or explicitly refresh

--- a/packages/cf-harness/docs/LOOM_AUTHORING.md
+++ b/packages/cf-harness/docs/LOOM_AUTHORING.md
@@ -145,6 +145,17 @@ receipts produce no authored entries. An explicit replay in the current turn is
 included as a replay. Callers open a returned Loom by its receipt id through
 their Loom host; they never infer success from assistant text.
 
+A named Pattern also carries optional `loomComponents: [{loomId, componentId}]`
+when its successful `assign_slug` call and a successful `loom_compose` call used
+exactly the same held token in this turn. Tool-call IDs must uniquely pair with
+preceding current-turn calls; receipt component count must match the request,
+and receipt IDs retain request order. Missing, historical, malformed or
+ambiguous pairs prove no membership. Different tokens for one Pattern can
+therefore leave a conservative duplicate; the console does not resolve token
+aliases here. The native client must check both IDs against a freshly read
+opened manifest before suppressing its ordinary Pattern placement. No token or
+cell address is exposed by this metadata.
+
 Existing durable sessions retain their recorded tool policy. An adapter enabling
 new tools must create a session with the updated policy or explicitly refresh
 its policy; merely restarting a console does not expand an existing session's

--- a/packages/cf-harness/docs/LOOM_AUTHORING.md
+++ b/packages/cf-harness/docs/LOOM_AUTHORING.md
@@ -13,10 +13,11 @@ duplicating it after an interruption.
 
 ## Host configuration
 
-The CLI and console accept `--loom-authoring-config /absolute/host-config.json`
-or `CF_HARNESS_LOOM_AUTHORING_CONFIG`. The file is supplied by the operator,
-read on the host, and never passed into the sandbox. Without it the three Loom
-tools are absent, including when an allowlist names them.
+The batch CLI, both interactive stdio entrypoints, and console accept
+`--loom-authoring-config /absolute/host-config.json` or
+`CF_HARNESS_LOOM_AUTHORING_CONFIG`. The file is supplied by the operator, read
+on the host, and never passed into the sandbox. Without it the three Loom tools
+are absent, including when an allowlist names them.
 
 A broker-backed configuration pins the existing scoped queue:
 

--- a/packages/cf-harness/docs/LOOM_AUTHORING.md
+++ b/packages/cf-harness/docs/LOOM_AUTHORING.md
@@ -63,7 +63,8 @@ supporting that routing flag, `loom.compose`, `loom.inspect`, and
 ## Tools and authority
 
 - `loom_compose` creates or extends a collection from 1–100 components. A
-  component supplies exactly one `ref` (`page:`, `artifact:`, or `url:`) or
+  component supplies exactly one `ref` (`page:`, `artifact:`, `url:`, `person:`,
+  `thread:`, `moment:`, `loom:`, `wish:`, `intention:`, `chat:`, or `run:`) or
   `pattern_token`, plus optional title, stage, and focus. An existing target is
   named by `loom_id` and may carry an `expected_version` guard.
 - `loom_inspect` reads the current version, component metadata, and layout of

--- a/packages/cf-harness/docs/WEAVER.md
+++ b/packages/cf-harness/docs/WEAVER.md
@@ -57,7 +57,7 @@ export CF_HARNESS_FABRIC_SPACE=<space name>
 export MEMORY_DIR=<store path>
 export CF_HARNESS_CONSOLE_PORT=8135
 export CF_HARNESS_CONSOLE_DIR=<directory for console state>
-deno task console
+deno task --no-lock console
 ```
 
 Add the pattern index and skills registry URLs your deployment uses, the CFC
@@ -65,6 +65,34 @@ posture flags, and the `runsc-cfc` result and invocation-context directories as
 the console README describes; an enforcing posture refuses to start without the
 sandbox directories. Launch the process so it outlives the shell that started
 it; macOS has no `setsid`, so a double fork with `nohup` is the usual form.
+
+To let `/cf-harness` collect existing assets into durable Looms, the console
+also needs an explicit host authoring configuration. The shared Fabric identity
+above is not a grant to the separate Common Fabric Service command host. Save a
+private host file (outside the model workspace) with absolute paths:
+
+```json
+{
+  "cliPath": "/absolute/loom/src/bin/loom",
+  "transport": {
+    "kind": "direct",
+    "instanceDir": "/absolute/loom/instances/your-instance",
+    "runId": "weaver-console",
+    "actor": "agent:cf-harness"
+  }
+}
+```
+
+Set `CF_HARNESS_LOOM_AUTHORING_CONFIG` to that file's absolute path in the
+console's launch environment, then restart the console with its existing Fabric
+and provider settings. Use the CLI and instance corresponding to this console's
+Fabric; do not reuse a different bench's file. The CLI must support the direct
+transport flag and three authoring commands described in
+[Durable Loom authoring](LOOM_AUTHORING.md). Each interactive session derives a
+separate stable receipt namespace from this configured base run identity.
+Without the file the console still builds Patterns, but it offers no Loom tools.
+Start a new session after changing the policy; existing sessions keep their
+recorded tool grants.
 
 Verify before opening Weaver:
 

--- a/packages/cf-harness/docs/system-map/cfc-system-map.html
+++ b/packages/cf-harness/docs/system-map/cfc-system-map.html
@@ -669,7 +669,7 @@
     // ------------------------------------------------------------------ layout data
     // The state of this repository the map describes. Bump both when the
     // map is re-verified; the stamp is drawn in the canvas's top-left corner.
-    const SNAPSHOT = { date: "2026-09-08", sha: "7062d0b05c" };
+    const SNAPSHOT = { date: "2026-09-08", sha: "04e66f818 + Loom authoring" };
     const W = 2760, H = 1840;
     const bands = [
       {
@@ -1810,7 +1810,7 @@
         kind: "Harness service",
         band: "agent",
         body:
-          `<p>The service the weaver pings. Bad input refs are a 400 before any turn spends, and so is a <code>patternRefs</code> entry outside the id grammar; a task may attach up to eight published pattern ids beside its input cells, which the run resolves through the index before its first model turn and seeds as searched hits, and an id the index does not hold fails the run by name rather than running without it. CLI and console assemble the <em>same</em> session from one config, so the class of “console lags the CLI” bugs is gone. The console's fabric session defaults to the <code>max-enforcement</code> posture: policy evaluation on, public-only ceilings on the fetch sinks, enforcement mode pinned at <code>enforce-explicit</code> (not strict, so writer-fit misfits flag rather than reject).</p>`,
+          `<p>The service the weaver pings. An explicit host Loom configuration also backs <code>loom_compose</code> and its two read tools. Task <code>loomId</code> is captured per turn; completed results include only verified current-turn Loom receipts beside named pieces. Composition passes the existing command-authority gate and a held-token custody check, not a new flow-aware Loom-store commit gate. Bad input refs are a 400 before any turn spends, and so is a <code>patternRefs</code> entry outside the id grammar; a task may attach up to eight published pattern ids beside its input cells, which the run resolves through the index before its first model turn and seeds as searched hits, and an id the index does not hold fails the run by name rather than running without it. CLI and console assemble the <em>same</em> session from one config, so the class of “console lags the CLI” bugs is gone. The console's fabric session defaults to the <code>max-enforcement</code> posture: policy evaluation on, public-only ceilings on the fetch sinks, enforcement mode pinned at <code>enforce-explicit</code> (not strict, so writer-fit misfits flag rather than reject).</p>`,
         threats: ["t16", "t17", "t18"],
         links: [["one config for CLI and console", 6743], [
           "turn lifecycle",

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -1,3 +1,4 @@
+import { readLoomAuthoringConfig } from "./loom-authoring.ts";
 import { parseArgs } from "@std/cli/parse-args";
 import {
   basename,
@@ -202,6 +203,7 @@ const CLI_STRING_FLAGS = [
   "sandbox-docker-runtime",
   "max-model-turns",
   "fabric-mount",
+  "loom-authoring-config",
   "fabric-api-url",
   "fabric-identity",
   "fabric-space",
@@ -540,6 +542,7 @@ Options:
   --sandbox-image <image>       Docker image for the runsc-cfc sandbox (default: ${DEFAULT_DOCKER_RUNSC_IMAGE})
   --sandbox-docker-runtime <n>  Docker runtime for the sandbox (default: runsc-cfc)
   --fabric-mount <path>         Host path for a Fabric FUSE mount (mounted at /fabric in the sandbox)
+  --loom-authoring-config <path> Absolute host-owned JSON file backing Loom tools
   --fabric-api-url <url>        Deployed Fabric API URL for the fabric-session tools (run_pattern, assign_slug)
   --fabric-identity <path>      PKCS#8 identity keyfile for the fabric session
   --fabric-space <space>        Target space (name or did:key) for the fabric-session tools;
@@ -586,6 +589,7 @@ Environment:
   CF_HARNESS_HOME               Local cf-harness credential/config directory
   CF_HARNESS_SKILLS_REGISTRY_URL Default value for --skills-registry-url
   CF_HARNESS_DOCKER_NETWORK_MODE none | bridge | host (default: bridge)
+  CF_HARNESS_LOOM_AUTHORING_CONFIG Default host authoring configuration file
   CF_HARNESS_FABRIC_API_URL     Default value for --fabric-api-url
   CF_HARNESS_FABRIC_IDENTITY    Default value for --fabric-identity
   CF_HARNESS_FABRIC_SPACE       Default value for --fabric-space
@@ -1558,6 +1562,12 @@ export const parseCfHarnessCliArgs = async (
     );
   }
   const readTextFile = deps.readTextFile ?? Deno.readTextFile;
+  const loomAuthoring = await readLoomAuthoringConfig(
+    typeof args["loom-authoring-config"] === "string"
+      ? args["loom-authoring-config"]
+      : env.CF_HARNESS_LOOM_AUTHORING_CONFIG,
+    readTextFile,
+  );
   const inputCells = parseInputCells(
     args["input-cell"] as string | readonly string[] | undefined,
   );
@@ -1974,6 +1984,7 @@ export const parseCfHarnessCliArgs = async (
     ...(fabricMount !== undefined ? { fabricMount } : {}),
     ...(fabricSession !== undefined ? { fabricSession } : {}),
     ...(spaceDbPath !== undefined ? { spaceDbPath } : {}),
+    ...(loomAuthoring !== undefined ? { loomAuthoring } : {}),
     ...(patternIndex !== undefined ? { patternIndex } : {}),
     ...(skillsSh !== undefined ? { skillsSh } : {}),
     hostMounts,
@@ -3219,6 +3230,7 @@ export const runCfHarnessCli = async (
         new CfHarnessPromptLoop(options));
     const writeTextFile = deps.writeTextFile ?? Deno.writeTextFile;
     const readTextFile = deps.readTextFile ?? Deno.readTextFile;
+
     const startedAt = Date.now();
     let result: HarnessPromptLoopResult;
     let runManifest = await readRunManifest(

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -1,4 +1,8 @@
 import {
+  type HarnessLoomAuthoringConfig,
+  validateLoomAuthoringConfig,
+} from "./loom-authoring.ts";
+import {
   type CfcConfClause,
   type CfcEnforcementMode,
   cfcEnforcementStrictness,
@@ -212,6 +216,9 @@ interface HarnessCommonConfig {
   cfcEnforcementMode: CfcEnforcementMode;
   cfcEnforcementModeSource: HarnessCfcEnforcementModeSource;
   fabricSession?: HarnessFabricSessionConfig;
+  /** Explicit host command backing; never inferred from a model input. */
+  loomAuthoring?: HarnessLoomAuthoringConfig;
+
   patternIndex?: HarnessPatternIndexConfig;
   skillsSh?: HarnessSkillsShConfig;
   sandbox?: DockerRunscSandboxConfig;
@@ -284,6 +291,9 @@ export interface ResolveHarnessConfigOptions {
   fabricSession?:
     | HarnessFabricSessionConfig
     | ResolvedHarnessFabricSessionConfig;
+  /** Explicit host command backing; never inferred from a model input. */
+  loomAuthoring?: HarnessLoomAuthoringConfig;
+
   patternIndex?: HarnessPatternIndexConfig;
   skillsSh?: HarnessSkillsShConfig;
   sandbox?: DockerRunscSandboxConfig;
@@ -572,6 +582,9 @@ export const resolveFabricSessionConfig = (
 export const resolveHarnessConfig = (
   options: ResolveHarnessConfigOptions = {},
 ): ResolvedHarnessConfig => {
+  if (options.loomAuthoring !== undefined) {
+    validateLoomAuthoringConfig(options.loomAuthoring);
+  }
   const modelProvider = options.modelProvider ?? "openai-compatible-gateway";
   if (
     options.credentialOwner !== undefined &&
@@ -667,6 +680,9 @@ export const resolveHarnessConfig = (
     cfcEnforcementMode: resolveCfcEnforcementMode(options),
     cfcEnforcementModeSource: resolveCfcEnforcementModeSource(options),
     ...(fabricSession !== undefined ? { fabricSession } : {}),
+    ...(options.loomAuthoring !== undefined
+      ? { loomAuthoring: structuredClone(options.loomAuthoring) }
+      : {}),
     ...(options.patternIndex !== undefined
       ? { patternIndex: options.patternIndex }
       : {}),

--- a/packages/cf-harness/src/contracts/interactive-chat.ts
+++ b/packages/cf-harness/src/contracts/interactive-chat.ts
@@ -8,6 +8,7 @@ import type { LoomLocalHostBinding } from "./run-manifest.ts";
 import {
   type BuiltinToolId,
   DEFAULT_PARENT_TOOL_IDS,
+  LOOM_AUTHORING_TOOL_IDS,
 } from "./tool-descriptor.ts";
 import {
   DEFAULT_SUBAGENT_PROFILE,
@@ -146,8 +147,7 @@ export const resolveHarnessChatPolicy = (
           allowedToolIds: [
             ...READONLY_INTERACTIVE_CHAT_TOOL_IDS,
             ...policy.allowedToolIds.filter((id) =>
-              ["loom_compose", "loom_inspect", "loom_authoring_context"]
-                .includes(id)
+              LOOM_AUTHORING_TOOL_IDS.has(id)
             ),
           ],
         }

--- a/packages/cf-harness/src/contracts/interactive-chat.ts
+++ b/packages/cf-harness/src/contracts/interactive-chat.ts
@@ -136,10 +136,22 @@ const READONLY_INTERACTIVE_CHAT_TOOL_ID_SET = new Set<BuiltinToolId>(
 export const resolveHarnessChatPolicy = (
   policy: HarnessChatPolicy = DEFAULT_HARNESS_CHAT_POLICY,
   context?: HarnessChatContext,
+  allowCommentLoomAuthoring = false,
 ): HarnessChatPolicy => {
   if (context?.type === "comment-thread") {
     return {
       ...COMMENT_THREAD_HARNESS_CHAT_POLICY,
+      ...(allowCommentLoomAuthoring
+        ? {
+          allowedToolIds: [
+            ...READONLY_INTERACTIVE_CHAT_TOOL_IDS,
+            ...policy.allowedToolIds.filter((id) =>
+              ["loom_compose", "loom_inspect", "loom_authoring_context"]
+                .includes(id)
+            ),
+          ],
+        }
+        : {}),
       ...(policy.cfcEnforcementMode !== undefined
         ? { cfcEnforcementMode: policy.cfcEnforcementMode }
         : {}),
@@ -163,6 +175,9 @@ export const resolveHarnessChatPolicy = (
 
 export interface HarnessChatTurnInput {
   text: string;
+
+  /** Originating Loom supplied by the caller, persisted with this turn only. */
+  loomId?: string;
   imageAttachments?: readonly HarnessImageAttachment[];
 }
 

--- a/packages/cf-harness/src/contracts/tool-descriptor.ts
+++ b/packages/cf-harness/src/contracts/tool-descriptor.ts
@@ -18,7 +18,10 @@ export type BuiltinToolId =
   | "record_feedback"
   | "search_skills"
   | "acquire_skill"
-  | "query_docs";
+  | "query_docs"
+  | "loom_compose"
+  | "loom_inspect"
+  | "loom_authoring_context";
 
 export const DEFAULT_PARENT_TOOL_IDS = [
   "bash",
@@ -79,6 +82,13 @@ const SKILL_REGISTRY_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
   ["read_skill_resource", "run_skill_script"] as const,
 );
 
+/** Tools backed only by an explicitly configured host Loom transport. */
+const LOOM_AUTHORING_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set([
+  "loom_compose",
+  "loom_inspect",
+  "loom_authoring_context",
+]);
+
 /** What a run can back the gated tools with. */
 export interface HarnessToolBackingAvailability {
   fabricSessionAvailable: boolean;
@@ -87,6 +97,9 @@ export interface HarnessToolBackingAvailability {
   skillsShAcquisitionAvailable: boolean;
   skillRegistryAvailable: boolean;
   docsCorpusAvailable: boolean;
+
+  /** Whether the operator configured host Loom authoring for this run. */
+  loomAuthoringAvailable?: boolean;
 }
 
 /** The gated tools this run cannot back, and so does not offer. */
@@ -102,6 +115,7 @@ export const withheldToolIds = (
       : SKILLS_SH_ACQUISITION_TOOL_IDS),
     ...(availability.skillRegistryAvailable ? [] : SKILL_REGISTRY_TOOL_IDS),
     ...(availability.docsCorpusAvailable ? [] : DOCS_CORPUS_TOOL_IDS),
+    ...(availability.loomAuthoringAvailable ? [] : LOOM_AUTHORING_TOOL_IDS),
   ]);
 
 /**
@@ -127,6 +141,7 @@ export const parentToolIdsForBacking = (
       ? SKILLS_SH_ACQUISITION_TOOL_IDS
       : []),
     ...(availability.docsCorpusAvailable ? DOCS_CORPUS_TOOL_IDS : []),
+    ...(availability.loomAuthoringAvailable ? LOOM_AUTHORING_TOOL_IDS : []),
   ].filter((toolId, index, ids) =>
     !withheld.has(toolId) && ids.indexOf(toolId) === index
   );

--- a/packages/cf-harness/src/contracts/tool-descriptor.ts
+++ b/packages/cf-harness/src/contracts/tool-descriptor.ts
@@ -83,7 +83,7 @@ const SKILL_REGISTRY_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
 );
 
 /** Tools backed only by an explicitly configured host Loom transport. */
-const LOOM_AUTHORING_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set([
+export const LOOM_AUTHORING_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set([
   "loom_compose",
   "loom_inspect",
   "loom_authoring_context",

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -1,3 +1,8 @@
+import type {
+  LoomAuthoringToolOutput,
+  LoomComposeToolInput,
+  LoomReadToolInput,
+} from "./tools/loom-authoring.ts";
 import {
   dirname,
   join as joinHostPath,
@@ -245,6 +250,9 @@ export interface BuiltinToolInputMap {
   search_skills: SearchSkillsToolInput;
   acquire_skill: AcquireSkillToolInput;
   query_docs: QueryDocsToolInput;
+  loom_compose: LoomComposeToolInput;
+  loom_inspect: LoomReadToolInput;
+  loom_authoring_context: LoomReadToolInput;
 }
 
 export interface BuiltinToolOutputMap {
@@ -266,6 +274,9 @@ export interface BuiltinToolOutputMap {
   search_skills: SearchSkillsToolOutput;
   acquire_skill: AcquireSkillToolOutput;
   query_docs: QueryDocsToolOutput;
+  loom_compose: LoomAuthoringToolOutput;
+  loom_inspect: LoomAuthoringToolOutput;
+  loom_authoring_context: LoomAuthoringToolOutput;
 }
 
 interface ToolOutputWithId {
@@ -2247,6 +2258,7 @@ export class CfHarnessEngine {
       ...(this.#taskText !== undefined ? { taskText: this.#taskText } : {}),
       sandbox: this.sandbox,
       hostProcessRunner: this.hostProcessRunner,
+      loomAuthoring: this.config.loomAuthoring,
       resolvePath: (path: string) =>
         this.sandbox.resolvePath(path, this.#runState.currentDir),
       resolveHostPath: (path: string) => this.#resolveHostPath(path),

--- a/packages/cf-harness/src/host-mounts.ts
+++ b/packages/cf-harness/src/host-mounts.ts
@@ -13,6 +13,10 @@
  * engine; it must not mean inventing a second way in.
  */
 
+import {
+  type HarnessLoomAuthoringConfig,
+  readLoomAuthoringConfig,
+} from "./loom-authoring.ts";
 import { dirname, isAbsolute, resolve } from "@std/path";
 import {
   isAbsolute as isAbsoluteSandboxPath,
@@ -171,18 +175,24 @@ export const parseHostMountSpecs = async (
 export const resolveInteractiveProvisioning = async (
   parsed: {
     hostMountSpecs?: readonly string[];
+    loomAuthoringConfigPath?: string;
     maxModelTurns?: number;
   },
   cwd: string,
 ): Promise<{
   additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
+  loomAuthoring?: HarnessLoomAuthoringConfig;
   maxModelTurns?: number;
 }> => {
+  const loomAuthoring = await readLoomAuthoringConfig(
+    parsed.loomAuthoringConfigPath,
+  );
   const mounts = hostMountsToAdditionalMounts(
     await parseHostMountSpecs(parsed.hostMountSpecs, cwd),
   );
   return {
     ...(mounts.length > 0 ? { additionalMounts: mounts } : {}),
+    ...(loomAuthoring !== undefined ? { loomAuthoring } : {}),
     ...(parsed.maxModelTurns !== undefined
       ? { maxModelTurns: parsed.maxModelTurns }
       : {}),

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -1,3 +1,4 @@
+import { loomAuthoringForTurn } from "./loom-authoring.ts";
 import {
   isObjectNotArray,
   type ReadonlyRecord,
@@ -1171,7 +1172,11 @@ export class HarnessInteractiveChatService {
       loomLocalHostBinding: this.#loomLocalHostBinding,
       artifactRoot: params.artifactRoot,
       capabilities: params.capabilities,
-      policy: resolveHarnessChatPolicy(params.policy, params.context),
+      policy: resolveHarnessChatPolicy(
+        params.policy,
+        params.context,
+        this.#basePromptLoopOptions.loomAuthoring?.allowCommentThreads === true,
+      ),
       browserAccess: params.browserAccess,
       metadata: params.metadata,
     });
@@ -1197,6 +1202,16 @@ export class HarnessInteractiveChatService {
     requestId: string,
     params: HarnessChatStartTurnParams,
   ): Promise<HarnessChatResponse<HarnessChatTurnStatus>> {
+    if (
+      params.input.loomId !== undefined &&
+      (typeof params.input.loomId !== "string" ||
+        !/^loom-[a-f0-9]{16}$/.test(params.input.loomId))
+    ) {
+      return createHarnessChatErrorResponse(requestId, {
+        code: "invalid_request",
+        message: "loomId must be a canonical Loom identifier",
+      });
+    }
     const record = this.#sessions.get(params.sessionId);
     if (record === undefined) {
       return sessionNotFoundError(requestId, params.sessionId);
@@ -1270,6 +1285,7 @@ export class HarnessInteractiveChatService {
     const policy = resolveHarnessChatPolicy(
       params.policy ?? record.status.policy,
       context,
+      this.#basePromptLoopOptions.loomAuthoring?.allowCommentThreads === true,
     );
     const browserAccess = params.browserAccess ?? record.status.browserAccess;
     if (
@@ -1482,6 +1498,7 @@ export class HarnessInteractiveChatService {
           browserAccess,
           params.inputCells,
           params.patternRefs,
+          params.input.loomId,
         ),
       );
       // The context messages announce what this turn's own run holds — its
@@ -1491,6 +1508,12 @@ export class HarnessInteractiveChatService {
       const transcript: HarnessTranscriptMessage[] = [
         ...seededSystemPrompt,
         ...record.transcript,
+        ...(this.#basePromptLoopOptions.loomAuthoring === undefined ? [] : [{
+          role: "user" as const,
+          content: params.input.loomId === undefined
+            ? "Host Loom context: this turn has no originating Loom. Use loom_authoring_context to recover historical receipts; history does not select a target or count as new work."
+            : `Host Loom context: this turn originates in ${params.input.loomId}. Inspect that exact target before extending it. A request to create a separate Loom still creates one. Historical receipts are not new work.`,
+        }]),
         ...contextMessages.map((content) =>
           ({ role: "user", content }) as const
         ),
@@ -1655,9 +1678,16 @@ export class HarnessInteractiveChatService {
     browserAccess?: HarnessChatBrowserAccessLease,
     inputCells?: readonly HarnessInputCellSpec[],
     patternRefs?: readonly HarnessPatternRefSpec[],
+    loomId?: string,
   ): CreateHarnessPromptLoopOptions {
+    const loomAuthoring = loomAuthoringForTurn(
+      this.#basePromptLoopOptions.loomAuthoring,
+      session.sessionId,
+      loomId,
+    );
     return {
       ...this.#basePromptLoopOptions,
+      ...(loomAuthoring !== undefined ? { loomAuthoring } : {}),
       ...(inputCells !== undefined && inputCells.length > 0
         ? { inputCells }
         : {}),

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -72,6 +72,9 @@ export interface RunHarnessInteractiveChatStdioOptions {
 }
 
 export interface HarnessInteractiveChatStdioCliOptions {
+  /** Operator-owned configuration resolved before the interactive service starts. */
+  loomAuthoringConfigPath?: string;
+
   sessionDbPath?: string;
   maxInMemoryEvents?: number;
 
@@ -110,9 +113,11 @@ Options:
   --host-mount <spec>                  Extra host bind mount, same grammar as the batch CLI
                                        (repeatable: name=<id>,source=<host>,target=<sandbox>,mode=readonly|writable)
   --max-model-turns <count>            Model turns allowed per user message (default 8)
+  --loom-authoring-config <path>       Absolute host-owned JSON file backing Loom tools
   --help                              Print this help text to stderr
 
 Environment:
+  CF_HARNESS_LOOM_AUTHORING_CONFIG     Default host authoring configuration file
   ${CHAT_SESSION_DB_ENV}                 Default SQLite chat session DB path
   ${CHAT_MAX_IN_MEMORY_EVENTS_ENV}       Default in-memory event retention cap
 `;
@@ -160,6 +165,7 @@ export const parseHarnessInteractiveChatStdioCliOptions = (
   env: Record<string, string | undefined> = Deno.env.toObject(),
 ): HarnessInteractiveChatStdioCliOptions => {
   let sessionDbPath = env[CHAT_SESSION_DB_ENV];
+  let loomAuthoringConfigPath = env.CF_HARNESS_LOOM_AUTHORING_CONFIG;
   let maxInMemoryEvents = env[CHAT_MAX_IN_MEMORY_EVENTS_ENV] === undefined ||
       env[CHAT_MAX_IN_MEMORY_EVENTS_ENV]?.trim() === ""
     ? undefined
@@ -174,6 +180,18 @@ export const parseHarnessInteractiveChatStdioCliOptions = (
     const arg = args[index];
     if (arg === "--help" || arg === "-h") {
       help = true;
+      continue;
+    }
+    if (arg === "--loom-authoring-config") {
+      index += 1;
+      loomAuthoringConfigPath = nonEmptyOptionValue(arg, args[index]);
+      continue;
+    }
+    if (arg.startsWith("--loom-authoring-config=")) {
+      loomAuthoringConfigPath = nonEmptyOptionValue(
+        "--loom-authoring-config",
+        arg.slice("--loom-authoring-config=".length),
+      );
       continue;
     }
     if (arg === "--host-mount") {
@@ -230,6 +248,9 @@ export const parseHarnessInteractiveChatStdioCliOptions = (
       ? { sessionDbPath }
       : {}),
     ...(maxInMemoryEvents !== undefined ? { maxInMemoryEvents } : {}),
+    ...(loomAuthoringConfigPath !== undefined
+      ? { loomAuthoringConfigPath }
+      : {}),
     ...(hostMountSpecs.length > 0 ? { hostMountSpecs } : {}),
     ...(maxModelTurns !== undefined ? { maxModelTurns } : {}),
     help,

--- a/packages/cf-harness/src/loom-authoring.ts
+++ b/packages/cf-harness/src/loom-authoring.ts
@@ -1,0 +1,412 @@
+/**
+ * Executes the explicitly configured host's Loom authoring commands. Successful
+ * composition requires a matching durable receipt beside its current manifest.
+ */
+
+import { sha256 } from "@commonfabric/content-hash";
+import { isAbsolute } from "@std/path";
+
+import type { ProcessRunner } from "./sandbox/process-runner.ts";
+import { createClearedHostProcessEnv } from "./tools/host-process-env.ts";
+
+/** Host-owned attribution and routing for the Loom command transport. */
+export type HarnessLoomAuthoringTransport =
+  | { kind: "broker"; queuePath: string }
+  | { kind: "direct"; instanceDir: string; runId: string; actor: string };
+
+/** Configuration supplied by the operator, outside the model's tool inputs. */
+export interface HarnessLoomAuthoringConfig {
+  /** Absolute path to the host's executable Loom CLI. */
+  cliPath: string;
+
+  /** A separately bound target for context reads; never an implicit write target. */
+  boundLoomId?: string;
+
+  /** Enables only dedicated Loom tools in otherwise read-only comment threads. */
+  allowCommentThreads?: boolean;
+
+  /** The scoped broker, or an explicitly identified local instance and agent. */
+  transport: HarnessLoomAuthoringTransport;
+}
+
+/** Commands admitted by the dedicated authoring tools. */
+export type LoomAuthoringCommand =
+  | "loom.compose"
+  | "loom.inspect"
+  | "loom.authoring-context";
+
+/** A host response checked at the command's serialization boundary. */
+export type LoomAuthoringCommandOutput =
+  | { status: "ok"; result: Record<string, unknown> }
+  | {
+    status: "error";
+    message: string;
+    mayHaveCommitted: boolean;
+    code?: string;
+  };
+
+/** Canonical identifier of a durable Loom record. */
+const LOOM_ID = /^loom-[a-f0-9]{16}$/;
+
+/** Whether a decoded JSON value is an object with named properties. */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Whether an identity contains an ASCII control character. */
+const hasControlCharacter = (value: string): boolean =>
+  Array.from(value).some((character) => character.charCodeAt(0) < 32);
+
+/** Whether a record version is a positive safe integer. */
+const isVersion = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+
+/** Whether a receipt contains a list of nonempty string handles. */
+const isHandleList = (value: unknown): value is string[] =>
+  Array.isArray(value) &&
+  value.every((id) => typeof id === "string" && id.length > 0);
+
+/**
+ * Returns whether a composition receipt agrees with its request and current
+ * target. It proves the daemon reported a commit, not that components render.
+ */
+export const isLoomCompositionResult = (
+  result: unknown,
+  requestId?: string,
+  target?: string,
+): result is Record<string, unknown> & {
+  receipt: Record<string, unknown> & {
+    loom_id: string;
+    request_id: string;
+    version: number;
+  };
+  replayed: boolean;
+} => {
+  if (
+    !isRecord(result) || !isRecord(result.receipt) || !isRecord(result.manifest)
+  ) {
+    return false;
+  }
+  const { receipt, manifest } = result;
+  return typeof receipt.loom_id === "string" && LOOM_ID.test(receipt.loom_id) &&
+    typeof receipt.request_id === "string" &&
+    receipt.request_id.trim().length > 0 &&
+    (requestId === undefined || receipt.request_id === requestId) &&
+    (target === undefined || receipt.loom_id === target) &&
+    typeof receipt.created === "boolean" &&
+    isVersion(receipt.version) && isVersion(manifest.version) &&
+    manifest.version >= receipt.version &&
+    manifest.loom_id === receipt.loom_id &&
+    isHandleList(receipt.component_ids) && receipt.component_ids.length > 0 &&
+    isHandleList(receipt.operation_ids) && receipt.operation_ids.length > 0 &&
+    Array.isArray(receipt.displaced) && typeof result.replayed === "boolean";
+};
+
+/** Validates host configuration before it can advertise an authoring tool. */
+export const validateLoomAuthoringConfig = (
+  config: HarnessLoomAuthoringConfig,
+): void => {
+  if (
+    config.allowCommentThreads !== undefined &&
+    typeof config.allowCommentThreads !== "boolean"
+  ) {
+    throw new Error("allowCommentThreads must be a boolean host grant.");
+  }
+  if (config.boundLoomId !== undefined && !LOOM_ID.test(config.boundLoomId)) {
+    throw new Error("Loom authoring requires a canonical bound Loom id.");
+  }
+  if (!isAbsolute(config.cliPath)) {
+    throw new Error("Loom authoring requires an absolute `cliPath`.");
+  }
+  if (config.transport.kind === "broker") {
+    if (!isAbsolute(config.transport.queuePath)) {
+      throw new Error(
+        "Loom authoring requires an absolute broker `queuePath`.",
+      );
+    }
+  } else if (config.transport.kind === "direct") {
+    const { instanceDir, runId, actor } = config.transport;
+    if (
+      !isAbsolute(instanceDir) || !runId || runId.trim() !== runId ||
+      runId.length > 128 ||
+      hasControlCharacter(runId) ||
+      !/^agent:[a-z0-9][a-z0-9-]{0,63}$/.test(actor)
+    ) {
+      throw new Error(
+        "Direct Loom authoring requires an instance directory, run identity, and agent actor.",
+      );
+    }
+  } else {
+    throw new Error("Loom authoring requires a supported transport.");
+  }
+};
+
+/**
+ * Executes one command through argv and stdin. An uncertain composition retains
+ * its logical request key for a caller-directed retry through the same transport.
+ */
+export const executeLoomAuthoringCommand = async (
+  config: HarnessLoomAuthoringConfig,
+  command: LoomAuthoringCommand,
+  input: unknown,
+  runner: ProcessRunner,
+): Promise<LoomAuthoringCommandOutput> => {
+  const failure = (
+    message: string,
+    mayHaveCommitted = false,
+    code?: string,
+  ): LoomAuthoringCommandOutput => ({
+    status: "error",
+    message,
+    mayHaveCommitted,
+    ...(code !== undefined ? { code } : {}),
+  });
+  validateLoomAuthoringConfig(config);
+  if (
+    !["loom.compose", "loom.inspect", "loom.authoring-context"].includes(
+      command,
+    ) || !isRecord(input)
+  ) {
+    return failure(
+      "Loom authoring requires a supported command and object input.",
+    );
+  }
+  const allowed = command === "loom.compose"
+    ? ["request_id", "title", "components", "loom_id", "expected_version"]
+    : ["loom_id"];
+  if (Object.keys(input).some((key) => !allowed.includes(key))) {
+    return failure(
+      "The tool accepts composition and target fields only; routing and attribution belong to the host.",
+    );
+  }
+  const { loom_id: suppliedTarget, expected_version: version, ...args } = input;
+  if (suppliedTarget !== undefined && typeof suppliedTarget !== "string") {
+    return failure("An explicit Loom target must be a canonical string id.");
+  }
+  const target = suppliedTarget ??
+    (command === "loom.authoring-context" ? config.boundLoomId : undefined);
+  if (
+    (target !== undefined &&
+      (typeof target !== "string" || !LOOM_ID.test(target))) ||
+    (command === "loom.inspect" && target === undefined) ||
+    (version !== undefined && (!isVersion(version) || target === undefined))
+  ) {
+    return failure(
+      "Use a canonical Loom target and a positive expected version when extending it.",
+    );
+  }
+  if (
+    command === "loom.compose" &&
+    (typeof args.request_id !== "string" || !args.request_id.trim() ||
+      args.request_id.length > 200 ||
+      hasControlCharacter(args.request_id) || !Array.isArray(args.components) ||
+      args.components.length < 1 || args.components.length > 100)
+  ) {
+    return failure(
+      "Composition requires a logical request id and 1–100 components.",
+    );
+  }
+  const argv = ["command", "run"];
+  if (config.transport.kind === "direct") argv.push("--transport", "direct");
+  argv.push(command, "--args-json", "-", "--json");
+  if (typeof target === "string") argv.push("--loom", target);
+  if (typeof version === "number") argv.push("--expect", String(version));
+  const env = createClearedHostProcessEnv();
+  if (config.transport.kind === "broker") {
+    env.LOOM_PAGE_RPC_QUEUE = config.transport.queuePath;
+  } else {
+    env.LOOM_INSTANCE_DIR = config.transport.instanceDir;
+    env.LOOM_DISPATCH_ID = config.transport.runId;
+    argv.push("--actor", config.transport.actor);
+  }
+  const uncertain = command === "loom.compose";
+  try {
+    const response = await runner.run({
+      command: config.cliPath,
+      args: argv,
+      env,
+      clearEnv: true,
+      stdinText: JSON.stringify(args),
+    });
+    const body: unknown = JSON.parse(response.stdout);
+    if (
+      isRecord(body) && body.ok === false && typeof body.code === "string" &&
+      [
+        "version-conflict",
+        "request-conflict",
+        "bad-args",
+        "bad-body",
+        "no-loom",
+        "archived",
+        "bad-context",
+        "unknown-command",
+      ].includes(body.code)
+    ) {
+      if (
+        command === "loom.authoring-context" && body.code === "no-loom" &&
+        suppliedTarget === undefined && config.boundLoomId !== undefined
+      ) {
+        // The missing origin is context, not the scope of the run's receipts.
+        const historical = await executeLoomAuthoringCommand(
+          { ...config, boundLoomId: undefined },
+          command,
+          {},
+          runner,
+        );
+        return historical.status === "ok"
+          ? {
+            status: "ok",
+            result: {
+              ...historical.result,
+              bound_loom: {
+                loom_id: target,
+                available: false,
+                source: "host-context",
+              },
+            },
+          }
+          : historical;
+      }
+      return failure(
+        "The host rejected the command before applying this request.",
+        false,
+        body.code,
+      );
+    }
+    if (
+      response.exitCode !== 0 || !isRecord(body) || body.ok !== true ||
+      !isRecord(body.result)
+    ) {
+      const detail = isRecord(body) && typeof body.error === "string"
+        ? body.error
+        : "The host command did not return success.";
+      return failure(detail, uncertain);
+    }
+    const result = body.result;
+    if (
+      command === "loom.compose" &&
+      !isLoomCompositionResult(
+        result,
+        args.request_id as string,
+        target as string | undefined,
+      )
+    ) {
+      return failure(
+        "The host response lacks a matching durable receipt. Retry the identical request with the same key.",
+        true,
+      );
+    }
+    if (
+      command === "loom.inspect" && (!isRecord(result.manifest) ||
+        result.manifest.loom_id !== target ||
+        !isVersion(result.manifest.version))
+    ) {
+      return failure(
+        "The host response does not identify the requested Loom manifest.",
+      );
+    }
+    if (
+      command === "loom.authoring-context" &&
+      (result.kind !== "authoring-context" ||
+        result.historical !== true || !Array.isArray(result.authored) ||
+        typeof result.truncated !== "boolean")
+    ) {
+      return failure(
+        "The host response does not identify historical authoring context.",
+      );
+    }
+    return { status: "ok", result };
+  } catch {
+    return failure(
+      "The host command outcome could not be read. For composition, retry the identical request with the same key.",
+      uncertain,
+    );
+  }
+};
+
+/** Reads an explicit operator-owned configuration file; absence grants nothing. */
+export const readLoomAuthoringConfig = async (
+  path: string | undefined,
+  readTextFile: (path: string) => Promise<string> = Deno.readTextFile,
+): Promise<HarnessLoomAuthoringConfig | undefined> => {
+  if (path === undefined) return undefined;
+  if (!isAbsolute(path)) {
+    throw new Error("The Loom authoring configuration path must be absolute.");
+  }
+  const value: unknown = JSON.parse(await readTextFile(path));
+  if (
+    !isRecord(value) || typeof value.cliPath !== "string" ||
+    !isRecord(value.transport)
+  ) {
+    throw new Error(
+      "Loom authoring requires a host CLI and a transport configuration.",
+    );
+  }
+  const config = value as unknown as HarnessLoomAuthoringConfig;
+  validateLoomAuthoringConfig(config);
+  return config;
+};
+
+/**
+ * Binds one turn's explicit Loom context while keeping direct authoring receipts
+ * under the conversation's identity. A broker owns its existing namespace.
+ */
+export const loomAuthoringForTurn = (
+  config: HarnessLoomAuthoringConfig | undefined,
+  sessionId: string,
+  loomId?: string,
+): HarnessLoomAuthoringConfig | undefined => {
+  if (config === undefined) return undefined;
+  const bound = structuredClone(config);
+  delete bound.boundLoomId;
+  if (loomId !== undefined) bound.boundLoomId = loomId;
+  if (bound.transport.kind === "direct") {
+    const digest = sha256(
+      new TextEncoder().encode(
+        JSON.stringify([bound.transport.runId, sessionId]),
+      ),
+    );
+    bound.transport.runId = "cfh-chat-" +
+      Array.from(
+        new Uint8Array(digest),
+        (byte) => byte.toString(16).padStart(2, "0"),
+      ).join("");
+  }
+  validateLoomAuthoringConfig(bound);
+  return bound;
+};
+
+/** Verifiable model-facing composition evidence, separate from rendered state. */
+export interface LoomAuthoredObservation {
+  /** Successful dedicated tool observation discriminator. */
+  status: "ok";
+
+  /** Indicates a receipt produced by composition, never by an inspection. */
+  kind: "loom-authored";
+
+  /** Immutable historical receipt from the command host. */
+  receipt: Record<string, unknown> & {
+    loom_id: string;
+    request_id: string;
+    version: number;
+  };
+
+  /** Whether this invocation recovered a previous commit. */
+  replayed: boolean;
+
+  /** Target version when this invocation read it; may exceed receipt.version. */
+  current_version: number;
+}
+
+/** Validates evidence when projecting a dedicated tool into a turn result. */
+export const isLoomAuthoredObservation = (
+  value: unknown,
+): value is LoomAuthoredObservation =>
+  isRecord(value) && value.status === "ok" && value.kind === "loom-authored" &&
+  isVersion(value.current_version) && isLoomCompositionResult({
+    receipt: value.receipt,
+    replayed: value.replayed,
+    manifest: {
+      loom_id: isRecord(value.receipt) ? value.receipt.loom_id : undefined,
+      version: value.current_version,
+    },
+  });

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -2840,6 +2840,7 @@ export class CfHarnessPromptLoop {
       // neither tool.
       skillRegistryAvailable: this.engine.config.skillsRoot !== undefined,
       docsCorpusAvailable: this.engine.docsCorpusAvailable,
+      loomAuthoringAvailable: this.engine.config.loomAuthoring !== undefined,
     };
   }
 
@@ -3292,18 +3293,22 @@ export class CfHarnessPromptLoop {
 
   /**
    * Helper for `#invokeToolCall()`, which replaces handle tokens in a parsed
-   * tool input with their canonical address strings. Two tools are exempt:
+   * tool input with their canonical address strings. Custody-checking tools are exempt:
    * `delegate_task`, whose `goal` and `context` reach the child as the model
    * wrote them (its `skillHandle` is resolved separately, trusted-side,
    * before dispatch), and `describe_handle`, whose input names a token rather
-   * than a referent — it looks the token up in the table itself. Returns
+   * than a referent — it looks the token up in the table itself. `loom_compose`
+   * also proves membership before resolving a Pattern Instance. Returns
    * `input` itself when no substitution applies.
    */
   #resolveHandleTokensInToolInput(
     toolId: string,
     input: Record<string, unknown>,
   ): Record<string, unknown> {
-    if (toolId === "delegate_task" || toolId === "describe_handle") {
+    if (
+      toolId === "delegate_task" || toolId === "describe_handle" ||
+      toolId === "loom_compose"
+    ) {
       return input;
     }
     const table = this.engine.handleTable;

--- a/packages/cf-harness/src/session-assembly.ts
+++ b/packages/cf-harness/src/session-assembly.ts
@@ -21,6 +21,7 @@
  */
 
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type { HarnessLoomAuthoringConfig } from "./loom-authoring.ts";
 import type { CfHarnessEngine } from "./engine.ts";
 import type {
   HarnessFabricSessionConfig,
@@ -113,6 +114,9 @@ export interface HarnessSessionConfig {
    */
   spaceDbPath?: string;
 
+  /** Explicit host-owned backing for durable Loom authoring. */
+  loomAuthoring?: HarnessLoomAuthoringConfig;
+
   patternIndex?: HarnessPatternIndexConfig;
   skillsSh?: HarnessSkillsShConfig;
 
@@ -155,6 +159,7 @@ export const harnessSessionToolBacking = (
   config: HarnessSessionConfig,
 ): HarnessToolBackingAvailability => ({
   fabricSessionAvailable: config.fabricSession !== undefined,
+  loomAuthoringAvailable: config.loomAuthoring !== undefined,
   patternIndexAvailable: config.patternIndex !== undefined,
   skillsShSearchAvailable: config.skillsSh !== undefined,
   skillsShAcquisitionAvailable: config.skillsSh !== undefined,
@@ -257,6 +262,9 @@ export const harnessSessionEngineOptions = (
       : {}),
     ...(config.spaceDbPath !== undefined
       ? { spaceDbPath: config.spaceDbPath }
+      : {}),
+    ...(config.loomAuthoring !== undefined
+      ? { loomAuthoring: config.loomAuthoring }
       : {}),
     ...(config.patternIndex !== undefined
       ? { patternIndex: config.patternIndex }

--- a/packages/cf-harness/src/tools/loom-authoring.ts
+++ b/packages/cf-harness/src/tools/loom-authoring.ts
@@ -1,0 +1,422 @@
+/**
+ * Composes durable Loom collections through a host-owned command transport.
+ * Pattern Instance addresses are resolved from held tokens on the trusted side;
+ * model-visible inspection describes layout without granting new cell handles.
+ */
+
+import { getPatternIdentityRef } from "@commonfabric/runner";
+import { pieceId } from "@commonfabric/piece";
+import type { JSONSchema } from "@commonfabric/api";
+
+import { parseHandleRef, resolveHandleToken } from "../handle-table.ts";
+import {
+  executeLoomAuthoringCommand,
+  type LoomAuthoringCommand,
+} from "../loom-authoring.ts";
+import type { HarnessToolContext, HarnessToolDefinition } from "./types.ts";
+
+/** A requested addition, with one ordinary reference or one held pattern token. */
+export interface LoomComposeComponent {
+  /** A typed page, artifact, or URL reference. */
+  ref?: string;
+
+  /** A held whole Pattern Instance address, resolved by the host. */
+  pattern_token?: string;
+
+  /** Human-facing component label. */
+  title?: string;
+
+  /** Whether to place this component on stage. */
+  stage?: boolean;
+
+  /** Whether to focus this component. */
+  focus?: boolean;
+}
+
+/** One logical composition; retries retain every field and the request key. */
+export interface LoomComposeToolInput {
+  /** Stable key chosen for this logical request, retained across retries. */
+  request_id: string;
+
+  /** Title when creating a collection. */
+  title?: string;
+
+  /** Ordered additions to the collection. */
+  components: LoomComposeComponent[];
+
+  /** Existing Loom to extend; absence creates a new collection. */
+  loom_id?: string;
+
+  /** Version guard for an existing Loom. */
+  expected_version?: number;
+}
+
+/** An exact inspection target or an optional authoring-context override. */
+export interface LoomReadToolInput {
+  /** Canonical Loom identifier supplied by a person or a previous receipt. */
+  loom_id?: string;
+}
+
+/** A tool observation whose success always originates at the configured host. */
+export type LoomAuthoringToolOutput =
+  | { outputId: string; status: "ok"; [key: string]: unknown }
+  | {
+    outputId: string;
+    status: "error";
+    message: string;
+    mayHaveCommitted: boolean;
+    code?: string;
+  };
+
+/** Helper for projection, which recognizes decoded JSON objects. */
+const record = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+
+/** Helper for projection, which picks named fields without expanding a schema. */
+const pick = (value: unknown, keys: readonly string[]) => {
+  const source = record(value);
+  return Object.fromEntries(
+    keys.filter((key) => source[key] !== undefined).map((
+      key,
+    ) => [key, source[key]]),
+  );
+};
+
+/**
+ * Helper for evidence projection, which omits displacement title fallbacks:
+ * the daemon may use an unlabelled component's raw Pattern Instance reference.
+ */
+const projectReceipt = (value: unknown) => ({
+  ...pick(value, [
+    "loom_id",
+    "request_id",
+    "version",
+    "created",
+    "component_ids",
+    "operation_ids",
+  ]),
+  displaced: Array.isArray(record(value).displaced)
+    ? (record(value).displaced as unknown[]).map((item) =>
+      pick(item, ["component_id"])
+    )
+    : [],
+});
+
+/**
+ * Helper for inspection, which describes existing layout without returning
+ * renderer URLs, resolver internals, or cell references the run does not hold.
+ */
+const projectManifest = (value: unknown) => {
+  const manifest = record(value);
+  return {
+    ...pick(manifest, [
+      "loom_id",
+      "title",
+      "version",
+      "archived",
+      "starred",
+      "staged",
+      "focused",
+    ]),
+    components: Array.isArray(manifest.components)
+      ? manifest.components.map((item: unknown) => {
+        const component = record(item);
+        const ref = record(component.subject).ref;
+        const kind = typeof ref === "string" ? ref.split(":", 1)[0] : undefined;
+        return {
+          ...pick(component, ["component_id", "title"]),
+          ...(kind !== undefined
+            ? { reference_kind: kind === "piece" ? "pattern" : kind }
+            : {}),
+        };
+      })
+      : [],
+  };
+};
+
+/**
+ * Helper for composition, which accepts only held whole Pattern Instances in
+ * the session's own space. Restricted skill handles never grant composition.
+ */
+const patternReference = async (
+  context: HarnessToolContext,
+  token: string,
+): Promise<string> => {
+  const entry = context.handleTable === undefined
+    ? undefined
+    : resolveHandleToken(context.handleTable, token);
+  if (entry === undefined || entry.capability !== undefined) {
+    throw new Error("Use a general Pattern Instance token this run holds.");
+  }
+  if (context.getFabricSession === undefined) {
+    throw new Error("Pattern Instance composition requires a Fabric session.");
+  }
+  const { pieces } = await context.getFabricSession();
+  const space = pieces.getSpace();
+  const link = parseHandleRef(entry.ref);
+  if (
+    (link.space !== undefined && link.space !== space) ||
+    link.path.length > 0 || link.scope !== "space"
+  ) {
+    throw new Error("Use a whole Pattern Instance in this run's own space.");
+  }
+  const cell = pieces.runtime.getCellFromLink({
+    ...link,
+    space,
+    schema: undefined,
+  });
+  await cell.sync();
+  const id = pieceId(cell);
+  if (id === undefined || getPatternIdentityRef(cell) === undefined) {
+    throw new Error("The held token does not identify a Pattern Instance.");
+  }
+  return `pattern:${space}/${id}`;
+};
+
+/**
+ * Helper for the three tools, which projects only their public observation.
+ * A started host command settles even when the model turn is cancelled; a
+ * receipt reports that settlement, and unreadable outcomes remain uncertain.
+ */
+const invoke = async (
+  context: HarnessToolContext,
+  command: LoomAuthoringCommand,
+  input: LoomComposeToolInput | LoomReadToolInput,
+): Promise<LoomAuthoringToolOutput> => {
+  const outputId = context.nextOutputId(command.replaceAll(".", "_"));
+  const fail = (
+    message: string,
+    mayHaveCommitted = false,
+  ): LoomAuthoringToolOutput => ({
+    outputId,
+    status: "error",
+    message,
+    mayHaveCommitted,
+  });
+  if (context.loomAuthoring === undefined) {
+    return fail("This run has no host Loom authoring configuration.");
+  }
+  if (context.signal?.aborted) {
+    return fail("The turn was cancelled before the host command.");
+  }
+  let args: Record<string, unknown> = { ...input };
+  if (command === "loom.compose") {
+    const components = record(input).components;
+    if (
+      !Array.isArray(components) || components.length < 1 ||
+      components.length > 100
+    ) {
+      return fail("Composition requires 1–100 components.");
+    }
+    const normalized: Record<string, unknown>[] = [];
+    for (const value of components) {
+      const item = record(value);
+      if (
+        Object.keys(item).some((key) =>
+          !["ref", "pattern_token", "title", "stage", "focus"].includes(key)
+        )
+      ) {
+        return fail(
+          "A component accepts a reference, title, stage, and focus only.",
+        );
+      }
+      if ((item.ref !== undefined) === (item.pattern_token !== undefined)) {
+        return fail("Give each component exactly one ref or pattern_token.");
+      }
+      if (item.pattern_token !== undefined) {
+        if (typeof item.pattern_token !== "string") {
+          return fail("A pattern_token must be a held token.");
+        }
+        try {
+          const ref = await patternReference(context, item.pattern_token);
+          const { pattern_token: _token, ...rest } = item;
+          normalized.push({ ...rest, ref });
+        } catch {
+          return fail(
+            "Use a held, unrestricted whole Pattern Instance in this run's own space.",
+          );
+        }
+      } else {
+        if (
+          typeof item.ref !== "string" ||
+          !/^(page|artifact|url):/.test(item.ref)
+        ) {
+          return fail(
+            "Use page:, artifact:, or url: references; Pattern Instances require pattern_token.",
+          );
+        }
+        normalized.push(item);
+      }
+    }
+    args = { ...args, components: normalized };
+  }
+  if (context.signal?.aborted) {
+    return fail("The turn was cancelled before the host command.");
+  }
+  const response = await executeLoomAuthoringCommand(
+    context.loomAuthoring,
+    command,
+    args,
+    context.hostProcessRunner,
+  );
+  if (response.status === "error") {
+    if (response.code !== undefined) {
+      const recovery = response.code === "version-conflict"
+        ? "Inspect the target's current version, then reconsider the change. A revised composition uses a new request_id."
+        : response.code === "request-conflict"
+        ? "This request_id already names different committed arguments. Recover the original receipt with loom_authoring_context or replay its original arguments; use a new key only for new work."
+        : "Correct the command's target or input fields before submitting it again.";
+      return { ...fail(recovery), code: response.code };
+    }
+
+    // Transport errors may quote internal references. The tool's retry contract
+    // is sufficient to recover without disclosing those host-only details.
+    return fail(
+      response.mayHaveCommitted
+        ? "The host did not return verifiable commit evidence. Retry the identical composition with the same request_id; do not claim it failed to commit."
+        : "The host rejected the command. Check its target and input fields.",
+      response.mayHaveCommitted,
+    );
+  }
+  const result = response.result;
+  if (command === "loom.compose") {
+    return {
+      outputId,
+      status: "ok",
+      kind: "loom-authored",
+      receipt: projectReceipt(result.receipt),
+      replayed: result.replayed,
+      displaced: result.replayed === true
+        ? []
+        : projectReceipt(result.receipt).displaced,
+      current_version: record(result.manifest).version,
+    };
+  }
+  if (command === "loom.inspect") {
+    return {
+      outputId,
+      status: "ok",
+      kind: "manifest",
+      manifest: projectManifest(result.manifest),
+    };
+  }
+  return {
+    outputId,
+    status: "ok",
+    kind: "authoring-context",
+    historical: true,
+    ...pick(result, ["run_scoped", "truncated"]),
+    bound_loom: result.bound_loom === null ? null : pick(result.bound_loom, [
+      "loom_id",
+      "version",
+      "archived",
+      "source",
+      "available",
+    ]),
+    authored: (result.authored as unknown[]).map((entry) => ({
+      receipt: projectReceipt(record(entry).receipt),
+    })),
+  };
+};
+
+/** An exact durable Loom identifier; targets never change the host's identity. */
+const targetSchema: JSONSchema = {
+  type: "string",
+  pattern: "^loom-[a-f0-9]{16}$",
+};
+
+/** Composes a collection with a host-verified durable receipt. */
+export const loomComposeTool: HarnessToolDefinition<
+  LoomComposeToolInput,
+  LoomAuthoringToolOutput
+> = {
+  descriptor: {
+    toolId: "loom_compose",
+    title: "Compose Loom",
+    effectClass: "write",
+    description:
+      "Create or extend a durable Loom collection of pages, links, artifacts, and held Pattern Instances. Choose one logical request_id and retain every argument on retry. Inspect an existing target before extending it with expected_version. A receipt proves a commit, not that every component renders. Report only the current displaced component ids; receipt.displaced is historical and a replay performs no new displacement.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["request_id", "components"],
+      properties: {
+        request_id: { type: "string", minLength: 1, maxLength: 200 },
+        title: { type: "string" },
+        loom_id: targetSchema,
+        expected_version: { type: "integer", minimum: 1 },
+        components: {
+          type: "array",
+          minItems: 1,
+          maxItems: 100,
+          items: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              ref: {
+                type: "string",
+                description:
+                  "A page:, artifact:, or url: reference; mutually exclusive with pattern_token.",
+              },
+              pattern_token: {
+                type: "string",
+                description:
+                  "A held cfh:a: token naming a whole Pattern Instance; mutually exclusive with ref.",
+              },
+              title: { type: "string" },
+              stage: { type: "boolean" },
+              focus: { type: "boolean" },
+            },
+          },
+        },
+      },
+    },
+    tags: ["loom"],
+  },
+  invoke: (context, input) => invoke(context, "loom.compose", input),
+};
+
+/** Inspects the target's current layout without granting its referenced cells. */
+export const loomInspectTool: HarnessToolDefinition<
+  LoomReadToolInput,
+  LoomAuthoringToolOutput
+> = {
+  descriptor: {
+    toolId: "loom_inspect",
+    title: "Inspect Loom",
+    effectClass: "read",
+    description:
+      "Read the current version and layout of one exact Loom before extending it. Component metadata grants no Pattern Instance handles and does not prove live rendering.",
+    inputSchema: {
+      type: "object",
+      properties: { loom_id: targetSchema },
+      required: ["loom_id"],
+      additionalProperties: false,
+    },
+    tags: ["loom"],
+  },
+  invoke: (context, input) => invoke(context, "loom.inspect", input),
+};
+
+/** Reads bounded historical receipts and a separate explicitly bound target. */
+export const loomAuthoringContextTool: HarnessToolDefinition<
+  LoomReadToolInput,
+  LoomAuthoringToolOutput
+> = {
+  descriptor: {
+    toolId: "loom_authoring_context",
+    title: "Loom Authoring Context",
+    effectClass: "read",
+    description:
+      "Recover up to 32 historical receipts for this host-owned run identity and its separately bound Loom. History is not newly authored work and never selects an implicit target. An explicit loom_id overrides only the context target. Inspect the exact chosen target before editing.",
+    inputSchema: {
+      type: "object",
+      properties: { loom_id: targetSchema },
+      additionalProperties: false,
+    },
+    tags: ["loom"],
+  },
+  invoke: (context, input) => invoke(context, "loom.authoring-context", input),
+};

--- a/packages/cf-harness/src/tools/loom-authoring.ts
+++ b/packages/cf-harness/src/tools/loom-authoring.ts
@@ -17,7 +17,7 @@ import type { HarnessToolContext, HarnessToolDefinition } from "./types.ts";
 
 /** A requested addition, with one ordinary reference or one held pattern token. */
 export interface LoomComposeComponent {
-  /** A typed page, artifact, or URL reference. */
+  /** A typed non-Fabric object reference, validated by the Loom host. */
   ref?: string;
 
   /** A held whole Pattern Instance address, resolved by the host. */
@@ -241,10 +241,11 @@ const invoke = async (
       } else {
         if (
           typeof item.ref !== "string" ||
-          !/^(page|artifact|url):/.test(item.ref)
+          !/^(page|artifact|url|person|thread|moment|loom|wish|intention|chat|run):/
+            .test(item.ref)
         ) {
           return fail(
-            "Use page:, artifact:, or url: references; Pattern Instances require pattern_token.",
+            "Use a supported typed Loom object reference; Pattern Instances require pattern_token.",
           );
         }
         normalized.push(item);
@@ -337,7 +338,7 @@ export const loomComposeTool: HarnessToolDefinition<
     title: "Compose Loom",
     effectClass: "write",
     description:
-      "Create or extend a durable Loom collection of pages, links, artifacts, and held Pattern Instances. Choose one logical request_id and retain every argument on retry. Inspect an existing target before extending it with expected_version. A receipt proves a commit, not that every component renders. Report only the current displaced component ids; receipt.displaced is historical and a replay performs no new displacement.",
+      "Create or extend a durable Loom collection of existing objects and held Pattern Instances. Choose one logical request_id and retain every argument on retry. Inspect an existing target before extending it with expected_version. A receipt proves a commit, not that every component renders. Report only the current displaced component ids; receipt.displaced is historical and a replay performs no new displacement.",
     inputSchema: {
       type: "object",
       additionalProperties: false,
@@ -358,7 +359,7 @@ export const loomComposeTool: HarnessToolDefinition<
               ref: {
                 type: "string",
                 description:
-                  "A page:, artifact:, or url: reference; mutually exclusive with pattern_token.",
+                  "An existing page:, artifact:, url:, person:, thread:, moment:, loom:, wish:, intention:, chat:, or run: reference. The host validates its grammar and binding. Mutually exclusive with pattern_token.",
               },
               pattern_token: {
                 type: "string",

--- a/packages/cf-harness/src/tools/registry.ts
+++ b/packages/cf-harness/src/tools/registry.ts
@@ -1,6 +1,11 @@
 import type { BuiltinToolId } from "../contracts/tool-descriptor.ts";
 import { acquireSkillTool } from "./acquire-skill.ts";
 import { assignSlugTool } from "./assign-slug.ts";
+import {
+  loomAuthoringContextTool,
+  loomComposeTool,
+  loomInspectTool,
+} from "./loom-authoring.ts";
 import { bashTool } from "./bash.ts";
 import { browserTool } from "./browser.ts";
 import { delegateTaskTool } from "./delegate-task.ts";
@@ -38,6 +43,9 @@ export const BUILTIN_TOOLS = [
   searchSkillsTool,
   acquireSkillTool,
   queryDocsTool,
+  loomComposeTool,
+  loomInspectTool,
+  loomAuthoringContextTool,
 ] as const;
 
 export const BUILTIN_TOOL_REGISTRY = new Map<

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -28,6 +28,7 @@ import type { SkillsShAcquisitionClient } from "../skills-sh/acquisition.ts";
 import type { SkillsShSearchClient } from "../skills-sh/search-client.ts";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { ToolOutputId } from "../contracts/tool-result.ts";
+import type { HarnessLoomAuthoringConfig } from "../loom-authoring.ts";
 import type { ProcessRunner } from "../sandbox/process-runner.ts";
 import type { SandboxRuntime } from "../sandbox/types.ts";
 
@@ -157,6 +158,9 @@ export interface HarnessToolContext {
 
   sandbox: SandboxRuntime;
   hostProcessRunner: ProcessRunner;
+
+  /** Host-owned Loom command routing, absent when the run has no grant. */
+  loomAuthoring?: HarnessLoomAuthoringConfig;
   currentDir: string;
   workspaceHostPath?: string;
   resolvePath(path: string): string;

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -656,6 +656,35 @@ describe("console/server", () => {
     });
   });
 
+  describe("task Loom context", () => {
+    it("rejects malformed Loom targets before starting a turn", async () => {
+      for (const loomId of ["../private", {}, "loom-not-valid"]) {
+        const response = await server.handle(
+          jsonRequest("/api/task", { text: "Make a Loom", loomId }, { cookie }),
+        );
+        expect(response.status).toBe(400);
+      }
+      expect(server.service.turns()).toHaveLength(0);
+    });
+
+    it("persists the submitted origin even when the next turn names another Loom", async () => {
+      const first = await startTask({
+        text: "First",
+        loomId: "loom-1111111111111111",
+      });
+      await startTask({
+        text: "Second",
+        sessionId: first.sessionId,
+        loomId: "loom-2222222222222222",
+      });
+      expect(
+        server.service.turns(first.sessionId).map((entry) =>
+          entry.input.loomId
+        ),
+      ).toEqual(["loom-1111111111111111", "loom-2222222222222222"]);
+    });
+  });
+
   describe("GET /api/turns/<turnId>/result", () => {
     it("returns named errors for malformed and unknown turn paths", async () => {
       const malformedRoute = await server.handle(getRequest(
@@ -728,7 +757,10 @@ describe("console/server", () => {
         await page.body?.cancel();
         const resultCookie = page.headers.get("set-cookie")!.split(";")[0];
         const startedResponse = await resultServer.handle(
-          jsonRequest("/api/task", { text: "track my books" }, {
+          jsonRequest("/api/task", {
+            text: "track my books",
+            loomId: "loom-1111111111111111",
+          }, {
             cookie: resultCookie,
           }),
         );
@@ -759,6 +791,8 @@ describe("console/server", () => {
 
         expect(response.status).toBe(200);
         expect(await response.json()).toEqual({
+          originLoomId: "loom-1111111111111111",
+          looms: [],
           pieces: [{
             slug: "reading-list",
             url: "http://localhost:8000/console-test/reading-list",
@@ -839,6 +873,7 @@ describe("console/server", () => {
 
         expect(response.status).toBe(200);
         expect(await response.json()).toEqual({
+          looms: [],
           pieces: [],
           spaceName: "console-test",
           finalText: "restored result",
@@ -1378,6 +1413,7 @@ describe("console/server", () => {
           { role: "assistant", content: "built it" },
         ]),
       ).toEqual({
+        looms: [],
         pieces: [{
           slug: "reading-list",
           url: "http://localhost:8000/console-test/reading-list",
@@ -1393,6 +1429,7 @@ describe("console/server", () => {
           { role: "assistant", content: "calculated it" },
         ]),
       ).toEqual({
+        looms: [],
         pieces: [],
         spaceName: "console-test",
         finalText: "calculated it",

--- a/packages/cf-harness/test/console/src/live-view.test.ts
+++ b/packages/cf-harness/test/console/src/live-view.test.ts
@@ -70,6 +70,7 @@ describe("console/src/live-view", () => {
     kind: "turn_completed",
     turnId: "turn-1",
     result: {
+      looms: [],
       pieces: [{
         slug: "reading-list",
         url: "http://localhost:8000/my-space/reading-list",
@@ -81,6 +82,7 @@ describe("console/src/live-view", () => {
 
   /** The result a completed turn carries when it named no piece. */
   const EMPTY_RESULT = {
+    looms: [],
     pieces: [],
     spaceName: "console-test",
     finalText: "",
@@ -331,6 +333,7 @@ describe("console/src/live-view", () => {
         turnId: "turn-1",
         finalText: "built it",
         result: {
+          looms: [],
           pieces: [{ slug: "reading-list", url: "http://localhost:8000/s/r" }],
           spaceName: "s",
           finalText: "built it",
@@ -1336,6 +1339,7 @@ describe("console/src/live-view", () => {
           kind: "turn_completed",
           turnId: "turn-1",
           result: {
+            looms: [],
             pieces: [{
               slug: "reading-list",
               url: "http://localhost:8000/s/reading-list",

--- a/packages/cf-harness/test/console/turn-result.test.ts
+++ b/packages/cf-harness/test/console/turn-result.test.ts
@@ -81,6 +81,12 @@ describe("console/turn-result", () => {
           receipt: { ...receipt, operation_ids: [] },
         }),
         message("loom_compose", output),
+        {
+          role: "tool",
+          toolName: "loom_compose",
+          toolCallId: "unreadable-receipt",
+          content: "{broken",
+        },
       ], 2);
       const result = await readConsoleTurnResult({
         artifactRoot,

--- a/packages/cf-harness/test/console/turn-result.test.ts
+++ b/packages/cf-harness/test/console/turn-result.test.ts
@@ -114,6 +114,21 @@ describe("console/turn-result", () => {
         }],
       }]);
       expect(JSON.stringify(result)).not.toContain("@held-clock");
+      // A reused call id later in the transcript cannot retroactively make
+      // the preceding successful call/result pair ambiguous.
+      transcript.push(
+        call("named", "other_tool", {}),
+        call("composed", "other_tool", {}),
+        call("composed", "loom_compose", {}),
+      );
+      await writeTranscript(artifactRoot, "later-duplicates", transcript);
+      const laterDuplicates = await readConsoleTurnResult({
+        artifactRoot,
+        turnId: "later-duplicates",
+        spaceName: "space",
+      });
+      expect(laterDuplicates?.pieces).toEqual(result?.pieces);
+      transcript.splice(5);
       // A separate named Pattern is not covered by the source-link collection.
       transcript[1] = call("named", "assign_slug", {
         token: "@independent-clock",
@@ -195,6 +210,16 @@ describe("console/turn-result", () => {
       (messages: HarnessTranscriptMessage[]) => void,
       number?,
     ][] = [
+      ...[null, {}, { id: 42 }].map((malformed, index): [
+        string,
+        (messages: HarnessTranscriptMessage[]) => void,
+      ] => ["malformed-call-id-" + index, (m) => {
+        m[3] = {
+          role: "assistant",
+          content: "",
+          toolCalls: [malformed],
+        } as unknown as HarnessTranscriptMessage;
+      }]),
       ["duplicate-id-different-tool", (m) => {
         m.splice(3, 0, call("compose", "other_tool", args));
       }],

--- a/packages/cf-harness/test/console/turn-result.test.ts
+++ b/packages/cf-harness/test/console/turn-result.test.ts
@@ -39,6 +39,234 @@ const writeTranscript = async (
 };
 
 describe("console/turn-result", () => {
+  it("ties a named Pattern to its verified composition component without exposing its cell address", async () => {
+    const artifactRoot = await Deno.makeTempDir();
+    const call = (
+      id: string,
+      name: string,
+      args: unknown,
+    ): HarnessTranscriptMessage => ({
+      role: "assistant",
+      content: "",
+      toolCalls: [{
+        id,
+        type: "function",
+        function: { name, arguments: JSON.stringify(args) },
+      }],
+    });
+    const output = (
+      id: string,
+      name: string,
+      value: unknown,
+    ): HarnessTranscriptMessage => ({
+      role: "tool",
+      toolName: name,
+      toolCallId: id,
+      content: JSON.stringify(value),
+    });
+    const transcript = [
+      {
+        role: "user",
+        content: "Make a clock and collect it",
+      } as HarnessTranscriptMessage,
+      call("named", "assign_slug", { token: "@held-clock", slug: "clock" }),
+      output("named", "assign_slug", {
+        status: "ok",
+        slug: "clock",
+        url: "http://localhost:8000/space/clock",
+      }),
+      call("composed", "loom_compose", {
+        request_id: "collect-clock",
+        components: [
+          { ref: "url:https://example.com/source" },
+          { pattern_token: "@held-clock" },
+        ],
+      }),
+      output("composed", "loom_compose", {
+        status: "ok",
+        kind: "loom-authored",
+        replayed: false,
+        current_version: 3,
+        receipt: {
+          loom_id: "loom-1111111111111111",
+          request_id: "collect-clock",
+          version: 3,
+          created: true,
+          component_ids: ["source-link", "opaque-clock-component"],
+          operation_ids: ["create", "add-source", "add-clock"],
+          displaced: [],
+        },
+      }),
+    ];
+    try {
+      await writeTranscript(artifactRoot, "coverage", transcript);
+      const result = await readConsoleTurnResult({
+        artifactRoot,
+        turnId: "coverage",
+        spaceName: "space",
+      });
+      expect(result?.pieces).toEqual([{
+        slug: "clock",
+        url: "http://localhost:8000/space/clock",
+        loomComponents: [{
+          loomId: "loom-1111111111111111",
+          componentId: "opaque-clock-component",
+        }],
+      }]);
+      expect(JSON.stringify(result)).not.toContain("@held-clock");
+      // A separate named Pattern is not covered by the source-link collection.
+      transcript[1] = call("named", "assign_slug", {
+        token: "@independent-clock",
+        slug: "clock",
+      });
+      await writeTranscript(artifactRoot, "independent", transcript);
+      const independent = await readConsoleTurnResult({
+        artifactRoot,
+        turnId: "independent",
+        spaceName: "space",
+      });
+      expect(independent?.pieces).toEqual([{
+        slug: "clock",
+        url: "http://localhost:8000/space/clock",
+      }]);
+    } finally {
+      await Deno.remove(artifactRoot, { recursive: true });
+    }
+  });
+
+  it("does not infer coverage from ambiguous, historical, or malformed calls", async () => {
+    const artifactRoot = await Deno.makeTempDir();
+    const call = (
+      id: string,
+      name: string,
+      args: unknown,
+    ): HarnessTranscriptMessage => ({
+      role: "assistant",
+      content: "",
+      toolCalls: [{
+        id,
+        type: "function",
+        function: { name, arguments: JSON.stringify(args) },
+      }],
+    });
+    const output = (
+      id: string,
+      name: string,
+      value: unknown,
+    ): HarnessTranscriptMessage => ({
+      role: "tool",
+      toolName: name,
+      toolCallId: id,
+      content: JSON.stringify(value),
+    });
+    const named = {
+      status: "ok",
+      slug: "clock",
+      url: "http://localhost:8000/space/clock",
+    };
+    const args = {
+      request_id: "collect",
+      components: [{ pattern_token: "@clock" }],
+    };
+    const authored = {
+      status: "ok",
+      kind: "loom-authored",
+      replayed: false,
+      current_version: 2,
+      receipt: {
+        loom_id: "loom-1111111111111111",
+        request_id: "collect",
+        version: 2,
+        created: true,
+        component_ids: ["opaque-component"],
+        operation_ids: ["create", "add"],
+        displaced: [],
+      },
+    };
+    const base = (): HarnessTranscriptMessage[] => [
+      { role: "user", content: "Collect" },
+      call("named", "assign_slug", { token: "@clock" }),
+      output("named", "assign_slug", named),
+      call("compose", "loom_compose", args),
+      output("compose", "loom_compose", authored),
+    ];
+    const cases: [
+      string,
+      (messages: HarnessTranscriptMessage[]) => void,
+      number?,
+    ][] = [
+      ["duplicate-id-different-tool", (m) => {
+        m.splice(3, 0, call("compose", "other_tool", args));
+      }],
+      ["duplicate-id", (m) => {
+        m.splice(3, 0, call("compose", "loom_compose", args));
+      }],
+      ["wrong-tool", (m) => {
+        m[3] = call("compose", "other_tool", args);
+      }],
+      ["missing-call", (m) => {
+        m.splice(3, 1);
+      }],
+      ["call-after-result", (m) => {
+        [m[3], m[4]] = [m[4], m[3]];
+      }],
+      ["historical-naming", () => {}, 2],
+      ["bad-json", (m) => {
+        const c = m[3];
+        if (c.role === "assistant") c.toolCalls![0].function.arguments = "{";
+      }],
+      ["array-args", (m) => {
+        m[3] = call("compose", "loom_compose", []);
+      }],
+      ["null-args", (m) => {
+        m[3] = call("compose", "loom_compose", null);
+      }],
+      ["wrong-request", (m) => {
+        m[3] = call("compose", "loom_compose", {
+          ...args,
+          request_id: "other",
+        });
+      }],
+      ["wrong-cardinality", (m) => {
+        m[3] = call("compose", "loom_compose", { ...args, components: [] });
+      }],
+      ["missing-components", (m) => {
+        m[3] = call("compose", "loom_compose", { request_id: "collect" });
+      }],
+      ["empty-token", (m) => {
+        m[3] = call("compose", "loom_compose", {
+          ...args,
+          components: [{ pattern_token: "" }],
+        });
+      }],
+      ["missing-named-token", (m) => {
+        m[1] = call("named", "assign_slug", {});
+      }],
+      ["null-component", (m) => {
+        m[3] = call("compose", "loom_compose", { ...args, components: [null] });
+      }],
+    ];
+    try {
+      for (const [name, mutate, first = 1] of cases) {
+        const transcript = base();
+        mutate(transcript);
+        await writeTranscript(artifactRoot, name, transcript, first);
+        const result = await readConsoleTurnResult({
+          artifactRoot,
+          turnId: name,
+          spaceName: "space",
+        });
+        expect(result?.pieces, name).toEqual([{
+          slug: named.slug,
+          url: named.url,
+        }]);
+        expect(result?.looms, name).toHaveLength(1);
+      }
+    } finally {
+      await Deno.remove(artifactRoot, { recursive: true });
+    }
+  });
+
   it("returns only this turn's verified Loom receipts and preserves replay versions", async () => {
     const artifactRoot = await Deno.makeTempDir();
     const receipt = {

--- a/packages/cf-harness/test/console/turn-result.test.ts
+++ b/packages/cf-harness/test/console/turn-result.test.ts
@@ -39,6 +39,67 @@ const writeTranscript = async (
 };
 
 describe("console/turn-result", () => {
+  it("returns only this turn's verified Loom receipts and preserves replay versions", async () => {
+    const artifactRoot = await Deno.makeTempDir();
+    const receipt = {
+      loom_id: "loom-1111111111111111",
+      request_id: "collection-one",
+      version: 2,
+      created: true,
+      component_ids: ["c-1"],
+      operation_ids: ["op-1", "op-2"],
+      displaced: [],
+    };
+    const output = {
+      status: "ok",
+      kind: "loom-authored",
+      receipt,
+      replayed: true,
+      current_version: 4,
+    };
+    const message = (
+      toolName: string,
+      value: unknown,
+    ): HarnessTranscriptMessage => ({
+      role: "tool",
+      toolName,
+      toolCallId: crypto.randomUUID(),
+      content: JSON.stringify(value),
+    });
+    try {
+      await writeTranscript(artifactRoot, "turn-looms", [
+        message("loom_compose", {
+          ...output,
+          receipt: { ...receipt, request_id: "old" },
+        }),
+        { role: "user", content: "Continue" },
+        message("loom_authoring_context", output),
+        message("loom_inspect", output),
+        { role: "assistant", content: JSON.stringify(output) },
+        message("loom_compose", {
+          ...output,
+          receipt: { ...receipt, operation_ids: [] },
+        }),
+        message("loom_compose", output),
+      ], 2);
+      const result = await readConsoleTurnResult({
+        artifactRoot,
+        turnId: "turn-looms",
+        spaceName: "test-space",
+        originLoomId: "loom-2222222222222222",
+      });
+      expect(result?.looms).toEqual([{
+        receipt,
+        replayed: true,
+        current_version: 4,
+      }]);
+      expect(result?.originLoomId).toBe("loom-2222222222222222");
+      expect(result?.pieces).toEqual([]);
+    } finally {
+      await Deno.remove(artifactRoot, { recursive: true });
+    }
+  });
+
   it("returns successful `assign_slug` values exactly as the model received them", async () => {
     const artifactRoot = await Deno.makeTempDir({
       prefix: "cf-harness-console-result-",
@@ -65,6 +126,7 @@ describe("console/turn-result", () => {
         turnId: "turn-with-piece",
         spaceName: "console-test",
       })).resolves.toEqual({
+        looms: [],
         pieces: [{
           slug: "reading-list",
           url: "http://localhost:8000/console-test/reading-list",
@@ -101,6 +163,7 @@ describe("console/turn-result", () => {
         turnId: "turn-without-piece",
         spaceName: "console-test",
       })).resolves.toEqual({
+        looms: [],
         pieces: [],
         spaceName: "console-test",
         finalText: "The total is 42.",
@@ -142,6 +205,7 @@ describe("console/turn-result", () => {
         turnId: "follow-up-turn",
         spaceName: "console-test",
       })).resolves.toEqual({
+        looms: [],
         pieces: [],
         spaceName: "console-test",
         finalText: "",
@@ -171,6 +235,7 @@ describe("console/turn-result", () => {
         turnId,
         spaceName: "console-test",
       })).resolves.toEqual({
+        looms: [],
         pieces: [],
         spaceName: "console-test",
         finalText: "The total is 42.",
@@ -304,6 +369,7 @@ describe("console/turn-result", () => {
         turnId,
         spaceName: "console-test",
       })).resolves.toEqual({
+        looms: [],
         pieces: [],
         spaceName: "console-test",
         finalText: "I could not name it.",

--- a/packages/cf-harness/test/loom-authoring-session.test.ts
+++ b/packages/cf-harness/test/loom-authoring-session.test.ts
@@ -1,0 +1,172 @@
+/** Checks explicit CLI configuration and per-turn Loom context isolation. */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { parseCfHarnessCliArgs } from "../src/cli.ts";
+import { resolveConsoleConfig } from "../console/server.ts";
+import { HarnessInteractiveChatService } from "../src/interactive-chat-service.ts";
+import type { CreateHarnessPromptLoopOptions } from "../src/prompt-loop.ts";
+import { createHarnessRunState } from "../src/run-state.ts";
+import { DEFAULT_HARNESS_CHAT_POLICY } from "../src/contracts/interactive-chat.ts";
+import type { HarnessLoomAuthoringConfig } from "../src/loom-authoring.ts";
+
+/** Host-owned direct routing, independent of a model turn id. */
+const authoring: HarnessLoomAuthoringConfig = {
+  cliPath: "/trusted/loom",
+  transport: {
+    kind: "direct",
+    instanceDir: "/trusted/instance",
+    runId: "owner-console",
+    actor: "agent:cf-harness",
+  },
+};
+
+describe("loom-authoring-session", () => {
+  it("admits only dedicated Loom tools to comment threads when the host explicitly grants them", async () => {
+    for (const allowCommentThreads of [false, true]) {
+      const observed: CreateHarnessPromptLoopOptions[] = [];
+      const service = new HarnessInteractiveChatService({
+        basePromptLoopOptions: {
+          loomAuthoring: { ...authoring, allowCommentThreads },
+        },
+        createPromptLoop: (options) => {
+          observed.push(options);
+          return {
+            runTranscript: (request) =>
+              Promise.resolve({
+                model: "test",
+                finalAssistantText: "Done",
+                transcript: [...request.transcript, {
+                  role: "assistant",
+                  content: "Done",
+                }],
+                modelTurns: 1,
+                runState: createHarnessRunState({
+                  cfcEnforcementMode: "disabled",
+                  currentDir: "/workspace",
+                }),
+              }),
+          };
+        },
+      });
+      await service.startSession("start", {
+        sessionId: "comments",
+        workspace: { hostPath: "/tmp" },
+        context: { type: "comment-thread" },
+        policy: {
+          ...DEFAULT_HARNESS_CHAT_POLICY,
+          allowedToolIds: [
+            "bash",
+            "write_file",
+            "delegate_task",
+            "loom_compose",
+            "loom_inspect",
+            "loom_authoring_context",
+          ],
+        },
+      });
+      const turn = await service.startTurn("turn", {
+        sessionId: "comments",
+        turnId: "turn",
+        input: { text: "Make a Loom" },
+      });
+      expect(turn.ok).toBe(true);
+      await service.waitForTurn("comments", "turn");
+      const ids = observed[0].allowedToolIds;
+      if (allowCommentThreads) expect(ids).toContain("loom_compose");
+      else expect(ids).not.toContain("loom_compose");
+      expect(ids).not.toContain("bash");
+      expect(ids).not.toContain("write_file");
+      expect(ids).not.toContain("delegate_task");
+      expect(observed[0].allowedSubagentProfiles).toEqual([]);
+    }
+  });
+
+  it("loads the same explicit host configuration for CLI and console", async () => {
+    const path = await Deno.makeTempFile();
+    try {
+      await Deno.writeTextFile(path, JSON.stringify(authoring));
+      const cli = await parseCfHarnessCliArgs([
+        "--loom-authoring-config",
+        path,
+        "Make a Loom",
+      ], { env: {}, cwd: "/tmp" });
+      if ("help" in cli) throw new Error("Expected CLI configuration");
+      const consoleConfig = await resolveConsoleConfig([], {
+        CF_HARNESS_LOOM_AUTHORING_CONFIG: path,
+        CF_HARNESS_FABRIC_IDENTITY: "/trusted/key",
+        CF_HARNESS_FABRIC_SPACE: "test-space",
+      }, "/tmp");
+      expect(cli.loomAuthoring).toEqual(authoring);
+      expect(consoleConfig.loomAuthoring).toEqual(authoring);
+    } finally {
+      await Deno.remove(path);
+    }
+  });
+
+  it("keeps authoring identity stable while clearing the previous turn's Loom target", async () => {
+    const observed: CreateHarnessPromptLoopOptions[] = [];
+    const service = new HarnessInteractiveChatService({
+      basePromptLoopOptions: {
+        loomAuthoring: { ...authoring, boundLoomId: "loom-3333333333333333" },
+      },
+      runIdForTurn: (_session, turn) => turn,
+      createPromptLoop: (options) => {
+        observed.push(options);
+        return {
+          runTranscript: (request) =>
+            Promise.resolve({
+              model: "test-model",
+              finalAssistantText: "Done",
+              transcript: [...request.transcript, {
+                role: "assistant",
+                content: "Done",
+              }],
+              modelTurns: 1,
+              runState: createHarnessRunState({
+                runId: options.runId,
+                cfcEnforcementMode: "disabled",
+                currentDir: "/workspace",
+              }),
+            }),
+        };
+      },
+    });
+    const started = await service.startSession("start", {
+      sessionId: "session-one",
+      workspace: { hostPath: "/tmp" },
+    });
+    expect(started.ok).toBe(true);
+    for (
+      const [turnId, loomId] of [["turn-one", "loom-1111111111111111"], [
+        "turn-two",
+        undefined,
+      ]] as const
+    ) {
+      const turn = await service.startTurn(turnId, {
+        sessionId: "session-one",
+        turnId,
+        input: {
+          text: "Continue",
+          ...(loomId === undefined ? {} : { loomId }),
+        },
+      });
+      expect(turn.ok).toBe(true);
+      await service.waitForTurn("session-one", turnId);
+    }
+    expect(observed).toHaveLength(2);
+    expect(observed[0].runId).not.toBe(observed[1].runId);
+    expect(observed[0].loomAuthoring?.transport).toEqual(
+      observed[1].loomAuthoring?.transport,
+    );
+    expect(observed[0].loomAuthoring?.boundLoomId).toBe(
+      "loom-1111111111111111",
+    );
+    expect(observed[1].loomAuthoring?.boundLoomId).toBeUndefined();
+    expect(service.turns("session-one")[0].input.loomId).toBe(
+      "loom-1111111111111111",
+    );
+    expect(authoring.transport).toMatchObject({ runId: "owner-console" });
+  });
+});

--- a/packages/cf-harness/test/loom-authoring-session.test.ts
+++ b/packages/cf-harness/test/loom-authoring-session.test.ts
@@ -29,6 +29,20 @@ const authoring: HarnessLoomAuthoringConfig = {
 };
 
 describe("loom-authoring-session", () => {
+  it("rejects invalid originating Loom identities before admitting a turn", async () => {
+    const service = new HarnessInteractiveChatService();
+    for (const loomId of [null, 4, "../other", "loom-not-an-id"]) {
+      const result = await service.startTurn("invalid-origin", {
+        sessionId: "not-yet-admitted",
+        input: { text: "Collect", loomId: loomId as unknown as string },
+      });
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: "invalid_request" },
+      });
+    }
+  });
+
   it("admits only dedicated Loom tools to comment threads when the host explicitly grants them", async () => {
     for (const allowCommentThreads of [false, true]) {
       const observed: CreateHarnessPromptLoopOptions[] = [];

--- a/packages/cf-harness/test/loom-authoring-session.test.ts
+++ b/packages/cf-harness/test/loom-authoring-session.test.ts
@@ -1,5 +1,11 @@
 /** Checks explicit CLI configuration and per-turn Loom context isolation. */
 
+import { createLoomLocalCfHarnessHost } from "../src/loom-local-host.ts";
+import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
+import {
+  parseHarnessInteractiveChatStdioCliOptions,
+  runHarnessInteractiveChatStdioCli,
+} from "../src/interactive-chat-stdio.ts";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
@@ -80,6 +86,57 @@ describe("loom-authoring-session", () => {
       expect(ids).not.toContain("write_file");
       expect(ids).not.toContain("delegate_task");
       expect(observed[0].allowedSubagentProfiles).toEqual([]);
+    }
+  });
+
+  it("provisions authoring through both interactive executables and the host environment", async () => {
+    const home = await Deno.makeTempDir();
+    const path = home + "/authoring.json";
+    try {
+      await Deno.writeTextFile(path, JSON.stringify(authoring));
+      const observed: unknown[] = [];
+      await runHarnessInteractiveChatStdioCli(
+        ["--loom-authoring-config", path],
+        home,
+        (options) => {
+          observed.push(options.basePromptLoopOptions?.loomAuthoring);
+          return Promise.resolve();
+        },
+      );
+      for (const args of [["--loom-authoring-config=" + path], []]) {
+        const host = await createLoomLocalCfHarnessHost({
+          harnessHome: home,
+          env: {
+            CF_HARNESS_LOOM_AUTHORING_CONFIG: path,
+            CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+          },
+          credentialStore: new InMemoryHarnessCredentialStore(),
+          providerSettingsStore: {
+            inspect: () =>
+              Promise.resolve({
+                state: "configured",
+                settings: {
+                  version: 1,
+                  modelProvider: "openai-compatible-gateway",
+                },
+              }),
+          },
+          interactiveStdioRunner: (options) => {
+            observed.push(options.basePromptLoopOptions?.loomAuthoring);
+            return Promise.resolve();
+          },
+        });
+        await host.runInteractive(args);
+      }
+      expect(observed).toEqual([authoring, authoring, authoring]);
+      expect(() =>
+        parseHarnessInteractiveChatStdioCliOptions(
+          ["--loom-authoring-config"],
+          {},
+        )
+      ).toThrow();
+    } finally {
+      await Deno.remove(home, { recursive: true });
     }
   });
 

--- a/packages/cf-harness/test/loom-authoring.test.ts
+++ b/packages/cf-harness/test/loom-authoring.test.ts
@@ -5,6 +5,9 @@ import { describe, it } from "@std/testing/bdd";
 
 import {
   executeLoomAuthoringCommand,
+  type HarnessLoomAuthoringConfig,
+  type LoomAuthoringCommand,
+  readLoomAuthoringConfig,
   validateLoomAuthoringConfig,
 } from "../src/loom-authoring.ts";
 import type { ProcessRunRequest } from "../src/sandbox/process-runner.ts";
@@ -39,6 +42,152 @@ const input = {
 };
 
 describe("loom-authoring", () => {
+  const broker: HarnessLoomAuthoringConfig = {
+    cliPath: "/trusted/loom",
+    transport: { kind: "broker", queuePath: "/trusted/queue" },
+  };
+
+  it("rejects malformed operator routing and grants before offering tools", async () => {
+    for (
+      const config of [
+        { ...broker, cliPath: "relative" },
+        { ...broker, allowCommentThreads: "yes" },
+        { ...broker, boundLoomId: "unbound" },
+        { ...broker, transport: { kind: "broker", queuePath: "relative" } },
+        { ...broker, transport: { kind: "unknown" } },
+      ]
+    ) {
+      expect(() =>
+        validateLoomAuthoringConfig(config as HarnessLoomAuthoringConfig)
+      ).toThrow();
+    }
+    await expect(readLoomAuthoringConfig("relative")).rejects.toThrow();
+    for (
+      const value of [null, [], {}, {
+        cliPath: "/trusted/loom",
+        transport: null,
+      }]
+    ) {
+      await expect(
+        readLoomAuthoringConfig(
+          "/trusted/config",
+          () => Promise.resolve(JSON.stringify(value)),
+        ),
+      )
+        .rejects.toThrow();
+    }
+  });
+
+  it("rejects invalid requests before any process can apply a write", async () => {
+    let calls = 0;
+    const runner = {
+      run: () => {
+        calls++;
+        return Promise.resolve({
+          exitCode: 0,
+          stdout: JSON.stringify(reply),
+          stderr: "",
+        });
+      },
+    };
+    const cases: [LoomAuthoringCommand, unknown][] = [
+      ["unsupported" as LoomAuthoringCommand, {}],
+      ["loom.compose", null],
+      ["loom.inspect", {}],
+      ["loom.inspect", { loom_id: "not-an-id" }],
+      ["loom.compose", { ...input, expected_version: 3 }],
+      ["loom.compose", {
+        ...input,
+        loom_id: receipt.loom_id,
+        expected_version: 0,
+      }],
+      ...["", " ", "x\n", "x".repeat(201)].map((
+        request_id,
+      ): [LoomAuthoringCommand, unknown] => ["loom.compose", {
+        ...input,
+        request_id,
+      }]),
+      ...[null, [], Array(101).fill({ ref: "url:https://example.com" })].map((
+        components,
+      ): [LoomAuthoringCommand, unknown] => ["loom.compose", {
+        ...input,
+        components,
+      }]),
+    ];
+    for (const [command, args] of cases) {
+      expect(await executeLoomAuthoringCommand(broker, command, args, runner))
+        .toMatchObject({ status: "error", mayHaveCommitted: false });
+    }
+    expect(calls).toBe(0);
+    const result = await executeLoomAuthoringCommand(broker, "loom.compose", {
+      ...input,
+      loom_id: receipt.loom_id,
+      expected_version: 1,
+    }, {
+      run: (request) => {
+        expect(request.args.slice(-4)).toEqual([
+          "--loom",
+          receipt.loom_id,
+          "--expect",
+          "1",
+        ]);
+        expect(JSON.parse(request.stdinText!)).toEqual(input);
+        return runner.run();
+      },
+    });
+    expect(result.status).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  it("keeps unknown and unreadable write outcomes uncertain but never claims read commits", async () => {
+    for (const command of ["loom.compose", "loom.inspect"] as const) {
+      for (
+        const response of [
+          {
+            exitCode: 1,
+            stdout: JSON.stringify({ ok: false, error: "backend error" }),
+            stderr: "",
+          },
+          { exitCode: 0, stdout: "null", stderr: "" },
+          { exitCode: 0, stdout: "{broken", stderr: "" },
+          null,
+        ]
+      ) {
+        const result = await executeLoomAuthoringCommand(
+          broker,
+          command,
+          command === "loom.compose" ? input : { loom_id: receipt.loom_id },
+          {
+            run: () =>
+              response === null
+                ? Promise.reject(new Error("lost connection"))
+                : Promise.resolve(response),
+          },
+        );
+        expect(result).toMatchObject({
+          status: "error",
+          mayHaveCommitted: command === "loom.compose",
+        });
+      }
+    }
+    for (const command of ["loom.inspect", "loom.authoring-context"] as const) {
+      const result = await executeLoomAuthoringCommand(broker, command, {
+        loom_id: receipt.loom_id,
+      }, {
+        run: () =>
+          Promise.resolve({
+            exitCode: 0,
+            stderr: "",
+            stdout: JSON.stringify({ ok: true, result: {} }),
+          }),
+      });
+      expect(result).toMatchObject({
+        status: "error",
+        mayHaveCommitted: false,
+      });
+    }
+  });
+
   describe("executeLoomAuthoringCommand()", () => {
     it("preserves historical receipts when only the implicit origin is missing", async () => {
       const calls: ProcessRunRequest[] = [];

--- a/packages/cf-harness/test/loom-authoring.test.ts
+++ b/packages/cf-harness/test/loom-authoring.test.ts
@@ -1,0 +1,336 @@
+/** Checks transport attribution and receipt evidence for host Loom commands. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  executeLoomAuthoringCommand,
+  validateLoomAuthoringConfig,
+} from "../src/loom-authoring.ts";
+import type { ProcessRunRequest } from "../src/sandbox/process-runner.ts";
+
+/** A composition the daemon committed. */
+const receipt = {
+  loom_id: "loom-1111111111111111",
+  request_id: "collection-one",
+  version: 2,
+  created: true,
+  component_ids: ["c-1"],
+  operation_ids: ["op-1", "op-2"],
+  displaced: [],
+};
+
+/** A current manifest beside the historical composition. */
+const reply = {
+  ok: true,
+  result: {
+    kind: "manifest",
+    receipt,
+    replayed: true,
+    manifest: { loom_id: receipt.loom_id, version: 3, components: [] },
+  },
+};
+
+/** Arguments retained across retries of one logical request. */
+const input = {
+  request_id: "collection-one",
+  title: "Donut references",
+  components: [{ ref: "url:https://example.com/donuts" }],
+};
+
+describe("loom-authoring", () => {
+  describe("executeLoomAuthoringCommand()", () => {
+    it("preserves historical receipts when only the implicit origin is missing", async () => {
+      const calls: ProcessRunRequest[] = [];
+      const result = await executeLoomAuthoringCommand(
+        {
+          cliPath: "/trusted/loom",
+          boundLoomId: "loom-2222222222222222",
+          transport: { kind: "broker", queuePath: "/trusted/queue" },
+        },
+        "loom.authoring-context",
+        {},
+        {
+          run(request) {
+            calls.push(request);
+            return Promise.resolve(
+              request.args.includes("--loom")
+                ? {
+                  exitCode: 1,
+                  stderr: "",
+                  stdout: JSON.stringify({ ok: false, code: "no-loom" }),
+                }
+                : {
+                  exitCode: 0,
+                  stderr: "",
+                  stdout: JSON.stringify({
+                    ok: true,
+                    result: {
+                      kind: "authoring-context",
+                      historical: true,
+                      run_scoped: true,
+                      authored: [{ receipt }],
+                      bound_loom: null,
+                      truncated: false,
+                    },
+                  }),
+                },
+            );
+          },
+        },
+      );
+      expect(result).toMatchObject({
+        status: "ok",
+        result: {
+          authored: [{ receipt }],
+          bound_loom: { loom_id: "loom-2222222222222222", available: false },
+        },
+      });
+      expect(calls).toHaveLength(2);
+      expect(calls[1].args).not.toContain("--loom");
+    });
+
+    it("does not reinterpret an explicitly missing target as an unbound history read", async () => {
+      let calls = 0;
+      const result = await executeLoomAuthoringCommand(
+        {
+          cliPath: "/trusted/loom",
+          boundLoomId: "loom-1111111111111111",
+          transport: { kind: "broker", queuePath: "/trusted/queue" },
+        },
+        "loom.authoring-context",
+        { loom_id: "loom-2222222222222222" },
+        {
+          run() {
+            calls++;
+            return Promise.resolve({
+              exitCode: 1,
+              stderr: "",
+              stdout: JSON.stringify({ ok: false, code: "no-loom" }),
+            });
+          },
+        },
+      );
+      expect(result).toMatchObject({
+        status: "error",
+        code: "no-loom",
+        mayHaveCommitted: false,
+      });
+      expect(calls).toBe(1);
+    });
+
+    it("rejects explicitly null targets instead of creating or choosing the implicit origin", async () => {
+      for (
+        const command of ["loom.compose", "loom.authoring-context"] as const
+      ) {
+        let calls = 0;
+        const result = await executeLoomAuthoringCommand(
+          {
+            cliPath: "/trusted/loom",
+            boundLoomId: "loom-1111111111111111",
+            transport: { kind: "broker", queuePath: "/trusted/queue" },
+          },
+          command,
+          { ...(command === "loom.compose" ? input : {}), loom_id: null },
+          {
+            run() {
+              calls++;
+              return Promise.resolve({
+                exitCode: 0,
+                stderr: "",
+                stdout: JSON.stringify(reply),
+              });
+            },
+          },
+        );
+        expect(result.status).toBe("error");
+        expect(calls).toBe(0);
+      }
+    });
+
+    it("rejects run ids that collapse under the host's whitespace normalization", () => {
+      for (const runId of ["   ", " run-one", "run-one "]) {
+        expect(() =>
+          validateLoomAuthoringConfig({
+            cliPath: "/trusted/loom",
+            transport: {
+              kind: "direct",
+              instanceDir: "/trusted/instance",
+              runId,
+              actor: "agent:cf-harness",
+            },
+          })
+        ).toThrow();
+      }
+    });
+
+    it("distinguishes verified command refusals from unreadable commit outcomes", async () => {
+      for (
+        const code of [
+          "version-conflict",
+          "request-conflict",
+          "bad-args",
+          "no-loom",
+        ]
+      ) {
+        const result = await executeLoomAuthoringCommand(
+          {
+            cliPath: "/trusted/loom",
+            transport: { kind: "broker", queuePath: "/trusted/queue" },
+          },
+          "loom.compose",
+          input,
+          {
+            run: () =>
+              Promise.resolve({
+                exitCode: 1,
+                stderr: "",
+                stdout: JSON.stringify({
+                  ok: false,
+                  code,
+                  error: "private backend detail",
+                }),
+              }),
+          },
+        );
+        expect(result).toMatchObject({
+          status: "error",
+          code,
+          mayHaveCommitted: false,
+        });
+      }
+    });
+
+    it("uses argv and stdin with the configured broker queue", async () => {
+      const calls: ProcessRunRequest[] = [];
+      const result = await executeLoomAuthoringCommand(
+        {
+          cliPath: "/trusted/loom",
+          transport: { kind: "broker", queuePath: "/trusted/queue" },
+        },
+        "loom.compose",
+        input,
+        {
+          run(request) {
+            calls.push(request);
+            return Promise.resolve({
+              exitCode: 0,
+              stdout: JSON.stringify(reply),
+              stderr: "",
+            });
+          },
+        },
+      );
+      expect(calls).toHaveLength(1);
+      expect(calls[0].command).toBe("/trusted/loom");
+      expect(calls[0].args).toEqual([
+        "command",
+        "run",
+        "loom.compose",
+        "--args-json",
+        "-",
+        "--json",
+      ]);
+      expect(JSON.parse(calls[0].stdinText!)).toEqual(input);
+      expect(calls[0].clearEnv).toBe(true);
+      expect(calls[0].env?.LOOM_PAGE_RPC_QUEUE).toBe("/trusted/queue");
+      expect(result.status).toBe("ok");
+      if (result.status === "ok") {
+        expect(result.result.receipt).toEqual(receipt);
+        expect(result.result.replayed).toBe(true);
+      }
+    });
+
+    it("pins direct calls to the configured instance, run, and agent", async () => {
+      const calls: ProcessRunRequest[] = [];
+      await executeLoomAuthoringCommand(
+        {
+          cliPath: "/trusted/loom",
+          transport: {
+            kind: "direct",
+            instanceDir: "/trusted/instance",
+            runId: "chat-session-one",
+            actor: "agent:cf-harness",
+          },
+        },
+        "loom.compose",
+        input,
+        {
+          run(request) {
+            calls.push(request);
+            return Promise.resolve({
+              exitCode: 0,
+              stdout: JSON.stringify(reply),
+              stderr: "",
+            });
+          },
+        },
+      );
+      expect(calls[0].args.slice(0, 5)).toEqual([
+        "command",
+        "run",
+        "--transport",
+        "direct",
+        "loom.compose",
+      ]);
+      expect(calls[0].env?.LOOM_INSTANCE_DIR).toBe("/trusted/instance");
+      expect(calls[0].env?.LOOM_DISPATCH_ID).toBe("chat-session-one");
+      expect(calls[0].args.slice(-2)).toEqual(["--actor", "agent:cf-harness"]);
+    });
+
+    it("returns uncertain failure for a mismatched or missing receipt", async () => {
+      for (
+        const result of [
+          {},
+          { ...reply.result, receipt: { ...receipt, request_id: "another" } },
+          {
+            ...reply.result,
+            manifest: { loom_id: "loom-2222222222222222", version: 3 },
+          },
+        ]
+      ) {
+        const output = await executeLoomAuthoringCommand(
+          {
+            cliPath: "/trusted/loom",
+            transport: { kind: "broker", queuePath: "/trusted/queue" },
+          },
+          "loom.compose",
+          input,
+          {
+            run() {
+              return Promise.resolve({
+                exitCode: 0,
+                stdout: JSON.stringify({ ok: true, result }),
+                stderr: "",
+              });
+            },
+          },
+        );
+        expect(output.status).toBe("error");
+        if (output.status === "error") {
+          expect(output.mayHaveCommitted).toBe(true);
+        }
+      }
+    });
+
+    it("refuses actor or transport arguments before spawning a process", async () => {
+      let calls = 0;
+      const output = await executeLoomAuthoringCommand(
+        {
+          cliPath: "/trusted/loom",
+          transport: { kind: "broker", queuePath: "/trusted/queue" },
+        },
+        "loom.compose",
+        { ...input, actor: "user" },
+        {
+          run() {
+            calls++;
+            return Promise.resolve({ exitCode: 1, stdout: "", stderr: "" });
+          },
+        },
+      );
+      expect(calls).toBe(0);
+      expect(output.status).toBe("error");
+    });
+  });
+});

--- a/packages/cf-harness/test/tools-registry.test.ts
+++ b/packages/cf-harness/test/tools-registry.test.ts
@@ -30,8 +30,11 @@ Deno.test("builtin tool registry includes the agreed first-pass tool floor", () 
     "search_skills",
     "acquire_skill",
     "query_docs",
+    "loom_compose",
+    "loom_inspect",
+    "loom_authoring_context",
   ]);
-  assertEquals(BUILTIN_TOOL_REGISTRY.size, 18);
+  assertEquals(BUILTIN_TOOL_REGISTRY.size, 21);
   assertEquals(
     [...DEFAULT_PARENT_TOOL_IDS],
     [

--- a/packages/cf-harness/test/tools/loom-authoring.test.ts
+++ b/packages/cf-harness/test/tools/loom-authoring.test.ts
@@ -1,0 +1,455 @@
+/** Checks the explicitly backed tool surface for durable Loom collections. */
+
+import { createSession, Identity } from "@commonfabric/identity";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { Runtime } from "@commonfabric/runner";
+import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  createHarnessHandleTable,
+  mintAddressHandle,
+} from "../../src/handle-table.ts";
+import { CfHarnessPromptLoop } from "../../src/prompt-loop.ts";
+import { directPromptSlotBindingFor } from "../support/prompt-slot-binding.ts";
+import { responsesBodyFromChatFixture } from "../support/responses-fixture.ts";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  parentToolIdsForBacking,
+  withheldToolIds,
+} from "../../src/contracts/tool-descriptor.ts";
+import { CfHarnessEngine } from "../../src/engine.ts";
+import type { SandboxRuntime } from "../../src/sandbox/types.ts";
+import type { ProcessRunRequest } from "../../src/sandbox/process-runner.ts";
+import { getBuiltinTool } from "../../src/tools/registry.ts";
+
+/** Backing sufficient only for the Loom authoring tools. */
+const backing = {
+  fabricSessionAvailable: false,
+  patternIndexAvailable: false,
+  skillsShSearchAvailable: false,
+  skillsShAcquisitionAvailable: false,
+  skillRegistryAvailable: false,
+  docsCorpusAvailable: false,
+  loomAuthoringAvailable: true,
+};
+
+/** Sandbox fixture which never starts a process. */
+const sandbox: SandboxRuntime = {
+  describe: () => ({
+    kind: "docker-runsc-cfc",
+    defaultWorkingDirectory: "/workspace",
+    cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+  }),
+  defaultWorkingDirectory: () => "/workspace",
+  resolvePath: (path) => path,
+  isPathWithinWorkspace: () => true,
+  isPathWithinAllowedRoots: () => true,
+  run: () => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }),
+  runShell: () => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }),
+};
+
+/** Matching host evidence, including renderer data that stays host-side. */
+const receipt = {
+  loom_id: "loom-1111111111111111",
+  request_id: "collection-one",
+  version: 2,
+  created: true,
+  component_ids: ["c-1"],
+  operation_ids: ["op-1", "op-2"],
+  displaced: [{
+    component_id: "c-old",
+    title: "pattern:did:key:private/fid1:private",
+  }],
+};
+
+/** Helper for tests, which records only explicitly routed host commands. */
+const engineFixture = (configured = true) => {
+  const calls: ProcessRunRequest[] = [];
+  const engine = new CfHarnessEngine({
+    model: "gpt-5.4",
+    sandboxRuntime: sandbox,
+    ...(configured
+      ? {
+        loomAuthoring: {
+          cliPath: "/trusted/loom",
+          transport: { kind: "broker" as const, queuePath: "/trusted/queue" },
+        },
+      }
+      : {}),
+    processRunner: {
+      run(request) {
+        calls.push(request);
+        return Promise.resolve({
+          exitCode: 0,
+          stderr: "",
+          stdout: JSON.stringify({
+            ok: true,
+            result: {
+              receipt,
+              replayed: false,
+              manifest: {
+                loom_id: receipt.loom_id,
+                version: 2,
+                title: "References",
+                components: [{
+                  component_id: "c-1",
+                  title: "A chart",
+                  subject: { ref: "pattern:did:key:private/fid1:private" },
+                  render: { url: "http://private-renderer" },
+                }],
+              },
+            },
+          }),
+        });
+      },
+    },
+  });
+  return { engine, calls };
+};
+
+describe("loom-authoring", () => {
+  describe("held Pattern Instances", () => {
+    it("resolves held whole instances and rejects restricted, foreign-space, and subpath tokens", async () => {
+      const identity = await Identity.fromPassphrase(
+        "Loom tool isolated fixture",
+      );
+      const storageManager = StorageManager.emulate({ as: identity });
+      const runtime = new Runtime({
+        apiUrl: new URL("http://toolshed.test"),
+        storageManager,
+      });
+      const pieces = new PiecesController(
+        await createSession({ identity, spaceName: "loom-tools" }),
+        runtime,
+      );
+      try {
+        const created = await pieces.create(
+          "import { pattern } from 'commonfabric'; export default pattern(() => ({ count: 1 }));",
+        );
+        await runtime.idle();
+        await pieces.synced();
+        const link = created.getCell().getAsNormalizedFullLink();
+        const foreign = await createSession({
+          identity,
+          spaceName: "another-space",
+        });
+        const cases = [
+          {
+            ref: createLLMFriendlyLink(link, pieces.getSpace()),
+            allowed: true,
+          },
+          {
+            ref: createLLMFriendlyLink(link, pieces.getSpace()),
+            capability: "skill-context" as const,
+            allowed: false,
+          },
+          {
+            ref: createLLMFriendlyLink(
+              { ...link, path: ["count"] },
+              pieces.getSpace(),
+            ),
+            allowed: false,
+          },
+          {
+            ref: createLLMFriendlyLink(
+              { ...link, scope: "session" },
+              pieces.getSpace(),
+            ),
+            allowed: false,
+          },
+          {
+            ref: createLLMFriendlyLink(
+              { ...link, space: foreign.space },
+              pieces.getSpace(),
+            ),
+            allowed: false,
+          },
+        ];
+        for (const candidate of cases) {
+          const calls: ProcessRunRequest[] = [];
+          const engine = new CfHarnessEngine({
+            sandboxRuntime: sandbox,
+            fabricSessionFactory: () => Promise.resolve({ pieces }),
+            loomAuthoring: {
+              cliPath: "/trusted/loom",
+              transport: { kind: "broker", queuePath: "/trusted/queue" },
+            },
+            processRunner: {
+              run(request) {
+                calls.push(request);
+                return Promise.resolve({
+                  exitCode: 0,
+                  stderr: "",
+                  stdout: JSON.stringify({
+                    ok: true,
+                    result: {
+                      receipt,
+                      replayed: false,
+                      manifest: { loom_id: receipt.loom_id, version: 2 },
+                    },
+                  }),
+                });
+              },
+            },
+          });
+          const minted = await mintAddressHandle(
+            createHarnessHandleTable(engine.getRunState().runId),
+            candidate.ref,
+            candidate.capability === undefined
+              ? {}
+              : { capability: candidate.capability },
+          );
+          await engine.recordHandleTable(minted.table);
+          const { output } = await engine.invokeBuiltinTool("loom_compose", {
+            request_id: "collection-one",
+            components: [{ pattern_token: minted.token }],
+          });
+          expect(output.status).toBe(candidate.allowed ? "ok" : "error");
+          expect(calls).toHaveLength(candidate.allowed ? 1 : 0);
+          if (candidate.allowed) {
+            expect(JSON.parse(calls[0].stdinText!).components[0].ref).toMatch(
+              /^pattern:did:key:.+\/fid1:/,
+            );
+          }
+          expect(JSON.stringify(output)).not.toContain("did:key:");
+        }
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
+  describe("prompt-loop authority", () => {
+    it("requires direct-command authority before invoking the host write", async () => {
+      for (const direct of [false, true]) {
+        const { engine, calls } = engineFixture();
+        const payloads = [
+          {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: "compose-one",
+                  type: "function",
+                  function: {
+                    name: "loom_compose",
+                    arguments: JSON.stringify({
+                      request_id: "collection-one",
+                      components: [{ ref: "url:https://example.com" }],
+                    }),
+                  },
+                }],
+              },
+            }],
+          },
+          {
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: "Done" },
+            }],
+          },
+        ];
+        let index = 0;
+        const loop = new CfHarnessPromptLoop({
+          engine,
+          apiKey: "synthetic-test-key",
+          model: "gpt-5.4",
+          allowedToolIds: ["loom_compose"],
+          fetchFn: () =>
+            Promise.resolve(
+              new Response(
+                JSON.stringify(responsesBodyFromChatFixture(payloads[index++])),
+                { status: 200 },
+              ),
+            ),
+        });
+        await loop.runPrompt({
+          prompt: "Make a Loom",
+          ...(direct
+            ? { promptSlotBinding: directPromptSlotBindingFor("loom-tools") }
+            : {}),
+        });
+        expect(calls).toHaveLength(direct ? 1 : 0);
+      }
+    });
+  });
+
+  describe("host command boundary", () => {
+    it("keeps current displacement empty when replaying an old receipt", async () => {
+      const engine = new CfHarnessEngine({
+        sandboxRuntime: sandbox,
+        loomAuthoring: {
+          cliPath: "/trusted/loom",
+          transport: { kind: "broker", queuePath: "/trusted/queue" },
+        },
+        processRunner: {
+          run: () =>
+            Promise.resolve({
+              exitCode: 0,
+              stderr: "",
+              stdout: JSON.stringify({
+                ok: true,
+                result: {
+                  receipt,
+                  replayed: true,
+                  displaced: [],
+                  manifest: { loom_id: receipt.loom_id, version: 9 },
+                },
+              }),
+            }),
+        },
+      });
+      const { output } = await engine.invokeBuiltinTool("loom_compose", {
+        request_id: "collection-one",
+        components: [{ ref: "url:https://example.com" }],
+      });
+      expect(output).toMatchObject({
+        status: "ok",
+        displaced: [],
+        receipt: { displaced: [{ component_id: "c-old" }] },
+        replayed: true,
+      });
+    });
+
+    it("gives conflict-specific recovery without disclosing host error text", async () => {
+      for (
+        const [code, recovery] of [["version-conflict", "Inspect"], [
+          "request-conflict",
+          "original",
+        ], ["bad-args", "Correct"]]
+      ) {
+        const engine = new CfHarnessEngine({
+          sandboxRuntime: sandbox,
+          loomAuthoring: {
+            cliPath: "/trusted/loom",
+            transport: { kind: "broker", queuePath: "/trusted/queue" },
+          },
+          processRunner: {
+            run: () =>
+              Promise.resolve({
+                exitCode: 1,
+                stderr: "",
+                stdout: JSON.stringify({
+                  ok: false,
+                  code,
+                  error: "private backend detail",
+                }),
+              }),
+          },
+        });
+        const { output } = await engine.invokeBuiltinTool("loom_compose", {
+          request_id: "collection-one",
+          components: [{ ref: "url:https://example.com" }],
+        });
+        expect(output).toMatchObject({
+          status: "error",
+          mayHaveCommitted: false,
+          code,
+        });
+        if (output.status === "error") {
+          expect(output.message).toContain(recovery);
+        }
+        expect(JSON.stringify(output)).not.toContain("private");
+      }
+    });
+
+    it("returns durable evidence without renderer data or raw Pattern Instance references", async () => {
+      const { engine, calls } = engineFixture();
+      const { output } = await engine.invokeBuiltinTool("loom_compose", {
+        request_id: "collection-one",
+        components: [{ ref: "url:https://example.com" }],
+      });
+      expect(output.status).toBe("ok");
+      expect(output).toMatchObject({
+        kind: "loom-authored",
+        current_version: 2,
+        receipt: {
+          loom_id: receipt.loom_id,
+          operation_ids: receipt.operation_ids,
+        },
+      });
+      expect(JSON.stringify(output)).not.toContain("private");
+      expect(calls).toHaveLength(1);
+    });
+
+    it("inspects layout without granting unheld Pattern Instances", async () => {
+      const { engine } = engineFixture();
+      const { output } = await engine.invokeBuiltinTool("loom_inspect", {
+        loom_id: receipt.loom_id,
+      });
+      expect(output.status).toBe("ok");
+      expect(output).toMatchObject({
+        manifest: {
+          components: [{
+            component_id: "c-1",
+            title: "A chart",
+            reference_kind: "pattern",
+          }],
+        },
+      });
+      expect(JSON.stringify(output)).not.toContain("private");
+    });
+
+    it("refuses raw Pattern Instance references and unknown tokens before a host write", async () => {
+      for (
+        const component of [{ ref: "pattern:did:key:private/fid1:private" }, {
+          pattern_token: "cfh:a:abcde",
+        }]
+      ) {
+        const { engine, calls } = engineFixture();
+        const { output } = await engine.invokeBuiltinTool("loom_compose", {
+          request_id: "collection-one",
+          components: [component],
+        });
+        expect(output.status).toBe("error");
+        expect(calls).toHaveLength(0);
+      }
+    });
+
+    it("refuses composition when configuration is absent or the turn is cancelled", async () => {
+      for (const configured of [true, false]) {
+        const { engine, calls } = engineFixture(configured);
+        const { output } = await engine.invokeBuiltinTool("loom_compose", {
+          request_id: "collection-one",
+          components: [{ ref: "url:https://example.com" }],
+        }, configured ? { signal: AbortSignal.abort() } : {});
+        expect(output.status).toBe("error");
+        expect(calls).toHaveLength(0);
+      }
+    });
+  });
+
+  describe("tool availability", () => {
+    it("offers authoring and exact reads when the host backs them", () => {
+      const ids = parentToolIdsForBacking(backing);
+      expect(ids).toContain("loom_compose");
+      expect(ids).toContain("loom_inspect");
+      expect(ids).toContain("loom_authoring_context");
+      expect(ids).not.toContain("run_pattern");
+    });
+
+    it("withholds the tools when the host has no authoring configuration", () => {
+      const unavailable = { ...backing, loomAuthoringAvailable: false };
+      expect([...withheldToolIds(unavailable)]).toContain("loom_compose");
+      expect(parentToolIdsForBacking(unavailable)).not.toContain(
+        "loom_compose",
+      );
+    });
+
+    it("classifies composition as a write and context retrieval as reads", () => {
+      expect(getBuiltinTool("loom_compose")?.descriptor.effectClass).toBe(
+        "write",
+      );
+      expect(getBuiltinTool("loom_inspect")?.descriptor.effectClass).toBe(
+        "read",
+      );
+      expect(getBuiltinTool("loom_authoring_context")?.descriptor.effectClass)
+        .toBe("read");
+    });
+  });
+});

--- a/packages/cf-harness/test/tools/loom-authoring.test.ts
+++ b/packages/cf-harness/test/tools/loom-authoring.test.ts
@@ -138,6 +138,24 @@ describe("loom-authoring", () => {
         const cases = [
           {
             ref: createLLMFriendlyLink(link, pieces.getSpace()),
+            noFabric: true,
+            allowed: false,
+          },
+          {
+            ref: createLLMFriendlyLink(link, pieces.getSpace()),
+            cancelDuringResolution: true,
+            allowed: false,
+          },
+          {
+            ref: createLLMFriendlyLink(
+              runtime.getCell(pieces.getSpace(), "held-non-pattern")
+                .getAsNormalizedFullLink(),
+              pieces.getSpace(),
+            ),
+            allowed: false,
+          },
+          {
+            ref: createLLMFriendlyLink(link, pieces.getSpace()),
             allowed: true,
           },
           {
@@ -169,9 +187,17 @@ describe("loom-authoring", () => {
         ];
         for (const candidate of cases) {
           const calls: ProcessRunRequest[] = [];
+          const controller = new AbortController();
           const engine = new CfHarnessEngine({
             sandboxRuntime: sandbox,
-            fabricSessionFactory: () => Promise.resolve({ pieces }),
+            ...(!candidate.noFabric
+              ? {
+                fabricSessionFactory: () => {
+                  if (candidate.cancelDuringResolution) controller.abort();
+                  return Promise.resolve({ pieces });
+                },
+              }
+              : {}),
             loomAuthoring: {
               cliPath: "/trusted/loom",
               transport: { kind: "broker", queuePath: "/trusted/queue" },
@@ -205,7 +231,7 @@ describe("loom-authoring", () => {
           const { output } = await engine.invokeBuiltinTool("loom_compose", {
             request_id: "collection-one",
             components: [{ pattern_token: minted.token }],
-          });
+          }, { signal: controller.signal });
           expect(output.status).toBe(candidate.allowed ? "ok" : "error");
           expect(calls).toHaveLength(candidate.allowed ? 1 : 0);
           if (candidate.allowed) {
@@ -280,6 +306,194 @@ describe("loom-authoring", () => {
   });
 
   describe("host command boundary", () => {
+    it("rejects ambiguous or malformed components without starting a host command", async () => {
+      for (
+        const components of [
+          [],
+          Array(101).fill({ ref: "url:https://example.com" }),
+          [{}],
+          [{ ref: "url:https://example.com", pattern_token: "cfh:a:abcde" }],
+          [{ ref: "url:https://example.com", actor: "user" }],
+          [{ pattern_token: 4 }],
+          [{ ref: "piece:space/id" }],
+        ]
+      ) {
+        const { engine, calls } = engineFixture();
+        const { output } = await engine.invokeBuiltinTool("loom_compose", {
+          request_id: "collection-one",
+          components,
+        });
+        expect(output).toMatchObject({
+          status: "error",
+          mayHaveCommitted: false,
+        });
+        expect(calls).toHaveLength(0);
+      }
+    });
+
+    it("projects historical context without leaking host paths or referenced cells", async () => {
+      for (
+        const bound_loom of [null, {
+          loom_id: receipt.loom_id,
+          version: 7,
+          archived: false,
+          source: "host-context",
+          private: "private-host-path",
+        }]
+      ) {
+        const engine = new CfHarnessEngine({
+          sandboxRuntime: sandbox,
+          loomAuthoring: {
+            cliPath: "/trusted/loom",
+            transport: { kind: "broker", queuePath: "/trusted/queue" },
+          },
+          processRunner: {
+            run: () =>
+              Promise.resolve({
+                exitCode: 0,
+                stderr: "",
+                stdout: JSON.stringify({
+                  ok: true,
+                  result: {
+                    kind: "authoring-context",
+                    historical: true,
+                    run_scoped: true,
+                    truncated: true,
+                    bound_loom,
+                    authored: [{ receipt }, {
+                      receipt: { loom_id: receipt.loom_id },
+                    }],
+                    secret: "private-host-path",
+                  },
+                }),
+              }),
+          },
+        });
+        const { output } = await engine.invokeBuiltinTool(
+          "loom_authoring_context",
+          {},
+        );
+        expect(output).toMatchObject({
+          status: "ok",
+          kind: "authoring-context",
+          historical: true,
+          truncated: true,
+          authored: [{
+            receipt: {
+              loom_id: receipt.loom_id,
+              displaced: [{ component_id: "c-old" }],
+            },
+          }, { receipt: { loom_id: receipt.loom_id, displaced: [] } }],
+        });
+        expect(JSON.stringify(output)).not.toContain("private");
+        if (output.status !== "ok") {
+          throw new Error("Expected historical context");
+        }
+        if (bound_loom === null) expect(output.bound_loom).toBeNull();
+        else {expect(output.bound_loom).toMatchObject({
+            loom_id: receipt.loom_id,
+            version: 7,
+          });}
+      }
+    });
+
+    it("does not disclose uncertain host errors as proof of failed composition", async () => {
+      const engine = new CfHarnessEngine({
+        sandboxRuntime: sandbox,
+        loomAuthoring: {
+          cliPath: "/trusted/loom",
+          transport: { kind: "broker", queuePath: "/trusted/queue" },
+        },
+        processRunner: {
+          run: () =>
+            Promise.resolve({
+              exitCode: 1,
+              stderr: "",
+              stdout: JSON.stringify({
+                ok: false,
+                error: "private-cell-address",
+              }),
+            }),
+        },
+      });
+      const { output } = await engine.invokeBuiltinTool("loom_compose", {
+        request_id: "collection-one",
+        components: [{ ref: "url:https://example.com" }],
+      });
+      expect(output).toMatchObject({ status: "error", mayHaveCommitted: true });
+      expect(JSON.stringify(output)).not.toContain("private");
+    });
+
+    it("handles sparse inspection and failed reads without granting cell references", async () => {
+      for (
+        const manifest of [
+          { loom_id: receipt.loom_id, version: 3 },
+          {
+            loom_id: receipt.loom_id,
+            version: 3,
+            components: [{ component_id: "c-1", title: "Only a label" }],
+          },
+          {},
+        ]
+      ) {
+        const engine = new CfHarnessEngine({
+          sandboxRuntime: sandbox,
+          loomAuthoring: {
+            cliPath: "/trusted/loom",
+            transport: { kind: "broker", queuePath: "/trusted/queue" },
+          },
+          processRunner: {
+            run: () =>
+              Promise.resolve({
+                exitCode: 0,
+                stderr: "",
+                stdout: JSON.stringify({ ok: true, result: { manifest } }),
+              }),
+          },
+        });
+        const { output } = await engine.invokeBuiltinTool("loom_inspect", {
+          loom_id: receipt.loom_id,
+        });
+        if ("version" in manifest) {
+          expect(output).toMatchObject({
+            status: "ok",
+            manifest: {
+              components: "components" in manifest ? manifest.components : [],
+            },
+          });
+        } else {expect(output).toMatchObject({
+            status: "error",
+            mayHaveCommitted: false,
+          });}
+      }
+    });
+
+    it("forwards existing non-Fabric object references without inventing or resolving them", async () => {
+      for (
+        const ref of [
+          "wish:W-123",
+          "intention:step-11111111111111111111111111111111",
+          "chat:conv-example",
+          "person:email:synthetic@example.com",
+          "thread:signal.desktop:synthetic",
+          "moment:moment-example",
+          "loom:loom-2222222222222222",
+          "run:r-123456789abc",
+        ]
+      ) {
+        const { engine, calls } = engineFixture();
+        const { output } = await engine.invokeBuiltinTool("loom_compose", {
+          request_id: "collection-one",
+          components: [{ ref }],
+        });
+        expect(output.status).toBe("ok");
+        expect(calls).toHaveLength(1);
+        expect(JSON.parse(calls[0].stdinText ?? "").components).toEqual([{
+          ref,
+        }]);
+      }
+    });
+
     it("keeps current displacement empty when replaying an old receipt", async () => {
       const engine = new CfHarnessEngine({
         sandboxRuntime: sandbox,


### PR DESCRIPTION
## Why

Interactive agents can build Pattern Instances but cannot reliably deliver a durable Loom collection to Weaver. A continuation also needs the original commit receipt to avoid duplicating a collection after an interrupted turn. This adds an explicitly configured host capability for that separate object and returns evidence that a caller can use for delivery.

Part of the Loom-authoring arc: commontoolsinc/loom#5706, commontoolsinc/loom#5708, commontoolsinc/loom#5709, commontoolsinc/loom#5710, and commontoolsinc/loom#5711 provide the command host, broker grants, agent prompts, and recovery namespace.

## What Changed

- Add dedicated `loom_compose`, `loom_inspect`, and `loom_authoring_context` tools, advertised only with operator-owned batch, interactive stdio, and console configuration. Broker calls retain their scoped queue; direct calls pin instance/run/actor and require the host CLI's `command run --transport direct <id>` contract.
- Resolve held whole Pattern Instance tokens inside the trusted tool. Reject restricted, foreign-space, subpath, and non-pattern handles before writing; project receipts/layout without raw cell addresses or renderer internals.
- Preserve request identity on uncertain outcomes, distinguish confirmed pre-write refusals, retain historical recovery beside an unavailable inferred origin, and report replay displacement as historical.
- Bind and persist the originating Loom per interactive turn. Keep direct authoring identity stable across conversation turns and clear stale target context.
- Permit only dedicated Loom tools in comment threads when the host explicitly grants them; existing shell/write/delegation restrictions and direct-command policy checks remain enforced.
- Return verified current-turn `looms` receipts beside existing `pieces` in console results, including captured `originLoomId`. Existing warm sessions retain their recorded policy and require explicit host policy refresh or replacement to gain the tools.
- Document configuration, authority, custody, recovery, continuation, and result contracts; verify the updated system map in the browser.

## Test plan

- Regressions observed failing before implementation and before each independent-review fix; independent red-team loop cleared the final slice.
- Full cf-harness and audit suite: **1,018 tests / 2,539 steps passed** with Deno2.9.4.
- Repository formatting, lint, and package-cycle gate passed.
- Canonical repository typecheck collector/checker ran all46 groups with a private wrapper preserving `--no-lock`:45passed, including cf-harness. The patterns group has16errors in `iframe-impossible-machine/guest.tsx`; all16diagnostics reproduce identically in an untouched worktree at base `04e66f818`.
- Ephemeral clone-backed Loom acceptance: a held local Pattern Instance passed through the real harness tool, toolshed, daemon, and current-turn console projection. An exact retry returned the same Loom and replayed receipt; model output contained no raw Pattern Instance address. The model response was scripted for this contract test; native Weaver placement is a subsequent integration slice.
- No production instance rebound and no vendor or dependency pin changes.

- Interactive executable follow-up: observed the bare stdio flag rejection first, then verified bare stdio plus strict Loom-host flag/environment provisioning;39focusedtests and independent review passed.

- Coverage follow-up: the full package/audit run passes with zero uncovered lines in both new authoring source files. Dedicated tools forward all supported non-Fabric typed references to host grammar/binding validation; raw Pattern Instance references still require held tokens. Independent review cleared the implementation and corrected synthetic success fixtures.


### Console/native membership follow-up

Named Pattern outputs now include optional verified `{loomId, componentId}` membership for the exact held token used in composition. The native handoff in [Weaver #283](https://github.com/commontoolsinc/commonfabric-weaver/pull/283) checks that pair against a freshly opened manifest; it no longer guesses canonical identity from a friendly slug. Ambiguous/historical call pairs and different tokens leave legacy placement available. The operator runbook now includes the explicit authoring configuration for the console.

Observed the missing membership and ambiguous-call regressions fail before fixing them. Independent red team cleared the mapping and native consumer together. Latest local full cf-harness/audit run: **1,018 tests / 2,541 steps passed** with coverage; the changed console projection has no uncovered lines. Targeted fmt/lint pass. Fresh CI and Cubic review apply to the updated head.

## Cubic review disposition

Cubic CLI completed a substantive full review of `3c1c2f272` while the hosted check reported exhausted review capacity. All three findings were read:

- P2 duplicated Loom tool IDs: fixed by exporting and reusing the canonical set for comment grants.
- P3 repeated transcript scans: fixed by indexing current-turn calls once while preserving uniqueness at each result's preceding transcript prefix. Malformed IDs and later duplicates are covered through the public result projection.
- P3 move inferred-origin recovery out of the executor: overridden. This is the dedicated Loom host boundary, not a generic command executor. The fallback is one bounded read-only history request after a missing inferred origin; it does not relax explicit targets or retry composition. Keeping it here preserves the same recovery semantics for every caller. Independent review agreed with this disposition.

Independent re-review found no remaining issue. Full cf-harness tests/audits passed: 1,018 tests / 2,541 steps. Console result projection has 223/223 covered lines. CI and Cubic review of the follow-up head are required before merge.


Final head `5cf09d6b33976262a79d81eb542331f7e58809b2`: Cubic CLI follow-up completed clean with no issues. Independent cf-review cleared the exact head. Repo-wide formatting (5,827 files) and lint (5,659 files) passed; CI has 65 successful checks, with only the three expected deployment/attestation skips and hosted Cubic quota refusal. The hosted review body, inline comments, review summaries, and issue comments were read; the coverage-debt bot confirms the regression is resolved. Main CI was green before merge.
