### PR TITLE
fix(cf-harness): bind interactive Fabric sessions and admit Loom tools

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1614,6 +1614,23 @@ turn records, and replayable events across process restarts. Pass
 bound the transport's in-memory event cache while keeping durable replay
 available through SQLite.
 
+Both this entrypoint and the strict Loom host's `interactive` subcommand accept
+`--fabric-api-url`, `--fabric-identity`, and `--fabric-space`, with defaults
+from `CF_HARNESS_FABRIC_API_URL`, `CF_HARNESS_FABRIC_IDENTITY`, and
+`CF_HARNESS_FABRIC_SPACE`. Explicit flags override the environment; relative
+identity paths resolve against the host process's working directory. All three
+values form one binding, and partial or invalid configuration fails before the
+service starts. Without that binding the service has no Fabric session.
+
+These entrypoints share the batch CLI's CFC session options:
+`--fabric-cfc-enforcement-mode`, `--fabric-cfc-flow-labels`,
+`--fabric-cfc-posture`, and `--max-confidentiality`, including their validation
+and runtime defaults. The Fabric identity stays on the host. Per-turn
+`inputCells` supply held handles in that space; a model cannot configure the
+session or turn a raw Pattern Instance reference into a held token. See
+[Durable Loom authoring](docs/LOOM_AUTHORING.md) for the separate host grant
+required to collect those tokens into a Loom.
+
 Initial prompt image attachments:
 
 ```bash

--- a/packages/cf-harness/docs/LOOM_AUTHORING.md
+++ b/packages/cf-harness/docs/LOOM_AUTHORING.md
@@ -19,6 +19,20 @@ The batch CLI, both interactive stdio entrypoints, and console accept
 on the host, and never passed into the sandbox. Without it the three Loom tools
 are absent, including when an allowlist names them.
 
+Batch profiles can grant `loom_compose`, `loom_inspect`, and
+`loom_authoring_context` through `--allow-tool` or a run manifest. The CLI
+capability response lists all three as parent tools. Such a grant still needs
+the host configuration above before the tools become available.
+
+To collect a held Pattern Instance token, both interactive stdio entrypoints
+accept the same complete Fabric binding as batch: `--fabric-api-url`,
+`--fabric-identity`, and `--fabric-space`, or their `CF_HARNESS_FABRIC_API_URL`,
+`CF_HARNESS_FABRIC_IDENTITY`, and `CF_HARNESS_FABRIC_SPACE` environment
+defaults. CFC posture and read ceiling options retain the batch CLI's validation
+and defaults. A partial binding fails before the service starts. The host
+supplies `inputCells` per turn to grant existing handles; this does not relax
+the token checks below.
+
 A broker-backed configuration pins the existing scoped queue:
 
 ```json

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -487,11 +487,12 @@ Options:
   --workspace <path>            Workspace host path (defaults to current directory)
   --cwd <path>                  Initial working directory inside the workspace
   --focus-root <path>           Narrow exploration to a workspace subpath when possible
-  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | view_image | web_fetch | read_skill_resource | run_skill_script | edit_file | write_file | delegate_task | describe_handle | run_pattern | assign_slug | search_patterns | record_feedback | search_skills | acquire_skill | query_docs);
+  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | view_image | web_fetch | read_skill_resource | run_skill_script | edit_file | write_file | delegate_task | describe_handle | run_pattern | assign_slug | search_patterns | record_feedback | search_skills | acquire_skill | query_docs | loom_compose | loom_inspect | loom_authoring_context);
                                 run_pattern, assign_slug, and acquire_skill additionally require the three --fabric-* session flags,
                                 search_patterns and record_feedback require --pattern-index-url,
                                 search_skills and acquire_skill require --skills-registry-url,
-                                and query_docs requires a resolved documentation corpus
+                                query_docs requires a resolved documentation corpus,
+                                and the three loom_* tools require --loom-authoring-config (or CF_HARNESS_LOOM_AUTHORING_CONFIG)
   --allow-skill-script <spec>   Allow exact skill script execution (repeatable: skill:scripts/path)
   --allow-subagent-profile <p>  Authorize delegate_task to spawn a profile (repeatable: default | browser | web_fetch | web_search)
   --output-mode <mode>          operator | batch (default: operator)

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -10,10 +10,8 @@ import {
 } from "@std/path";
 import { normalize as normalizeSandboxPath } from "@std/path/posix";
 import type { JSONSchema } from "@commonfabric/api";
-import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import {
   DEFAULT_GATEWAY_BASE_URL,
-  type HarnessFabricSessionConfig,
   type HarnessGatewayAuthMode,
   type HarnessModelProviderId,
   type HarnessPatternIndexConfig,
@@ -52,7 +50,6 @@ import {
   type HarnessRunManifest,
   type LoomLocalHostBinding,
   parseLoomRunManifestJson,
-  readCeilingFromInput,
 } from "./contracts/run-manifest.ts";
 import type { HarnessFetch } from "./contracts/http-fetch.ts";
 import {
@@ -73,6 +70,7 @@ import type {
   HarnessTranscriptMessage,
 } from "./contracts/transcript.ts";
 import { CfHarnessEngine } from "./engine.ts";
+import { resolveHarnessFabricSessionConfig } from "./fabric-session-options.ts";
 import type { HarnessFabricSessionFactory } from "./fabric-session.ts";
 import {
   establishHarnessSessionContext,
@@ -657,6 +655,9 @@ const CLI_PARENT_TOOL_IDS = [
   "write_file",
   "delegate_task",
   "describe_handle",
+  "loom_compose",
+  "loom_inspect",
+  "loom_authoring_context",
   "run_pattern",
   "assign_slug",
   "search_patterns",
@@ -1662,148 +1663,7 @@ export const parseCfHarnessCliArgs = async (
   const fabricMount = rawFabricMount !== undefined
     ? resolve(cwd, rawFabricMount)
     : undefined;
-  const fabricSessionFlagValue = (
-    flag:
-      | "fabric-api-url"
-      | "fabric-identity"
-      | "fabric-space"
-      | "fabric-cfc-enforcement-mode"
-      | "fabric-cfc-flow-labels"
-      | "fabric-cfc-posture",
-    envValue: string | undefined,
-  ): string | undefined => {
-    const raw = typeof args[flag] === "string"
-      ? args[flag].trim()
-      : nonEmptyEnvValue(envValue);
-    if (raw === "") {
-      throw new Error(`--${flag} requires a non-empty value`);
-    }
-    return raw;
-  };
-  const fabricApiUrl = fabricSessionFlagValue(
-    "fabric-api-url",
-    env.CF_HARNESS_FABRIC_API_URL,
-  );
-  const fabricIdentity = fabricSessionFlagValue(
-    "fabric-identity",
-    env.CF_HARNESS_FABRIC_IDENTITY,
-  );
-  const fabricSpace = fabricSessionFlagValue(
-    "fabric-space",
-    env.CF_HARNESS_FABRIC_SPACE,
-  );
-  const fabricCfcEnforcementMode = fabricSessionFlagValue(
-    "fabric-cfc-enforcement-mode",
-    env.CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE,
-  );
-  if (
-    fabricCfcEnforcementMode !== undefined &&
-    fabricCfcEnforcementMode !== "enforce-explicit" &&
-    fabricCfcEnforcementMode !== "enforce-strict"
-  ) {
-    // Raise-only: the fabric session's preset already pins enforce-explicit,
-    // so the dial admits that pin or a raise to strict, never a relaxation.
-    throw new Error(
-      `--fabric-cfc-enforcement-mode must be enforce-explicit or enforce-strict: ${fabricCfcEnforcementMode}`,
-    );
-  }
-  const fabricCfcFlowLabels = fabricSessionFlagValue(
-    "fabric-cfc-flow-labels",
-    env.CF_HARNESS_FABRIC_CFC_FLOW_LABELS,
-  );
-  if (
-    fabricCfcFlowLabels !== undefined && fabricCfcFlowLabels !== "off" &&
-    fabricCfcFlowLabels !== "observe" && fabricCfcFlowLabels !== "persist"
-  ) {
-    throw new Error(
-      `--fabric-cfc-flow-labels must be off, observe, or persist: ${fabricCfcFlowLabels}`,
-    );
-  }
-  const fabricCfcPosture = fabricSessionFlagValue(
-    "fabric-cfc-posture",
-    env.CF_HARNESS_FABRIC_CFC_POSTURE,
-  );
-  if (
-    fabricCfcPosture !== undefined && fabricCfcPosture !== "max-enforcement"
-  ) {
-    throw new Error(
-      `--fabric-cfc-posture must be max-enforcement: ${fabricCfcPosture}`,
-    );
-  }
-  const rawMaxConfidentiality = typeof args["max-confidentiality"] === "string"
-    ? args["max-confidentiality"].trim()
-    : undefined;
-  let maxConfidentiality: readonly CfcConfClause[] | undefined;
-  if (rawMaxConfidentiality !== undefined) {
-    let parsedCeiling: unknown;
-    try {
-      parsedCeiling = JSON.parse(rawMaxConfidentiality);
-    } catch (error) {
-      throw new Error(
-        `--max-confidentiality must be JSON: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
-    maxConfidentiality = readCeilingFromInput(
-      parsedCeiling,
-      undefined,
-      { ceiling: "--max-confidentiality", onExceed: "--max-confidentiality" },
-    ).maxConfidentiality;
-  }
-  let fabricSession: HarnessFabricSessionConfig | undefined;
-  if (
-    fabricApiUrl !== undefined || fabricIdentity !== undefined ||
-    fabricSpace !== undefined
-  ) {
-    const missing = [
-      ...(fabricApiUrl === undefined ? ["--fabric-api-url"] : []),
-      ...(fabricIdentity === undefined ? ["--fabric-identity"] : []),
-      ...(fabricSpace === undefined ? ["--fabric-space"] : []),
-    ];
-    if (missing.length > 0) {
-      throw new Error(
-        `--fabric-api-url, --fabric-identity, and --fabric-space configure one fabric session and go together; missing ${
-          missing.join(", ")
-        }`,
-      );
-    }
-    try {
-      new URL(fabricApiUrl!);
-    } catch {
-      throw new Error(`--fabric-api-url must be a valid URL: ${fabricApiUrl}`);
-    }
-    fabricSession = {
-      apiUrl: fabricApiUrl!,
-      identityKeyPath: resolve(cwd, fabricIdentity!),
-      space: fabricSpace!,
-      ...(fabricCfcEnforcementMode !== undefined
-        ? { cfcEnforcementMode: fabricCfcEnforcementMode }
-        : {}),
-      ...(fabricCfcFlowLabels !== undefined
-        ? { cfcFlowLabels: fabricCfcFlowLabels }
-        : {}),
-      ...(fabricCfcPosture !== undefined
-        ? { cfcPosture: fabricCfcPosture }
-        : {}),
-      ...(maxConfidentiality !== undefined
-        ? { cfcReadMaxConfidentiality: maxConfidentiality }
-        : {}),
-    };
-  } else if (
-    fabricCfcEnforcementMode !== undefined ||
-    fabricCfcFlowLabels !== undefined || fabricCfcPosture !== undefined
-  ) {
-    throw new Error(
-      "--fabric-cfc-enforcement-mode, --fabric-cfc-flow-labels, and --fabric-cfc-posture configure the fabric session's runtime and need --fabric-api-url, --fabric-identity, and --fabric-space",
-    );
-  } else if (maxConfidentiality !== undefined) {
-    // A ceiling with no session bounds nothing, and one accepted here would
-    // read as working all run.
-    throw new Error(
-      "--max-confidentiality bounds the fabric session's reads and needs --fabric-api-url, --fabric-identity, and --fabric-space",
-    );
-  }
+  const fabricSession = resolveHarnessFabricSessionConfig(args, env, cwd);
   const rawSpaceDb = typeof args["space-db"] === "string"
     ? args["space-db"].trim()
     : nonEmptyEnvValue(env.CF_HARNESS_SPACE_DB);

--- a/packages/cf-harness/src/fabric-session-options.ts
+++ b/packages/cf-harness/src/fabric-session-options.ts
@@ -1,0 +1,176 @@
+/**
+ * Resolves host-owned Fabric session options for batch and interactive runs.
+ * A complete API, identity, and space binding carries the runtime's CFC posture.
+ */
+
+import { resolve } from "@std/path";
+
+import type { CfcConfClause } from "@commonfabric/runner/cfc";
+
+import type { HarnessFabricSessionConfig } from "./config.ts";
+import { readCeilingFromInput } from "./contracts/run-manifest.ts";
+
+/** Options which configure a Fabric session and its read posture. */
+export const HARNESS_FABRIC_SESSION_OPTION_NAMES = [
+  "fabric-api-url",
+  "fabric-identity",
+  "fabric-space",
+  "fabric-cfc-enforcement-mode",
+  "fabric-cfc-flow-labels",
+  "fabric-cfc-posture",
+  "max-confidentiality",
+] as const;
+
+/**
+ * Resolves flags over environment defaults, with relative identity paths based
+ * on `cwd`. Throws for a partial binding or an invalid session option.
+ */
+export const resolveHarnessFabricSessionConfig = (
+  args: Readonly<Record<string, unknown>>,
+  env: Readonly<Record<string, string | undefined>>,
+  cwd: string,
+): HarnessFabricSessionConfig | undefined => {
+  const fabricSessionFlagValue = (
+    flag:
+      | "fabric-api-url"
+      | "fabric-identity"
+      | "fabric-space"
+      | "fabric-cfc-enforcement-mode"
+      | "fabric-cfc-flow-labels"
+      | "fabric-cfc-posture",
+    envValue: string | undefined,
+  ): string | undefined => {
+    const raw = typeof args[flag] === "string"
+      ? args[flag].trim()
+      : (envValue?.trim() || undefined);
+    if (raw === "") {
+      throw new Error(`--${flag} requires a non-empty value`);
+    }
+    return raw;
+  };
+  const fabricApiUrl = fabricSessionFlagValue(
+    "fabric-api-url",
+    env.CF_HARNESS_FABRIC_API_URL,
+  );
+  const fabricIdentity = fabricSessionFlagValue(
+    "fabric-identity",
+    env.CF_HARNESS_FABRIC_IDENTITY,
+  );
+  const fabricSpace = fabricSessionFlagValue(
+    "fabric-space",
+    env.CF_HARNESS_FABRIC_SPACE,
+  );
+  const fabricCfcEnforcementMode = fabricSessionFlagValue(
+    "fabric-cfc-enforcement-mode",
+    env.CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE,
+  );
+  if (
+    fabricCfcEnforcementMode !== undefined &&
+    fabricCfcEnforcementMode !== "enforce-explicit" &&
+    fabricCfcEnforcementMode !== "enforce-strict"
+  ) {
+    // The runtime preset enforces explicit labels; this setting may raise
+    // enforcement to strict.
+    throw new Error(
+      `--fabric-cfc-enforcement-mode must be enforce-explicit or enforce-strict: ${fabricCfcEnforcementMode}`,
+    );
+  }
+  const fabricCfcFlowLabels = fabricSessionFlagValue(
+    "fabric-cfc-flow-labels",
+    env.CF_HARNESS_FABRIC_CFC_FLOW_LABELS,
+  );
+  if (
+    fabricCfcFlowLabels !== undefined && fabricCfcFlowLabels !== "off" &&
+    fabricCfcFlowLabels !== "observe" && fabricCfcFlowLabels !== "persist"
+  ) {
+    throw new Error(
+      `--fabric-cfc-flow-labels must be off, observe, or persist: ${fabricCfcFlowLabels}`,
+    );
+  }
+  const fabricCfcPosture = fabricSessionFlagValue(
+    "fabric-cfc-posture",
+    env.CF_HARNESS_FABRIC_CFC_POSTURE,
+  );
+  if (
+    fabricCfcPosture !== undefined && fabricCfcPosture !== "max-enforcement"
+  ) {
+    throw new Error(
+      `--fabric-cfc-posture must be max-enforcement: ${fabricCfcPosture}`,
+    );
+  }
+  const rawMaxConfidentiality = typeof args["max-confidentiality"] === "string"
+    ? args["max-confidentiality"].trim()
+    : undefined;
+  let maxConfidentiality: readonly CfcConfClause[] | undefined;
+  if (rawMaxConfidentiality !== undefined) {
+    let parsedCeiling: unknown;
+    try {
+      parsedCeiling = JSON.parse(rawMaxConfidentiality);
+    } catch (error) {
+      throw new Error(
+        `--max-confidentiality must be JSON: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    maxConfidentiality = readCeilingFromInput(
+      parsedCeiling,
+      undefined,
+      { ceiling: "--max-confidentiality", onExceed: "--max-confidentiality" },
+    ).maxConfidentiality;
+  }
+  let fabricSession: HarnessFabricSessionConfig | undefined;
+  if (
+    fabricApiUrl !== undefined || fabricIdentity !== undefined ||
+    fabricSpace !== undefined
+  ) {
+    const missing = [
+      ...(fabricApiUrl === undefined ? ["--fabric-api-url"] : []),
+      ...(fabricIdentity === undefined ? ["--fabric-identity"] : []),
+      ...(fabricSpace === undefined ? ["--fabric-space"] : []),
+    ];
+    if (missing.length > 0) {
+      throw new Error(
+        `--fabric-api-url, --fabric-identity, and --fabric-space configure one fabric session and go together; missing ${
+          missing.join(", ")
+        }`,
+      );
+    }
+    try {
+      new URL(fabricApiUrl!);
+    } catch {
+      throw new Error(`--fabric-api-url must be a valid URL: ${fabricApiUrl}`);
+    }
+    fabricSession = {
+      apiUrl: fabricApiUrl!,
+      identityKeyPath: resolve(cwd, fabricIdentity!),
+      space: fabricSpace!,
+      ...(fabricCfcEnforcementMode !== undefined
+        ? { cfcEnforcementMode: fabricCfcEnforcementMode }
+        : {}),
+      ...(fabricCfcFlowLabels !== undefined
+        ? { cfcFlowLabels: fabricCfcFlowLabels }
+        : {}),
+      ...(fabricCfcPosture !== undefined
+        ? { cfcPosture: fabricCfcPosture }
+        : {}),
+      ...(maxConfidentiality !== undefined
+        ? { cfcReadMaxConfidentiality: maxConfidentiality }
+        : {}),
+    };
+  } else if (
+    fabricCfcEnforcementMode !== undefined ||
+    fabricCfcFlowLabels !== undefined || fabricCfcPosture !== undefined
+  ) {
+    throw new Error(
+      "--fabric-cfc-enforcement-mode, --fabric-cfc-flow-labels, and --fabric-cfc-posture configure the fabric session's runtime and need --fabric-api-url, --fabric-identity, and --fabric-space",
+    );
+  } else if (maxConfidentiality !== undefined) {
+    // A ceiling with no session bounds nothing, and one accepted here would
+    // read as working all run.
+    throw new Error(
+      "--max-confidentiality bounds the fabric session's reads and needs --fabric-api-url, --fabric-identity, and --fabric-space",
+    );
+  }
+  return fabricSession;
+};

--- a/packages/cf-harness/src/host-mounts.ts
+++ b/packages/cf-harness/src/host-mounts.ts
@@ -23,6 +23,7 @@ import {
   normalize as normalizeSandboxPath,
 } from "@std/path/posix";
 
+import type { HarnessFabricSessionConfig } from "./config.ts";
 import type { DockerRunscAdditionalMountConfig } from "./sandbox/types.ts";
 
 export type CfHarnessHostMountMode = "readonly" | "writable";
@@ -164,23 +165,20 @@ export const parseHostMountSpecs = async (
 };
 
 /**
- * Engine options for an interactive run's provisioning flags.
- *
- * Both interactive entrypoints call this — the standalone stdio CLI and the
- * Loom-local host — so neither can advertise a flag it then drops. The first
- * version of this change wired only the Loom host, and the standalone
- * entrypoint accepted `--host-mount`, printed it in its usage text, and ignored
- * it: the same "second entrypoint, no provisioning" defect one layer in.
+ * Resolves host mounts, Loom tools, and the Fabric binding into prompt-loop
+ * options. Throws when a configured host resource cannot be resolved.
  */
 export const resolveInteractiveProvisioning = async (
   parsed: {
     hostMountSpecs?: readonly string[];
+    fabricSession?: HarnessFabricSessionConfig;
     loomAuthoringConfigPath?: string;
     maxModelTurns?: number;
   },
   cwd: string,
 ): Promise<{
   additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
+  fabricSession?: HarnessFabricSessionConfig;
   loomAuthoring?: HarnessLoomAuthoringConfig;
   maxModelTurns?: number;
 }> => {
@@ -192,6 +190,9 @@ export const resolveInteractiveProvisioning = async (
   );
   return {
     ...(mounts.length > 0 ? { additionalMounts: mounts } : {}),
+    ...(parsed.fabricSession !== undefined
+      ? { fabricSession: parsed.fabricSession }
+      : {}),
     ...(loomAuthoring !== undefined ? { loomAuthoring } : {}),
     ...(parsed.maxModelTurns !== undefined
       ? { maxModelTurns: parsed.maxModelTurns }

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -77,7 +77,7 @@ export interface RunHarnessInteractiveChatStdioOptions {
 }
 
 export interface HarnessInteractiveChatStdioCliOptions {
-  /** Trusted Fabric binding shared by every turn in the service. */
+  /** Resolved CLI binding, supplied through the host's basePromptLoopOptions. */
   fabricSession?: HarnessFabricSessionConfig;
 
   /** Operator-owned configuration resolved before the interactive service starts. */
@@ -210,6 +210,11 @@ export const parseHarnessInteractiveChatStdioCliOptions = (
     );
     if (fabricOption !== undefined) {
       const prefix = `--${fabricOption}=`;
+      // A following flag is not an option value. Literal leading dashes can
+      // still be supplied with `--name=value`, as in the batch CLI.
+      if (!arg.startsWith(prefix) && args[index + 1]?.startsWith("-")) {
+        throw new Error(`--${fabricOption} requires a non-empty value`);
+      }
       fabricSessionArgs[fabricOption] = arg.startsWith(prefix)
         ? nonEmptyOptionValue(`--${fabricOption}`, arg.slice(prefix.length))
         : nonEmptyOptionValue(`--${fabricOption}`, args[++index]);
@@ -730,7 +735,12 @@ export const runHarnessInteractiveChatStdioCli = async (
     cwd ?? Deno.cwd(),
   );
   await run({
-    ...options,
+    ...(options.sessionDbPath !== undefined
+      ? { sessionDbPath: options.sessionDbPath }
+      : {}),
+    ...(options.maxInMemoryEvents !== undefined
+      ? { maxInMemoryEvents: options.maxInMemoryEvents }
+      : {}),
     ...(Object.keys(provisioning).length > 0
       ? { basePromptLoopOptions: provisioning }
       : {}),

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -24,6 +24,11 @@ import {
   type HarnessSubagentProfile,
 } from "./contracts/subagent.ts";
 import type { BuiltinToolId } from "./contracts/tool-descriptor.ts";
+import type { HarnessFabricSessionConfig } from "./config.ts";
+import {
+  HARNESS_FABRIC_SESSION_OPTION_NAMES,
+  resolveHarnessFabricSessionConfig,
+} from "./fabric-session-options.ts";
 import { resolveInteractiveProvisioning } from "./host-mounts.ts";
 import { BUILTIN_TOOLS } from "./tools/registry.ts";
 import {
@@ -72,6 +77,9 @@ export interface RunHarnessInteractiveChatStdioOptions {
 }
 
 export interface HarnessInteractiveChatStdioCliOptions {
+  /** Trusted Fabric binding shared by every turn in the service. */
+  fabricSession?: HarnessFabricSessionConfig;
+
   /** Operator-owned configuration resolved before the interactive service starts. */
   loomAuthoringConfigPath?: string;
 
@@ -114,10 +122,23 @@ Options:
                                        (repeatable: name=<id>,source=<host>,target=<sandbox>,mode=readonly|writable)
   --max-model-turns <count>            Model turns allowed per user message (default 8)
   --loom-authoring-config <path>       Absolute host-owned JSON file backing Loom tools
+  --fabric-api-url <url>              Fabric API URL for held Pattern Instance handles
+  --fabric-identity <path>            Host PKCS#8 identity keyfile, relative to the caller's cwd
+  --fabric-space <space>              Fabric space name or did:key; all three session flags go together
+  --fabric-cfc-enforcement-mode <mode> enforce-explicit | enforce-strict
+  --fabric-cfc-flow-labels <mode>      off | observe | persist
+  --fabric-cfc-posture <name>          max-enforcement runtime posture
+  --max-confidentiality <json>         Fabric read ceiling, using the batch CLI's grammar
   --help                              Print this help text to stderr
 
 Environment:
   CF_HARNESS_LOOM_AUTHORING_CONFIG     Default host authoring configuration file
+  CF_HARNESS_FABRIC_API_URL            Default value for --fabric-api-url
+  CF_HARNESS_FABRIC_IDENTITY           Default value for --fabric-identity
+  CF_HARNESS_FABRIC_SPACE              Default value for --fabric-space
+  CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE Default value for --fabric-cfc-enforcement-mode
+  CF_HARNESS_FABRIC_CFC_FLOW_LABELS     Default value for --fabric-cfc-flow-labels
+  CF_HARNESS_FABRIC_CFC_POSTURE         Default value for --fabric-cfc-posture
   ${CHAT_SESSION_DB_ENV}                 Default SQLite chat session DB path
   ${CHAT_MAX_IN_MEMORY_EVENTS_ENV}       Default in-memory event retention cap
 `;
@@ -163,6 +184,7 @@ const parsePositiveIntegerOption = (
 export const parseHarnessInteractiveChatStdioCliOptions = (
   args: readonly string[],
   env: Record<string, string | undefined> = Deno.env.toObject(),
+  cwd: string = Deno.cwd(),
 ): HarnessInteractiveChatStdioCliOptions => {
   let sessionDbPath = env[CHAT_SESSION_DB_ENV];
   let loomAuthoringConfigPath = env.CF_HARNESS_LOOM_AUTHORING_CONFIG;
@@ -173,6 +195,7 @@ export const parseHarnessInteractiveChatStdioCliOptions = (
       CHAT_MAX_IN_MEMORY_EVENTS_ENV,
       env[CHAT_MAX_IN_MEMORY_EVENTS_ENV],
     );
+  const fabricSessionArgs: Record<string, string> = {};
   let help = false;
   const hostMountSpecs: string[] = [];
   let maxModelTurns: number | undefined;
@@ -180,6 +203,16 @@ export const parseHarnessInteractiveChatStdioCliOptions = (
     const arg = args[index];
     if (arg === "--help" || arg === "-h") {
       help = true;
+      continue;
+    }
+    const fabricOption = HARNESS_FABRIC_SESSION_OPTION_NAMES.find((name) =>
+      arg === `--${name}` || arg.startsWith(`--${name}=`)
+    );
+    if (fabricOption !== undefined) {
+      const prefix = `--${fabricOption}=`;
+      fabricSessionArgs[fabricOption] = arg.startsWith(prefix)
+        ? nonEmptyOptionValue(`--${fabricOption}`, arg.slice(prefix.length))
+        : nonEmptyOptionValue(`--${fabricOption}`, args[++index]);
       continue;
     }
     if (arg === "--loom-authoring-config") {
@@ -243,7 +276,11 @@ export const parseHarnessInteractiveChatStdioCliOptions = (
     }
     throw new Error(`unsupported interactive chat stdio argument: ${arg}`);
   }
+  const fabricSession = help
+    ? undefined
+    : resolveHarnessFabricSessionConfig(fabricSessionArgs, env, cwd);
   return {
+    ...(fabricSession !== undefined ? { fabricSession } : {}),
     ...(sessionDbPath !== undefined && sessionDbPath.trim() !== ""
       ? { sessionDbPath }
       : {}),
@@ -675,7 +712,11 @@ export const runHarnessInteractiveChatStdioCli = async (
     options: RunHarnessInteractiveChatStdioOptions,
   ) => Promise<void> = runHarnessInteractiveChatStdio,
 ): Promise<void> => {
-  const options = parseHarnessInteractiveChatStdioCliOptions(args);
+  const options = parseHarnessInteractiveChatStdioCliOptions(
+    args,
+    Deno.env.toObject(),
+    cwd ?? Deno.cwd(),
+  );
   if (options.help) {
     await Deno.stderr.write(
       new TextEncoder().encode(harnessInteractiveChatStdioUsageText()),

--- a/packages/cf-harness/src/loom-local-host.ts
+++ b/packages/cf-harness/src/loom-local-host.ts
@@ -556,6 +556,7 @@ export const createLoomLocalCfHarnessHost = async (
       const parsed = parseHarnessInteractiveChatStdioCliOptions(
         args,
         processEnv,
+        options.cliDependencies?.cwd ?? Deno.cwd(),
       );
       if (parsed.help) {
         Deno.stderr.writeSync(

--- a/packages/cf-harness/test/interactive-fabric-session.test.ts
+++ b/packages/cf-harness/test/interactive-fabric-session.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Verifies that host-configured Fabric sessions reach interactive prompt loops.
+ * Provider clients and Fabric I/O are replaced at their construction boundary.
+ */
+
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
+import type {
+  CreateHarnessPromptLoopOptions,
+  HarnessPromptLoopResult,
+} from "../src/prompt-loop.ts";
+import {
+  HARNESS_CHAT_PROTOCOL_VERSION,
+  HARNESS_CHAT_REQUEST_TYPE,
+} from "../src/contracts/interactive-chat.ts";
+import {
+  runHarnessInteractiveChatStdio,
+  runHarnessInteractiveChatStdioCli,
+  type RunHarnessInteractiveChatStdioOptions,
+} from "../src/interactive-chat-stdio.ts";
+import type { HarnessFabricSession } from "../src/fabric-session.ts";
+import { createLoomLocalCfHarnessHost } from "../src/loom-local-host.ts";
+
+/** Host settings isolated from the invoking developer's persisted sessions. */
+const hostKeys = [
+  "CF_HARNESS_CHAT_SESSION_DB",
+  "CF_HARNESS_CHAT_MAX_IN_MEMORY_EVENTS",
+  "CF_HARNESS_LOOM_AUTHORING_CONFIG",
+  "CF_HARNESS_FABRIC_API_URL",
+  "CF_HARNESS_FABRIC_IDENTITY",
+  "CF_HARNESS_FABRIC_SPACE",
+  "CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE",
+  "CF_HARNESS_FABRIC_CFC_FLOW_LABELS",
+  "CF_HARNESS_FABRIC_CFC_POSTURE",
+];
+
+/** Helper for entrypoint tests, which restores the process environment. */
+const withFabricEnv = async (
+  env: Record<string, string>,
+  run: () => Promise<void>,
+) => {
+  const original = new Map(hostKeys.map((key) => [key, Deno.env.get(key)]));
+  try {
+    for (const key of hostKeys) {
+      if (env[key] === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, env[key]);
+    }
+    await run();
+  } finally {
+    for (const [key, value] of original) {
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  }
+};
+
+/** Helper for entrypoint tests, which observes a real service turn's options. */
+const observeTurn = async (
+  entrypoint: "stdio" | "loom",
+  flags: string[],
+  env: Record<string, string> = {},
+) => {
+  const root = await Deno.makeTempDir();
+  const seen: CreateHarnessPromptLoopOptions[] = [];
+  const run = async (options: RunHarnessInteractiveChatStdioOptions) => {
+    const encoder = new TextEncoder();
+    const requests = [
+      {
+        method: "start_session",
+        params: {
+          sessionId: "synthetic",
+          workspace: { hostPath: root },
+          model: "synthetic-model",
+        },
+      },
+      {
+        method: "start_turn",
+        params: {
+          sessionId: "synthetic",
+          turnId: "synthetic-turn",
+          input: { text: "Synthetic input" },
+        },
+      },
+    ];
+    await runHarnessInteractiveChatStdio({
+      ...options,
+      basePromptLoopOptions: {
+        ...options.basePromptLoopOptions,
+        ...(options.basePromptLoopOptions?.fabricSession === undefined ? {} : {
+          fabricSessionFactory: () =>
+            Promise.resolve({
+              pieces: {
+                getSpace: () =>
+                  "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+                getDefaultPattern: () =>
+                  Promise.resolve({
+                    key: (segment: string) => ({
+                      getAsNormalizedFullLink: () => ({
+                        space:
+                          "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+                        id: `of:fid1:${"A".repeat(43)}`,
+                        path: [segment],
+                      }),
+                    }),
+                  }),
+              },
+            } as unknown as HarnessFabricSession),
+        }),
+      },
+      input: new ReadableStream({
+        start(controller) {
+          for (const [index, request] of requests.entries()) {
+            controller.enqueue(
+              encoder.encode(
+                JSON.stringify({
+                  type: HARNESS_CHAT_REQUEST_TYPE,
+                  protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+                  requestId: String(index),
+                  ...request,
+                }) + "\n",
+              ),
+            );
+          }
+          controller.close();
+        },
+      }),
+      output: new WritableStream({ write() {} }),
+      createPromptLoop: (loopOptions) => {
+        seen.push(loopOptions);
+        return {
+          runTranscript: (turn) =>
+            Promise.resolve({
+              model: "synthetic-model",
+              finalAssistantText: "Synthetic result",
+              transcript: [...turn.transcript],
+              modelTurns: 1,
+              runState: {} as HarnessPromptLoopResult["runState"],
+            }),
+        };
+      },
+    });
+  };
+  try {
+    if (entrypoint === "stdio") {
+      await withFabricEnv(
+        env,
+        () => runHarnessInteractiveChatStdioCli(flags, root, run),
+      );
+    } else {
+      const host = await createLoomLocalCfHarnessHost({
+        harnessHome: await Deno.realPath(root),
+        env,
+        providerSettingsStore: {
+          inspect: () =>
+            Promise.resolve({
+              state: "configured" as const,
+              settings: {
+                version: 1 as const,
+                modelProvider: "openai-compatible-gateway" as const,
+              },
+            }),
+        },
+        cliDependencies: { cwd: root },
+        interactiveStdioRunner: run,
+      });
+      await host.runInteractive(flags);
+    }
+    expect(seen).toHaveLength(1);
+    return { options: seen[0], root };
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+};
+
+describe("interactive-fabric-session", () => {
+  for (const entrypoint of ["stdio", "loom"] as const) {
+    describe(entrypoint, () => {
+      it("passes the configured Fabric session to the actual prompt loop", async () => {
+        const { options, root } = await observeTurn(entrypoint, [
+          "--fabric-api-url",
+          "http://localhost:8123",
+          "--fabric-identity",
+          "identity.pem",
+          "--fabric-space",
+          "synthetic-space",
+        ]);
+        expect(options.fabricSession).toEqual({
+          apiUrl: "http://localhost:8123",
+          identityKeyPath: join(root, "identity.pem"),
+          space: "synthetic-space",
+        });
+      });
+      it("uses the host environment and retains the selected CFC posture", async () => {
+        const { options, root } = await observeTurn(entrypoint, [], {
+          CF_HARNESS_FABRIC_API_URL: "http://localhost:8123",
+          CF_HARNESS_FABRIC_IDENTITY: "identity.pem",
+          CF_HARNESS_FABRIC_SPACE: "synthetic-space",
+          CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE: "enforce-strict",
+          CF_HARNESS_FABRIC_CFC_FLOW_LABELS: "persist",
+        });
+        expect(options.fabricSession).toEqual({
+          apiUrl: "http://localhost:8123",
+          identityKeyPath: join(root, "identity.pem"),
+          space: "synthetic-space",
+          cfcEnforcementMode: "enforce-strict",
+          cfcFlowLabels: "persist",
+        });
+      });
+      it("passes a named posture and read ceiling through the same host binding", async () => {
+        const { options } = await observeTurn(entrypoint, [
+          "--fabric-cfc-posture",
+          "max-enforcement",
+          "--max-confidentiality",
+          '["did:key:zOwner"]',
+        ], {
+          CF_HARNESS_FABRIC_API_URL: "http://localhost:8123",
+          CF_HARNESS_FABRIC_IDENTITY: "/tmp/synthetic-identity.pem",
+          CF_HARNESS_FABRIC_SPACE: "synthetic-space",
+        });
+        expect(options.fabricSession?.cfcPosture).toBe("max-enforcement");
+        expect(options.fabricSession?.cfcReadMaxConfidentiality).toEqual([
+          "did:key:zOwner",
+        ]);
+      });
+      for (
+        const [flags, env, error] of [
+          [
+            [
+              "--fabric-api-url",
+              "not-a-url",
+              "--fabric-identity",
+              "identity.pem",
+              "--fabric-space",
+              "synthetic-space",
+            ],
+            {},
+            "valid URL",
+          ],
+          [
+            ["--fabric-space="],
+            { CF_HARNESS_FABRIC_SPACE: "synthetic-space" },
+            "non-empty",
+          ],
+          [
+            [],
+            { CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE: "observe" },
+            "enforce-explicit or enforce-strict",
+          ],
+          [
+            [],
+            { CF_HARNESS_FABRIC_CFC_FLOW_LABELS: "unsupported" },
+            "off, observe, or persist",
+          ],
+          [
+            [],
+            { CF_HARNESS_FABRIC_CFC_POSTURE: "max-enforcement" },
+            "need --fabric-api-url",
+          ],
+          [
+            ["--max-confidentiality", '["did:key:zOwner"]'],
+            {},
+            "needs --fabric-api-url",
+          ],
+        ] as const
+      ) {
+        it(`refuses invalid configuration: ${error}`, async () => {
+          await expect(observeTurn(entrypoint, [...flags], env)).rejects
+            .toThrow(error);
+        });
+      }
+      it("leaves Fabric session options absent without configuration", async () => {
+        const { options } = await observeTurn(entrypoint, []);
+        expect(options.fabricSession).toBeUndefined();
+      });
+      it("throws before starting a turn when the host supplies only part of a session", async () => {
+        await expect(
+          observeTurn(entrypoint, [], {
+            CF_HARNESS_FABRIC_SPACE: "synthetic-space",
+          }),
+        ).rejects.toThrow("go together");
+      });
+      it("lets explicit flags override the host environment", async () => {
+        const { options } = await observeTurn(entrypoint, [
+          "--fabric-space=chosen-space",
+        ], {
+          CF_HARNESS_FABRIC_API_URL: "http://localhost:8123",
+          CF_HARNESS_FABRIC_IDENTITY: "/tmp/synthetic-identity.pem",
+          CF_HARNESS_FABRIC_SPACE: "environment-space",
+        });
+        expect(options.fabricSession?.space).toBe("chosen-space");
+      });
+    });
+  }
+});

--- a/packages/cf-harness/test/interactive-fabric-session.test.ts
+++ b/packages/cf-harness/test/interactive-fabric-session.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../src/interactive-chat-stdio.ts";
 import type { HarnessFabricSession } from "../src/fabric-session.ts";
 import { createLoomLocalCfHarnessHost } from "../src/loom-local-host.ts";
+import { parseCfHarnessCliArgs } from "../src/cli.ts";
 
 /** Host settings isolated from the invoking developer's persisted sessions. */
 const hostKeys = [
@@ -290,6 +291,34 @@ describe("interactive-fabric-session", () => {
           CF_HARNESS_FABRIC_SPACE: "environment-space",
         });
         expect(options.fabricSession?.space).toBe("chosen-space");
+      });
+      it("keeps repeated Fabric flags consistent with the batch parser", async () => {
+        const flags = [
+          "--fabric-space",
+          "first-space",
+          "--fabric-space",
+          "last-space",
+        ];
+        const env = {
+          CF_HARNESS_FABRIC_API_URL: "http://localhost:8123",
+          CF_HARNESS_FABRIC_IDENTITY: "/tmp/synthetic-identity.pem",
+          CF_HARNESS_FABRIC_SPACE: "environment-space",
+        };
+        const batch = await parseCfHarnessCliArgs([
+          "--prompt",
+          "Synthetic input",
+          ...flags,
+        ], { cwd: "/tmp", env });
+        if ("help" in batch) throw new Error("Unexpected help");
+        const { options } = await observeTurn(entrypoint, flags, env);
+        expect(options.fabricSession).toEqual(batch.fabricSession);
+        expect(options.fabricSession?.space).toBe("last-space");
+      });
+      it("refuses a missing Fabric value instead of treating the next flag as its value", async () => {
+        await expect(observeTurn(entrypoint, ["--fabric-space", "--help"], {
+          CF_HARNESS_FABRIC_API_URL: "http://localhost:8123",
+          CF_HARNESS_FABRIC_IDENTITY: "/tmp/synthetic-identity.pem",
+        })).rejects.toThrow("--fabric-space requires a non-empty value");
       });
     });
   }

--- a/packages/cf-harness/test/loom-authoring-batch-admission.test.ts
+++ b/packages/cf-harness/test/loom-authoring-batch-admission.test.ts
@@ -1,0 +1,105 @@
+/** Verifies that batch hosts admit the declared Loom authoring tools. */
+
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  createCfHarnessCliCapabilities,
+  parseCfHarnessCliArgs,
+} from "../src/cli.ts";
+import { createLoomLocalCfHarnessHost } from "../src/loom-local-host.ts";
+import type { CreateHarnessPromptLoopOptions } from "../src/prompt-loop.ts";
+
+/** Tool grant used by Loom's collection-capable batch profiles. */
+const authoringTools = [
+  "loom_compose",
+  "loom_inspect",
+  "loom_authoring_context",
+];
+
+describe("loom-authoring-batch-admission", () => {
+  it("advertises each Loom authoring tool as a parent tool", () => {
+    for (const tool of authoringTools) {
+      expect(createCfHarnessCliCapabilities().parentToolIds).toContain(tool);
+    }
+  });
+  for (const tool of authoringTools) {
+    it(`accepts an explicit ${tool} grant in the batch CLI`, async () => {
+      const parsed = await parseCfHarnessCliArgs([
+        "--prompt",
+        "Synthetic collection",
+        "--allow-tool",
+        tool,
+      ], { cwd: "/tmp", env: {} });
+      expect("help" in parsed).toBe(false);
+      if ("help" in parsed) throw new Error("Unexpected help");
+      expect(parsed.allowedToolIds).toEqual([tool]);
+    });
+  }
+  it("passes all three grants through the strict Loom batch host to its prompt loop", async () => {
+    const home = await Deno.makeTempDir();
+    const seen: CreateHarnessPromptLoopOptions[] = [];
+    try {
+      const authoringConfig = {
+        cliPath: Deno.execPath(),
+        transport: {
+          kind: "direct",
+          instanceDir: home,
+          runId: "synthetic-batch",
+          actor: "agent:acceptance",
+        },
+      };
+      const configPath = join(home, "loom-authoring.json");
+      await Deno.writeTextFile(configPath, JSON.stringify(authoringConfig));
+      const host = await createLoomLocalCfHarnessHost({
+        harnessHome: await Deno.realPath(home),
+        env: { CF_HARNESS_GATEWAY_AUTH_MODE: "none" },
+        providerSettingsStore: {
+          inspect: () =>
+            Promise.resolve({
+              state: "configured" as const,
+              settings: {
+                version: 1 as const,
+                modelProvider: "openai-compatible-gateway" as const,
+              },
+            }),
+        },
+        cliDependencies: {
+          cwd: home,
+          io: { stdout() {}, stderr() {} },
+          createPromptLoop: (options) => {
+            seen.push(options);
+            return {
+              runPrompt: () =>
+                Promise.resolve({
+                  model: "synthetic-model",
+                  finalAssistantText: "Synthetic result",
+                  transcript: [],
+                  modelTurns: 1,
+                  runState: options.engine!.getRunState(),
+                }),
+              runTranscript: () =>
+                Promise.reject(new Error("Unexpected resume")),
+            };
+          },
+        },
+      });
+      const code = await host.runBatch([
+        "--prompt",
+        "Synthetic collection",
+        "--output-mode",
+        "batch",
+        "--loom-authoring-config",
+        configPath,
+        ...authoringTools.flatMap((tool) => ["--allow-tool", tool]),
+      ]);
+      expect(code).toBe(0);
+      expect(seen).toHaveLength(1);
+      expect(seen[0].allowedToolIds).toEqual(authoringTools);
+      expect(seen[0].engine?.config.loomAuthoring).toEqual(authoringConfig);
+    } finally {
+      await Deno.remove(home, { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Why

Loom grants `loom_compose`, `loom_inspect`, and `loom_authoring_context` to collection-capable batch runs, but the CLI's parent-tool allowlist rejects those registered tools before a model turn starts. Interactive stdio hosts also lack a way to configure the Fabric session needed to resolve a held existing Pattern Instance token.

## What Changed

- Admit the three existing authoring tools through CLI grants and capability discovery. Tools still require explicit host authoring configuration.
- Share the batch Fabric-session resolver with both interactive stdio entrypoints. Host flags or environment supply a complete API URL, identity, and space binding, including the existing CFC options and read-ceiling contract.
- Forward the resolved binding to actual prompt-loop construction and document host configuration. Raw Pattern references and token-custody checks retain their existing behavior.

## Test plan

- Watched five batch capability/parser/strict-host regressions fail, then pass; independent actual Wish argv reproduction also covers all three grants.
- Watched eight interactive configuration cases fail before the fix; both entrypoints now cover actual turn construction, no configuration, partial/invalid configuration, flag precedence, and CFC posture/ceiling forwarding.
- Full cf-harness and audit suite: 1,021 tests passed, 2,594 steps. Focused entrypoint suite after review corrections: 258 tests passed, 35 steps.
- Repository formatting and lint pass; tracked lockfile unchanged.
- Canonical repository typecheck: 45 of 46 groups pass, including cf-harness. The patterns group reports 16 errors in unchanged `iframe-impossible-machine/guest.tsx`; the same messages and locations reproduce on a clean checkout of the base a49aa582.

## Review follow-up

- Completed independent review and read Cubic's full three-finding body. Removed the dead top-level Fabric option copy while retaining one shared prompt-loop provisioning path.
- Missing Fabric values no longer consume the next flag as a space or identity; both actual entrypoints failed this regression before the correction. An actual batch/interactive comparison confirms repeated flags already use the same last-value behavior, so that behavior remains.
- Updated CLI help to list the new grants and their host configuration requirement.

Cubic's completed correction review also raised the existing parser behavior of unrelated options and the help word "require." The Fabric guard remains scoped to these new binding flags; broader parser changes are outside this fix. The tool-config statement describes availability: without host authoring configuration the tools are withheld, preserving the existing default posture. It does not add a startup rejection for an otherwise valid explicit tool grant.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

