### PR TITLE
feat(cf-harness): collect verified same-run Pattern deployments into Looms

### DIFF
--- a/packages/cf-harness/docs/LOOM_AUTHORING.md
+++ b/packages/cf-harness/docs/LOOM_AUTHORING.md
@@ -116,6 +116,26 @@ automatically.
 
 ## Receipts and recovery
 
+After a successful Loom-mediated Pattern deployment, call
+`loom_authoring_context` with no deployment arguments. Supporting hosts return
+run-scoped `loom-deployed-pattern-v1` receipts in a separate
+`deployed_patterns.receipts` field. The tool admits at most 32 entries, checks
+each API base URL and space against the host-configured Fabric session, and
+loads the cell to verify its whole Pattern identity. It returns accepted entries
+as `deployed_patterns: [{pattern_token}]`; the prompt loop replaces canonical
+links with opaque handles in model-facing messages and persists those handles
+for subsequent composition and resume. Tool artifacts retain the canonical links
+as host-side evidence.
+
+Repeated context calls reuse general handles, including qualified own-space
+addresses, and do not expand a restricted skill handle into a composition grant.
+Missing Fabric backing, omitted receipt fields from older hosts, foreign or
+malformed receipts, and unavailable cells contribute no Pattern tokens while
+ordinary Loom context remains available. Shell output and model supplied Pattern
+addresses do not authorize this handoff. The Loom deployment route remains
+responsible for recording actual success under its broker run identity
+independently of best-effort placeholder placement.
+
 Choose one `request_id` for one logical composition and retain its exact
 arguments on retry. The host atomically commits components, operations, and a
 receipt. A successful tool observation has `kind: "loom-authored"`, its

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -2226,6 +2226,14 @@ export class CfHarnessEngine {
       ...(this.#fabricSessionFactory !== undefined
         ? { getFabricSession: this.#fabricSessionFactory }
         : {}),
+      ...(this.config.fabricSession !== undefined
+        ? {
+          fabricSessionTarget: {
+            apiUrl: this.config.fabricSession.apiUrl,
+            space: this.config.fabricSession.space,
+          },
+        }
+        : {}),
       ...(this.#openProbeRuntime !== undefined
         ? { openProbeRuntime: this.#openProbeRuntime }
         : {}),

--- a/packages/cf-harness/src/tools/loom-authoring.ts
+++ b/packages/cf-harness/src/tools/loom-authoring.ts
@@ -5,6 +5,7 @@
  */
 
 import { getPatternIdentityRef } from "@commonfabric/runner";
+import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
 import { pieceId } from "@commonfabric/piece";
 import type { JSONSchema } from "@commonfabric/api";
 
@@ -175,6 +176,79 @@ const patternReference = async (
   return `pattern:${space}/${id}`;
 };
 
+/** Helper for deployment binding, which normalizes an HTTP API base URL. */
+const apiBase = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  try {
+    const url = new URL(value);
+    if (
+      !["http:", "https:"].includes(url.protocol) ||
+      url.username || url.password || url.search || url.hash
+    ) return undefined;
+    return url.href.replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Helper for context, which admits at most 32 successful host deployments
+ * bound to this Fabric session and verified as whole Pattern Instances.
+ * Canonical links enter the prompt loop's persisted handle projection.
+ */
+const deployedPatterns = async (
+  context: HarnessToolContext,
+  value: unknown,
+): Promise<{ pattern_token: string }[]> => {
+  const receipts = record(value).receipts;
+  const target = context.fabricSessionTarget;
+  const api = apiBase(target?.apiUrl);
+  if (
+    !Array.isArray(receipts) || context.getFabricSession === undefined ||
+    target === undefined || api === undefined
+  ) return [];
+  const output: { pattern_token: string }[] = [];
+  const seen = new Set<string>();
+  for (const candidate of receipts.slice(0, 32)) {
+    const receipt = record(candidate);
+    if (
+      receipt.schema !== "loom-deployed-pattern-v1" ||
+      apiBase(receipt.api_url) !== api ||
+      typeof receipt.piece_id !== "string" ||
+      !/^fid1:[A-Za-z0-9_-]{43}$/.test(receipt.piece_id)
+    ) continue;
+    try {
+      const { pieces } = await context.getFabricSession();
+      const space = pieces.getSpace();
+      if (receipt.space !== target.space && receipt.space !== space) continue;
+      if (seen.has(receipt.piece_id)) continue;
+      seen.add(receipt.piece_id);
+      const cell = pieces.runtime.getCellFromLink({
+        ...parseHandleRef(`/of:${receipt.piece_id}`),
+        space,
+        schema: undefined,
+      });
+      await cell.sync();
+      if (
+        pieceId(cell) !== receipt.piece_id ||
+        getPatternIdentityRef(cell) === undefined
+      ) continue;
+      const link = createLLMFriendlyLink(cell.getAsNormalizedFullLink(), space);
+      const held = context.handleTable?.entries.filter((entry) => {
+        const address = parseHandleRef(entry.ref);
+        return address.id === `of:${receipt.piece_id}` &&
+          address.path.length === 0 && address.scope === "space" &&
+          (address.space === undefined || address.space === space);
+      }) ?? [];
+      if (held.some((entry) => entry.capability !== undefined)) continue;
+      output.push({ pattern_token: held[0]?.token ?? link });
+    } catch {
+      // Unavailable deployment cells do not prevent ordinary Loom recovery.
+    }
+  }
+  return output;
+};
+
 /**
  * Helper for the three tools, which projects only their public observation.
  * A started host command settles even when the model turn is cancelled; a
@@ -319,6 +393,10 @@ const invoke = async (
     authored: (result.authored as unknown[]).map((entry) => ({
       receipt: projectReceipt(record(entry).receipt),
     })),
+    deployed_patterns: await deployedPatterns(
+      context,
+      result.deployed_patterns,
+    ),
   };
 };
 
@@ -411,7 +489,7 @@ export const loomAuthoringContextTool: HarnessToolDefinition<
     title: "Loom Authoring Context",
     effectClass: "read",
     description:
-      "Recover up to 32 historical receipts for this host-owned run identity and its separately bound Loom. History is not newly authored work and never selects an implicit target. An explicit loom_id overrides only the context target. Inspect the exact chosen target before editing.",
+      "Recover up to 32 historical receipts for this host-owned run identity and its separately bound Loom. Successful Pattern deployments from this run can provide held pattern_token values for loom_compose. History is not newly authored work and never selects an implicit target. An explicit loom_id overrides only the context target. Inspect the exact chosen target before editing.",
     inputSchema: {
       type: "object",
       properties: { loom_id: targetSchema },

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -65,6 +65,15 @@ export interface HarnessToolContext {
    */
   getFabricSession?: () => Promise<HarnessFabricSession>;
 
+  /** Host-configured deployment target, without its identity key path. */
+  fabricSessionTarget?: {
+    /** Toolshed API base URL for the run. */
+    apiUrl: string;
+
+    /** Configured space name or DID for the run. */
+    space: string;
+  };
+
   /**
    * Opens the render gate's probe runtime; `openProbeRuntime` by default. A
    * test replaces it to see what the gate opens the probe under.

--- a/packages/cf-harness/test/tools/loom-deployment-handoff.test.ts
+++ b/packages/cf-harness/test/tools/loom-deployment-handoff.test.ts
@@ -1,0 +1,388 @@
+/** Checks host deployment receipts at the model-facing Loom tool boundary. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { createSession, Identity } from "@commonfabric/identity";
+import { pieceId } from "@commonfabric/piece";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { Runtime } from "@commonfabric/runner";
+import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import {
+  createFileSystemHarnessArtifactStore,
+  readHarnessRunState,
+} from "../../src/artifacts.ts";
+import { CfHarnessEngine } from "../../src/engine.ts";
+import {
+  createHarnessHandleTable,
+  mintAddressHandle,
+} from "../../src/handle-table.ts";
+import { CfHarnessPromptLoop } from "../../src/prompt-loop.ts";
+import type { HarnessRunState } from "../../src/run-state.ts";
+import type { SandboxRuntime } from "../../src/sandbox/types.ts";
+import { directPromptSlotBindingFor } from "../support/prompt-slot-binding.ts";
+import { responsesBodyFromChatFixture } from "../support/responses-fixture.ts";
+
+/** Sandbox fixture whose operations have no process or network effects. */
+const sandbox: SandboxRuntime = {
+  describe: () => ({
+    kind: "docker-runsc-cfc",
+    defaultWorkingDirectory: "/workspace",
+    cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+  }),
+  defaultWorkingDirectory: () => "/workspace",
+  resolvePath: (path) => path,
+  isPathWithinWorkspace: () => true,
+  isPathWithinAllowedRoots: () => true,
+  run: () => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }),
+  runShell: () => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }),
+};
+
+/** Helper for tests, which gives each case an isolated real Pattern Instance. */
+const fixture = async () => {
+  const identity = await Identity.fromPassphrase("deployed-pattern-fixture");
+  const storage = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    apiUrl: new URL("http://toolshed.test/base"),
+    storageManager: storage,
+  });
+  const pieces = new PiecesController(
+    await createSession({ identity, spaceName: "handoff" }),
+    runtime,
+  );
+  const created = await pieces.create(
+    "import { pattern } from 'commonfabric'; export default pattern(() => ({ count: 1 }));",
+  );
+  await runtime.idle();
+  await pieces.synced();
+  const cell = created.getCell();
+  return {
+    pieces,
+    runtime,
+    link: createLLMFriendlyLink(
+      cell.getAsNormalizedFullLink(),
+      pieces.getSpace(),
+    ),
+    receipt: {
+      schema: "loom-deployed-pattern-v1",
+      api_url: "http://toolshed.test/base/",
+      space: "handoff",
+      piece_id: pieceId(cell)!,
+    },
+    async close() {
+      await runtime.dispose();
+      await storage.close();
+    },
+  };
+};
+
+/** One model-selected tool call. */
+interface Call {
+  /** The dedicated tool's name. */
+  name: string;
+
+  /** Model-owned input fields. */
+  args: Record<string, unknown>;
+}
+
+/** Helper for tests, which drives actual tool dispatch and model projection. */
+const runCalls = async (engine: CfHarnessEngine, calls: Call[]) => {
+  let index = 0;
+  const loop = new CfHarnessPromptLoop({
+    engine,
+    apiKey: "synthetic-key",
+    model: "gpt-5.4",
+    allowedToolIds: ["loom_authoring_context", "loom_compose"],
+    fetchFn: () => {
+      const call = calls[index++];
+      const message = call === undefined
+        ? { role: "assistant", content: "Done" }
+        : {
+          role: "assistant",
+          content: "",
+          tool_calls: [{
+            id: `call-${index}`,
+            type: "function",
+            function: {
+              name: call.name,
+              arguments: JSON.stringify(call.args),
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(responsesBodyFromChatFixture({
+            choices: [{ index: 0, message }],
+          })),
+          { status: 200 },
+        ),
+      );
+    },
+  });
+  return await loop.runPrompt({
+    prompt: "Collect the Pattern I deployed into a Loom.",
+    promptSlotBinding: directPromptSlotBindingFor("handoff"),
+  });
+};
+
+/** Helper for tests, which represents a successful host context command. */
+const contextResult = (deployed: unknown) => ({
+  kind: "authoring-context",
+  historical: true,
+  run_scoped: true,
+  truncated: false,
+  bound_loom: { loom_id: "loom-1111111111111111", available: true },
+  authored: [],
+  ...(deployed === undefined ? {} : { deployed_patterns: deployed }),
+});
+
+describe("loom-deployment-handoff", () => {
+  it("persists one general token across repeated context and a resumed dedicated composition", async () => {
+    const f = await fixture();
+    const root = await Deno.makeTempDir({ prefix: "loom-handoff-" });
+    try {
+      const runId = "deployment-handoff";
+      const artifactStore = createFileSystemHarnessArtifactStore({
+        artifactRoot: root,
+        runId,
+      });
+      const submitted: Record<string, unknown>[] = [];
+      const makeEngine = (runState?: HarnessRunState) =>
+        new CfHarnessEngine({
+          runId,
+          runState,
+          artifactStore,
+          model: "gpt-5.4",
+          sandboxRuntime: sandbox,
+          fabricSession: {
+            apiUrl: "http://toolshed.test/base",
+            space: "handoff",
+            identityKeyPath: "/synthetic/key",
+          },
+          fabricSessionFactory: () => Promise.resolve({ pieces: f.pieces }),
+          loomAuthoring: {
+            cliPath: "/trusted/loom",
+            transport: { kind: "broker", queuePath: "/trusted/queue" },
+          },
+          processRunner: {
+            run(request) {
+              const command = request.args.indexOf("loom.compose");
+              let result: unknown;
+              if (command >= 0) {
+                const input = JSON.parse(request.stdinText!);
+                submitted.push(input);
+                result = {
+                  receipt: {
+                    loom_id: "loom-1111111111111111",
+                    request_id: input.request_id,
+                    version: 1,
+                    created: true,
+                    component_ids: ["c-1"],
+                    operation_ids: ["op-1"],
+                    displaced: [],
+                  },
+                  replayed: false,
+                  manifest: { loom_id: "loom-1111111111111111", version: 1 },
+                };
+              } else {
+                result = contextResult({ receipts: [f.receipt, f.receipt] });
+              }
+              return Promise.resolve({
+                exitCode: 0,
+                stderr: "",
+                stdout: JSON.stringify({ ok: true, result }),
+              });
+            },
+          },
+        });
+      const minted = await mintAddressHandle(
+        createHarnessHandleTable(runId),
+        f.link,
+      );
+      const composition = {
+        request_id: "same-run-collection",
+        components: [{ pattern_token: minted.token, stage: true }],
+      };
+      const first = await runCalls(makeEngine(), [
+        { name: "loom_authoring_context", args: {} },
+        { name: "loom_authoring_context", args: {} },
+        { name: "loom_compose", args: composition },
+      ]);
+      const observations = first.transcript.filter((m) =>
+        m.role === "tool" &&
+        JSON.parse(m.content!).kind === "authoring-context"
+      );
+      for (const observation of observations) {
+        expect(JSON.parse(observation.content!)).toMatchObject({
+          status: "ok",
+          deployed_patterns: [{ pattern_token: minted.token }],
+        });
+        expect(observation.content).not.toContain(f.receipt.piece_id);
+      }
+      expect(observations).toHaveLength(2);
+      expect(first.runState.handleTable?.entries).toHaveLength(1);
+      const saved = await readHarnessRunState(
+        `${artifactStore.runRoot}/run-state.json`,
+      );
+      expect(saved.handleTable).toEqual(first.runState.handleTable);
+      const raw = await Deno.readTextFile(saved.toolOutputs[0].artifactPath!);
+      expect(raw).toContain(f.receipt.piece_id);
+      expect(raw).not.toContain(minted.token);
+      const second = await runCalls(makeEngine(saved), [
+        { name: "loom_authoring_context", args: {} },
+        { name: "loom_compose", args: composition },
+      ]);
+      const lowered = {
+        request_id: "same-run-collection",
+        components: [{
+          ref: `pattern:${f.pieces.getSpace()}/${f.receipt.piece_id}`,
+          stage: true,
+        }],
+      };
+      expect(submitted).toEqual([lowered, lowered]);
+      expect(second.runState.handleTable?.entries).toHaveLength(1);
+    } finally {
+      await f.close();
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("projects verified deployments while retaining ordinary context for unavailable inputs", async () => {
+    const f = await fixture();
+    try {
+      const cases = [
+        { name: "old-host", deployed: undefined },
+        {
+          name: "no-fabric",
+          noFabric: true,
+          deployed: { receipts: [f.receipt] },
+        },
+        {
+          name: "no-target",
+          noTarget: true,
+          deployed: { receipts: [f.receipt] },
+        },
+        { name: "missing-list", deployed: {} },
+        { name: "invalid-list", deployed: { receipts: "not a receipt array" } },
+        {
+          name: "bounded-list",
+          deployed: { receipts: [...Array(32).fill({}), f.receipt] },
+        },
+        ...[
+          { api_url: "http://toolshed.test:8001/base" },
+          { api_url: "http://toolshed.test/other" },
+          { api_url: "http://alias.test/base" },
+          { api_url: "http://toolshed.test/base?run=other" },
+          { space: "foreign" },
+          { piece_id: "fid1:bad" },
+          { piece_id: `fid1:${"A".repeat(43)}` },
+          {
+            piece_id: f.runtime.getCell(f.pieces.getSpace(), "ordinary-cell")
+              .getAsNormalizedFullLink().id.slice(3),
+          },
+          { schema: "unknown" },
+          { api_url: undefined },
+        ].map((delta, index) => ({
+          name: `invalid-${index}`,
+          deployed: { receipts: [{ ...f.receipt, ...delta }] },
+        })),
+        {
+          name: "restricted",
+          restricted: true,
+          deployed: { receipts: [f.receipt] },
+        },
+        {
+          name: "restricted-qualified",
+          restricted: true,
+          qualified: true,
+          deployed: { receipts: [f.receipt] },
+        },
+        {
+          name: "general-qualified",
+          general: true,
+          qualified: true,
+          deployed: {
+            receipts: [{ ...f.receipt, space: f.pieces.getSpace() }],
+          },
+        },
+      ];
+      for (const candidate of cases) {
+        const engine = new CfHarnessEngine({
+          runId: candidate.name,
+          model: "gpt-5.4",
+          sandboxRuntime: sandbox,
+          ...(!("noFabric" in candidate)
+            ? {
+              fabricSessionFactory: () => Promise.resolve({ pieces: f.pieces }),
+            }
+            : {}),
+          ...(!("noTarget" in candidate) && !("noFabric" in candidate)
+            ? {
+              fabricSession: {
+                apiUrl: "http://toolshed.test/base",
+                space: "handoff",
+                identityKeyPath: "/synthetic/key",
+              },
+            }
+            : {}),
+          loomAuthoring: {
+            cliPath: "/trusted/loom",
+            transport: { kind: "broker", queuePath: "/trusted/queue" },
+          },
+          processRunner: {
+            run: () =>
+              Promise.resolve({
+                exitCode: 0,
+                stderr: "",
+                stdout: JSON.stringify({
+                  ok: true,
+                  result: contextResult(candidate.deployed),
+                }),
+              }),
+          },
+        });
+        let expectedToken: string | undefined;
+        if ("restricted" in candidate || "general" in candidate) {
+          const held = await mintAddressHandle(
+            createHarnessHandleTable(candidate.name),
+            "qualified" in candidate
+              ? `/@${f.pieces.getSpace()}/of:${f.receipt.piece_id}`
+              : f.link,
+            "restricted" in candidate ? { capability: "skill-context" } : {},
+          );
+          await engine.recordHandleTable(held.table);
+          if ("general" in candidate) expectedToken = held.token;
+        }
+        const result = await runCalls(engine, [{
+          name: "loom_authoring_context",
+          args: {},
+        }]);
+        const observation = result.transcript.find((m) => m.role === "tool")!;
+        expect(JSON.parse(observation.content!)).toMatchObject({
+          status: "ok",
+          kind: "authoring-context",
+          bound_loom: { loom_id: "loom-1111111111111111", available: true },
+          deployed_patterns: expectedToken === undefined
+            ? []
+            : [{ pattern_token: expectedToken }],
+        });
+        expect(observation.content).not.toContain(f.receipt.piece_id);
+        if (expectedToken === undefined) {
+          expect(observation.content).not.toContain("cfh:a:");
+        }
+        expect(result.runState.handleTable?.entries ?? []).toHaveLength(
+          "restricted" in candidate || "general" in candidate ? 1 : 0,
+        );
+        if ("restricted" in candidate) {
+          expect(result.runState.handleTable?.entries[0].capability).toBe(
+            "skill-context",
+          );
+        }
+      }
+    } finally {
+      await f.close();
+    }
+  });
+});

--- a/packages/cf-harness/test/tools/loom-deployment-handoff.test.ts
+++ b/packages/cf-harness/test/tools/loom-deployment-handoff.test.ts
@@ -264,6 +264,11 @@ describe("loom-deployment-handoff", () => {
           noTarget: true,
           deployed: { receipts: [f.receipt] },
         },
+        {
+          name: "unavailable-fabric",
+          unavailableFabric: true,
+          deployed: { receipts: [f.receipt] },
+        },
         { name: "missing-list", deployed: {} },
         { name: "invalid-list", deployed: { receipts: "not a receipt array" } },
         {
@@ -271,6 +276,7 @@ describe("loom-deployment-handoff", () => {
           deployed: { receipts: [...Array(32).fill({}), f.receipt] },
         },
         ...[
+          { api_url: "not a URL" },
           { api_url: "http://toolshed.test:8001/base" },
           { api_url: "http://toolshed.test/other" },
           { api_url: "http://alias.test/base" },
@@ -315,7 +321,12 @@ describe("loom-deployment-handoff", () => {
           sandboxRuntime: sandbox,
           ...(!("noFabric" in candidate)
             ? {
-              fabricSessionFactory: () => Promise.resolve({ pieces: f.pieces }),
+              fabricSessionFactory: () =>
+                "unavailableFabric" in candidate
+                  ? Promise.reject(
+                    new Error("Synthetic unavailable Fabric session"),
+                  )
+                  : Promise.resolve({ pieces: f.pieces }),
             }
             : {}),
           ...(!("noTarget" in candidate) && !("noFabric" in candidate)


### PR DESCRIPTION
## Why

A cf-harness-backed Loom Wish can deploy a Pattern Instance through the host `loom piece agent-deploy` CLI, but that instance was not available when the run's input handles were seeded. Unlike the existing in-engine `run_pattern` path, this host deployment did not supply an engine-held token for dedicated Loom composition. The agent needs a host-verified way to collect its own successful deployment without accepting raw Pattern references. Existing Pattern placement is unchanged. This builds on merged #7144's Fabric session wiring and host receipt recording in commontoolsinc/loom#5724; vendor adoption is separate.

## What Changed

- Read optional typed deployment receipts from the existing no-argument `loom_authoring_context` response and verify them against the engine's configured API/space and the runtime's whole Pattern identity.
- Project valid instances through the existing model-bound Cell-link conversion, yielding opaque held tokens that dedicated `loom_compose` can use immediately and after session resume. Durable raw artifacts retain the verified link; model output receives the token.
- Bound each context read to 32 candidates, deduplicate instances, reuse general tokens, and preserve restricted-handle boundaries, including qualified cell addresses. Missing, mismatched, partial, and old-host responses preserve ordinary Loom context without granting Pattern access.
- Document the host receipt contract and its custody boundary.

## Test plan

- Red-first: the real prompt-loop deployment handoff tests failed in both behavioral steps before implementation; a separate qualified restricted-handle regression failed before its correction. Private evidence: `/tmp/agent-loom-deployment-handoff-upstream-red.log` and `/tmp/agent-loom-deployment-handoff-upstream-alias-red.log`.
- Full cf-harness tests and audit tests after rebasing onto #7144: **1,022 tests / 2,600 steps passed** (`/tmp/agent-loom-handoff-rebase-full-suite.log`). Tests use the real emulated Runtime and PiecesController, actual model-bound projection, dedicated next-call composition, persisted state resume, and refusal controls.
- Canonical cf-harness typecheck passed. Repository-wide `deno fmt --check` and `deno lint` passed: 5,833 and 5,665 files checked respectively.
- Independent red team verified the exact five frozen files, reviewed production code/docs/tests, and ran the handoff plus adjacent authoring contracts: **27 steps passed** (`/tmp/agent-loom-handoff-upstream-independent.log`).
- Additional private integration proof: both `pattern-dev` and `full-stack` passed the actual `loom piece agent-deploy` CLI → file broker → HTTP → deployment route → durable store path, followed by the actual upstream `executeLoomAuthoringCommand` → CLI → same broker → no-argument authoring-context route. Both calls arrived with the exact broker-owned Wish ID despite a conflicting ambient dispatch ID; that forged ID recovered no receipts. Only the compiler/toolshed boundary was stubbed; this is not a full-model or live Pattern deployment claim. Private evidence: `/tmp/agent-loom-deployment-bridge-probe.log` (**2 profile probes passed on Python 3.9.6**).
- The initial CI coverage gate identified three uncovered exception-path lines. Added meaningful malformed-URL and unavailable-Fabric-session cases; the real prompt-loop tests passed, and local LCOV confirms all three lines execute. No production behavior changed. Independent rebase/test-delta review reran **22 steps successfully**; the original production patch is identical over merged #7144 by `git range-diff`.
- Final CI at `5ce0d0b623be61104b6fcf41143ac91b44c7a210` passed **all 65 active checks**, with three expected skips; coverage is restored to the main baseline of **4,268 uncovered lines**. The completed full official Cubic review took **2,211,632 ms (36m 52s)** and reported exactly two P3 findings. Its complete body, including nested prose, was read and independently reviewed; both owner-approved dispositions are below. Private completed review: `/tmp/agent-loom-deployment-handoff-upstream-final-cubic-retry.jsonl`. Earlier failed or deliberately cancelled attempts are not counted as clearance. After marking the PR ready, the hosted Cubic check remained neutral because the monthly and flex review quotas were exhausted; that check is not the review evidence.
- Live end-to-end deployment-to-composition acceptance still requires official vendor adoption and a fresh ephemeral acceptance instance; no live execution is claimed here.


## Cubic dispositions

- **P3: fixed `fid1` digest encoding — override.** The current `loom-deployed-pattern-v1` host contract and runtime mint exactly this 43-character base64url identifier. The reviewer confirms the check is correct for the supported format. A future digest/encoding change requires a coordinated host/runtime contract update; refusing that unsupported receipt without granting a token is intentional. No currently supported receipt is rejected. This agrees with the strict validator already merged in commontoolsinc/loom#5724.
- **P3: sequential deployment reads — override.** A first cold context can perform up to 32 sequential cell loads, and that bounded cold cost is accepted. Repeated reads do not inherently cause 32 new network round trips: the runtime's existing selector coverage reuses settled or in-flight watch promises and returns without a new watch request. A private probe through the actual `Cell.sync`/storage implementation with a synthetic memory-protocol transport counted **32 cold watch-add requests, then zero new requests on each of two repeated 32-cell passes** (`/tmp/agent-loom-handoff-sync-cache-probe.log`). This is request-count evidence, not a live latency benchmark. Early exit would omit valid supported receipts; an unmeasured concurrency rewrite is unnecessary for this change.

The root agent independently read the exact completed review body and the current source, including the storage selector-coverage path, and accepted both dispositions at `5ce0d0b623be61104b6fcf41143ac91b44c7a210`. No source edits followed the completed full review.
