### PR TITLE
docs(development): a unit test file is not owed a file header

### DIFF
--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -699,7 +699,7 @@ nothing else. The blank line is load-bearing for that same reason: it is what
 keeps the header from being read as the doc comment of the first declaration
 under it.
 
-Every file gets one, except for the three kinds below.
+Every file gets one, except for the four kinds below.
 
 **A file that defines a single thing.** Where the whole content of a file is
 one declaration — one class, one function, one type — along with the imports
@@ -737,8 +737,31 @@ The exception ends where the file does. A second exported declaration, or
 module-level machinery that is not simply in service of the one, and the file
 has something to say about itself again.
 
-**A re-export barrel**, and **a test fixture whose content is the point**, are
-the other two.
+**A unit test file.** Its name says what it tests, and its one top-level
+`describe()` says it again, so the header a typical one could carry is either
+``Unit tests for `fryer.ts`.`` or a restatement of the contract that the code
+under test already documents. Neither is worth the slot, and a file whose
+header would be one of those has none.
+
+The exemption is narrower than its name, in two ways. It covers the `.test.ts`
+file itself and nothing beside it: a helper module under `test/` — shared
+setup, a fake, a builder for test values — is an ordinary file, and gets a
+header on the ordinary terms. And it is a default rather than a bar. A test
+file that does something a reader would not guess from its name — walks a
+generated corpus, drives the code under test from a second runtime, checks two
+implementations against each other — has something to say about itself that no
+declaration in it says, and a header is where that goes.
+
+**A re-export barrel.** Its whole content is the list of what it re-exports,
+and each entry carries its own doc comment where it is declared. A header
+could only repeat the list, and would stop matching it at the next line added
+to the file.
+
+**A test fixture whose content is the point.** The file is an input a test
+feeds to the code under test, or an output it compares against, and what it
+is for is stated in the test that reads it. A header inside it would be part
+of the content, and where the fixture is source that a compiler or transformer
+takes in, part of what the test measures.
 
 Two placements look close enough to pass and are not. A `//` block is not an
 alternative form of a header: it reads as a note about the line beneath it,

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -743,10 +743,12 @@ has something to say about itself again.
 under test already documents. Neither is worth the slot, and a file whose
 header would be one of those has none.
 
-The exemption is narrower than its name, in two ways. It covers the `.test.ts`
-file itself and nothing beside it: a helper module under `test/` — shared
-setup, a fake, a builder for test values — is an ordinary file, and gets a
-header on the ordinary terms. And it is a default rather than a bar. A test
+The exemption is narrower than its name, in two ways. It covers the unit test
+file itself, `.test.ts` or `.test.tsx`, and nothing beside it: a helper module
+under `test/` — shared setup, a fake, a builder for test values — is an
+ordinary file, and gets a header on the ordinary terms. A pattern test is a
+different form, as [`unit-test-coding-style.md`](unit-test-coding-style.md)
+says, and is not what this names. And it is a default rather than a bar. A test
 file that does something a reader would not guess from its name — walks a
 generated corpus, drives the code under test from a second runtime, checks two
 implementations against each other — has something to say about itself that no

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -258,7 +258,9 @@ Three nearby shapes are not this one:
 - A comment describing the **file** rather than any block in it is a file
   header. It goes at the top of the file as a doc comment, per
   [File headers](code-comment-style.md#file-headers), and not above the
-  top-level `describe()`.
+  top-level `describe()`. That section is also what says a test file is not
+  owed one: a header that would only name the file under test, or restate its
+  contract, is left out.
 - A [section marker](code-comment-style.md#section-markers) titles a region of
   the file holding several blocks. Reach is what tells the two apart, not
   length or subject matter.

--- a/skills/cf-review/SKILL.md
+++ b/skills/cf-review/SKILL.md
@@ -231,7 +231,9 @@ equally a thing a diff shows you. A file header is a doc comment at the very
 top, above the first `import` and the first `export`; a new file carrying none,
 or carrying one written as a `//` block or parked below the import block, is a
 finding nothing else in the file will point you at. See the same document, "File
-headers".
+headers", for the four kinds of file that carry none by design — a unit test
+file among them, since a header that would only name the file under test is left
+out — before writing the finding.
 
 ### 6. Craft & conventions
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

`docs/development/code-comment-style.md` § File headers names four kinds of file that carry no header by design, up from three. The new one is the unit test file itself. Its name and its top-level `describe()` already say what it tests, so the header a typical one could carry would either name the file under test or restate a contract that file documents, and neither is worth the slot.

The exemption is scoped in two ways:

* It covers the `.test.ts` file itself, not helper modules beside it. Shared setup, fakes, and builders under `test/` are ordinary files and get a header on the ordinary terms.
* It is a default, not a bar. A test file doing something a reader would not guess from its name (walking a generated corpus, driving the code from a second runtime, cross-checking two implementations) has something non-vacuous to say about itself, and says it in a header.

The re-export barrel and the content-is-the-point fixture, previously named in one shared sentence, each get a paragraph of their own saying why the header adds nothing, in the same shape as the other exemptions.

Two places echo the rule and follow it:

* The `cf-review` skill's missing-header finding now points at the exempt kinds before the finding is written.
* `docs/development/unit-test-coding-style.md`'s note on file-describing comments says a test file is not owed one.

## Verification

Prose only; no code block changed. `deno task check-docs` (596 blocks), `deno task check-skill-facts`, and `deno task check-conflict-markers` all pass. `deno fmt --check` passes on the skill file; `docs/` is excluded from fmt, so the two documents were checked by hand: every added line is at or under 80 characters.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


