### PR TITLE
test(cf-harness): read back the denial that hides opaque stdout

### DIFF
--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -7558,6 +7558,114 @@ Deno.test("CfHarnessPromptLoop ignores opaque and denied CFC observations for mo
   );
 });
 
+Deno.test("CfHarnessPromptLoop withholds opaque CFC stdout from the model", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const opaqueLabel = "did:key:opaque-stdout";
+  const printedBytes = "withheld-stdout-marker";
+  const withheldByteLength = new TextEncoder()
+    .encode(`${printedBytes}\n`).length;
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      // The sandbox prints these bytes and CFC marks the stdout channel
+      // opaque. stderr and the exit code stay observed, which isolates the
+      // stdout channel; the docker route marks all three of a command's
+      // channels together, so this shape comes from the contract rather than
+      // from that route.
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: `${printedBytes}\n`,
+          stderr: "",
+          exitCode: 0,
+          cfcResult: {
+            ...observedCfcResult(""),
+            stdout: {
+              channel: "stdout",
+              policy: "opaque",
+              label: { confidentiality: [opaqueLabel] },
+              byteLength: withheldByteLength,
+            },
+          },
+        },
+      ]),
+      runId: "run-cfc-opaque-stdout-withheld",
+      model: "gpt-5.4",
+      // The strictest rung, which is the posture this case is written for.
+      // Mediation of a CFC result runs at every rung, so each assertion below
+      // holds under all four.
+      cfcEnforcementMode: "enforce-strict",
+    }),
+    fetchFn: twoTurnBashFetch(
+      fetchCalls,
+      { command: "cat opaque.txt" },
+      "The output was withheld.",
+    ),
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Read the opaque file.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  // Withholding a stream is mediation rather than a denial, so the run
+  // carries on and the model gets the second turn that reads the result.
+  assertEquals(result.runState.status, "completed");
+  assertEquals(result.runState.policyEvents, []);
+  assertEquals(fetchCalls.length, 2);
+  const secondBody = String(fetchCalls[1]?.body);
+  const toolMessage = chatViewOfRequest(JSON.parse(secondBody)).messages.at(-1);
+  assert(toolMessage !== undefined && toolMessage.role === "tool");
+  assertEquals(toolMessage.tool_call_id, "call-1");
+  // The bytes are absent from the whole request, not only from the message
+  // the exact match below pins.
+  assertEquals(secondBody.includes(printedBytes), false);
+  // What the model reads in place of the bytes. The `denied` policy renders a
+  // denial through the same `stdout` field, so the reason and the handle's
+  // `passThrough` flag are what tell the two apart. Pinning the whole message
+  // also pins the `cfc` descriptor, which is where the label and the size of
+  // what was withheld travel.
+  const content = JSON.parse(toolMessage.content);
+  assertEquals(content, {
+    outputId: "run-cfc-opaque-stdout-withheld:bash:1",
+    stdout: {
+      type: "cf-harness.observation-denied",
+      reason: "needs-opaque-pass-through",
+      detail: "stdout was not released by CFC policy",
+      handle: {
+        type: "cf-harness.opaque-handle",
+        handleId: "run-cfc-opaque-stdout-withheld:bash:1:stdout",
+        scope: "run",
+        createdAt: content.stdout?.handle?.createdAt,
+        passThrough: true,
+      },
+    },
+    stderr: "",
+    exitCode: 0,
+    cwd: "/workspace",
+    cfc: {
+      version: 1,
+      stdout: {
+        channel: "stdout",
+        policy: "opaque",
+        label: { confidentiality: [opaqueLabel] },
+        byteLength: withheldByteLength,
+      },
+      stderr: {
+        channel: "stderr",
+        policy: "observed",
+        label: { confidentiality: ["public"] },
+      },
+      exitCode: {
+        policy: "observed",
+        label: { confidentiality: ["public"] },
+        value: 0,
+      },
+    },
+  });
+  // The released direction is covered by "exposes mediated bash output
+  // instead of raw stdout in enforce mode" earlier in this file.
+});
+
 Deno.test("CfHarnessPromptLoop returns observation-denied tool content in enforce-explicit mode", async () => {
   const fetchCalls: RequestInit[] = [];
   const loop = new CfHarnessPromptLoop({

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -10,6 +10,7 @@ import { parentToolIdsForBacking } from "../src/contracts/tool-descriptor.ts";
 import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
 
+import { CFC_ENFORCEMENT_MODES } from "@commonfabric/runner/cfc";
 import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 
 import {
@@ -7558,110 +7559,115 @@ Deno.test("CfHarnessPromptLoop ignores opaque and denied CFC observations for mo
   );
 });
 
-Deno.test("CfHarnessPromptLoop withholds opaque CFC stdout from the model", async () => {
-  const fetchCalls: RequestInit[] = [];
+Deno.test("CfHarnessPromptLoop withholds opaque CFC stdout from the model", async (t) => {
   const opaqueLabel = "did:key:opaque-stdout";
   const printedBytes = "withheld-stdout-marker";
   const withheldByteLength = new TextEncoder()
     .encode(`${printedBytes}\n`).length;
-  const loop = new CfHarnessPromptLoop({
-    apiKey: "test-key",
-    engine: new CfHarnessEngine({
-      // The sandbox prints these bytes and CFC marks the stdout channel
-      // opaque. stderr and the exit code stay observed, which isolates the
-      // stdout channel; the docker route marks all three of a command's
-      // channels together, so this shape comes from the contract rather than
-      // from that route.
-      sandboxRuntime: new FakeSandboxRuntime([
-        {
-          stdout: `${printedBytes}\n`,
-          stderr: "",
-          exitCode: 0,
-          cfcResult: {
-            ...observedCfcResult(""),
-            stdout: {
-              channel: "stdout",
-              policy: "opaque",
-              label: { confidentiality: [opaqueLabel] },
-              byteLength: withheldByteLength,
+  // Mediation of a CFC result does not consult the enforcement rung. A rung
+  // that released the bytes would be a hole in the boundary this case guards,
+  // so each one runs the same assertions, and a rung added later joins them.
+  for (const cfcEnforcementMode of CFC_ENFORCEMENT_MODES) {
+    await t.step(cfcEnforcementMode, async () => {
+      const fetchCalls: RequestInit[] = [];
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          // The sandbox prints these bytes and CFC marks the stdout channel
+          // opaque. stderr and the exit code stay observed, which isolates the
+          // stdout channel; the docker route marks all three of a command's
+          // channels together, so this shape comes from the contract rather
+          // than from that route.
+          sandboxRuntime: new FakeSandboxRuntime([
+            {
+              stdout: `${printedBytes}\n`,
+              stderr: "",
+              exitCode: 0,
+              cfcResult: {
+                ...observedCfcResult(""),
+                stdout: {
+                  channel: "stdout",
+                  policy: "opaque",
+                  label: { confidentiality: [opaqueLabel] },
+                  byteLength: withheldByteLength,
+                },
+              },
             },
+          ]),
+          runId: "run-cfc-opaque-stdout-withheld",
+          model: "gpt-5.4",
+          cfcEnforcementMode,
+        }),
+        fetchFn: twoTurnBashFetch(
+          fetchCalls,
+          { command: "cat opaque.txt" },
+          "The output was withheld.",
+        ),
+      });
+
+      const result = await loop.runPrompt({
+        prompt: "Read the opaque file.",
+        promptSlotBinding: directPromptSlotBinding,
+      });
+
+      // Withholding a stream is mediation rather than a denial, so the run
+      // carries on and the model gets the second turn that reads the result.
+      assertEquals(result.runState.status, "completed");
+      assertEquals(result.runState.policyEvents, []);
+      assertEquals(fetchCalls.length, 2);
+      const secondBody = String(fetchCalls[1]?.body);
+      const toolMessage = chatViewOfRequest(JSON.parse(secondBody))
+        .messages.at(-1);
+      assert(toolMessage !== undefined && toolMessage.role === "tool");
+      assertEquals(toolMessage.tool_call_id, "call-1");
+      // The bytes are absent from the whole request, not only from the message
+      // the exact match below pins.
+      assertEquals(secondBody.includes(printedBytes), false);
+      // What the model reads in place of the bytes. The `denied` policy
+      // renders a denial through the same `stdout` field, so the reason and
+      // the handle's `passThrough` flag are what tell the two apart. Pinning
+      // the whole message also pins the `cfc` descriptor, which is where the
+      // label and the size of what was withheld travel.
+      const content = JSON.parse(toolMessage.content);
+      assertEquals(content, {
+        outputId: "run-cfc-opaque-stdout-withheld:bash:1",
+        stdout: {
+          type: "cf-harness.observation-denied",
+          reason: "needs-opaque-pass-through",
+          detail: "stdout was not released by CFC policy",
+          handle: {
+            type: "cf-harness.opaque-handle",
+            handleId: "run-cfc-opaque-stdout-withheld:bash:1:stdout",
+            scope: "run",
+            createdAt: content.stdout?.handle?.createdAt,
+            passThrough: true,
           },
         },
-      ]),
-      runId: "run-cfc-opaque-stdout-withheld",
-      model: "gpt-5.4",
-      // The strictest rung, which is the posture this case is written for.
-      // Mediation of a CFC result runs at every rung, so each assertion below
-      // holds under all four.
-      cfcEnforcementMode: "enforce-strict",
-    }),
-    fetchFn: twoTurnBashFetch(
-      fetchCalls,
-      { command: "cat opaque.txt" },
-      "The output was withheld.",
-    ),
-  });
-
-  const result = await loop.runPrompt({
-    prompt: "Read the opaque file.",
-    promptSlotBinding: directPromptSlotBinding,
-  });
-
-  // Withholding a stream is mediation rather than a denial, so the run
-  // carries on and the model gets the second turn that reads the result.
-  assertEquals(result.runState.status, "completed");
-  assertEquals(result.runState.policyEvents, []);
-  assertEquals(fetchCalls.length, 2);
-  const secondBody = String(fetchCalls[1]?.body);
-  const toolMessage = chatViewOfRequest(JSON.parse(secondBody)).messages.at(-1);
-  assert(toolMessage !== undefined && toolMessage.role === "tool");
-  assertEquals(toolMessage.tool_call_id, "call-1");
-  // The bytes are absent from the whole request, not only from the message
-  // the exact match below pins.
-  assertEquals(secondBody.includes(printedBytes), false);
-  // What the model reads in place of the bytes. The `denied` policy renders a
-  // denial through the same `stdout` field, so the reason and the handle's
-  // `passThrough` flag are what tell the two apart. Pinning the whole message
-  // also pins the `cfc` descriptor, which is where the label and the size of
-  // what was withheld travel.
-  const content = JSON.parse(toolMessage.content);
-  assertEquals(content, {
-    outputId: "run-cfc-opaque-stdout-withheld:bash:1",
-    stdout: {
-      type: "cf-harness.observation-denied",
-      reason: "needs-opaque-pass-through",
-      detail: "stdout was not released by CFC policy",
-      handle: {
-        type: "cf-harness.opaque-handle",
-        handleId: "run-cfc-opaque-stdout-withheld:bash:1:stdout",
-        scope: "run",
-        createdAt: content.stdout?.handle?.createdAt,
-        passThrough: true,
-      },
-    },
-    stderr: "",
-    exitCode: 0,
-    cwd: "/workspace",
-    cfc: {
-      version: 1,
-      stdout: {
-        channel: "stdout",
-        policy: "opaque",
-        label: { confidentiality: [opaqueLabel] },
-        byteLength: withheldByteLength,
-      },
-      stderr: {
-        channel: "stderr",
-        policy: "observed",
-        label: { confidentiality: ["public"] },
-      },
-      exitCode: {
-        policy: "observed",
-        label: { confidentiality: ["public"] },
-        value: 0,
-      },
-    },
-  });
+        stderr: "",
+        exitCode: 0,
+        cwd: "/workspace",
+        cfc: {
+          version: 1,
+          stdout: {
+            channel: "stdout",
+            policy: "opaque",
+            label: { confidentiality: [opaqueLabel] },
+            byteLength: withheldByteLength,
+          },
+          stderr: {
+            channel: "stderr",
+            policy: "observed",
+            label: { confidentiality: ["public"] },
+          },
+          exitCode: {
+            policy: "observed",
+            label: { confidentiality: ["public"] },
+            value: 0,
+          },
+        },
+      });
+    });
+  }
   // The released direction is covered by "exposes mediated bash output
   // instead of raw stdout in enforce mode" earlier in this file.
 });


### PR DESCRIPTION
When CFC marks a sandboxed command's stdout opaque, the prompt loop replaces the printed bytes with an `ObservationDenied` carrying the reason `needs-opaque-pass-through`, so a command that printed a labeled secret sends the model a denial rather than the secret. Nothing asserted that. The case that used to, "prompt loop withholds tainted bash stdout from model", lived under `packages/cf-harness/integration/` and needed a host Docker daemon configured with the `runsc-cfc` gVisor runtime, which the repository neither builds nor fetches, so it never ran.

The property needs no runtime. This adds a unit case beside the existing "ignores opaque and denied CFC observations for model context", which already drives a fake sandbox printing bytes under an opaque stdout observation but stops at the label accumulator. The new case reads what the model was sent. The printed bytes appear nowhere in the request body, and one match against the whole tool message pins what arrives in their place: the `cf-harness.observation-denied`, its reason, and the opaque handle carrying `passThrough`.

Both of those fields are load-bearing. `observationDeniedForStream` separates the opaque policy from the denied one in two places, the reason and `passThrough`, so a case reading only the denial type passes under either policy, and a case reading only the reason admits a handle saying the bytes cannot be passed onward while the reason says they can. Matching the whole message also pins the `cfc` descriptor, which is where the confidentiality label and the size of what was withheld travel.

Checked by mutating `src/prompt-loop.ts` three ways and running the case against each. Releasing the raw bytes for an opaque stdout fails on the request-body check. Collapsing the reason to `not-observable`, and building the handle without `passThrough`, each fail on the message match at that field. The case was also run at each of the four enforcement rungs, since mediation of a CFC result runs at all of them and the comment beside the rung it names says so.

The released direction stays where it is, in "exposes mediated bash output instead of raw stdout in enforce mode".

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

