### PR TITLE
fix(runner): expression builtins key their result store on the output spot

### DIFF
--- a/packages/runner/src/builtins/if-else.ts
+++ b/packages/runner/src/builtins/if-else.ts
@@ -3,12 +3,12 @@ import { internSchema } from "@commonfabric/data-model-schema";
 import { type Cell } from "../cell.ts";
 import { resolveLink } from "../link-resolution.ts";
 import { parseLink } from "../link-utils.ts";
-import { type RawBuiltinResult } from "../module.ts";
+import { type RawBuiltinResult, type RawNodeCause } from "../module.ts";
 import { type Runtime } from "../runtime.ts";
 import { type Action } from "../scheduler.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { ownedCell } from "./runtime-owned-store.ts";
-import { resolvedCellScope } from "./scope-policy.ts";
+import { ownedResultCause, resolvedCellScope } from "./scope-policy.ts";
 
 /**
  * Argument schema for ifElse. The action value-reads ONLY `condition`; the
@@ -38,7 +38,7 @@ export function ifElse(
   inputsCell: Cell<[any, any, any]>,
   sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
   _addCancel: (cancel: () => void) => void,
-  cause: Cell<any>[],
+  cause: RawNodeCause,
   parentCell: Cell<any>,
   runtime: Runtime, // Runtime will be injected by the registration function
 ): RawBuiltinResult {
@@ -56,11 +56,14 @@ export function ifElse(
   const action: Action = (tx: IExtendedStorageTransaction) => {
     const { cell: conditionCell, value: condition } = readCondition(tx);
     const resultScope = resolvedCellScope(runtime, tx, conditionCell);
+    // Keyed on the output spot, never on the inputs document: every runtime
+    // sharing the piece must mint this one store, whatever its vintage
+    // serializes the inputs as (see `ownedResultCause`).
     const result = ownedCell<any>(
       runtime,
       tx,
       parentCell,
-      { ifElse: cause },
+      ownedResultCause("ifElse", cause, parentCell),
       undefined,
       resultScope,
     );

--- a/packages/runner/src/builtins/scope-policy.ts
+++ b/packages/runner/src/builtins/scope-policy.ts
@@ -55,18 +55,12 @@ export function outputSpotFromBinding(
 }
 
 /**
- * The cause an expression builtin (`ifElse`, `when`, `unless`) mints its
- * result store under: the piece that owns it and the output spot it fills —
- * the coordinates the list builtins key their container on — and nothing
- * else. Left out on purpose is the node's inputs document (`cause.inputs`):
- * its id is content-addressed on the serialized inputs, so it moves with a
- * branch literal, with a bound link's schema form, and with the runtime's own
- * serialization from one vintage to the next. The store's id is what every
- * runtime sharing the piece writes into the spot, so an id that moves is a
- * store two runtimes disagree on, and two runtimes disagreeing on one shared
- * spot rewrite it against each other, one commit per round trip each, for as
- * long as both run. The Topics board's profile badge — an `ifElse` over a
- * per-user condition — ran that storm across the 2026-09-03 deploy.
+ * Returns an expression builtin's result-store cause from its operation,
+ * owning piece, and output coordinates. The cause stays equal across changes
+ * to the serialized inputs while the owning piece and output spot are
+ * unchanged.
+ *
+ * Throws if the node's output binding has no write redirect.
  */
 export function ownedResultCause(
   op: "ifElse" | "when" | "unless",

--- a/packages/runner/src/builtins/scope-policy.ts
+++ b/packages/runner/src/builtins/scope-policy.ts
@@ -4,6 +4,7 @@ import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { CellScope } from "../builder/types.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
+import type { RawNodeCause } from "../module.ts";
 import { resolveLink } from "../link-resolution.ts";
 import {
   linkResolutionProbe,
@@ -51,6 +52,33 @@ export function outputSpotFromBinding(
 ): { space: string; id: string; path: readonly unknown[] } | undefined {
   if (!binding) return undefined;
   return { space: binding.space, id: binding.id, path: [...binding.path] };
+}
+
+/**
+ * The cause an expression builtin (`ifElse`, `when`, `unless`) mints its
+ * result store under: the piece that owns it and the output spot it fills —
+ * the coordinates the list builtins key their container on — and nothing
+ * else. Left out on purpose is the node's inputs document (`cause.inputs`):
+ * its id is content-addressed on the serialized inputs, so it moves with a
+ * branch literal, with a bound link's schema form, and with the runtime's own
+ * serialization from one vintage to the next. The store's id is what every
+ * runtime sharing the piece writes into the spot, so an id that moves is a
+ * store two runtimes disagree on, and two runtimes disagreeing on one shared
+ * spot rewrite it against each other, one commit per round trip each, for as
+ * long as both run. The Topics board's profile badge — an `ifElse` over a
+ * per-user condition — ran that storm across the 2026-09-03 deploy.
+ */
+export function ownedResultCause(
+  op: "ifElse" | "when" | "unless",
+  cause: RawNodeCause,
+  parentCell: Cell<any>,
+): Record<string, unknown> {
+  if (!cause.outputSpot) {
+    throw new Error(
+      `${op}: result store requires a write-redirect output binding`,
+    );
+  }
+  return { [op]: parentCell.entityId, outputSpot: cause.outputSpot };
 }
 
 export function cellIdentityKey(cell: Cell<any>): {

--- a/packages/runner/src/builtins/unless.ts
+++ b/packages/runner/src/builtins/unless.ts
@@ -4,8 +4,9 @@ import { type Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { resolveLink } from "../link-resolution.ts";
 import { ownedCell } from "./runtime-owned-store.ts";
-import { resolvedCellScope } from "./scope-policy.ts";
+import { ownedResultCause, resolvedCellScope } from "./scope-policy.ts";
 import { parseLink } from "../link-utils.ts";
+import type { RawNodeCause } from "../module.ts";
 
 /**
  * unless(condition, fallback) - || semantics
@@ -15,18 +16,20 @@ export function unless(
   inputsCell: Cell<{ condition: any; fallback: any }>,
   sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
   _addCancel: (cancel: () => void) => void,
-  cause: Cell<any>[],
+  cause: RawNodeCause,
   parentCell: Cell<any>,
   runtime: Runtime,
 ): Action {
   return (tx: IExtendedStorageTransaction) => {
     const conditionCell = inputsCell.key("condition");
     const resultScope = resolvedCellScope(runtime, tx, conditionCell);
+    // Keyed on the output spot, never on the inputs document (see
+    // `ownedResultCause`).
     const result = ownedCell<any>(
       runtime,
       tx,
       parentCell,
-      { unless: cause },
+      ownedResultCause("unless", cause, parentCell),
       undefined,
       resultScope,
     );

--- a/packages/runner/src/builtins/when.ts
+++ b/packages/runner/src/builtins/when.ts
@@ -4,8 +4,9 @@ import { type Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { resolveLink } from "../link-resolution.ts";
 import { ownedCell } from "./runtime-owned-store.ts";
-import { resolvedCellScope } from "./scope-policy.ts";
+import { ownedResultCause, resolvedCellScope } from "./scope-policy.ts";
 import { parseLink } from "../link-utils.ts";
+import type { RawNodeCause } from "../module.ts";
 
 /**
  * when(condition, value) - && semantics
@@ -15,18 +16,20 @@ export function when(
   inputsCell: Cell<{ condition: any; value: any }>,
   sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
   _addCancel: (cancel: () => void) => void,
-  cause: Cell<any>[],
+  cause: RawNodeCause,
   parentCell: Cell<any>,
   runtime: Runtime,
 ): Action {
   return (tx: IExtendedStorageTransaction) => {
     const conditionCell = inputsCell.key("condition");
     const resultScope = resolvedCellScope(runtime, tx, conditionCell);
+    // Keyed on the output spot, never on the inputs document (see
+    // `ownedResultCause`).
     const result = ownedCell<any>(
       runtime,
       tx,
       parentCell,
-      { when: cause },
+      ownedResultCause("when", cause, parentCell),
       undefined,
       resultScope,
     );

--- a/packages/runner/src/module.ts
+++ b/packages/runner/src/module.ts
@@ -163,6 +163,38 @@ export interface RawModuleOptions {
   argumentSchema?: JSONSchema;
 }
 
+/**
+ * What the runner hands a raw builtin as its `cause`: the coordinates naming
+ * the node it runs as. A builtin that mints a store of its own (`ownedCell`)
+ * keys the store on some of these, and the key must not move: the store's id
+ * is what every runtime sharing the piece writes into the node's output spot,
+ * so two runtimes that derive two ids for one node rewrite that spot against
+ * each other for as long as both run.
+ *
+ * `outputSpot` is the coordinate to key on: the write redirect the node's
+ * output binding resolves to, position-derived, the same across pattern edits
+ * and runtime vintages (CT-1623; the list builtins key their container on
+ * it). `inputs` is not: it is the inputs document, content-addressed on the
+ * serialized inputs, so its id moves with a branch literal, with a bound
+ * link's schema form, and with the serialization itself from one vintage to
+ * the next.
+ *
+ * `raw()` still declares the parameter `any`: most builtins declare it
+ * `Cell<any>[]`, which it has never been, and typing the seam is a change of
+ * its own.
+ */
+export interface RawNodeCause {
+  /** The node's immutable inputs document (`Runtime.getImmutableCell`). */
+  inputs: Cell<any>;
+  /** The piece's result cell, which owns every store the node mints. */
+  parents: Cell<any>["entityId"];
+  /**
+   * The node's output spot, scope and schema dropped. Absent only for a node
+   * whose output binding reaches no write redirect.
+   */
+  outputSpot?: { space: string; id: string; path: readonly unknown[] };
+}
+
 // This corresponds to the node factory factories in common-builder:module.ts.
 // But it's here, because the signature depends on implementation details of the
 // runner, and won't work with any other runners.

--- a/packages/runner/src/module.ts
+++ b/packages/runner/src/module.ts
@@ -164,30 +164,23 @@ export interface RawModuleOptions {
 }
 
 /**
- * What the runner hands a raw builtin as its `cause`: the coordinates naming
- * the node it runs as. A builtin that mints a store of its own (`ownedCell`)
- * keys the store on some of these, and the key must not move: the store's id
- * is what every runtime sharing the piece writes into the node's output spot,
- * so two runtimes that derive two ids for one node rewrite that spot against
- * each other for as long as both run.
+ * The inputs, owner, and output coordinates supplied to a raw builtin.
  *
- * `outputSpot` is the coordinate to key on: the write redirect the node's
- * output binding resolves to, position-derived, the same across pattern edits
- * and runtime vintages (CT-1623; the list builtins key their container on
- * it). `inputs` is not: it is the inputs document, content-addressed on the
- * serialized inputs, so its id moves with a branch literal, with a bound
- * link's schema form, and with the serialization itself from one vintage to
- * the next.
+ * `outputSpot` identifies the write redirect the output binding resolves to.
+ * A result store keyed on the owner and these coordinates keeps its identity
+ * while the output spot is unchanged. Renaming or reordering nodes can change
+ * their output coordinates and therefore their result-store identities.
  *
- * `raw()` still declares the parameter `any`: most builtins declare it
- * `Cell<any>[]`, which it has never been, and typing the seam is a change of
- * its own.
+ * `inputs` is content-addressed on the serialized inputs, so its identity can
+ * change with branch literals, link schemas, or runtime serialization.
  */
 export interface RawNodeCause {
-  /** The node's immutable inputs document (`Runtime.getImmutableCell`). */
+  /** The node's immutable inputs document. */
   inputs: Cell<any>;
+
   /** The piece's result cell, which owns every store the node mints. */
   parents: Cell<any>["entityId"];
+
   /**
    * The node's output spot, scope and schema dropped. Absent only for a node
    * whose output binding reaches no write redirect.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -98,7 +98,11 @@ import {
   parseLink,
   toMemorySpaceAddress,
 } from "./link-utils.ts";
-import { isRawBuiltinResult, type RawBuiltinReturnType } from "./module.ts";
+import {
+  isRawBuiltinResult,
+  type RawBuiltinReturnType,
+  type RawNodeCause,
+} from "./module.ts";
 import { runtimeOwnedStoreOwnerKey } from "./cfc/runtime-owned-stores.ts";
 import {
   resolveScopeKey,
@@ -10016,7 +10020,7 @@ export class Runner {
               },
             }
             : {}),
-        },
+        } satisfies RawNodeCause,
         resultCell,
         this.#runtime,
         outputBinding,

--- a/packages/runner/test/expression-builtin-result-identity.test.ts
+++ b/packages/runner/test/expression-builtin-result-identity.test.ts
@@ -1,0 +1,168 @@
+// The result store an expression builtin (`ifElse`, `when`, `unless`) mints
+// is named by the spot it fills, not by what fills it. The store's id is what
+// every runtime sharing the piece writes into the node's output spot, so an
+// id that moved with the inputs' serialization was a store two runtimes could
+// disagree on — and two runtimes disagreeing on one shared spot rewrite it
+// against each other for as long as both run. That storm ran on the Topics
+// board's profile badge across the 2026-09-03 deploy: the badge is an `ifElse`
+// over a per-user condition, and clients on the two vintages serialized the
+// node's inputs differently.
+//
+// A pattern edit that changes only a branch literal stands in for that
+// vintage change here: the inputs document moves, the output spot does not.
+
+import { assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type { NodeFactory } from "../src/builder/types.ts";
+import { type Cell, createCell } from "../src/cell.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+type Builder = ReturnType<typeof createTrustedBuilder>["commonfabric"];
+type Root = NodeFactory<{ condition: boolean }, { value: unknown }>;
+
+/**
+ * Runs `first` into a fresh piece over a user-scoped `condition`, then edits
+ * the piece to `second`, and returns the link stored in the `value` spot after
+ * each run together with the value it resolved to.
+ */
+async function acrossEdit(
+  op: string,
+  condition: boolean,
+  build: (builder: Builder) => { first: Root; second: Root },
+) {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+  try {
+    const { first, second } = build(createTrustedBuilder(runtime).commonfabric);
+    const conditionBase = runtime.getCell<boolean>(
+      space,
+      `${op} result identity condition`,
+      undefined,
+      tx,
+    );
+    const conditionCell = createCell<boolean>(
+      runtime,
+      { ...conditionBase.getAsNormalizedFullLink(), scope: "user" },
+      tx,
+    );
+    conditionCell.set(condition);
+    const resultCell = runtime.getCell<{ value: unknown }>(
+      space,
+      `${op} result identity`,
+      undefined,
+      tx,
+    );
+    const stored = (result: Cell<{ value: unknown }>) => {
+      const link = parseLink(
+        result.key("value").getRaw({ lastNode: "writeRedirect" }),
+        result,
+      );
+      return {
+        id: link?.id,
+        scope: link?.scope,
+        value: result.key("value").get(),
+      };
+    };
+
+    const result = runtime.run(
+      tx,
+      first,
+      { condition: conditionCell },
+      resultCell,
+    );
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+    const before = stored(result);
+
+    const editTx = runtime.edit();
+    const edited = runtime.run(
+      editTx,
+      second,
+      { condition: conditionCell },
+      resultCell,
+    );
+    runtime.prepareTxForCommit(editTx);
+    await editTx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await edited.pull();
+    const after = stored(edited);
+    return { before, after };
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+}
+
+Deno.test("ifElse keeps its result store across an edit of its branches", async () => {
+  const { before, after } = await acrossEdit(
+    "ifElse",
+    true,
+    ({ ifElse, pattern }) => ({
+      first: pattern<{ condition: boolean }>(({ condition }) => ({
+        value: ifElse(condition, "left-1", "right-1"),
+      })),
+      second: pattern<{ condition: boolean }>(({ condition }) => ({
+        value: ifElse(condition, "left-2", "right-2"),
+      })),
+    }),
+  );
+  assertEquals(before.value, "left-1");
+  assertEquals(after.value, "left-2");
+  // The store follows the condition's scope (scoped-cell-instances.md) …
+  assertEquals(before.scope, "user");
+  assertEquals(after.scope, "user");
+  // … and the shared spot names the same store before and after the edit.
+  assertEquals(after.id, before.id);
+});
+
+Deno.test("when keeps its result store across an edit of its value", async () => {
+  const { before, after } = await acrossEdit(
+    "when",
+    true,
+    ({ when, pattern }) => ({
+      first: pattern<{ condition: boolean }>(({ condition }) => ({
+        value: when(condition, "value-1"),
+      })),
+      second: pattern<{ condition: boolean }>(({ condition }) => ({
+        value: when(condition, "value-2"),
+      })),
+    }),
+  );
+  assertEquals(before.value, "value-1");
+  assertEquals(after.value, "value-2");
+  assertEquals(before.scope, "user");
+  assertEquals(after.id, before.id);
+});
+
+Deno.test("unless keeps its result store across an edit of its fallback", async () => {
+  const { before, after } = await acrossEdit(
+    "unless",
+    false,
+    ({ unless, pattern }) => ({
+      first: pattern<{ condition: boolean }>(({ condition }) => ({
+        value: unless(condition, "fallback-1"),
+      })),
+      second: pattern<{ condition: boolean }>(({ condition }) => ({
+        value: unless(condition, "fallback-2"),
+      })),
+    }),
+  );
+  assertEquals(before.value, "fallback-1");
+  assertEquals(after.value, "fallback-2");
+  assertEquals(before.scope, "user");
+  assertEquals(after.id, before.id);
+});

--- a/packages/runner/test/expression-builtin-result-identity.test.ts
+++ b/packages/runner/test/expression-builtin-result-identity.test.ts
@@ -14,7 +14,9 @@
 import { assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { assertThrows } from "@std/assert";
 import type { NodeFactory } from "../src/builder/types.ts";
+import { ownedResultCause } from "../src/builtins/scope-policy.ts";
 import { type Cell, createCell } from "../src/cell.ts";
 import { parseLink } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -165,4 +167,30 @@ Deno.test("unless keeps its result store across an edit of its fallback", async 
   assertEquals(after.value, "fallback-2");
   assertEquals(before.scope, "user");
   assertEquals(after.id, before.id);
+});
+
+Deno.test("an expression builtin with no output spot has no store to name", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    const piece = runtime.getCell(space, "no output spot");
+    const inputs = runtime.getImmutableCell(space, { condition: true });
+    // A node whose output binding reaches no write redirect: nothing reads
+    // the spot, so nothing can name the store every runtime must share.
+    assertThrows(
+      () =>
+        ownedResultCause("ifElse", {
+          inputs,
+          parents: piece.entityId,
+        }, piece),
+      Error,
+      "ifElse: result store requires a write-redirect output binding",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
 });

--- a/packages/runner/test/expression-builtin-result-identity.test.ts
+++ b/packages/runner/test/expression-builtin-result-identity.test.ts
@@ -1,20 +1,14 @@
-// The result store an expression builtin (`ifElse`, `when`, `unless`) mints
-// is named by the spot it fills, not by what fills it. The store's id is what
-// every runtime sharing the piece writes into the node's output spot, so an
-// id that moved with the inputs' serialization was a store two runtimes could
-// disagree on — and two runtimes disagreeing on one shared spot rewrite it
-// against each other for as long as both run. That storm ran on the Topics
-// board's profile badge across the 2026-09-03 deploy: the badge is an `ifElse`
-// over a per-user condition, and clients on the two vintages serialized the
-// node's inputs differently.
-//
-// A pattern edit that changes only a branch literal stands in for that
-// vintage change here: the inputs document moves, the output spot does not.
+/**
+ * Expression result-store identity across branch-literal edits at a fixed
+ * output spot, with condition-scoped storage and a required output binding.
+ */
 
-import { assertEquals } from "@std/assert";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { assertThrows } from "@std/assert";
+
 import type { NodeFactory } from "../src/builder/types.ts";
 import { ownedResultCause } from "../src/builtins/scope-policy.ts";
 import { type Cell, createCell } from "../src/cell.ts";
@@ -109,88 +103,88 @@ async function acrossEdit(
   }
 }
 
-Deno.test("ifElse keeps its result store across an edit of its branches", async () => {
-  const { before, after } = await acrossEdit(
-    "ifElse",
-    true,
-    ({ ifElse, pattern }) => ({
-      first: pattern<{ condition: boolean }>(({ condition }) => ({
-        value: ifElse(condition, "left-1", "right-1"),
-      })),
-      second: pattern<{ condition: boolean }>(({ condition }) => ({
-        value: ifElse(condition, "left-2", "right-2"),
-      })),
-    }),
-  );
-  assertEquals(before.value, "left-1");
-  assertEquals(after.value, "left-2");
-  // The store follows the condition's scope (scoped-cell-instances.md) …
-  assertEquals(before.scope, "user");
-  assertEquals(after.scope, "user");
-  // … and the shared spot names the same store before and after the edit.
-  assertEquals(after.id, before.id);
-});
-
-Deno.test("when keeps its result store across an edit of its value", async () => {
-  const { before, after } = await acrossEdit(
-    "when",
-    true,
-    ({ when, pattern }) => ({
-      first: pattern<{ condition: boolean }>(({ condition }) => ({
-        value: when(condition, "value-1"),
-      })),
-      second: pattern<{ condition: boolean }>(({ condition }) => ({
-        value: when(condition, "value-2"),
-      })),
-    }),
-  );
-  assertEquals(before.value, "value-1");
-  assertEquals(after.value, "value-2");
-  assertEquals(before.scope, "user");
-  assertEquals(after.id, before.id);
-});
-
-Deno.test("unless keeps its result store across an edit of its fallback", async () => {
-  const { before, after } = await acrossEdit(
-    "unless",
-    false,
-    ({ unless, pattern }) => ({
-      first: pattern<{ condition: boolean }>(({ condition }) => ({
-        value: unless(condition, "fallback-1"),
-      })),
-      second: pattern<{ condition: boolean }>(({ condition }) => ({
-        value: unless(condition, "fallback-2"),
-      })),
-    }),
-  );
-  assertEquals(before.value, "fallback-1");
-  assertEquals(after.value, "fallback-2");
-  assertEquals(before.scope, "user");
-  assertEquals(after.id, before.id);
-});
-
-Deno.test("an expression builtin with no output spot has no store to name", async () => {
-  const storageManager = StorageManager.emulate({ as: signer });
-  const runtime = new Runtime({
-    apiUrl: new URL(import.meta.url),
-    storageManager,
+describe("expression-builtin-result-identity", () => {
+  it("keeps the `ifElse()` result store when branch literals change", async () => {
+    const { before, after } = await acrossEdit(
+      "ifElse",
+      true,
+      ({ ifElse, pattern }) => ({
+        first: pattern<{ condition: boolean }>(({ condition }) => ({
+          value: ifElse(condition, "left-1", "right-1"),
+        })),
+        second: pattern<{ condition: boolean }>(({ condition }) => ({
+          value: ifElse(condition, "left-2", "right-2"),
+        })),
+      }),
+    );
+    expect(before.value).toBe("left-1");
+    expect(after.value).toBe("left-2");
+    // The store follows the condition's scope (scoped-cell-instances.md).
+    expect(before.scope).toBe("user");
+    expect(after.scope).toBe("user");
+    expect(after.id).toBe(before.id);
   });
-  try {
-    const piece = runtime.getCell(space, "no output spot");
-    const inputs = runtime.getImmutableCell(space, { condition: true });
-    // A node whose output binding reaches no write redirect: nothing reads
-    // the spot, so nothing can name the store every runtime must share.
-    assertThrows(
-      () =>
+
+  it("keeps the `when()` result store when its value literal changes", async () => {
+    const { before, after } = await acrossEdit(
+      "when",
+      true,
+      ({ when, pattern }) => ({
+        first: pattern<{ condition: boolean }>(({ condition }) => ({
+          value: when(condition, "value-1"),
+        })),
+        second: pattern<{ condition: boolean }>(({ condition }) => ({
+          value: when(condition, "value-2"),
+        })),
+      }),
+    );
+    expect(before.value).toBe("value-1");
+    expect(after.value).toBe("value-2");
+    expect(before.scope).toBe("user");
+    expect(after.id).toBe(before.id);
+  });
+
+  it("keeps the `unless()` result store when its fallback literal changes", async () => {
+    const { before, after } = await acrossEdit(
+      "unless",
+      false,
+      ({ unless, pattern }) => ({
+        first: pattern<{ condition: boolean }>(({ condition }) => ({
+          value: unless(condition, "fallback-1"),
+        })),
+        second: pattern<{ condition: boolean }>(({ condition }) => ({
+          value: unless(condition, "fallback-2"),
+        })),
+      }),
+    );
+    expect(before.value).toBe("fallback-1");
+    expect(after.value).toBe("fallback-2");
+    expect(before.scope).toBe("user");
+    expect(after.id).toBe(before.id);
+  });
+
+  it("throws when the output binding has no write redirect", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const piece = runtime.getCell(space, "no output spot");
+      const inputs = runtime.getImmutableCell(space, { condition: true });
+      // A node whose output binding reaches no write redirect: nothing reads
+      // the spot, so nothing can name the store every runtime must share.
+      expect(() =>
         ownedResultCause("ifElse", {
           inputs,
           parents: piece.entityId,
-        }, piece),
-      Error,
-      "ifElse: result store requires a write-redirect output binding",
-    );
-  } finally {
-    await runtime.dispose();
-    await storageManager.close();
-  }
+        }, piece)
+      ).toThrow(
+        "ifElse: result store requires a write-redirect output binding",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
 });


### PR DESCRIPTION
## What

`ifElse`, `when` and `unless` mint a store of their own for their result (`ownedCell`), scoped to the condition. They keyed that store on the whole `cause` object the runner hands a raw node — which includes `inputs`, the node's immutable inputs document, content-addressed on the serialized inputs. So the store's id moved whenever the branch literals, a bound link's schema form, or the runtime's own serialization of the inputs changed.

This PR keys the store on the piece and the node's **output spot** instead — the position-derived coordinate the list builtins already key their container on (CT-1623) — and names what the runner hands a raw node as `RawNodeCause`, so the identity coordinate is stated in one place rather than implied by a comment on `raw()`. Store identity remains stable while the owning piece and output coordinates are unchanged; renaming or reordering nodes can change those coordinates.

## Why it matters

The store's id is what every runtime sharing the piece writes into the node's output spot. Two runtimes that mint two ids for one node rewrite that shared spot against each other, one commit per round trip each, for as long as both run.

That storm was live on the Topics board. Its profile badge is `ifElse(hasProfile, <badge/>, <div>{wish[UI]}</div>)` over a per-user condition, and the output spot (`$generated:3` → `computed:fid1:IXRq…`) is space-scoped. After the 2026-09-03 deploy, a client on the old vintage and a client on the new one minted different store ids for the same node and took turns overwriting the slot:

| principal (session prefix) | link written into the slot | commits, last 2,000 |
|---|---|---|
| `z6MkqyUt…` | `of:fid1:U91mg…` (pre-9/3 id) | 824 |
| `z6MkhiVr…` | `of:fid1:-re9sF…` (post-9/3 id) | 823 |

Cadence ≈ 2.4 s per principal — one network round trip. The clone taken before the deploy holds only `U91mg…`; the second id appears only afterwards. Every other writer on the space (the CLI's `addComment`, `addLink`, `addTopic`) queued behind the memory server's per-commit refresh of every open session's watches, which is where the 14 s of an 18 s `addLink` and 129 s of a 165 s `addTopic` went in the bracketed measurements on the tracking topic.

## The fix

- `ownedResultCause(op, cause, parentCell)` (`builtins/scope-policy.ts`, next to `outputSpotFromBinding`) returns `{ [op]: parentCell.entityId, outputSpot }` and refuses a node with no write-redirect output binding, as `listCoordinatorPlan` does.
- `ifElse`, `when`, `unless` mint their store under it. Scoping is unchanged: the store still follows the condition's resolved scope (`scoped-cell-instances.md`, "`ifElse` keeps condition scope").
- `RawNodeCause` (`module.ts`) names the object the runner builds; the runner's literal is checked against it with `satisfies`. `raw()`'s parameter stays `any` because most builtins still declare it `Cell<any>[]` (which it never was) — typing that seam is a change of its own.

## Test

`packages/runner/test/expression-builtin-result-identity.test.ts`: run a piece over a user-scoped condition, then edit it to a pattern that differs only in a branch literal, and assert the link stored in the output spot names the same store before and after (and stays user-scoped). The edit stands in for the vintage change: it moves the inputs document and nothing else. All three cases fail on `main` (three different ids) and pass here.

## Rollout note

Deploying this moves the three builtins' store ids one more time. Until clients on the current vintage reload, they and clients on this vintage disagree on the profile badge's store exactly as the two vintages do today — so this change does not eliminate the disagreement until those clients reload. Once clients use the new identity rule, differences in serialized inputs no longer fork the store at a fixed output spot. Edits that change the output coordinates can still change the store identity. Worth deploying at a quiet hour and asking people to reload.

## Not in this PR

- The same inputs-keyed cause is used by `inspectConfLabel`, `fetch*`, `streamData`, `llm*`, `compileAndRun`, `fetchProgram`. Those are non-replayable and their stores are not linked from shared spots the same way; no evidence of a storm, and re-keying them would move their ids for no measured gain. Flagged for a follow-up if one is wanted.
- Typing `raw()`'s `cause` parameter as `RawNodeCause` and fixing the 13 builtins that declare it `Cell<any>[]`.
- The memory server's per-commit refresh cost (the next PR in this series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


