### PR TITLE
feat(utils): `Constructor<T>` carries `prototype: T`

### DIFF
--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -84,8 +84,15 @@
  * `isFabricObjectOrArray()` for the same reason.
  */
 
-/** Standard type meaning constructor function, a/k/a "class object." */
-export type Constructor<T = unknown> = abstract new (...args: any[]) => T;
+/**
+ * The type of a class object, a/k/a constructor function: a class, abstract or
+ * concrete, whose instances are `T`. The `prototype` property is part of the
+ * shape so that a read of it is typed `T`; the `Function` interface alone
+ * would type it `any`.
+ */
+export type Constructor<T = unknown> =
+  & (abstract new (...args: any[]) => T)
+  & { prototype: T };
 
 /** Helper type to recursively add `readonly` properties to type `T`. */
 export type Immutable<T> = T extends ReadonlyArray<infer U>

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  type Constructor,
   isBoolean,
   isFiniteNumber,
   isFunction,
@@ -68,6 +69,42 @@ describe("types", () => {
       const _: Mutable<null> = null;
       const __: Mutable<number> = 5;
       const ___: Mutable<string> = "hi";
+    });
+  });
+
+  describe("Constructor", () => {
+    class Donut {
+      readonly glaze = "plain";
+    }
+
+    abstract class Fryer {
+      abstract fry(): void;
+    }
+
+    it("admits a concrete class and an abstract one", () => {
+      const concrete: Constructor<Donut> = Donut;
+      const abstractOne: Constructor<Fryer> = Fryer;
+      expect(concrete).toBe(Donut);
+      expect(abstractOne).toBe(Fryer);
+    });
+
+    it("types `.prototype` as the instance type", () => {
+      const ctor: Constructor<Donut> = Donut;
+      const proto: Donut = ctor.prototype;
+      expect(proto).toBe(Donut.prototype);
+    });
+
+    it("types `.prototype` as `unknown` given no instance type", () => {
+      const ctor: Constructor = Donut;
+      // @ts-expect-error `unknown` is not assignable to `Donut`.
+      const proto: Donut = ctor.prototype;
+      expect(proto).toBe(Donut.prototype);
+    });
+
+    it("refuses a class whose instances are not `T`", () => {
+      // @ts-expect-error a `Fryer` is not a `Donut`.
+      const ctor: Constructor<Donut> = Fryer;
+      expect(ctor).toBe(Fryer);
     });
   });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## What

`Constructor<T>` in `@commonfabric/utils/types` becomes

```ts
export type Constructor<T = unknown> =
  & (abstract new (...args: any[]) => T)
  & { prototype: T };
```

A construct-signature type reads `.prototype` through the global `Function` interface, which declares it `any`, so a read off a `Constructor` has been an untyped value that every assignment accepts. With the intersection the read is `T`, and `unknown` where no instance type is given. Every class is still assignable, abstract ones included, as are the builtins the tree hands to it (`Object`, `Array`, `Date`, `Error`, `Map`, `Uint8Array`, `RegExp`).

The doc comment says why the property is part of the shape. The `Constructor` group in the `utils` type tests pins assignability of a concrete and an abstract class, what `.prototype` reads as with and without an instance type, and that a class of the wrong instance type is refused.

Nothing else changes. The three sites that write `{ prototype: unknown }` by hand -- `constructorOfPrototype()`, `constructorOfObject()`, and `tagFromNativeBuiltinClass()`'s parameter -- stay as they are: each holds a `prototype.constructor` read, which is untyped data that nothing proves is constructible, so `Constructor` would overclaim there. A `Constructor` is assignable to that shape, which is the direction the callers need. `data-model/src/api.ts` declares its own `abstract new (...args: any) => X` intersections and imports nothing by design, being inlined into the pattern-visible type surface, so it keeps them.

## Verification

- Repo-wide `deno task check` green, and `deno check .` in `data-model`, whose codec registry and class rosters are the main consumers.
- `utils` suite (101 files) green, and lint on the two touched files.
- Against the old definition, the test file fails to type-check: the `unknown` case's `@ts-expect-error` reports as unused, since `.prototype` read as `any` there.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

