### PR TITLE
ci: one declaration of what a change reaches, for every consumer

### DIFF
--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -367,9 +367,9 @@ Answering "what does this item cover" belongs to the suite, because a
 unit that is not a path is one only its suite can map a diff onto. A
 suite whose units are files needs to say nothing: the diff naming the
 file is the whole of the question. A suite whose units are type-check
-groups or binaries maps the diff itself, and a suite that maps it wrongly
-runs too much or too little rather than reporting anything, so the answer
-errs toward running.
+groups, gate names, or binaries maps the diff itself, and a suite that
+maps it wrongly runs too much or too little rather than reporting
+anything, so the answer errs toward running.
 
 ### Today's jobs as suites
 
@@ -1431,12 +1431,32 @@ one of them that it does not say about a unit test. A gate above the
 flake threshold leaves the selectable set, and appears on the wall as the
 defect in the gate that it is.
 
-The exception the rule carries cannot fire for a gate. A gate's unit is
-the name of a gate rather than a path, and its suite maps no change onto
-its units, so nothing a pull request touches reaches one. A flaky gate
-therefore stays out of pull requests until it stops disagreeing with
-itself, and `main`, which runs the whole corpus, is where it goes on
-running until somebody fixes it.
+The exception the rule carries reaches a gate through the paths the gate
+declares a change reaches it by. A gate's unit is the name of a gate
+rather than a path, so the suite maps a change onto its units from a list
+each gate carries: `check-test-aliases` names
+`tasks/test-identity-aliases.jsonl`, `check-action-pins` names
+`.github/`, and a change touching one of those makes that gate mandatory.
+The pull request that fixes a gate too flaky to judge by therefore runs
+it, which is what the exception is for.
+
+What a gate declares is bounded rather than exhaustive, and two bounds
+are what keep this a fraction of what a lane runs rather than the bulk of
+it. No one gate may be reached by a significant share of the tree, and no
+one file may reach more than a few gates. So a gate whose input is a
+large part of the repository names the small and specific part of it —
+`check-docs` names the documents holding the code blocks, and not the
+modules those blocks compile against — or names nothing at all, which is
+what formatting, linting, the drift guard and the cycle check get. A gate
+naming nothing reaches a lane on what it is worth or because nothing has
+a record of it, so a flaky one stays out of pull requests until it stops
+disagreeing with itself.
+
+The asymmetry is what makes those bounds affordable. A gate named by too
+little is decided by the score, which is the same decision every test
+gets. A gate named by too much takes its share of every lane's budget
+forever, on the strength of a declaration rather than of anything
+measured, which is what the removed exemption did.
 
 What the lane owes people in exchange is clarity about whose problem it
 is. The job summary names what was withheld and why, and says of each
@@ -2637,6 +2657,27 @@ the exclusion list — all three being decisions about the repository rather
 than about one pull request, which is why they belong to a person and not
 to a threshold.
 
+#### Which packages a change reaches
+
+The gate makes two decisions — which tests to run, and which packages to
+measure — and both are the same question: which covered packages did this
+change reach. It answers that question the way everything else in this
+design answers it, from the declarations described under [what the change
+touches must run](#two-rules-that-force-a-test-in), rather than from a
+rule of its own. A covered package declares the paths a change reaches
+its own measured test set by, which is its own tree; the packages a
+change reaches are the packages whose sets become mandatory and the
+packages the gate scores. Two mechanisms answering one question is two
+things to be wrong about, and the failure they produce is silent: the
+gate would run a package's tests and decline to score it, or score a
+package whose tests it did not force.
+
+That also settles what a package may declare. The bounds the declarations
+are under are the ones stated there — nothing reached by a significant
+share of the tree, and no file reaching a significant share of the things
+declaring — and a package's own tree satisfies the first by construction.
+`LOCAL_COVERAGE_MAX_PACKAGES` is the second, said in packages.
+
 #### A change that touches more than two covered packages is not gated
 
 The mandatory set a covered package adds is its whole measured test set,
@@ -2646,7 +2687,7 @@ the gate's value falls as the change gets broader anyway: over three or
 four packages at once, "did this leave more untested" stops being a
 question about one thing somebody can look at.
 
-So when the diff touches more than `LOCAL_COVERAGE_MAX_PACKAGES` covered
+So when the diff reaches more than `LOCAL_COVERAGE_MAX_PACKAGES` covered
 packages, the gate is off for that pull request entirely. No package's set
 is forced whole, nothing is gated, and `Status` says the gate did not run
 and why. The tests are still selected normally, and the items the diff
@@ -2668,10 +2709,10 @@ gate would have caught.
 
 #### What a pull request does
 
-When the diff touches a covered package's tracked source or its tests, and
-the pull request is under the cap above, every item in that package's
-measured test set becomes mandatory, and runs once with coverage turned
-on. They are packed like any other mandatory items, so a large package
+When the diff reaches a covered package, by the declaration that package
+carries, and the pull request is under the cap above, every item in that
+package's measured test set becomes mandatory, and runs once with
+coverage turned on. They are packed like any other mandatory items, so a large package
 spreads across lanes rather than filling one.
 
 Run once is enforced rather than hoped for. A mandatory item leaves the
@@ -2683,7 +2724,7 @@ ordinary ones, fitted the same way every other cost in this design is.
 
 Each lane converts the coverage it produced into one report per workspace
 member and uploads it. `Status` adds the five together, scores each
-covered package the diff touched, and fails when the uncovered count has
+covered package the diff reached, and fails when the uncovered count has
 risen. A rise is accepted with the marker the repository already has, in
 the same form and with the same rebase-proof meaning:
 
@@ -2751,8 +2792,8 @@ pull request's own run could not have:
   green — and never for one line.
 - **A rise in a covered package's own-tests number**, named as one the
   per-package gate exists to catch. There are three ways one reaches
-  `main`: the change touched more covered packages than the cap allows, so
-  the gate did not run; a package the change touched is on the exclusion
+  `main`: the change reached more covered packages than the cap allows, so
+  the gate did not run; a package the change reached is on the exclusion
   list; or a change somewhere else moved which lines of that package its
   own tests reach. The comment says which, because the three call for
   different things — nothing, a look at the exclusion list, and a look at
@@ -2816,8 +2857,8 @@ notes that the option exists and that nothing here forecloses it.
 
 **Outside a covered package, a change to a source file does not pull in
 the tests that execute it.** Selection knows which test files a change
-edited, and which units each suite says the change touched. Where the diff
-touches a covered package and stays under the cap, [the per-package
+edited, and which units the declarations reach. Where those reach a
+covered package and the diff stays under the cap, [the per-package
 gate](#the-one-coverage-gate-that-survives) makes that package's whole
 measured set mandatory, which reaches the tests executing the changed
 lines by running every test the package has. Everywhere else, selection

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -178,10 +178,27 @@ Two rules force a test in.
   data and that a renamed test is an unknown identity until an alias line
   lands.
 - **What the change touches must run.** A changed test file's identities
-  are mandatory. A unit that is not a file, such as a type-check group or
-  a binary, is one its suite maps the change onto, because only the suite
-  knows what its unit covers. Nothing else about a changed source file
-  forces a test in. Which tests run for it is what the score decides.
+  are mandatory. Everything else a change forces in goes through one
+  rule, and there is no second rule beside it: a declaration names the
+  paths a change reaches something by, and what a change reaches is what
+  it forces. That is how a unit which is not a file — a type-check group,
+  a repository gate, a binary — is reached at all, because only its suite
+  knows what its unit covers. Anything else that has to answer "which
+  parts of this repository did the change touch" answers from the same
+  declarations, including a consumer deciding not which tests to run but
+  which packages to measure. A second mechanism for the same question is
+  a second thing to be wrong about, and the two would disagree.
+
+  A declaration is bounded rather than exhaustive, so that what a change
+  runs stays mostly what the score chose. No one unit may be reached by a
+  significant share of the tree, and no one file may reach a significant
+  share of the units. Something whose input is a large part of the
+  repository declares the small and specific part of it, or declares
+  nothing and is reached by the score alone. Declaring too little costs
+  only that; declaring too much places the unit in every lane by
+  declaration rather than by what it has caught. Nothing about a changed
+  source file forces a test in except through a declaration that reaches
+  it. Which tests run for it otherwise is what the score decides.
 
 ## The manifest
 

--- a/tasks/test-selection/census.ts
+++ b/tasks/test-selection/census.ts
@@ -162,9 +162,9 @@ export function census(
   for (const suite of suites) {
     const unavailable = unavailableUnits(suite);
     // A unit that is a path is made mandatory by the diff naming it. A
-    // unit that is not — a type-check group, a binary — is one the suite
-    // has to map the diff onto itself, because only it knows what its
-    // unit covers.
+    // unit that is not — a type-check group, a repository gate, a
+    // binary — is one the suite has to map the diff onto itself,
+    // because only it knows what its unit covers.
     const touched = new Set<string>(
       suite.unitsForChange !== undefined
         ? suite.unitsForChange(changed)

--- a/tasks/test-topology/gates.test.ts
+++ b/tasks/test-topology/gates.test.ts
@@ -1,11 +1,29 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { loadGateSuites } from "./gates.ts";
-import type { Suite } from "./suite.ts";
+import { DOC_DEMOS } from "../check-verb-session-sync.ts";
+import { TRIPWIRES } from "../check-tripwires.ts";
+import {
+  type Gate,
+  HISTORY_GATES,
+  loadGateSuites,
+  WORKING_TREE_GATES,
+} from "./gates.ts";
+import { entryNames, type Suite } from "./suite.ts";
 
-const suites = await loadGateSuites(
-  new URL("../..", import.meta.url).pathname.replace(/\/$/, ""),
-);
+const gates: readonly Gate[] = [...WORKING_TREE_GATES, ...HISTORY_GATES];
+
+/**
+ * The most of the tree one gate may be reached by, as a divisor. A gate
+ * more than one file in eight reaches is one most changes would run.
+ */
+const TREE_SHARE_DIVISOR = 8;
+
+/** The most gates one file may reach. */
+const GATES_PER_FILE = 4;
+
+const root = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
+
+const suites = await loadGateSuites(root);
 const byId = (id: string): Suite => suites.find((s) => s.id === id)!;
 const context = { root: "/repo", outputDir: "/out" };
 
@@ -34,6 +52,176 @@ describe("the repository's gate suites", () => {
       "check-test-aliases",
     ]);
     expect(declared.toSorted()).toEqual(reading.toSorted());
+  });
+
+  it("reaches the gates a change names, and no others", () => {
+    // Built over every gate of both suites, so a declaration wider than
+    // the change fails this rather than quietly running more.
+    const reached = (...changed: string[]): string[] =>
+      [byId("repo-gates"), byId("repo-history-gates")]
+        .flatMap((suite) => [...suite.unitsForChange!(new Set(changed))])
+        .toSorted();
+    expect(reached("tasks/test-identity-aliases.jsonl")).toEqual([
+      "check-test-aliases",
+    ]);
+    expect(reached(".github/workflows/deno.yml")).toEqual([
+      "check-action-pins",
+    ]);
+    // The baselines and the patterns beside them reach one gate each,
+    // rather than both reaching both.
+    expect(reached("packages/patterns/baselines/system/home.tsx/a.json"))
+      .toEqual(["check-baselines-append-only"]);
+    expect(reached("packages/patterns/system/home.tsx")).toEqual([
+      "check-pattern-tiers",
+    ]);
+    // A `**` segment stands for any run of directories, so every
+    // package's integration tree reaches the gate reading them.
+    expect(reached("packages/cli/integration/verb-session-demo.sh")).toEqual([
+      "check-no-waitfor",
+      "check-verb-session-sync",
+    ]);
+    expect(reached("packages/static/assets/types/dom.d.ts")).toEqual([
+      "check-cfc-types",
+      "check-commonfabric-types",
+      "check-withheld-globals",
+    ]);
+    expect(reached("packages/toolshed/routes/ingest-channels/route.ts"))
+      .toEqual(["check-tripwires"]);
+    // The historical tree is taken back out of the two gates reading
+    // `docs/`, since neither compiles nor reads a document in it.
+    expect(reached("docs/history/INDEX.md")).toEqual([
+      "check-docs-history-index",
+    ]);
+    expect(reached("mise.toml")).toEqual(["check-deno-pins"]);
+    expect(reached("deno.lock")).toEqual(["check-single-copy-deps"]);
+    // An ordinary source file reaches no gate. What runs for it is what
+    // the score chose, which is what keeps this feature a fraction of a
+    // lane rather than the bulk of one.
+    expect(reached("packages/runner/src/cell.ts")).toEqual([]);
+    expect(reached("elsewhere/thing.txt")).toEqual([]);
+  });
+
+  it("holds a gate to little of the tree, and a file to few gates", async () => {
+    // The two bounds that keep this feature a fraction of what a lane
+    // runs. A declaration wide enough to break either places its gate in
+    // every lane on the strength of what it says rather than of what it
+    // has caught, which is the decision the score exists to make. Every
+    // entry is held to naming something as well, so one whose directory
+    // the tree no longer has fails here rather than going quiet behind a
+    // sibling entry that still matches.
+    const listed = await new Deno.Command("git", {
+      args: ["-C", root, "ls-files", "-z"],
+    }).output();
+    const files = new TextDecoder().decode(listed.stdout)
+      .split("\0").filter((path) => path !== "");
+    const reached = (at: string): readonly string[] =>
+      [byId("repo-gates"), byId("repo-history-gates")]
+        .flatMap((suite) => [...suite.unitsForChange!(new Set([at]))]);
+    const share = new Map<string, number>();
+    let crowded: { at: string; names: readonly string[] } = {
+      at: "",
+      names: [],
+    };
+    for (const at of files) {
+      const names = reached(at);
+      if (names.length > crowded.names.length) crowded = { at, names };
+      for (const name of names) share.set(name, (share.get(name) ?? 0) + 1);
+    }
+    const over: string[] = [];
+    for (const gate of gates) {
+      for (const entry of gate.reachedBy) {
+        const at = entry.replace(/^!/, "");
+        if (!files.some((path) => entryNames(at, path))) {
+          over.push(`${gate.name} names ${entry}, which the tree has not`);
+        }
+      }
+      const reaching = share.get(gate.name) ?? 0;
+      if (reaching * TREE_SHARE_DIVISOR > files.length) {
+        over.push(
+          `${gate.name} is reached by ${reaching} of ${files.length} files`,
+        );
+      }
+    }
+    if (crowded.names.length > GATES_PER_FILE) {
+      over.push(
+        `${crowded.at} reaches ${crowded.names.length} gates: ` +
+          crowded.names.toSorted().join(", "),
+      );
+    }
+    expect(over).toEqual([]);
+  });
+
+  it("declares nothing for the gates whose input is most of the tree", () => {
+    // No small and specific part of the tree decides any of these, so
+    // each is left to the score. The list is exact, so a gate added with
+    // no declaration fails here rather than joining them in silence.
+    const everything = gates
+      .filter((gate) => gate.reachedBy.length === 0)
+      .map((gate) => gate.name)
+      .toSorted();
+    expect(everything).toEqual([
+      "check-conflict-markers",
+      "check-control-characters",
+      "check-local-program",
+      "check-package-cycles",
+      "check-skill-facts",
+      "check-test-topology",
+      "check-unused-deps",
+      "deno-fmt",
+      "deno-lint",
+    ]);
+  });
+
+  it("names paths the tree holds, as the kind the entry says", async () => {
+    // A renamed input leaves the gate reachable by a path nobody edits,
+    // which reads as a gate nothing touches rather than as a mistake.
+    const kindOf = async (entry: string): Promise<string> => {
+      try {
+        const info = await Deno.stat(`${root}/${entry}`);
+        return info.isDirectory ? "directory" : "file";
+      } catch {
+        return "missing";
+      }
+    };
+    const found: string[] = [];
+    const declared: string[] = [];
+    for (const gate of gates) {
+      for (const entry of gate.reachedBy) {
+        const at = entry.replace(/^!/, "");
+        // An entry carrying a `**` segment names no one path, and the
+        // bounds test is what holds it to reaching something.
+        if (at.includes("**/")) continue;
+        found.push(`${entry} ${await kindOf(at)}`);
+        declared.push(`${entry} ${at.endsWith("/") ? "directory" : "file"}`);
+      }
+    }
+    expect(found).toEqual(declared);
+  });
+
+  it("is reached by the inputs the gates that enumerate their own name", () => {
+    // Two gates hold their inputs as constants, and the declarations
+    // here are a second copy of the same facts. Comparing the copies is
+    // what catches a gate that grows an input its declaration does not
+    // name, which the two tests above cannot see.
+    const reachedBy = (name: string, at: string): string =>
+      `${name} ${
+        byId("repo-gates").unitsForChange!(new Set([at])).includes(name)
+          ? "runs for"
+          : "misses"
+      } ${at}`;
+    const found: string[] = [];
+    const declared: string[] = [];
+    for (const { doc, demo } of DOC_DEMOS) {
+      for (const at of [doc, demo]) {
+        found.push(reachedBy("check-verb-session-sync", at));
+        declared.push(`check-verb-session-sync runs for ${at}`);
+      }
+    }
+    for (const tripwire of TRIPWIRES) {
+      found.push(reachedBy("check-tripwires", tripwire.testFile));
+      declared.push(`check-tripwires runs for ${tripwire.testFile}`);
+    }
+    expect(found).toEqual(declared);
   });
 
   it("runs a gate through the recorder that names its identity", async () => {

--- a/tasks/test-topology/gates.ts
+++ b/tasks/test-topology/gates.ts
@@ -7,8 +7,9 @@
  * suite needs before it runs any of it. Two of them read the revision the
  * change is measured against, which takes a checkout carrying history;
  * the rest read the working tree and need nothing but the toolchain. A
- * gate reaches a lane the way a test does: on what it is worth, or
- * because nothing has a record of it.
+ * gate reaches a lane the way a test does: because the change touches
+ * what it reads, on what it is worth, or because nothing has a record of
+ * it.
  */
 
 import { collectPathsByScope, scopeOfPath } from "../typecheck.ts";
@@ -22,6 +23,8 @@ import {
   claimsIdentity,
   type Invocation,
   type Location,
+  type ReachedBy,
+  reachedByChange,
   type RecordSurface,
   type Suite,
   type UnitRequest,
@@ -29,7 +32,7 @@ import {
 import type { CapabilityId } from "../ci-capabilities.ts";
 
 /** One repository gate: what it is called, and what runs it. */
-interface Gate {
+export interface Gate {
   /** The name its record carries. */
   name: string;
 
@@ -44,71 +47,269 @@ interface Gate {
 
   /** Where it runs, repository-relative, when that is not the root. */
   cwd?: string;
+
+  /**
+   * The paths a change reaches this gate by, in the vocabulary
+   * {@link ReachedBy} defines. A change touching one of them makes the
+   * gate mandatory, ahead of everything the score chooses, and
+   * `gates.test.ts` holds every gate's declaration to the two bounds
+   * that vocabulary is under.
+   *
+   * This is not a claim about everything the gate opens. A gate whose
+   * input runs to a large part of the repository names the small and
+   * specific part of it, or names nothing at all and is left to the
+   * score.
+   *
+   * Within the bounds the answer errs toward running, since a suite
+   * mapping a change onto its units wrongly runs too much or too little
+   * rather than reporting anything. So a gate reading a set of files
+   * names the directory holding them, and a gate examining live code
+   * stops at the package declaring what it examines rather than naming
+   * everything that package imports.
+   */
+  reachedBy: ReachedBy;
 }
 
 /** The gates that read nothing but the working tree. */
-const WORKING_TREE_GATES: readonly Gate[] = [
-  { name: "deno-fmt", kind: "format", task: "fmt", args: () => ["--check"] },
-  { name: "deno-lint", kind: "lint", task: "lint" },
-  { name: "check-test-topology", kind: "gate", task: "check-test-topology" },
-  { name: "check-skill-facts", kind: "gate", task: "check-skill-facts" },
-  { name: "check-tripwires", kind: "gate", task: "check-tripwires" },
-  { name: "check-docs", kind: "gate", task: "check-docs" },
+export const WORKING_TREE_GATES: readonly Gate[] = [
+  {
+    name: "deno-fmt",
+    kind: "format",
+    task: "fmt",
+    args: () => ["--check"],
+    // Reads every file the root configuration does not exclude.
+    reachedBy: [],
+  },
+  {
+    name: "deno-lint",
+    kind: "lint",
+    task: "lint",
+    // The same, over the extensions the linter opens.
+    reachedBy: [],
+  },
+  {
+    name: "check-test-topology",
+    kind: "gate",
+    task: "check-test-topology",
+    // Walks every tree this repository keeps source in for anything
+    // that looks like a test, and holds the topology to what it finds.
+    // The topology enumerates from those same trees, so a set stated
+    // here names every directory holding code and comes to all but a
+    // change that touches none of it.
+    reachedBy: [],
+  },
+  {
+    name: "check-skill-facts",
+    kind: "gate",
+    task: "check-skill-facts",
+    // Holds every path a skill, an `AGENTS.md` or a rule cites to
+    // resolving against the tree, so a file moved or removed anywhere
+    // can fail it.
+    reachedBy: [],
+  },
+  {
+    name: "check-tripwires",
+    kind: "gate",
+    task: "check-tripwires",
+    // Probes the weakness each tripwire asserts is still present, and
+    // reads the test file carrying the same assertion. A tripwire added
+    // against another package widens this list.
+    reachedBy: [
+      "packages/identity/",
+      "packages/toolshed/routes/ingest-channels/",
+      "tasks/check-tripwires.ts",
+    ],
+  },
+  {
+    name: "check-docs",
+    kind: "gate",
+    task: "check-docs",
+    // The documents holding the blocks, and the import map they
+    // compile through. The historical tree is walked past: those blocks
+    // reflect the API of their era. A block also compiles against this
+    // repository's own modules, which is most of `packages/` and so
+    // stays with the score.
+    reachedBy: ["deno.jsonc", "docs/", "!docs/history/"],
+  },
   {
     name: "check-docs-history-index",
     kind: "gate",
     task: "check-docs-history-index",
+    reachedBy: ["docs/history/", "tasks/check-docs-history-index.ts"],
   },
-  { name: "check-no-waitfor", kind: "gate", task: "check-no-waitfor" },
+  {
+    name: "check-no-waitfor",
+    kind: "gate",
+    task: "check-no-waitfor",
+    // The `integration` directories under `packages`, less the package
+    // declaring the polling helper, which is out of the check's scope.
+    reachedBy: [
+      "packages/**/integration/",
+      "!packages/integration/",
+      "tasks/check-no-waitfor.ts",
+    ],
+  },
   {
     name: "check-conflict-markers",
     kind: "gate",
     task: "check-conflict-markers",
+    // Reads every tracked file: a marker left behind is a mistake
+    // wherever it lands.
+    reachedBy: [],
   },
   {
     name: "check-control-characters",
     kind: "gate",
     task: "check-control-characters",
+    // The same, over every tracked file the extension list does not
+    // call binary.
+    reachedBy: [],
   },
   {
     name: "check-verb-session-sync",
     kind: "gate",
     task: "check-verb-session-sync",
+    reachedBy: [
+      "docs/common/verbs/",
+      "docs/common/workflows/",
+      "packages/cli/integration/",
+      "tasks/check-verb-session-sync.ts",
+    ],
   },
-  { name: "check-pattern-tiers", kind: "gate", task: "check-pattern-tiers" },
-  { name: "check-unused-deps", kind: "gate", task: "check-unused-deps" },
-  { name: "check-deno-pins", kind: "gate", task: "check-deno-pins" },
-  { name: "check-action-pins", kind: "gate", task: "check-action-pins" },
+  {
+    name: "check-pattern-tiers",
+    kind: "gate",
+    task: "check-pattern-tiers",
+    // The pattern sources, the tier tables, and the collector deciding
+    // which files take a marker at all. The baselines are data beside
+    // the patterns and carry no marker.
+    reachedBy: [
+      "packages/patterns/",
+      "!packages/patterns/baselines/",
+      "tasks/check-pattern-tiers.ts",
+      "tasks/pattern-files.ts",
+      "tasks/pattern-tiers.ts",
+    ],
+  },
+  {
+    name: "check-unused-deps",
+    kind: "gate",
+    task: "check-unused-deps",
+    // Reads every tracked code file, since the import that justifies a
+    // declared dependency can sit in any of them.
+    reachedBy: [],
+  },
+  {
+    name: "check-deno-pins",
+    kind: "gate",
+    task: "check-deno-pins",
+    reachedBy: [
+      ".github/actions/deno-setup/action.yml",
+      "Dockerfile.dashboard",
+      "Dockerfile.toolshed",
+      "mise.toml",
+      "tasks/check-deno-pins.ts",
+      "tasks/check.sh",
+    ],
+  },
+  {
+    name: "check-action-pins",
+    kind: "gate",
+    task: "check-action-pins",
+    reachedBy: [".github/", "tasks/check-action-pins.ts"],
+  },
   {
     name: "check-single-copy-deps",
     kind: "gate",
     task: "check-single-copy-deps",
+    reachedBy: ["deno.lock", "tasks/check-single-copy-deps.ts"],
   },
-  { name: "check-package-cycles", kind: "gate", task: "check-package-cycles" },
-  { name: "check-local-program", kind: "gate", task: "check-local-program" },
+  {
+    name: "check-package-cycles",
+    kind: "gate",
+    task: "check-package-cycles",
+    // Reads every production module under `packages/` for its imports,
+    // which is most of the repository, and no smaller part of it
+    // decides the verdict.
+    reachedBy: [],
+  },
+  {
+    name: "check-local-program",
+    kind: "gate",
+    task: "check-local-program",
+    // Reads every tracked TypeScript file, since the resolver it looks
+    // for can be named from any of them.
+    reachedBy: [],
+  },
   {
     name: "check-completion-slots",
     kind: "gate",
     task: "check-completion-slots",
+    // The command tree it walks and the two provider tables it
+    // subtracts against.
+    reachedBy: [
+      "packages/cli/commands/",
+      "packages/cli/lib/completion/",
+      "tasks/check-completion-slots.ts",
+    ],
   },
-  { name: "check-command-docs", kind: "gate", task: "check-command-docs" },
+  {
+    name: "check-command-docs",
+    kind: "gate",
+    task: "check-command-docs",
+    // The command tree and the shuttle verbs, against the documents
+    // that could describe them: the documentation tree less the two
+    // parts of it no live document sits in, the authored skills, and
+    // the README of each workspace member the root config names.
+    reachedBy: [
+      "deno.jsonc",
+      "docs/",
+      "!docs/history/",
+      "!docs/plans/",
+      "packages/**/README.md",
+      "packages/cli/commands/",
+      "packages/cli/lib/shuttle/",
+      "skills/",
+      "tasks/check-command-docs.ts",
+    ],
+  },
   {
     name: "check-cfc-types",
     kind: "gate",
     task: "check-cfc-types",
     cwd: "packages/static",
+    reachedBy: [
+      "packages/api/",
+      "packages/static/assets/types/",
+      "packages/static/scripts/",
+    ],
   },
   {
     name: "check-commonfabric-types",
     kind: "gate",
     task: "check-commonfabric-types",
     cwd: "packages/static",
+    // The pattern API and the workspace modules it re-exports, whose
+    // text this one inlines.
+    reachedBy: [
+      "packages/api/",
+      "packages/data-model/",
+      "packages/static/assets/types/",
+      "packages/static/scripts/",
+    ],
   },
   {
     name: "check-withheld-globals",
     kind: "gate",
     task: "check-withheld-globals",
     cwd: "packages/static",
+    // The type libraries, and the sandbox contract naming the globals
+    // to be stripped from them.
+    reachedBy: [
+      "packages/static/assets/types/",
+      "packages/static/scripts/",
+      "packages/utils/",
+    ],
   },
 ];
 
@@ -117,18 +318,35 @@ const WORKING_TREE_GATES: readonly Gate[] = [
  * it stood at the merge base with the revision the change is measured
  * against, which takes a checkout carrying history.
  */
-const HISTORY_GATES: readonly Gate[] = [
+export const HISTORY_GATES: readonly Gate[] = [
   {
     name: "check-baselines-append-only",
     kind: "gate",
     task: "check-baselines-append-only",
     args: ({ baseRef }) => [baseRef],
+    // The baselines. A deleted pattern file is what excuses deleting
+    // the baselines beside it, so it can turn this gate's verdict from
+    // a failure into a pass but never the other way, and reaches the
+    // gate by nothing on its own.
+    reachedBy: [
+      "packages/patterns/baselines/",
+      "tasks/check-baselines-append-only.ts",
+      "tasks/pattern-files.ts",
+    ],
   },
   {
     name: "check-test-aliases",
     kind: "gate",
     task: "check-test-aliases",
     args: ({ baseRef }) => [baseRef],
+    // The file, and the module holding the line format it parses and
+    // the graph rules it applies; the task itself is a `git show`
+    // wrapper around those.
+    reachedBy: [
+      "packages/test-support/",
+      "tasks/check-test-aliases.ts",
+      "tasks/test-identity-aliases.jsonl",
+    ],
   },
 ];
 
@@ -152,6 +370,15 @@ function gateSuite(
     needs,
     units: gates.map((gate) => gate.name),
     unavailable: [],
+    // A gate's unit is the name of a gate rather than a path, so what a
+    // change reaches is what each gate declares it reads. A gate that
+    // declares nothing reads the whole tree, and reaches a lane on what
+    // it is worth or because nothing has a record of it.
+    unitsForChange(changed) {
+      return gates
+        .filter((gate) => reachedByChange(gate.reachedBy, changed))
+        .map((gate) => gate.name);
+    },
     locate(record): Location | undefined {
       if (!claimsIdentity({ recordSurfaces }, record.test)) return undefined;
       return byName.has(record.test.n)

--- a/tasks/test-topology/suite.ts
+++ b/tasks/test-topology/suite.ts
@@ -153,10 +153,17 @@ export interface Suite {
   /**
    * Which units a change makes mandatory. Absent where a unit is a path,
    * because the diff naming that path is the whole of the question. A
-   * suite whose units are not paths — a type-check group, a binary —
-   * answers it here, and a suite that answers it wrongly runs too much
-   * or too little rather than reporting anything, so the answer errs
-   * toward running.
+   * suite whose units are not paths — a type-check group, a repository
+   * gate, a binary — answers it here, from a {@link ReachedBy} for each
+   * of them, and a suite that answers it wrongly runs too much or too
+   * little rather than reporting anything, so the answer errs toward
+   * running.
+   *
+   * It is absent too where what a unit covers is a large part of the
+   * repository, since a declaration for such a unit comes to most
+   * changes and places it in most lanes by declaration rather than by
+   * what it has caught. Such a unit reaches a lane on what it is worth,
+   * or because nothing has a record of it.
    */
   unitsForChange?(changed: ReadonlySet<string>): readonly Unit[];
 
@@ -168,6 +175,64 @@ export interface Suite {
     units: readonly UnitRequest[],
     context: CommandContext,
   ): Promise<Invocation[]>;
+}
+
+/**
+ * The paths a change reaches something by: a unit whose runner cannot be
+ * pointed at a path, a repository gate, a package whose coverage is being
+ * measured. Everything a change makes mandatory beyond the diff naming a
+ * unit outright is decided from one of these, so that one vocabulary
+ * answers the question wherever it comes up.
+ *
+ * An entry ending in a slash is a directory and covers everything under
+ * it; every other entry is one file; `**\/` in the middle of either
+ * stands for any run of directories. An entry opening with `!` takes what
+ * it names back out.
+ *
+ * A declaration is bounded rather than exhaustive, and the bounds are
+ * what keep this a fraction of what a lane runs rather than the bulk of
+ * it: nothing may be reached by a significant share of the tree, and no
+ * one file may reach a significant share of the things declaring. So what
+ * reads a large part of the repository declares the small and specific
+ * part of it, or declares nothing and is left to the score. Declaring too
+ * little costs only that; declaring too much spends part of every lane's
+ * budget forever.
+ */
+export type ReachedBy = readonly string[];
+
+/**
+ * Whether one entry names a path. `**\/` stands for any run of
+ * directories, so the segments on either side of it are matched against
+ * the ends of the path rather than against the whole of it.
+ */
+export function entryNames(entry: string, at: string): boolean {
+  const wildcard = entry.indexOf("**/");
+  if (wildcard === -1) {
+    return entry.endsWith("/") ? at.startsWith(entry) : at === entry;
+  }
+  const above = entry.slice(0, wildcard);
+  if (!at.startsWith(above)) return false;
+  const below = entry.slice(wildcard + "**/".length);
+  const rest = `/${at.slice(above.length)}`;
+  return below.endsWith("/")
+    ? rest.includes(`/${below}`)
+    : rest.endsWith(`/${below}`);
+}
+
+/** Whether a declaration comes to any of the changed paths. */
+export function reachedByChange(
+  reachedBy: ReachedBy,
+  changed: ReadonlySet<string>,
+): boolean {
+  const taken = reachedBy.filter((entry) => !entry.startsWith("!"));
+  const dropped = reachedBy
+    .filter((entry) => entry.startsWith("!"))
+    .map((entry) => entry.slice(1));
+  for (const at of changed) {
+    if (dropped.some((entry) => entryNames(entry, at))) continue;
+    if (taken.some((entry) => entryNames(entry, at))) return true;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
PROBLEM

`census` makes a unit mandatory when the change touches what it covers. For a suite whose units are paths that is the diff naming the path; for a suite whose units are not paths it is the suite's own `unitsForChange`. A gate's unit is the name of a gate, `deno-fmt` or `check-docs`, and `gateSuite` supplies no `unitsForChange`, so no diff reaches any of the 25 gates. The exception both exclusion rules carry — an item comes back for a change touching what it covers, since that change is likely the fix — cannot fire for one. The pull request that edits `tasks/test-identity-aliases.jsonl` cannot run the gate holding that file to being appended to.

SOLUTION

One vocabulary answers "which parts of the repository did this change reach", and everything that has to ask it asks the same way. A declaration names paths: an entry ending in a slash is a directory, every other entry is one file, `**/` stands for any run of directories, and an entry opening with `!` takes what it names back out. Each gate carries one, and `gateSuite` maps a change onto its units by matching the diff against them.

Two bounds hold a declaration, because this must stay a fraction of what a lane runs rather than the bulk of it: nothing is reached by more than one file in eight, and no file reaches more than four things. What reads a large part of the repository declares the small and specific part of it — `check-docs` names the documents holding the code blocks, not the modules those blocks compile against — or declares nothing and is left to the score, which is what formatting, linting, the drift guard and the cycle check get. Declaring too little costs only the score deciding; declaring too much spends part of every lane's budget forever, on the strength of a declaration rather than of anything measured.

Measured over the tracked files, the widest gate is reached by 9.4% of the tree, the most any one file reaches is three gates, and five files in eight reach none.

DESIGN DISCUSSION

The specification states the rule once and says the per-package coverage gate is that rule rather than an exception to it. That gate makes two decisions — which tests to run, and which packages to measure — and both are the question above, so a covered package declares the paths reaching its own measured test set and the packages a change reaches decide both. Two mechanisms answering one question is two things to be wrong about, and the failure is silent: the gate would run a package's tests and decline to score it, or score a package whose tests it did not force. `LOCAL_COVERAGE_MAX_PACKAGES` is the second bound above, said in packages.

Within the bounds the answer errs toward running, since a suite mapping a change onto its units wrongly runs too much or too little rather than reporting anything. So a gate reading a set of files names the directory holding them, and a gate examining live code stops at the package declaring what it examines rather than naming everything that package imports.

`check-baselines-append-only` is the one narrowed on an argument rather than a measurement. A deleted pattern file is what excuses deleting the baselines beside it, which can only turn its verdict from a failure into a pass, so a change touching pattern sources alone reaches it by nothing. It names the baselines.

Five tests hold the declarations to something. One states exactly which gates a given change reaches, built over every gate of both suites. One measures both bounds against the tracked files, and holds every entry to naming something the tree has — per entry rather than per gate, since a dead entry beside a live one is otherwise invisible. One closes the set of gates declaring nothing. One stats each literal entry and compares what it found against what the entry claims. The fifth compares a declaration against the constants the gate holds its own inputs in, for the two gates that have them, which is what catches a gate that grows an input.

Three sibling suites in the same file have the shape the problem above describes: `pattern-compat`'s units are pattern keys, and `cfcheck` and `pattern-vintage` are each one unit, and none supplies `unitsForChange`. That is left for its own change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

