### PR TITLE
perf(memory): attribute a watch refresh per session and per phase

### DIFF
--- a/packages/memory/test/v2-server-refresh-timing.test.ts
+++ b/packages/memory/test/v2-server-refresh-timing.test.ts
@@ -1,0 +1,362 @@
+/**
+ * The refresh's timing rows close in `finally` blocks: a refresh that throws
+ * is skipped and requeued by its caller, and the rows are what say what it
+ * cost. The session row closes after the catch-up frame, which can still
+ * attach operation-watch fields when no document was upserted.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { toFileUrl } from "@std/path";
+import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";
+import { getLogger } from "@commonfabric/utils/logger";
+import { applyCommit, close, type Engine, open } from "../v2/engine.ts";
+import {
+  refreshTrackedGraph,
+  SchemaClosureError,
+  toDirtyKey,
+  trackGraph,
+} from "../v2/query.ts";
+import { Server } from "../v2/server.ts";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionOpenAuthMetadata,
+  toValuePath,
+  type TransactRequest,
+} from "../v2.ts";
+
+const TEST_AUDIENCE = "did:key:z6Mk-memory-v2-refresh-timing-audience";
+
+// `root` references `leaf`, so re-validating the closure reaches `leaf`
+// through `root`. The commit boundary refuses to change a content-addressed
+// document, so a leaf that no longer hashes to its id is written below it,
+// the way the engine-validation tests corrupt rows.
+const leafSchema = { type: "string", title: "timing-leaf" } as const;
+const leafHash = internSchemaAsTaggedHashString(leafSchema);
+const rootSchema = {
+  type: "object",
+  properties: { x: { $ref: `cid:${leafHash}` } },
+} as const;
+const rootHash = internSchemaAsTaggedHashString(rootSchema);
+const corruptLeaf = { type: "number", title: "timing-corrupt" } as const;
+
+/** A link whose schema position carries `$ref: cid:<hash>`. */
+const linkWithSchemaRef = (id: string, hash: string) => ({
+  "/": { "link@1": { id, path: [], schema: { $ref: `cid:${hash}` } } },
+});
+
+const memoryTiming = getLogger("memory");
+const countOf = (row: string): number =>
+  memoryTiming.getTimeStats(row)?.count ?? 0;
+
+const createServer = (store: string) =>
+  new Server({
+    store: new URL(store),
+    subscriptionRefreshDelayMs: "manual",
+    authorizeSessionOpen() {
+      return "did:key:z6Mk-memory-v2-refresh-timing-principal";
+    },
+    sessionOpenAuth: { audience: TEST_AUDIENCE },
+  });
+
+const openSession = async (
+  connection: ReturnType<Server["connect"]>,
+  messages: ServerMessage[],
+  space: string,
+): Promise<string> => {
+  await connection.receive(encodeMemoryBoundary({
+    type: "hello",
+    protocol: MEMORY_PROTOCOL,
+    flags: getMemoryProtocolFlags(),
+  }));
+  const hello = messages.shift() as
+    | { type: string; sessionOpen?: SessionOpenAuthMetadata }
+    | undefined;
+  expect(hello?.type).toBe("hello.ok");
+  const sessionOpen = hello!.sessionOpen!;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "open",
+    space,
+    session: {},
+    invocation: {
+      aud: sessionOpen.audience,
+      challenge: sessionOpen.challenge.value,
+    },
+  }));
+  const opened = messages.shift() as ResponseMessage<{ sessionId: string }>;
+  expect(opened.ok).toBeDefined();
+  return opened.ok!.sessionId;
+};
+
+const transactMessage = (
+  space: string,
+  sessionId: string,
+  commit: TransactRequest["commit"],
+): TransactRequest => ({
+  type: "transact",
+  requestId: crypto.randomUUID(),
+  space,
+  sessionId,
+  commit,
+});
+
+/** The closure fixture: two schema documents and a root whose link names
+ * the outer one. */
+const closureOperations = (root: string, target: string) => [
+  { op: "set" as const, id: `cid:${leafHash}`, value: { value: leafSchema } },
+  { op: "set" as const, id: `cid:${rootHash}`, value: { value: rootSchema } },
+  { op: "set" as const, id: target, value: { value: { n: 1 } } },
+  {
+    op: "set" as const,
+    id: root,
+    value: { value: { x: linkWithSchemaRef(target, rootHash) } },
+  },
+];
+
+describe("v2-server-refresh-timing", () => {
+  describe("refreshTrackedGraph()", () => {
+    it("records the closure phase and the total when the closure fails to verify", async () => {
+      const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+      let engine = await open({ url: toFileUrl(path) });
+      const space = "did:key:z6Mk-memory-v2-refresh-timing-query";
+      const root = "of:timing-query-root";
+      try {
+        applyCommit(engine, {
+          sessionId: "session:writer",
+          commit: {
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            operations: closureOperations(root, "of:timing-query-target"),
+          },
+        });
+        const tracked = trackGraph(space, engine, {
+          roots: [{ id: root, selector: { path: [], schema: false } }],
+        });
+        expect(tracked.state.entities.has(`${space}/space/cid:${leafHash}`))
+          .toBe(true);
+
+        // The stored leaf no longer hashes to its id. A reopened engine has
+        // verified nothing yet, so the refresh re-verifies the closure and
+        // throws — the restart case, where a corrupted store is first met.
+        engine.database.prepare(
+          `UPDATE revision SET data = :data WHERE id = :id`,
+        ).run({
+          data: encodeMemoryBoundary({ value: corruptLeaf }),
+          id: `cid:${leafHash}`,
+        });
+        close(engine);
+        engine = await open({ url: toFileUrl(path) });
+        const before = {
+          rewalk: countOf("memory/refresh/walk/rewalk"),
+          closure: countOf("memory/refresh/walk/closure"),
+          total: countOf("memory/refresh/walk/total"),
+        };
+        expect(() =>
+          refreshTrackedGraph(
+            space,
+            engine,
+            tracked.state,
+            new Set([toDirtyKey(`cid:${leafHash}`)]),
+          )
+        ).toThrow(SchemaClosureError);
+        expect(countOf("memory/refresh/walk/rewalk")).toBe(before.rewalk + 1);
+        expect(countOf("memory/refresh/walk/closure")).toBe(
+          before.closure + 1,
+        );
+        expect(countOf("memory/refresh/walk/total")).toBe(before.total + 1);
+      } finally {
+        close(engine);
+        await Deno.remove(path);
+      }
+    });
+  });
+
+  describe("Server", () => {
+    describe("instance members", () => {
+      describe("flushSessions()", () => {
+        const realError = console.error;
+        let errors: string[];
+
+        beforeEach(() => {
+          errors = [];
+          console.error = (...args: unknown[]) => {
+            errors.push(args.map(String).join(" "));
+          };
+        });
+
+        afterEach(() => {
+          console.error = realError;
+        });
+
+        it("records the session and walk rows of a refresh that throws", async () => {
+          const space = "did:key:z6Mk-memory-v2-refresh-timing-throw";
+          const root = "of:timing-throw-root";
+          const server = createServer("memory://refresh-timing-throw");
+          // The space's engine, kept so the test can reach its store below
+          // the commit boundary.
+          let engine: Engine | undefined;
+          server.accessForTestingOnly.engineOpener = async (
+            requested,
+            openEngine,
+          ) => {
+            engine = await openEngine(requested);
+            return engine;
+          };
+          const messages: ServerMessage[] = [];
+          const connection = server.connect((message) =>
+            messages.push(message)
+          );
+          try {
+            const sessionId = await openSession(connection, messages, space);
+            const seeded = await server.transact(
+              transactMessage(space, sessionId, {
+                localSeq: 1,
+                reads: { confirmed: [], pending: [] },
+                operations: closureOperations(root, "of:timing-throw-target"),
+              }),
+            );
+            expect(seeded.error).toBeUndefined();
+            await connection.receive(encodeMemoryBoundary({
+              type: "session.watch.add",
+              requestId: "watch-throw",
+              space,
+              sessionId,
+              watches: [{
+                id: "watch-throw-id",
+                kind: "graph",
+                query: {
+                  roots: [{ id: root, selector: { path: [], schema: true } }],
+                },
+              }],
+            }));
+
+            const before = {
+              touched: countOf("memory/refresh/session/touched"),
+              walk: countOf("memory/refresh/phase/walk"),
+              rewalk: countOf("memory/refresh/walk/rewalk"),
+              total: countOf("memory/refresh/walk/total"),
+              frame: countOf("memory/refresh/phase/frame"),
+            };
+            // A legitimate change dirties the root; its new revision row is
+            // then corrupted in place (a valid encoding whose root is not a
+            // plain object), so the refresh's re-walk throws on decode. The
+            // refresh is manual, so the corruption lands before it runs.
+            const written = await server.writeDocument(space, root, {
+              x: linkWithSchemaRef("of:timing-throw-target", rootHash),
+              n: 2,
+            });
+            engine!.database.prepare(
+              `UPDATE revision SET data = :data WHERE id = :id AND seq = :seq`,
+            ).run({
+              data: encodeMemoryBoundary([1]),
+              id: root,
+              seq: written.seq,
+            });
+            await server.flushSessions();
+
+            // The failed refresh is logged and its frame skipped …
+            expect(
+              errors.some((line) =>
+                line.includes("watch refresh evaluation failed")
+              ),
+            ).toBe(true);
+            // … and still shows in the rows that attribute the pass: the
+            // session, the walk phase, the graph phase the throw landed in
+            // (the re-walk decodes the corrupted row) and the graph total.
+            expect(countOf("memory/refresh/session/touched")).toBe(
+              before.touched + 1,
+            );
+            expect(countOf("memory/refresh/phase/walk")).toBe(before.walk + 1);
+            expect(countOf("memory/refresh/walk/rewalk")).toBe(
+              before.rewalk + 1,
+            );
+            expect(countOf("memory/refresh/walk/total")).toBe(before.total + 1);
+            expect(countOf("memory/refresh/phase/frame")).toBe(before.frame);
+          } finally {
+            connection.close();
+          }
+        });
+
+        it("closes the session row after an operation-watch catch-up that upserts nothing", async () => {
+          const space = "did:key:z6Mk-memory-v2-refresh-timing-operation";
+          const doc = "of:timing-operation-doc";
+          const server = createServer("memory://refresh-timing-operation");
+          const messages: ServerMessage[] = [];
+          const connection = server.connect((message) =>
+            messages.push(message)
+          );
+          try {
+            const sessionId = await openSession(connection, messages, space);
+            const seeded = await server.transact(
+              transactMessage(space, sessionId, {
+                localSeq: 1,
+                reads: { confirmed: [], pending: [] },
+                operations: [{
+                  op: "set",
+                  id: doc,
+                  value: { value: { n: 1 } },
+                }],
+              }),
+            );
+            expect(seeded.error).toBeUndefined();
+            await connection.receive(encodeMemoryBoundary({
+              type: "session.watch.add",
+              requestId: "watch-operation",
+              space,
+              sessionId,
+              watches: [{
+                id: "watch-operation-graph",
+                kind: "graph",
+                query: {
+                  roots: [{ id: doc, selector: { path: [], schema: true } }],
+                },
+              }, {
+                id: "watch-operation-field",
+                kind: "operation",
+                query: { id: doc, path: toValuePath([]) },
+              }],
+            }));
+
+            const before = {
+              touched: countOf("memory/refresh/session/touched"),
+              tracked: countOf("memory/refresh/phase/tracked"),
+              frame: countOf("memory/refresh/phase/frame"),
+            };
+            // The session's own `set` is elided from its frame (the writer
+            // holds the bytes), so the refresh upserts nothing and takes the
+            // catch-up path that still attaches operation-watch fields.
+            const own = await server.transact(
+              transactMessage(space, sessionId, {
+                localSeq: 2,
+                reads: { confirmed: [], pending: [] },
+                operations: [{
+                  op: "set",
+                  id: doc,
+                  value: { value: { n: 2 } },
+                }],
+              }),
+            );
+            expect(own.error).toBeUndefined();
+            await server.flushSessions();
+
+            expect(errors).toEqual([]);
+            expect(countOf("memory/refresh/session/touched")).toBe(
+              before.touched + 1,
+            );
+            expect(countOf("memory/refresh/phase/tracked")).toBe(
+              before.tracked + 1,
+            );
+            expect(countOf("memory/refresh/phase/frame")).toBe(before.frame);
+          } finally {
+            connection.close();
+          }
+        });
+      });
+    });
+  });
+});

--- a/packages/memory/test/v2-server-refresh-timing.test.ts
+++ b/packages/memory/test/v2-server-refresh-timing.test.ts
@@ -342,7 +342,41 @@ describe("v2-server-refresh-timing", () => {
               }),
             );
             expect(own.error).toBeUndefined();
-            await server.flushSessions();
+            const attachmentStarted = Promise.withResolvers<void>();
+            const releaseAttachment = Promise.withResolvers<void>();
+            server.accessForTestingOnly.engineOpener = async (
+              requested,
+              openEngine,
+            ) => {
+              // After the tracked set is committed, this path opens the
+              // engine to attach operation-watch fields to the catch-up.
+              if (
+                countOf("memory/refresh/phase/tracked") === before.tracked + 1
+              ) {
+                attachmentStarted.resolve();
+                await releaseAttachment.promise;
+              }
+              return await openEngine(requested);
+            };
+            const messageCount = messages.length;
+            const flushing = server.flushSessions();
+            try {
+              await Promise.race([
+                attachmentStarted.promise,
+                flushing.then(() => {
+                  throw new Error(
+                    "`flushSessions()` completed without pausing operation-field attachment",
+                  );
+                }),
+              ]);
+              expect(countOf("memory/refresh/session/touched")).toBe(
+                before.touched,
+              );
+            } finally {
+              releaseAttachment.resolve();
+              server.accessForTestingOnly.engineOpener = undefined;
+              await flushing;
+            }
 
             expect(errors).toEqual([]);
             expect(countOf("memory/refresh/session/touched")).toBe(
@@ -352,6 +386,15 @@ describe("v2-server-refresh-timing", () => {
               before.tracked + 1,
             );
             expect(countOf("memory/refresh/phase/frame")).toBe(before.frame);
+            const effects = messages.slice(messageCount).filter((message) =>
+              message.type === "session/effect"
+            );
+            expect(effects).toHaveLength(1);
+            expect(effects[0].effect.upserts).toEqual([]);
+            expect(
+              effects[0].effect.operationFields?.map(({ watchId }) => watchId),
+            )
+              .toEqual(["watch-operation-field"]);
           } finally {
             connection.close();
           }

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -1685,6 +1685,43 @@ export const queryGraph = (
 // as one number. Recorded whether or not the logger prints.
 const refreshTiming = getLogger("memory", { enabled: false });
 
+/**
+ * The phase clock of one graph's incremental re-evaluation. `enter(name)`
+ * closes the phase in progress, if any, and opens `name`; `close()` closes
+ * the phase in progress and records the whole as `total`, once. The
+ * evaluation closes the clock in a `finally`, so one that throws still
+ * records the phase it was in and its total — an expensive failure is the
+ * one most worth attributing, and it is skipped and requeued by its caller
+ * rather than surfaced anywhere else.
+ */
+const walkPhaseClock = (): {
+  enter(name: string): void;
+  close(): void;
+} => {
+  const startedAt = performance.now();
+  let phaseAt = startedAt;
+  let current: string | undefined;
+  let closed = false;
+  const record = (name: string, now: number) =>
+    refreshTiming.time(phaseAt, now, "memory", "refresh", "walk", name);
+  return {
+    enter(name) {
+      const now = performance.now();
+      if (current !== undefined) record(current, now);
+      current = name;
+      phaseAt = now;
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      const now = performance.now();
+      if (current !== undefined) record(current, now);
+      current = undefined;
+      refreshTiming.time(startedAt, now, "memory", "refresh", "walk", "total");
+    },
+  };
+};
+
 export const refreshTrackedGraph = (
   space: string,
   engine: Engine.Engine,
@@ -1702,230 +1739,224 @@ export const refreshTrackedGraph = (
   const affectedMisses = new Map<QueryDocKey, Set<SchemaPathSelector>>();
   const invalidations = new Map<CellScope, Set<string>>();
   const identity = identityOf(state.manager);
-  const phaseStart = performance.now();
-  let phaseAt = phaseStart;
-  // Closes the phase that began at the previous mark (or the entry).
-  const phase = (name: string) => {
-    const now = performance.now();
-    refreshTiming.time(phaseAt, now, "memory", "refresh", "walk", name);
-    phaseAt = now;
-  };
-  for (const dirtyId of dirtyIds) {
-    // Dirtiness arrives keyed by scope INSTANCE (M4, stage F): the dirty
-    // key's scope_key segment IS the tracked doc key's middle segment, so
-    // the affected-tracker lookup is a direct join — no session-identity
-    // re-resolution, and another principal's instance simply never
-    // matches this state's tracker.
-    const { id, scopeKey, scope } = fromDirtyKey(dirtyId);
-    // The manager's read cache keys by (scope name, id) under its ONE
-    // bound identity, so invalidate only dirtiness aimed at THIS
-    // identity's own instance — a foreign instance was never cached here.
-    if (
-      canResolveScopeKey(scope, identity) &&
-      resolveScopeKey(scope, identity) === scopeKey
-    ) {
-      let scopedIds = invalidations.get(scope);
-      if (scopedIds === undefined) {
-        scopedIds = new Set();
-        invalidations.set(scope, scopedIds);
+  const phases = walkPhaseClock();
+  try {
+    phases.enter("select");
+    for (const dirtyId of dirtyIds) {
+      // Dirtiness arrives keyed by scope INSTANCE (M4, stage F): the dirty
+      // key's scope_key segment IS the tracked doc key's middle segment, so
+      // the affected-tracker lookup is a direct join — no session-identity
+      // re-resolution, and another principal's instance simply never
+      // matches this state's tracker.
+      const { id, scopeKey, scope } = fromDirtyKey(dirtyId);
+      // The manager's read cache keys by (scope name, id) under its ONE
+      // bound identity, so invalidate only dirtiness aimed at THIS
+      // identity's own instance — a foreign instance was never cached here.
+      if (
+        canResolveScopeKey(scope, identity) &&
+        resolveScopeKey(scope, identity) === scopeKey
+      ) {
+        let scopedIds = invalidations.get(scope);
+        if (scopedIds === undefined) {
+          scopedIds = new Set();
+          invalidations.set(scope, scopedIds);
+        }
+        scopedIds.add(id);
       }
-      scopedIds.add(id);
+      const key: QueryDocKey = `${space}/${scopeKey}/${id}`;
+      const selectors = state.tracker.get(key);
+      if (selectors !== undefined && selectors.size > 0) {
+        affectedDocs.set(key, new Set(selectors));
+      }
+      // A dirty doc the query's walks MISSED (read as absent) re-fires the
+      // query exactly like a tracked one: this is the arrival half of the
+      // dead-end read contract — the write that creates the document is the
+      // event that heals every read that dead-ended on it. Without this, a
+      // first-hydration miss on a quiet space starves for the session's
+      // life (OW45 arm B).
+      const missedSelectors = state.missed.get(key);
+      if (missedSelectors !== undefined && missedSelectors.size > 0) {
+        affectedMisses.set(key, new Set(missedSelectors));
+      }
     }
-    const key: QueryDocKey = `${space}/${scopeKey}/${id}`;
-    const selectors = state.tracker.get(key);
-    if (selectors !== undefined && selectors.size > 0) {
-      affectedDocs.set(key, new Set(selectors));
+    if (affectedDocs.size === 0 && affectedMisses.size === 0) {
+      return null;
     }
-    // A dirty doc the query's walks MISSED (read as absent) re-fires the
-    // query exactly like a tracked one: this is the arrival half of the
-    // dead-end read contract — the write that creates the document is the
-    // event that heals every read that dead-ended on it. Without this, a
-    // first-hydration miss on a quiet space starves for the session's
-    // life (OW45 arm B).
-    const missedSelectors = state.missed.get(key);
-    if (missedSelectors !== undefined && missedSelectors.size > 0) {
-      affectedMisses.set(key, new Set(missedSelectors));
+    phases.enter("rewalk");
+
+    const manager = new EngineObjectManager(
+      engine,
+      state.branch,
+      state.manager.principal,
+      state.manager.sessionId,
+    );
+    const sharedMemo = createSchemaMemo();
+    const stats = createQueryTraversalStats();
+    const readCountBefore = manager.readCount;
+
+    const recorder = missRecorderFor(state);
+    for (const key of affectedDocs.keys()) {
+      state.tracker.delete(key);
+      // The re-walk below re-records this referrer's still-live misses;
+      // attributions from its PREVIOUS walk no longer stand, so a link
+      // edited away retires its miss instead of leaving a stale wake.
+      releaseReferrerMisses(state, key);
     }
-  }
-  if (affectedDocs.size === 0 && affectedMisses.size === 0) {
-    phase("select-none");
-    return null;
-  }
-  phase("select");
 
-  const manager = new EngineObjectManager(
-    engine,
-    state.branch,
-    state.manager.principal,
-    state.manager.sessionId,
-  );
-  const sharedMemo = createSchemaMemo();
-  const stats = createQueryTraversalStats();
-  const readCountBefore = manager.readCount;
+    // A document a query named, or one delivered as a member of a named
+    // document's family, is owed its family on every re-walk; a document the
+    // walks merely reached keeps its crossing shape.
+    const roleOf = (key: QueryDocKey) =>
+      state.roots.has(key) || state.chased.has(key)
+        ? "root" as const
+        : "crossing" as const;
+    // A named root that was absent when first tracked earns its family on
+    // the visit that finds it born, and a chase records every member it
+    // loaded so the member's own re-walk chases in turn.
+    const recordChased = (
+      key: QueryDocKey,
+      role: "root" | "crossing",
+      evaluated: EvaluatedDocument | null,
+    ) => {
+      if (evaluated === null || role !== "root") return;
+      state.chased.add(key);
+      for (const chasedKey of evaluated.chasedFamilyKeys) {
+        state.chased.add(chasedKey);
+      }
+    };
 
-  const recorder = missRecorderFor(state);
-  for (const key of affectedDocs.keys()) {
-    state.tracker.delete(key);
-    // The re-walk below re-records this referrer's still-live misses;
-    // attributions from its PREVIOUS walk no longer stand, so a link
-    // edited away retires its miss instead of leaving a stale wake.
-    releaseReferrerMisses(state, key);
-  }
-
-  // A document a query named, or one delivered as a member of a named
-  // document's family, is owed its family on every re-walk; a document the
-  // walks merely reached keeps its crossing shape.
-  const roleOf = (key: QueryDocKey) =>
-    state.roots.has(key) || state.chased.has(key)
-      ? "root" as const
-      : "crossing" as const;
-  // A named root that was absent when first tracked earns its family on
-  // the visit that finds it born, and a chase records every member it
-  // loaded so the member's own re-walk chases in turn.
-  const recordChased = (
-    key: QueryDocKey,
-    role: "root" | "crossing",
-    evaluated: EvaluatedDocument | null,
-  ) => {
-    if (evaluated === null || role !== "root") return;
-    state.chased.add(key);
-    for (const chasedKey of evaluated.chasedFamilyKeys) {
-      state.chased.add(chasedKey);
+    for (const [key, selectors] of affectedDocs) {
+      const { id, scope, scopeKey } = fromDocKey(key);
+      const role = roleOf(key);
+      for (const selector of selectors) {
+        const evaluated = evaluateTrackedDocument(
+          space,
+          manager,
+          { id, scope, scopeKey },
+          selector,
+          state.tracker,
+          recorder,
+          sharedMemo,
+          stats,
+          undefined,
+          role,
+        );
+        recordChased(key, role, evaluated);
+      }
     }
-  };
+    phases.enter("misses");
+    // Re-evaluate the dirtied misses. A BORN target is visited — it enters
+    // the tracker (and the update assembly below delivers it) — and its
+    // miss retires; a still-absent one keeps its miss and attributions
+    // untouched (the throwaway sink swallows the absent re-registration:
+    // a miss never migrates into the tracker, whose entries reach the
+    // wire).
+    const stillAbsent = new MapSetStringToPathSelectors(true);
+    for (const [key, selectors] of affectedMisses) {
+      const { id, scope, scopeKey } = fromDocKey(key);
+      const role = roleOf(key);
+      for (const selector of selectors) {
+        const evaluated = evaluateTrackedDocument(
+          space,
+          manager,
+          { id, scope, scopeKey },
+          selector,
+          state.tracker,
+          recorder,
+          sharedMemo,
+          stats,
+          stillAbsent,
+          role,
+        );
+        recordChased(key, role, evaluated);
+      }
+      // Retirement is decided by THIS evaluation's own outcome — the
+      // throwaway sink received the key iff the doc was still absent. The
+      // tracker is no witness here: the same key can be an absent watch
+      // ROOT whose re-evaluation just re-added its seq-0 marker, and
+      // retiring the miss on that would lose the link-derived selector's
+      // closure when the doc is finally born.
+      if (!stillAbsent.has(key)) {
+        retireMiss(state, key);
+      }
+    }
 
-  for (const [key, selectors] of affectedDocs) {
-    const { id, scope, scopeKey } = fromDocKey(key);
-    const role = roleOf(key);
-    for (const selector of selectors) {
-      const evaluated = evaluateTrackedDocument(
+    phases.enter("loaded");
+    const touched = new Set<QueryDocKey>(affectedDocs.keys());
+    for (const key of affectedMisses.keys()) touched.add(key);
+    for (const address of manager.loadedAddresses()) {
+      const key: QueryDocKey = `${space}/${address.scopeKey}/${address.id}`;
+      const previous = state.entities.get(key);
+      const detail = manager.detail({
+        id: address.id,
+        scope: address.scope,
+        scopeKey: address.scopeKey,
+      });
+      if (previous !== undefined && detail?.seq === previous.seq) {
+        continue;
+      }
+      touched.add(key);
+    }
+    phases.enter("snapshot");
+    const updates = new Map<QueryDocKey, EntitySnapshot>();
+    for (const key of touched) {
+      if (!state.tracker.has(key)) {
+        continue;
+      }
+      const snapshot = snapshotForDocKey(
         space,
         manager,
-        { id, scope, scopeKey },
-        selector,
-        state.tracker,
-        recorder,
-        sharedMemo,
-        stats,
-        undefined,
-        role,
+        state.branch,
+        key,
       );
-      recordChased(key, role, evaluated);
+      if (snapshot === null) {
+        continue;
+      }
+      updates.set(key, snapshot);
     }
-  }
-  phase("rewalk");
-  // Re-evaluate the dirtied misses. A BORN target is visited — it enters
-  // the tracker (and the update assembly below delivers it) — and its
-  // miss retires; a still-absent one keeps its miss and attributions
-  // untouched (the throwaway sink swallows the absent re-registration:
-  // a miss never migrates into the tracker, whose entries reach the
-  // wire).
-  const stillAbsent = new MapSetStringToPathSelectors(true);
-  for (const [key, selectors] of affectedMisses) {
-    const { id, scope, scopeKey } = fromDocKey(key);
-    const role = roleOf(key);
-    for (const selector of selectors) {
-      const evaluated = evaluateTrackedDocument(
-        space,
-        manager,
-        { id, scope, scopeKey },
-        selector,
-        state.tracker,
-        recorder,
-        sharedMemo,
-        stats,
-        stillAbsent,
-        role,
-      );
-      recordChased(key, role, evaluated);
-    }
-    // Retirement is decided by THIS evaluation's own outcome — the
-    // throwaway sink received the key iff the doc was still absent. The
-    // tracker is no witness here: the same key can be an absent watch
-    // ROOT whose re-evaluation just re-added its seq-0 marker, and
-    // retiring the miss on that would lose the link-derived selector's
-    // closure when the doc is finally born.
-    if (!stillAbsent.has(key)) {
-      retireMiss(state, key);
-    }
-  }
 
-  phase("misses");
-  const touched = new Set<QueryDocKey>(affectedDocs.keys());
-  for (const key of affectedMisses.keys()) touched.add(key);
-  for (const address of manager.loadedAddresses()) {
-    const key: QueryDocKey = `${space}/${address.scopeKey}/${address.id}`;
-    const previous = state.entities.get(key);
-    const detail = manager.detail({
-      id: address.id,
-      scope: address.scope,
-      scopeKey: address.scopeKey,
-    });
-    if (previous !== undefined && detail?.seq === previous.seq) {
-      continue;
-    }
-    touched.add(key);
-  }
-  phase("loaded");
-
-  const updates = new Map<QueryDocKey, EntitySnapshot>();
-  for (const key of touched) {
-    if (!state.tracker.has(key)) {
-      continue;
-    }
-    const snapshot = snapshotForDocKey(
+    // `established` extends validation over the whole previously delivered
+    // state, so a corrupted dependency fails the refresh even when its
+    // referrer did not change. A throw here can leave this graph's tracker
+    // partially advanced; the caller marks the session for a full
+    // re-evaluation, which re-diffs everything on the next successful pass
+    // rather than trusting increments computed over the failure.
+    phases.enter("closure");
+    const staged = assembleSchemaDocClosures(
       space,
+      engine,
       manager,
       state.branch,
-      key,
+      state.tracker,
+      updates,
+      state.entities,
     );
-    if (snapshot === null) {
-      continue;
+    phases.enter("merge");
+    for (const key of staged.trackerAdds) {
+      state.tracker.add(key, REJECTING_SELECTOR);
     }
-    updates.set(key, snapshot);
-  }
+    for (const [key, snapshot] of staged.additions) {
+      updates.set(key, snapshot);
+    }
 
-  // `established` extends validation over the whole previously delivered
-  // state, so a corrupted dependency fails the refresh even when its
-  // referrer did not change. A throw here can leave this graph's tracker
-  // partially advanced; the caller marks the session for a full
-  // re-evaluation, which re-diffs everything on the next successful pass
-  // rather than trusting increments computed over the failure.
-  phase("snapshot");
-  const staged = assembleSchemaDocClosures(
-    space,
-    engine,
-    manager,
-    state.branch,
-    state.tracker,
-    updates,
-    state.entities,
-  );
-  phase("closure");
-  for (const key of staged.trackerAdds) {
-    state.tracker.add(key, REJECTING_SELECTOR);
-  }
-  for (const [key, snapshot] of staged.additions) {
-    updates.set(key, snapshot);
-  }
+    for (const [key, snapshot] of updates) {
+      state.entities.set(key, snapshot);
+    }
+    for (const [scope, ids] of invalidations) {
+      state.manager.invalidateIds(ids, scope);
+    }
+    state.manager.mergeFrom(manager);
 
-  for (const [key, snapshot] of updates) {
-    state.entities.set(key, snapshot);
-  }
-  for (const [scope, ids] of invalidations) {
-    state.manager.invalidateIds(ids, scope);
-  }
-  state.manager.mergeFrom(manager);
-  phase("merge");
-  refreshTiming.time(phaseStart, "memory", "refresh", "walk", "total");
+    stats.managerReads = manager.readCount - readCountBefore;
 
-  stats.managerReads = manager.readCount - readCountBefore;
-
-  return {
-    serverSeq: Engine.serverSeq(engine),
-    updates,
-    stats,
-  };
+    return {
+      serverSeq: Engine.serverSeq(engine),
+      updates,
+      stats,
+    };
+  } finally {
+    phases.close();
+  }
 };
 
 /** What `evaluateTrackedDocument` reports of a document it found present. */

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -1,4 +1,5 @@
 import type { FabricValue, JSONSchema } from "@commonfabric/api";
+import { getLogger } from "@commonfabric/utils/logger";
 import {
   internPathSelector,
   internSchemaAsTaggedHashString,
@@ -1677,6 +1678,13 @@ export const queryGraph = (
   };
 };
 
+// The refresh's own phase rows (`memory/refresh/walk/<phase>` on the
+// health route's timing stats, beside the server's `memory/refresh/phase/*`
+// rows): one row per phase of one graph's incremental re-evaluation, so a
+// slow pass can be read as "the closure scan" or "the re-walk" rather than
+// as one number. Recorded whether or not the logger prints.
+const refreshTiming = getLogger("memory", { enabled: false });
+
 export const refreshTrackedGraph = (
   space: string,
   engine: Engine.Engine,
@@ -1694,6 +1702,14 @@ export const refreshTrackedGraph = (
   const affectedMisses = new Map<QueryDocKey, Set<SchemaPathSelector>>();
   const invalidations = new Map<CellScope, Set<string>>();
   const identity = identityOf(state.manager);
+  const phaseStart = performance.now();
+  let phaseAt = phaseStart;
+  // Closes the phase that began at the previous mark (or the entry).
+  const phase = (name: string) => {
+    const now = performance.now();
+    refreshTiming.time(phaseAt, now, "memory", "refresh", "walk", name);
+    phaseAt = now;
+  };
   for (const dirtyId of dirtyIds) {
     // Dirtiness arrives keyed by scope INSTANCE (M4, stage F): the dirty
     // key's scope_key segment IS the tracked doc key's middle segment, so
@@ -1732,8 +1748,10 @@ export const refreshTrackedGraph = (
     }
   }
   if (affectedDocs.size === 0 && affectedMisses.size === 0) {
+    phase("select-none");
     return null;
   }
+  phase("select");
 
   const manager = new EngineObjectManager(
     engine,
@@ -1795,6 +1813,7 @@ export const refreshTrackedGraph = (
       recordChased(key, role, evaluated);
     }
   }
+  phase("rewalk");
   // Re-evaluate the dirtied misses. A BORN target is visited — it enters
   // the tracker (and the update assembly below delivers it) — and its
   // miss retires; a still-absent one keeps its miss and attributions
@@ -1831,6 +1850,7 @@ export const refreshTrackedGraph = (
     }
   }
 
+  phase("misses");
   const touched = new Set<QueryDocKey>(affectedDocs.keys());
   for (const key of affectedMisses.keys()) touched.add(key);
   for (const address of manager.loadedAddresses()) {
@@ -1846,6 +1866,7 @@ export const refreshTrackedGraph = (
     }
     touched.add(key);
   }
+  phase("loaded");
 
   const updates = new Map<QueryDocKey, EntitySnapshot>();
   for (const key of touched) {
@@ -1870,6 +1891,7 @@ export const refreshTrackedGraph = (
   // partially advanced; the caller marks the session for a full
   // re-evaluation, which re-diffs everything on the next successful pass
   // rather than trusting increments computed over the failure.
+  phase("snapshot");
   const staged = assembleSchemaDocClosures(
     space,
     engine,
@@ -1879,6 +1901,7 @@ export const refreshTrackedGraph = (
     updates,
     state.entities,
   );
+  phase("closure");
   for (const key of staged.trackerAdds) {
     state.tracker.add(key, REJECTING_SELECTOR);
   }
@@ -1893,6 +1916,8 @@ export const refreshTrackedGraph = (
     state.manager.invalidateIds(ids, scope);
   }
   state.manager.mergeFrom(manager);
+  phase("merge");
+  refreshTiming.time(phaseStart, "memory", "refresh", "walk", "total");
 
   stats.managerReads = manager.readCount - readCountBefore;
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -251,6 +251,10 @@ export type SlowQuery = {
   roots?: number;
   watches?: number;
 
+  /** session.watch.refresh only: the refreshed session's principal, so a
+   * slow refresh names whose watch set cost it. */
+  principal?: string;
+
   /** transact only: milliseconds the commit waited for the space
    * publication lock before evaluation began. Flush passes hold the same
    * lock, so a large value is head-of-line blocking behind fan-out rather
@@ -5308,7 +5312,21 @@ export class Server {
               }
             }
             span.setAttribute("ct.touched", touched);
+            // Per-session refresh rows (`memory/refresh/session/{untouched,
+            // touched}`) and, for a touched session, the phase rows
+            // (`memory/refresh/phase/{walk,diff,tracked,frame}` with the
+            // tracked-set rebuild split further): `memory/flush/refresh`
+            // is a whole pass over every session, so this is what says
+            // which sessions a commit cost and where in one session the
+            // time went.
             if (!touched) {
+              timing.time(
+                startedAt,
+                "memory",
+                "refresh",
+                "session",
+                "untouched",
+              );
               return await emptyCatchUp();
             }
 
@@ -5316,6 +5334,7 @@ export class Server {
             const fromSeq = session.lastSyncedSeq;
             const identity = this.#sessionScopeIdentity(session);
             const updates = new Map<string, SessionCacheEntry>();
+            const walkStartedAt = performance.now();
 
             // Evaluation exceptions — schema-closure corruption included —
             // propagate to refreshDirty's catch, which logs, skips this
@@ -5350,10 +5369,13 @@ export class Server {
               }
             }
 
+            timing.time(walkStartedAt, "memory", "refresh", "phase", "walk");
             if (updates.size === 0) {
+              timing.time(startedAt, "memory", "refresh", "session", "touched");
               return await emptyCatchUp();
             }
 
+            const diffStartedAt = performance.now();
             // The lease-holder exemption was judged on CURRENT holdership
             // above, once per pass: a former holder's foreign instances
             // are filtered like any other session's (protocol.md §2's
@@ -5406,12 +5428,14 @@ export class Server {
             for (const key of filteredKeys) {
               updates.delete(key);
             }
+            timing.time(diffStartedAt, "memory", "refresh", "phase", "diff");
             // The session cache commits only after the frame is fully
             // built: a throw during marker/adoption attachment must leave
             // the diff recomputable, or the requeued batch would elide the
             // lost frame's docs as already-snapshotted (CT-1927 review,
             // round 6).
             const commitEntities = () => {
+              const trackedStartedAt = performance.now();
               // (d′) — design §2.8 flag 2: a push pass that changes the
               // session's tracked set is a demand change; notify so the
               // demand pass sees it without waiting for the next input.
@@ -5433,17 +5457,46 @@ export class Server {
               // away releases its miss), and a retired interest must
               // leave the wake set with it — while a re-walk's new absent
               // dead-ends are wake-reactivity the next commit needs.
+              const entriesAt = performance.now();
+              const fromEntries = trackedIdsFromEntries(
+                session.entities.values(),
+              );
+              const watchesAt = performance.now();
+              timing.time(
+                entriesAt,
+                watchesAt,
+                "memory",
+                "refresh",
+                "tracked",
+                "entries",
+              );
               session.trackedIds = addOperationWatchTrackedIds(
-                trackedIdsFromEntries(session.entities.values()),
+                fromEntries,
                 session.watches,
                 {
                   principal: session.principal,
                   sessionId: session.id,
                 },
               );
+              const missedAt = performance.now();
+              timing.time(
+                watchesAt,
+                missedAt,
+                "memory",
+                "refresh",
+                "tracked",
+                "watches",
+              );
               this.#addMissedToTrackedIds(
                 session.trackedIds,
                 session.graphs.values(),
+              );
+              timing.time(
+                missedAt,
+                "memory",
+                "refresh",
+                "tracked",
+                "missed",
               );
               let changed = false;
               if (wantsDemandNotify) {
@@ -5464,6 +5517,13 @@ export class Server {
                   session.principal,
                 );
               }
+              timing.time(
+                trackedStartedAt,
+                "memory",
+                "refresh",
+                "phase",
+                "tracked",
+              );
             };
             const toSeq = Engine.serverSeq(engine);
             if (upserts.length === 0) {
@@ -5474,12 +5534,15 @@ export class Server {
               // Cubic fix keeps fromSeq pinned to the pre-refresh value).
               commitEntities();
               session.lastSyncedSeq = Math.max(session.lastSyncedSeq, toSeq);
+              timing.time(startedAt, "memory", "refresh", "session", "touched");
               return await emptyCatchUp(fromSeq, toSeq);
             }
             recordSlowQueryDuration("session.watch.refresh", space, startedAt, {
               watches: session.watches.length,
               upserts: upserts.length,
+              principal: session.principal,
             });
+            const frameStartedAt = performance.now();
             const message = await finishCatchUp({
               type: "sync",
               fromSeq,
@@ -5504,8 +5567,10 @@ export class Server {
               upserts: [...upserts],
               removes: [],
             });
+            timing.time(frameStartedAt, "memory", "refresh", "phase", "frame");
             commitEntities();
             session.lastSyncedSeq = toSeq;
+            timing.time(startedAt, "memory", "refresh", "session", "touched");
             return message;
           }
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -5304,274 +5304,313 @@ export class Server {
             // branch).
             const batchDirtyIds = dirtyIds;
             const startedAt = performance.now();
-            let touched = false;
-            for (const dirtyId of batchDirtyIds) {
-              if (session.trackedIds.has(dirtyId)) {
-                touched = true;
-                break;
-              }
-            }
-            span.setAttribute("ct.touched", touched);
             // Per-session refresh rows (`memory/refresh/session/{untouched,
             // touched}`) and, for a touched session, the phase rows
             // (`memory/refresh/phase/{walk,diff,tracked,frame}` with the
             // tracked-set rebuild split further): `memory/flush/refresh`
             // is a whole pass over every session, so this is what says
             // which sessions a commit cost and where in one session the
-            // time went.
-            if (!touched) {
+            // time went. Every row closes in a `finally`: a refresh that
+            // throws is skipped and requeued by the caller, and an
+            // expensive failure is the one most worth attributing.
+            let sessionKind: "untouched" | "touched" = "untouched";
+            try {
+              let touched = false;
+              for (const dirtyId of batchDirtyIds) {
+                if (session.trackedIds.has(dirtyId)) {
+                  touched = true;
+                  break;
+                }
+              }
+              span.setAttribute("ct.touched", touched);
+              if (!touched) {
+                return await emptyCatchUp();
+              }
+              sessionKind = "touched";
+
+              const engine = await this.#openEngine(space);
+              const fromSeq = session.lastSyncedSeq;
+              const identity = this.#sessionScopeIdentity(session);
+              const updates = new Map<string, SessionCacheEntry>();
+              const walkStartedAt = performance.now();
+
+              // Evaluation exceptions — schema-closure corruption included —
+              // propagate to refreshDirty's catch, which logs, skips this
+              // session's frame, and marks it for a full re-evaluation.
+              try {
+                for (const graph of session.graphs.values()) {
+                  const refreshed = tracer.startActiveSpan(
+                    "memory.watch.refresh",
+                    (watchSpan) => {
+                      watchSpan.setAttribute("space.did", space);
+                      try {
+                        return refreshTrackedGraph(
+                          space,
+                          engine,
+                          graph,
+                          batchDirtyIds,
+                        );
+                      } finally {
+                        watchSpan.end();
+                      }
+                    },
+                  );
+                  if (refreshed === null) {
+                    continue;
+                  }
+                  for (const [docKey, entity] of refreshed.updates) {
+                    const { scopeKey } = fromDocKey(docKey);
+                    const entry = toCacheEntry(entity, identity, scopeKey);
+                    updates.set(
+                      cacheKeyForEntity(entry.branch, entry.id, entry.scopeKey),
+                      entry,
+                    );
+                  }
+                }
+              } finally {
+                timing.time(
+                  walkStartedAt,
+                  "memory",
+                  "refresh",
+                  "phase",
+                  "walk",
+                );
+              }
+              if (updates.size === 0) {
+                return await emptyCatchUp();
+              }
+
+              const diffStartedAt = performance.now();
+              const filteredKeys: string[] = [];
+              const upserts: SessionCacheEntry[] = [];
+              try {
+                // The lease-holder exemption was judged on CURRENT holdership
+                // above, once per pass: a former holder's foreign instances
+                // are filtered like any other session's (protocol.md §2's
+                // read row is live-lease admission).
+                for (const [key, entry] of updates) {
+                  const previous = session.entities.get(key);
+                  if (!sameSnapshot(previous, entry)) {
+                    // protocol.md §3's applicable-set filter, as
+                    // defense-in-depth: a session's graph evaluates under
+                    // its own identity, so an inapplicable instance here is
+                    // structurally unreachable — unless the session is a
+                    // CURRENT lease holder with explicit-instance reads
+                    // admitted (protocol.md §2's read row), which is exempt
+                    // by design (the server legitimately receives every
+                    // instance it serves).
+                    if (
+                      !leaseHolderExempt &&
+                      !scopeKeyApplicableTo(entry.scopeKey, identity)
+                    ) {
+                      // Never cache a filtered entry as delivered: a later
+                      // re-admission must still see the client's cache as
+                      // NOT holding it, or the withheld update is elided
+                      // forever.
+                      filteredKeys.push(key);
+                      continue;
+                    }
+                    const dirtyKey = toDirtyKey(entry.id, entry.scopeKey);
+                    const origin = dirtyOrigins?.get(dirtyKey);
+                    // Include the doc unless the writer provably holds it
+                    // (CT-1965). An origin matching this session AND the head seq
+                    // means the head is exactly this session's own accepted
+                    // write; under the per-space publication lock nothing can
+                    // have moved it since, so `entry.doc` IS that commit's
+                    // post-apply document. A `set`/`delete` head is then elided —
+                    // the client supplied the bytes (or the absence) and the
+                    // verdict + marker promote them — while a `patch` head is
+                    // delivered in full: its post-apply state can contain merged
+                    // foreign content the writer's own ops cannot reproduce.
+                    const held = origin !== undefined &&
+                      origin.sessionId === sessionId &&
+                      origin.seq === entry.seq &&
+                      (origin.op !== "patch" || !getOwnWriteEchoConfig());
+                    if (!held) {
+                      upserts.push(entry);
+                    }
+                  }
+                }
+                for (const key of filteredKeys) {
+                  updates.delete(key);
+                }
+              } finally {
+                timing.time(
+                  diffStartedAt,
+                  "memory",
+                  "refresh",
+                  "phase",
+                  "diff",
+                );
+              }
+              // The session cache commits only after the frame is fully
+              // built: a throw during marker/adoption attachment must leave
+              // the diff recomputable, or the requeued batch would elide the
+              // lost frame's docs as already-snapshotted (CT-1927 review,
+              // round 6).
+              const commitEntities = () => {
+                const trackedStartedAt = performance.now();
+                try {
+                  // (d′) — design §2.8 flag 2: a push pass that changes the
+                  // session's tracked set is a demand change; notify so the
+                  // demand pass sees it without waiting for the next input.
+                  // The set is rebuilt rather than grown, so the change can
+                  // be a same-size swap (a link retargeted from one absent
+                  // document to another) or a shrink — compared by
+                  // membership, exactly as the full-evaluation branch below
+                  // does, and like there the O(tracked) scan runs only when
+                  // a demand observer is attached (the serving posture; its
+                  // NIT-6 note covers the `push-growth` reason on a shrink).
+                  const wantsDemandNotify =
+                    this.#serverExecutionObserver?.demandChanged !== undefined;
+                  const previous = session.trackedIds;
+                  for (const [key, entry] of updates) {
+                    session.entities.set(key, entry);
+                  }
+                  // Rebuilt from provenance rather than grown in place: the
+                  // refresh above may have RETIRED interests (a link edited
+                  // away releases its miss), and a retired interest must
+                  // leave the wake set with it — while a re-walk's new absent
+                  // dead-ends are wake-reactivity the next commit needs.
+                  const entriesAt = performance.now();
+                  const fromEntries = trackedIdsFromEntries(
+                    session.entities.values(),
+                  );
+                  const watchesAt = performance.now();
+                  timing.time(
+                    entriesAt,
+                    watchesAt,
+                    "memory",
+                    "refresh",
+                    "tracked",
+                    "entries",
+                  );
+                  session.trackedIds = addOperationWatchTrackedIds(
+                    fromEntries,
+                    session.watches,
+                    {
+                      principal: session.principal,
+                      sessionId: session.id,
+                    },
+                  );
+                  const missedAt = performance.now();
+                  timing.time(
+                    watchesAt,
+                    missedAt,
+                    "memory",
+                    "refresh",
+                    "tracked",
+                    "watches",
+                  );
+                  this.#addMissedToTrackedIds(
+                    session.trackedIds,
+                    session.graphs.values(),
+                  );
+                  timing.time(
+                    missedAt,
+                    "memory",
+                    "refresh",
+                    "tracked",
+                    "missed",
+                  );
+                  let changed = false;
+                  if (wantsDemandNotify) {
+                    changed = previous.size !== session.trackedIds.size;
+                    if (!changed) {
+                      for (const key of session.trackedIds) {
+                        if (!previous.has(key)) {
+                          changed = true;
+                          break;
+                        }
+                      }
+                    }
+                  }
+                  if (changed) {
+                    this.#notifyDemandChanged(
+                      space,
+                      "push-growth",
+                      session.principal,
+                    );
+                  }
+                } finally {
+                  timing.time(
+                    trackedStartedAt,
+                    "memory",
+                    "refresh",
+                    "phase",
+                    "tracked",
+                  );
+                }
+              };
+              const toSeq = Engine.serverSeq(engine);
+              if (upserts.length === 0) {
+                // The watched set was re-evaluated current as of toSeq even though it
+                // produced no net upserts; advance the watermark so a later default
+                // fromSeq is not stale. emptyCatchUp receives the original fromSeq
+                // explicitly, so this does not mutate the bounds of this sync (the
+                // Cubic fix keeps fromSeq pinned to the pre-refresh value).
+                commitEntities();
+                session.lastSyncedSeq = Math.max(session.lastSyncedSeq, toSeq);
+                return await emptyCatchUp(fromSeq, toSeq);
+              }
+              recordSlowQueryDuration(
+                "session.watch.refresh",
+                space,
+                startedAt,
+                {
+                  watches: session.watches.length,
+                  upserts: upserts.length,
+                  principal: session.principal,
+                },
+              );
+              const frameStartedAt = performance.now();
+              let message: SessionEffectMessage;
+              try {
+                message = await finishCatchUp({
+                  type: "sync",
+                  fromSeq,
+                  toSeq,
+                  upserts: upserts.toSorted((left, right) =>
+                    left.branch.localeCompare(right.branch) ||
+                    left.id.localeCompare(right.id)
+                  ).map((entry) =>
+                    // Keyed by the session's wire vocabulary (stage A, OW17's
+                    // wire leg — see `keyed` above): the key is what keeps
+                    // two instances of one (branch, id, scope) apart in the
+                    // serving replica. Unkeyed frames are byte-identical to
+                    // before.
+                    toWireUpsert(entry, keyed)
+                  ),
+                  removes: [],
+                });
+                // An unkeyed wire frame strips instance keys; retain the
+                // frame's true instance-keyed entries so a delivery failure
+                // rolls back the EXACT instances (rollbackUndeliveredSync).
+                this.#deliveredFrameEntries.set(message, {
+                  upserts: [...upserts],
+                  removes: [],
+                });
+              } finally {
+                timing.time(
+                  frameStartedAt,
+                  "memory",
+                  "refresh",
+                  "phase",
+                  "frame",
+                );
+              }
+              commitEntities();
+              session.lastSyncedSeq = toSeq;
+              return message;
+            } finally {
               timing.time(
                 startedAt,
                 "memory",
                 "refresh",
                 "session",
-                "untouched",
+                sessionKind,
               );
-              return await emptyCatchUp();
             }
-
-            const engine = await this.#openEngine(space);
-            const fromSeq = session.lastSyncedSeq;
-            const identity = this.#sessionScopeIdentity(session);
-            const updates = new Map<string, SessionCacheEntry>();
-            const walkStartedAt = performance.now();
-
-            // Evaluation exceptions — schema-closure corruption included —
-            // propagate to refreshDirty's catch, which logs, skips this
-            // session's frame, and marks it for a full re-evaluation.
-            for (const graph of session.graphs.values()) {
-              const refreshed = tracer.startActiveSpan(
-                "memory.watch.refresh",
-                (watchSpan) => {
-                  watchSpan.setAttribute("space.did", space);
-                  try {
-                    return refreshTrackedGraph(
-                      space,
-                      engine,
-                      graph,
-                      batchDirtyIds,
-                    );
-                  } finally {
-                    watchSpan.end();
-                  }
-                },
-              );
-              if (refreshed === null) {
-                continue;
-              }
-              for (const [docKey, entity] of refreshed.updates) {
-                const { scopeKey } = fromDocKey(docKey);
-                const entry = toCacheEntry(entity, identity, scopeKey);
-                updates.set(
-                  cacheKeyForEntity(entry.branch, entry.id, entry.scopeKey),
-                  entry,
-                );
-              }
-            }
-
-            timing.time(walkStartedAt, "memory", "refresh", "phase", "walk");
-            if (updates.size === 0) {
-              timing.time(startedAt, "memory", "refresh", "session", "touched");
-              return await emptyCatchUp();
-            }
-
-            const diffStartedAt = performance.now();
-            // The lease-holder exemption was judged on CURRENT holdership
-            // above, once per pass: a former holder's foreign instances
-            // are filtered like any other session's (protocol.md §2's
-            // read row is live-lease admission).
-            const filteredKeys: string[] = [];
-            const upserts: SessionCacheEntry[] = [];
-            for (const [key, entry] of updates) {
-              const previous = session.entities.get(key);
-              if (!sameSnapshot(previous, entry)) {
-                // protocol.md §3's applicable-set filter, as
-                // defense-in-depth: a session's graph evaluates under
-                // its own identity, so an inapplicable instance here is
-                // structurally unreachable — unless the session is a
-                // CURRENT lease holder with explicit-instance reads
-                // admitted (protocol.md §2's read row), which is exempt
-                // by design (the server legitimately receives every
-                // instance it serves).
-                if (
-                  !leaseHolderExempt &&
-                  !scopeKeyApplicableTo(entry.scopeKey, identity)
-                ) {
-                  // Never cache a filtered entry as delivered: a later
-                  // re-admission must still see the client's cache as
-                  // NOT holding it, or the withheld update is elided
-                  // forever.
-                  filteredKeys.push(key);
-                  continue;
-                }
-                const dirtyKey = toDirtyKey(entry.id, entry.scopeKey);
-                const origin = dirtyOrigins?.get(dirtyKey);
-                // Include the doc unless the writer provably holds it
-                // (CT-1965). An origin matching this session AND the head seq
-                // means the head is exactly this session's own accepted
-                // write; under the per-space publication lock nothing can
-                // have moved it since, so `entry.doc` IS that commit's
-                // post-apply document. A `set`/`delete` head is then elided —
-                // the client supplied the bytes (or the absence) and the
-                // verdict + marker promote them — while a `patch` head is
-                // delivered in full: its post-apply state can contain merged
-                // foreign content the writer's own ops cannot reproduce.
-                const held = origin !== undefined &&
-                  origin.sessionId === sessionId &&
-                  origin.seq === entry.seq &&
-                  (origin.op !== "patch" || !getOwnWriteEchoConfig());
-                if (!held) {
-                  upserts.push(entry);
-                }
-              }
-            }
-            for (const key of filteredKeys) {
-              updates.delete(key);
-            }
-            timing.time(diffStartedAt, "memory", "refresh", "phase", "diff");
-            // The session cache commits only after the frame is fully
-            // built: a throw during marker/adoption attachment must leave
-            // the diff recomputable, or the requeued batch would elide the
-            // lost frame's docs as already-snapshotted (CT-1927 review,
-            // round 6).
-            const commitEntities = () => {
-              const trackedStartedAt = performance.now();
-              // (d′) — design §2.8 flag 2: a push pass that changes the
-              // session's tracked set is a demand change; notify so the
-              // demand pass sees it without waiting for the next input.
-              // The set is rebuilt rather than grown, so the change can
-              // be a same-size swap (a link retargeted from one absent
-              // document to another) or a shrink — compared by
-              // membership, exactly as the full-evaluation branch below
-              // does, and like there the O(tracked) scan runs only when
-              // a demand observer is attached (the serving posture; its
-              // NIT-6 note covers the `push-growth` reason on a shrink).
-              const wantsDemandNotify =
-                this.#serverExecutionObserver?.demandChanged !== undefined;
-              const previous = session.trackedIds;
-              for (const [key, entry] of updates) {
-                session.entities.set(key, entry);
-              }
-              // Rebuilt from provenance rather than grown in place: the
-              // refresh above may have RETIRED interests (a link edited
-              // away releases its miss), and a retired interest must
-              // leave the wake set with it — while a re-walk's new absent
-              // dead-ends are wake-reactivity the next commit needs.
-              const entriesAt = performance.now();
-              const fromEntries = trackedIdsFromEntries(
-                session.entities.values(),
-              );
-              const watchesAt = performance.now();
-              timing.time(
-                entriesAt,
-                watchesAt,
-                "memory",
-                "refresh",
-                "tracked",
-                "entries",
-              );
-              session.trackedIds = addOperationWatchTrackedIds(
-                fromEntries,
-                session.watches,
-                {
-                  principal: session.principal,
-                  sessionId: session.id,
-                },
-              );
-              const missedAt = performance.now();
-              timing.time(
-                watchesAt,
-                missedAt,
-                "memory",
-                "refresh",
-                "tracked",
-                "watches",
-              );
-              this.#addMissedToTrackedIds(
-                session.trackedIds,
-                session.graphs.values(),
-              );
-              timing.time(
-                missedAt,
-                "memory",
-                "refresh",
-                "tracked",
-                "missed",
-              );
-              let changed = false;
-              if (wantsDemandNotify) {
-                changed = previous.size !== session.trackedIds.size;
-                if (!changed) {
-                  for (const key of session.trackedIds) {
-                    if (!previous.has(key)) {
-                      changed = true;
-                      break;
-                    }
-                  }
-                }
-              }
-              if (changed) {
-                this.#notifyDemandChanged(
-                  space,
-                  "push-growth",
-                  session.principal,
-                );
-              }
-              timing.time(
-                trackedStartedAt,
-                "memory",
-                "refresh",
-                "phase",
-                "tracked",
-              );
-            };
-            const toSeq = Engine.serverSeq(engine);
-            if (upserts.length === 0) {
-              // The watched set was re-evaluated current as of toSeq even though it
-              // produced no net upserts; advance the watermark so a later default
-              // fromSeq is not stale. emptyCatchUp receives the original fromSeq
-              // explicitly, so this does not mutate the bounds of this sync (the
-              // Cubic fix keeps fromSeq pinned to the pre-refresh value).
-              commitEntities();
-              session.lastSyncedSeq = Math.max(session.lastSyncedSeq, toSeq);
-              timing.time(startedAt, "memory", "refresh", "session", "touched");
-              return await emptyCatchUp(fromSeq, toSeq);
-            }
-            recordSlowQueryDuration("session.watch.refresh", space, startedAt, {
-              watches: session.watches.length,
-              upserts: upserts.length,
-              principal: session.principal,
-            });
-            const frameStartedAt = performance.now();
-            const message = await finishCatchUp({
-              type: "sync",
-              fromSeq,
-              toSeq,
-              upserts: upserts.toSorted((left, right) =>
-                left.branch.localeCompare(right.branch) ||
-                left.id.localeCompare(right.id)
-              ).map((entry) =>
-                // Keyed by the session's wire vocabulary (stage A, OW17's
-                // wire leg — see `keyed` above): the key is what keeps
-                // two instances of one (branch, id, scope) apart in the
-                // serving replica. Unkeyed frames are byte-identical to
-                // before.
-                toWireUpsert(entry, keyed)
-              ),
-              removes: [],
-            });
-            // An unkeyed wire frame strips instance keys; retain the
-            // frame's true instance-keyed entries so a delivery failure
-            // rolls back the EXACT instances (rollbackUndeliveredSync).
-            this.#deliveredFrameEntries.set(message, {
-              upserts: [...upserts],
-              removes: [],
-            });
-            timing.time(frameStartedAt, "memory", "refresh", "phase", "frame");
-            commitEntities();
-            session.lastSyncedSeq = toSeq;
-            timing.time(startedAt, "memory", "refresh", "session", "touched");
-            return message;
           }
 
           const { serverSeq, graphs, entities } = await this.evaluateWatchSet(


### PR DESCRIPTION
## What

The health route's `memory/flush/refresh` times a whole fan-out pass: every session, every phase, one number. It could say the Topics shard spent 92% of its life refreshing (the bracketed measurements on the tracking topic) but not which sessions a commit touched, nor whether a touched session's time went to the re-walk, the schema-closure scan, or the rebuild of its wake set.

This PR records the rest, as timing rows on the same route:

| row | what it times |
|---|---|
| `memory/refresh/session/untouched` | a session the batch did not touch (the fast path) |
| `memory/refresh/session/touched` | a touched session, end to end |
| `memory/refresh/phase/walk` | every graph's incremental re-evaluation |
| `memory/refresh/walk/{select,rewalk,misses,loaded,snapshot,closure,merge,total}` | the steps inside one graph's re-evaluation (`closure` = the schema-closure scan and verification over delivered + established) |
| `memory/refresh/phase/diff` | applicable-set filter and upsert assembly |
| `memory/refresh/phase/tracked` and `memory/refresh/tracked/{entries,watches,missed}` | the wake-set rebuild and its three folds |
| `memory/refresh/phase/frame` | frame build |

A slow `session.watch.refresh` entry in `slowQueries` also carries the session's `principal`, so a slow refresh names whose watch set cost it (the "slowQueries carry no session id" gap from the bracket).

## What it measured

Measured before #7132 landed: the numbers below include the lazy-registration rail that PR removed (its fold was the `tracked/undelivered` row, now `tracked/missed` over misses alone), so the `tracked` figures will read lower on today's main. The closure figure does not depend on it.

Served clone of the Topics space, six sessions holding the board with its UI demanded (~18k delivered entities and ~6.2k watches each), one document rewritten once a second for 60 s:

| | per touched session |
|---|---|
| end to end | 243 ms |
| `walk/closure` | 189 ms |
| `tracked/undelivered` (now `tracked/missed`) | 32 ms |
| `tracked/entries` | 19 ms |
| `walk/rewalk` | 4 ms |

So a touched session's refresh is three-quarters the schema-closure scan over its *established* set and a fifth the wake-set rebuild; the re-walk of what actually changed is noise. The next PR in this series acts on the first number.

## Failure paths

Every row closes in a `finally`: the session row around the whole incremental branch, each phase around its own work, and a phase clock in the graph re-evaluation whose `close()` records the phase in progress plus `walk/total`. A refresh that throws (the caller skips its frame and requeues it) is therefore counted in the rows that attribute the pass, and the session row includes the catch-up frame, whose operation-watch fields can be attached when nothing was upserted. `packages/memory/test/v2-server-refresh-timing.test.ts` pins both with count deltas: a corrupted `cid:` dependency met by a reopened engine, a revision row corrupted in place after a legitimate commit, and an operation-watch catch-up with no document upserts. The second commit's diff is indentation-heavy for the `finally` blocks; `git diff -w` shows the substance.

## Cost

Eight `performance.now()` pairs per touched session per pass and one per untouched session; the timing logger records stats whether or not it prints. Nothing on the wire changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



