### PR TITLE
feat(ci): the capabilities a lane opens for its suites

### DIFF
--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1020,13 +1020,15 @@ batches.
 | `git-history` | Unshallows the checkout | 3–10 seconds |
 | `toolshed` | A Toolshed server listening on an allocated port | see below |
 | `local-dev-servers` | The whole local dev stack, brought up by `deno task integration` on a chosen port offset | 15–20 seconds |
+| `toolshed-baked` | The same, from a compiled binary, whose baked shell a browser can drive | 42 seconds to build, or 17 to restore |
 | `toolshed-baked-opposite` | The same, from a binary whose shell carries the server-execution define opposite the default | 42 seconds to build, or 17 to restore |
 | `bg-piece-service-binary` | The compiled background service used by its deployed-topology gate | about 30 seconds to build, or under a second to restore |
 | `cf` | The `cf` command-line tool on the path | as above |
 | `compile-cache` | Restores a pattern compile byte cache | 3 seconds |
 
-Two capabilities are worth explaining, because the choice made for them is
-what keeps the five-minute budget reachable.
+The three ways of providing a Toolshed server are worth explaining,
+because the choice made among them is what keeps the five-minute budget
+reachable.
 
 **`toolshed` runs from source.** Today a job that needs a server downloads
 a compiled binary produced by a separate build job. On a pull request that
@@ -1038,20 +1040,24 @@ source costs a few seconds. The full run on `main` keeps the
 compiled-binary path, because it needs the binary anyway for attestation
 and deployment.
 
-**`toolshed-baked-opposite` cannot.** The server-execution opposite arm depends
-on a compile-time define baked into the browser shell inside the binary, and a
-source run cannot reproduce that. So that capability has a different
-provider: restore the binary from the Actions cache if the key hits, and
-build it in place if it does not. The lane workflow carries one fixed
-`actions/cache` step covering `.ci-cache`, keyed on a hash of the sources
-the binaries are built from. Everything a lane wants to keep between runs
-sits under that one directory — the built binaries, and the pattern
-compile byte cache — because one step covering one directory is what
-keeps the workflow independent of what the lane turns out to need. That step is in the workflow rather
-than in the runner because the cache service is only reachable through the
-action, and it is written once and never touched again.
+**The baked capabilities cannot.** The browser shell is a bundle compiled
+into the binary, so a server run from source answers the API and serves no
+shell, and a suite that drives a browser at one is told the shell app is
+not available. `toolshed-baked` is the server for the default arm.
+`toolshed-baked-opposite` is the server for the other arm, whose posture is
+a compile-time define baked into that same shell whichever way it goes.
+Both have a different provider: restore the binary from the Actions cache
+if the key hits, and build it in place if it does not. The lane workflow
+carries one fixed `actions/cache` step covering `.ci-cache`, keyed on a
+hash of the sources the binaries are built from. Everything a lane wants
+to keep between runs sits under that one directory — the built binaries,
+and the pattern compile byte cache — because one step covering one
+directory is what keeps the workflow independent of what the lane turns
+out to need. That step is in the workflow rather than in the runner
+because the cache service is only reachable through the action, and it is
+written once and never touched again.
 
-That split is the argument for having capabilities at all. Two ways of
+That split is the argument for having capabilities at all. Three ways of
 providing "a Toolshed server" coexist, suites say which one they need, and
 neither the workflow nor the other suites know the difference.
 

--- a/tasks/ci-capabilities.test.ts
+++ b/tasks/ci-capabilities.test.ts
@@ -4,13 +4,31 @@ import {
   BINARY_CACHE_DIR,
   CACHE_DIR,
   CAPABILITIES,
+  type Capability,
   type CapabilityId,
   COMPILE_CACHE_FILE,
   openCapabilities,
   pidOfBackgroundLaunch,
   resolveCapabilities,
 } from "./ci-capabilities.ts";
-import { serverExecutionCiLane } from "./server-execution-ci.ts";
+import {
+  serverExecutionCiLane,
+  type ServerExecutionCiRole,
+} from "./server-execution-ci.ts";
+
+/** A capability exporting `env`, built on `needs`. */
+function stub(
+  id: CapabilityId,
+  env: Record<string, string>,
+  needs?: readonly CapabilityId[],
+): Capability {
+  return {
+    id,
+    description: `a capability exporting ${Object.keys(env).join(", ")}`,
+    ...(needs === undefined ? {} : { needs }),
+    open: () => Promise.resolve({ env, close: () => Promise.resolve() }),
+  };
+}
 
 describe("ci capabilities", () => {
   it("opens what a capability is built on before the capability", () => {
@@ -62,6 +80,7 @@ describe("ci capabilities", () => {
       "jq",
       "local-dev-servers",
       "toolshed",
+      "toolshed-baked",
       "toolshed-baked-opposite",
     ]);
   });
@@ -72,7 +91,7 @@ describe("ci capabilities", () => {
       dryRun: true,
       workDir: "/nonexistent",
     });
-    expect(opened.env.API_URL).toBe("http://localhost:8000/");
+    expect(opened.envFor(["toolshed"]).API_URL).toBe("http://localhost:8000");
     expect(opened.timings.map((timing) => timing.capability)).toEqual([
       "deno",
       "toolshed",
@@ -134,17 +153,65 @@ describe("ci capabilities", () => {
     expect(opened.timings.length).toBe(CAPABILITIES.size);
     // The two servers export the addresses their suites reach them at,
     // and the command line exports the path it is found on.
-    expect(opened.env.API_URL).toBeDefined();
-    expect(opened.env.TOOLSHED_PORT).toBeDefined();
-    expect(opened.env.CF_LABS_ROOT).toBe(Deno.cwd());
-    expect(opened.env.BG_PIECE_SERVICE_BIN).toBe(
+    const every = opened.envFor([...CAPABILITIES.keys()]);
+    expect(every.API_URL).toBeDefined();
+    expect(every.TOOLSHED_PORT).toBeDefined();
+    expect(every.CF_LABS_ROOT).toBe(Deno.cwd());
+    expect(every.BG_PIECE_SERVICE_BIN).toBe(
       `${Deno.cwd()}/${BINARY_CACHE_DIR}/bg-piece-service`,
     );
-    expect(opened.env.PATH?.startsWith(`${Deno.cwd()}/bin`)).toBe(true);
-    expect(opened.env.CF_COMPILE_CACHE_FILE).toBe(
+    expect(every.PATH?.startsWith(`${Deno.cwd()}/bin`)).toBe(true);
+    expect(every.CF_COMPILE_CACHE_FILE).toBe(
       `${Deno.cwd()}/${COMPILE_CACHE_FILE}`,
     );
     await opened.close();
+  });
+
+  it("gives a suite the addresses its own server is listening on", async () => {
+    // Both Toolshed capabilities export the address theirs is listening
+    // on, and a lane may hold the default and opposite server-execution
+    // arms at once.
+    const registry = new Map<CapabilityId, Capability>([
+      ["toolshed", stub("toolshed", { API_URL: "http://default.test" })],
+      [
+        "toolshed-baked-opposite",
+        stub("toolshed-baked-opposite", { API_URL: "http://opposite.test" }),
+      ],
+    ]);
+    const opened = await openCapabilities(
+      ["toolshed", "toolshed-baked-opposite"],
+      { root: Deno.cwd(), dryRun: true, workDir: "/nonexistent" },
+      registry,
+    );
+    try {
+      expect(opened.envFor(["toolshed"]).API_URL).toBe("http://default.test");
+      expect(opened.envFor(["toolshed-baked-opposite"]).API_URL)
+        .toBe("http://opposite.test");
+    } finally {
+      await opened.close();
+    }
+  });
+
+  it("gives a suite what the capabilities under its own export too", async () => {
+    // A suite names one capability, and the batch runs with what
+    // everything under that one exports as well.
+    const registry = new Map<CapabilityId, Capability>([
+      ["deno", stub("deno", { UNDERNEATH: "yes" })],
+      ["cf", stub("cf", { NAMED: "yes" }, ["deno"])],
+    ]);
+    const opened = await openCapabilities(["cf"], {
+      root: Deno.cwd(),
+      dryRun: true,
+      workDir: "/nonexistent",
+    }, registry);
+    try {
+      expect(opened.envFor(["cf"])).toEqual({
+        UNDERNEATH: "yes",
+        NAMED: "yes",
+      });
+    } finally {
+      await opened.close();
+    }
   });
 
   it("closes what it opened, in the reverse of the opening order", async () => {
@@ -255,12 +322,15 @@ describe("opening a capability on a machine that answers", () => {
   /** What a capability asked the machine, and what it was told. */
   function machine(answers: Record<string, string> = {}) {
     const asked: string[] = [];
+    const envs: Array<Record<string, string> | undefined> = [];
     const exec = (
       command: string,
       args: readonly string[],
+      options?: { cwd?: string; env?: Record<string, string> },
     ): Promise<string> => {
       const line = [command, ...args].join(" ");
       asked.push(line);
+      envs.push(options?.env);
       for (const [match, answer] of Object.entries(answers)) {
         if (line.includes(match)) {
           return answer.startsWith("!")
@@ -270,10 +340,35 @@ describe("opening a capability on a machine that answers", () => {
       }
       return Promise.resolve("");
     };
-    return { asked, exec };
+    return { asked, envs, exec };
   }
 
-  async function open(id: CapabilityId, m: ReturnType<typeof machine>) {
+  /** The environment the machine was given for the call naming `match`. */
+  function envOf(m: ReturnType<typeof machine>, match: string) {
+    return m.envs[m.asked.findIndex((line) => line.includes(match))];
+  }
+
+  /** A server answering what one on `role` answers. */
+  function serving(role: ServerExecutionCiRole): typeof fetch {
+    const lane = serverExecutionCiLane(role);
+    const bodies: Record<string, unknown> = {
+      "/api/meta": {
+        experimental: { serverExecution: lane.enabled },
+        shellServerExecutionDefine: lane.experimentalValue ?? null,
+      },
+      "/api/health/stats": { servingLoop: lane.enabled ? 1 : null },
+    };
+    return (input) =>
+      Promise.resolve(
+        Response.json(bodies[new URL(String(input)).pathname] ?? {}),
+      );
+  }
+
+  async function open(
+    id: CapabilityId,
+    m: ReturnType<typeof machine>,
+    role: ServerExecutionCiRole = "default",
+  ) {
     const root = await Deno.makeTempDir({ prefix: "capability-" });
     try {
       const opened = await openCapabilities([id], {
@@ -281,6 +376,7 @@ describe("opening a capability on a machine that answers", () => {
         dryRun: false,
         workDir: root,
         exec: m.exec,
+        fetch: serving(role),
       }, CAPABILITIES);
       await opened.close();
       return { opened, root };
@@ -300,7 +396,24 @@ describe("opening a capability on a machine that answers", () => {
     expect(present.asked.some((line) => line.includes("chmod 666 /dev/fuse")))
       .toBe(true);
 
-    const missing = machine({ "command -v fusermount3": "!not found" });
+    // The runner image carries the FUSE runtime and not its development
+    // files, so `fusermount3` answers while the library the mount opens
+    // is absent. What the probe asks has to be the library.
+    const library = machine({
+      "pkg-config --exists fuse3": "!no such package",
+    });
+    await open("fuse", library);
+    expect(library.asked.some((line) => line.includes("libfuse3-dev")))
+      .toBe(true);
+
+    // The unmount runs `fusermount3`, which the development files do not
+    // carry, so the runtime package gets a probe of its own.
+    const runtime = machine({ "command -v fusermount3": "!not found" });
+    await open("fuse", runtime);
+    expect(runtime.asked.some((line) => line.includes("apt-get install")))
+      .toBe(true);
+
+    const missing = machine({ "command -v gcc": "!not found" });
     await open("fuse", missing);
     expect(missing.asked.some((line) => line.includes("apt-get update")))
       .toBe(true);
@@ -342,14 +455,80 @@ describe("opening a capability on a machine that answers", () => {
   it("starts a server on a port of its own and kills what it started", async () => {
     const m = machine({ "index.ts": "listening (pid 999999). Logs: x\n" });
     const { opened } = await open("toolshed", m);
-    const port = Number(opened.env.TOOLSHED_PORT);
+    const served = opened.envFor(["toolshed"]);
+    const port = Number(served.TOOLSHED_PORT);
     expect(Number.isInteger(port) && port > 0).toBe(true);
-    expect(opened.env.API_URL).toBe(`http://localhost:${port}/`);
+    // No trailing slash: the shell suites compose a path onto this, and
+    // the Deno suites add a slash of their own when they need one.
+    expect(served.API_URL).toBe(`http://localhost:${port}`);
     expect(m.asked.some((line) => line.includes(`--port=${port}`))).toBe(true);
     expect(m.asked.some((line) => line.includes("--background"))).toBe(true);
     // Closing is what `open` already did; killing a process this test
     // invented would be worse than not checking, and what matters is
     // that it does not throw.
+  });
+
+  it("holds a server it started to the arm it started it for", async () => {
+    // A server on the other arm answers every request the suites make
+    // and passes, so the run reports that the arm it named works when
+    // nothing exercised it.
+    const answers = { "index.ts": "listening (pid 999999). Logs: x\n" };
+    await open("toolshed", machine(answers), "default");
+
+    const wrong = machine(answers);
+    await expect(open("toolshed", wrong, "opposite")).rejects.toThrow(
+      "default lane publishes serverExecution",
+    );
+  });
+
+  it("gives a server the define its own role names", async () => {
+    // A lane holding both arms carries one value in its ambient
+    // environment, and the shell bakes in whatever the build saw. The
+    // define a server builds and runs under is the one its role names:
+    // the value for the opposite arm, and none at all for the default.
+    const named = serverExecutionCiLane("opposite").experimentalValue;
+    const before = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION");
+    Deno.env.set(
+      "EXPERIMENTAL_SERVER_EXECUTION",
+      named === "true" ? "false" : "true",
+    );
+    try {
+      const source = machine({
+        "index.ts": "listening (pid 999999). Logs: x\n",
+      });
+      await open("toolshed", source);
+      expect(envOf(source, "index.ts")?.EXPERIMENTAL_SERVER_EXECUTION)
+        .toBeUndefined();
+
+      const baked = await openBaked(
+        "toolshed-baked",
+        "toolshed-baked-default",
+        "default",
+      );
+      expect(envOf(baked, "build-binaries")?.EXPERIMENTAL_SERVER_EXECUTION)
+        .toBeUndefined();
+      expect(
+        envOf(baked, "toolshed-baked-default")?.EXPERIMENTAL_SERVER_EXECUTION,
+      ).toBeUndefined();
+
+      const opposite = await openBaked(
+        "toolshed-baked-opposite",
+        "toolshed-baked-opposite",
+        "opposite",
+      );
+      expect(envOf(opposite, "build-binaries")?.EXPERIMENTAL_SERVER_EXECUTION)
+        .toBe(named);
+      expect(
+        envOf(opposite, "toolshed-baked-opposite")
+          ?.EXPERIMENTAL_SERVER_EXECUTION,
+      ).toBe(named);
+    } finally {
+      if (before === undefined) {
+        Deno.env.delete("EXPERIMENTAL_SERVER_EXECUTION");
+      } else {
+        Deno.env.set("EXPERIMENTAL_SERVER_EXECUTION", before);
+      }
+    }
   });
 
   it("refuses a launch that names no process to kill later", async () => {
@@ -359,9 +538,35 @@ describe("opening a capability on a machine that answers", () => {
     await expect(open("toolshed", m)).rejects.toThrow("named no process");
   });
 
+  /** Opens a baked capability against a root that has no binary yet. */
+  async function openBaked(
+    id: CapabilityId,
+    binaryName: string,
+    role: ServerExecutionCiRole,
+  ) {
+    const m = machine({ [binaryName]: "listening (pid 999999). Logs: x\n" });
+    const root = await Deno.makeTempDir({ prefix: "capability-" });
+    try {
+      // What a build leaves behind, so the copy into the cache has
+      // something to copy.
+      await Deno.mkdir(`${root}/dist`, { recursive: true });
+      await Deno.writeTextFile(`${root}/dist/toolshed`, "");
+      const opened = await openCapabilities([id], {
+        root,
+        dryRun: false,
+        workDir: root,
+        exec: m.exec,
+        fetch: serving(role),
+      }, CAPABILITIES);
+      await opened.close();
+    } finally {
+      await Deno.remove(root, { recursive: true }).catch(() => {});
+    }
+    return m;
+  }
+
   it("builds the server-execution binary only when none was restored", async () => {
-    const opposite = serverExecutionCiLane("opposite");
-    const binaryName = `toolshed-baked-${opposite.experimentalValue}`;
+    const binaryName = "toolshed-baked-opposite";
     const answers = {
       [binaryName]: "listening (pid 999999). Logs: x\n",
     };
@@ -384,6 +589,7 @@ describe("opening a capability on a machine that answers", () => {
         dryRun: false,
         workDir: root,
         exec: m.exec,
+        fetch: serving("opposite"),
       }, CAPABILITIES);
       await opened.close();
       await Deno.remove(root, { recursive: true });
@@ -456,7 +662,7 @@ describe("the compile cache a lane hands the pattern suites", () => {
         dryRun: false,
         workDir: root,
       });
-      expect(opened.env.CF_COMPILE_CACHE_FILE).toBe(
+      expect(opened.envFor(["compile-cache"]).CF_COMPILE_CACHE_FILE).toBe(
         `${root}/${COMPILE_CACHE_FILE}`,
       );
       expect((await Deno.stat(`${root}/${CACHE_DIR}/compile`)).isDirectory)

--- a/tasks/ci-capabilities.ts
+++ b/tasks/ci-capabilities.ts
@@ -3,12 +3,12 @@
  * implied.
  *
  * A lane works out the union of what its batches need, opens each one
- * once, and runs the batches inside it. Naming them is what lets two ways
- * of providing the same thing coexist: `toolshed` runs the default posture
- * from source, which is cheap enough for a pull request, while
- * `toolshed-baked-opposite` restores or builds a binary because the posture
- * opposite the first-party default is baked into the browser shell inside it
- * and a source run cannot reproduce that. A suite says which it needs and
+ * once, and runs the batches inside it. Naming them is what lets several
+ * ways of providing the same thing coexist: `toolshed` runs a server from
+ * source, which is cheap enough for a pull request and serves the API a
+ * suite reaches over HTTP, while `toolshed-baked` and
+ * `toolshed-baked-opposite` restore or build a binary, because the browser
+ * shell is a bundle compiled into one. A suite says which it needs and
  * neither the workflow nor the other suites know the difference.
  *
  * Every capability is idempotent: opening one that is already open is the
@@ -17,7 +17,11 @@
  */
 
 import * as path from "@std/path";
-import { serverExecutionCiLane } from "./server-execution-ci.ts";
+import {
+  serverExecutionCiLane,
+  type ServerExecutionCiRole,
+  verifyServerExecutionPosture,
+} from "./server-execution-ci.ts";
 
 /** Every piece of setup a suite may ask for. */
 export type CapabilityId =
@@ -27,6 +31,7 @@ export type CapabilityId =
   | "browser"
   | "git-history"
   | "toolshed"
+  | "toolshed-baked"
   | "toolshed-baked-opposite"
   | "bg-piece-service-binary"
   | "cf"
@@ -70,6 +75,13 @@ export interface CapabilityContext {
    * without a machine that has neither.
    */
   exec?: Exec;
+
+  /**
+   * How a capability asks a server it started what it is serving. A
+   * caller that supplies one is saying what the server would have
+   * answered, the way `exec` says what the machine would have answered.
+   */
+  fetch?: typeof fetch;
 }
 
 /** A capability that has been opened. */
@@ -146,25 +158,42 @@ function execOf(context: CapabilityContext): Exec {
   return context.exec ?? run;
 }
 
-/** Whether a command is already on the path. */
-async function onPath(exec: Exec, command: string): Promise<boolean> {
+/** A probe answering whether `command` is on the path. */
+function onPath(command: string): readonly string[] {
+  return ["sh", "-c", `command -v ${command}`];
+}
+
+/** Whether a command runs and reports success. */
+async function succeeds(
+  exec: Exec,
+  command: readonly string[],
+): Promise<boolean> {
+  const [name, ...args] = command;
   try {
-    await exec("sh", ["-c", `command -v ${command}`]);
+    await exec(name!, args);
     return true;
   } catch {
     return false;
   }
 }
 
-/** Installs Debian packages, and does nothing where they are all present. */
+/**
+ * Installs Debian packages, and does nothing where the probes say they
+ * are already there.
+ *
+ * A probe is a command whose success means what one of the packages
+ * provides is there. A package that puts a command on the path is
+ * probed with `onPath`; a package whose point is a file is probed with
+ * whatever answers about that file.
+ */
 async function apt(
   exec: Exec,
   packages: readonly string[],
-  probes: readonly string[],
+  probes: readonly (readonly string[])[],
 ): Promise<void> {
   let missing = false;
   for (const probe of probes) {
-    if (!await onPath(exec, probe)) missing = true;
+    if (!await succeeds(exec, probe)) missing = true;
   }
   if (!missing) return;
   await exec("sudo", ["apt-get", "update"]);
@@ -196,10 +225,21 @@ const fuse: Capability = {
   async open(context) {
     if (!context.dryRun) {
       const exec = execOf(context);
+      // The mount opens `libfuse3.so` through the foreign-function
+      // interface, and that unversioned name comes from the development
+      // package. `pkg-config --exists fuse3` is the question that names
+      // it: it fails where the development package is absent, and it
+      // fails where `pkg-config` itself is, which is the other thing this
+      // installs. `fusermount3` is what the unmount runs, and it is the
+      // remaining package.
       await apt(
         exec,
         ["pkg-config", "gcc", "libfuse3-dev", "fuse3"],
-        ["pkg-config", "gcc", "fusermount3"],
+        [
+          onPath("gcc"),
+          onPath("fusermount3"),
+          ["pkg-config", "--exists", "fuse3"],
+        ],
       );
       // The mount itself needs the device, and the runner image leaves it
       // owned by root.
@@ -213,7 +253,9 @@ const jq: Capability = {
   id: "jq",
   description: "jq, which the shell integration suites filter JSON with",
   async open(context) {
-    if (!context.dryRun) await apt(execOf(context), ["jq"], ["jq"]);
+    if (!context.dryRun) {
+      await apt(execOf(context), ["jq"], [onPath("jq")]);
+    }
     return exported({});
   },
 };
@@ -273,14 +315,37 @@ const gitHistory: Capability = {
   },
 };
 
+/**
+ * The environment a Toolshed at `role` builds and runs under: the ambient
+ * environment carrying the server-execution define the role names, and
+ * carrying none where the role names none.
+ *
+ * An unset define is a third state rather than a synonym for `false`. The
+ * shell bakes it in as `null`, which is what the default role's posture
+ * check asks for, so that role removes the name rather than setting it.
+ */
+function serverExecutionEnv(
+  role: ServerExecutionCiRole,
+): Record<string, string> {
+  const env = Deno.env.toObject();
+  const value = serverExecutionCiLane(role).experimentalValue;
+  if (value === undefined) delete env.EXPERIMENTAL_SERVER_EXECUTION;
+  else env.EXPERIMENTAL_SERVER_EXECUTION = value;
+  return env;
+}
+
 /** How a Toolshed server is started, whichever binary provides it. */
 interface ToolshedOptions {
   /** The command that starts it, and where it runs. */
   command: readonly string[];
   cwd: string;
 
-  /** Environment beyond the port, such as the server-execution define. */
-  env: Record<string, string>;
+  /**
+   * The server-execution arm this server is meant to be serving. A suite
+   * reaching a server on the other arm passes and reports that the arm
+   * it named works.
+   */
+  role: ServerExecutionCiRole;
 }
 
 /** The process identifier a background launch reports having detached. */
@@ -306,8 +371,11 @@ async function startToolshed(
   // port is chosen here and the server is told which one to bind.
   const port = context.dryRun ? 8000 : freePort();
   const url = `http://localhost:${port}`;
+  // Every name carries the origin with no trailing slash. The shell
+  // suites compose a path onto it as `${API_URL}/api/health/stats`, and
+  // a slash on both sides is a path the server does not serve.
   const env = {
-    API_URL: `${url}/`,
+    API_URL: url,
     MEMORY_URL: url,
     TOOLSHED_URL: url,
     TOOLSHED_PORT: `${port}`,
@@ -323,12 +391,11 @@ async function startToolshed(
   ], {
     cwd: options.cwd,
     env: {
-      ...Deno.env.toObject(),
+      ...serverExecutionEnv(options.role),
       // The server reaches for a gateway and a model key at startup. A
       // test server has neither.
       CFTS_AI_GATEWAY_URL: "",
       CFTS_AI_LLM_ANTHROPIC_API_KEY: "fake",
-      ...options.env,
       ...env,
     },
   });
@@ -336,14 +403,27 @@ async function startToolshed(
   if (pid === undefined) {
     throw new Error(`the toolshed launch named no process:\n${output}`);
   }
+  const stop = () => {
+    try {
+      Deno.kill(pid, "SIGTERM");
+    } catch {
+      // Already gone, which is the state this was after.
+    }
+  };
+  try {
+    await verifyServerExecutionPosture(
+      options.role,
+      url,
+      context.fetch ?? fetch,
+    );
+  } catch (error) {
+    stop();
+    throw error;
+  }
   return {
     env,
     close: () => {
-      try {
-        Deno.kill(pid, "SIGTERM");
-      } catch {
-        // Already gone, which is the state the close was after.
-      }
+      stop();
       return Promise.resolve();
     },
   };
@@ -375,67 +455,73 @@ const toolshed: Capability = {
     startToolshed(context, {
       command: [Deno.execPath(), "run", "--unstable-otel", "-A", "index.ts"],
       cwd: path.join(context.root, "packages", "toolshed"),
-      env: {},
+      role: "default",
     }),
 };
 
 /**
- * The same server with the posture opposite the first-party default, from a
- * compiled binary. The posture is a compile-time define baked into the browser
- * shell, so a source run cannot reproduce it. The lane's workflow restores the
- * binary from the Actions cache before the runner starts; building it here is
- * what happens when that cache missed.
+ * A Toolshed server from a compiled binary, at a stated server-execution
+ * role.
+ *
+ * The browser shell is a bundle baked into the binary, so this is what a
+ * suite that drives a browser needs; a server run from source answers the
+ * API and serves no shell. The opposite role needs a binary for a second
+ * reason — its posture is a compile-time define baked into that same
+ * shell.
+ *
+ * The lane's workflow restores these from the Actions cache before the
+ * runner starts; building one here is what happens when that cache
+ * missed. That is the slow path — about forty seconds against seventeen
+ * for a restore — and it is what the first run after a change to the
+ * sources pays.
  */
-const toolshedBakedOpposite: Capability = {
-  id: "toolshed-baked-opposite",
-  description: "a Toolshed server with the opposite posture in its baked shell",
-  needs: ["deno"],
-  async open(context) {
-    const opposite = serverExecutionCiLane("opposite");
-    const experimentalValue = String(opposite.enabled);
-    const binary = path.join(
-      context.root,
-      BINARY_CACHE_DIR,
-      `toolshed-baked-${experimentalValue}`,
-    );
-    if (!context.dryRun) {
-      let present = true;
-      try {
-        await Deno.stat(binary);
-      } catch {
-        // The workflow's cache step found nothing to restore, so the
-        // binary is built here instead. That is the slow path — about
-        // forty seconds against seventeen for a restore — and it is what
-        // the first run after a change to the sources pays.
-        present = false;
-      }
-      if (!present) {
-        await execOf(context)(
-          Deno.execPath(),
-          ["task", "build-binaries", "toolshed"],
-          {
-            cwd: context.root,
-            env: {
-              ...Deno.env.toObject(),
-              EXPERIMENTAL_SERVER_EXECUTION: experimentalValue,
+function bakedToolshed(role: ServerExecutionCiRole): Capability {
+  return {
+    id: role === "default" ? "toolshed-baked" : "toolshed-baked-opposite",
+    description:
+      `a Toolshed server with the ${role} posture in its baked shell`,
+    needs: ["deno"],
+    async open(context) {
+      const binary = path.join(
+        context.root,
+        BINARY_CACHE_DIR,
+        `toolshed-baked-${role}`,
+      );
+      if (!context.dryRun) {
+        let present = true;
+        try {
+          await Deno.stat(binary);
+        } catch {
+          present = false;
+        }
+        if (!present) {
+          await execOf(context)(
+            Deno.execPath(),
+            ["task", "build-binaries", "toolshed"],
+            {
+              cwd: context.root,
+              env: serverExecutionEnv(role),
             },
-          },
-        );
-        await Deno.mkdir(path.dirname(binary), { recursive: true });
-        await Deno.copyFile(
-          path.join(context.root, "dist", "toolshed"),
-          binary,
-        );
+          );
+          await Deno.mkdir(path.dirname(binary), { recursive: true });
+          await Deno.copyFile(
+            path.join(context.root, "dist", "toolshed"),
+            binary,
+          );
+        }
+        await Deno.chmod(binary, 0o755);
       }
-      await Deno.chmod(binary, 0o755);
-    }
-    return await startToolshed(context, {
-      command: [binary],
-      cwd: context.root,
-      env: { EXPERIMENTAL_SERVER_EXECUTION: experimentalValue },
-    });
-  },
-};
+      return await startToolshed(context, {
+        command: [binary],
+        cwd: context.root,
+        role,
+      });
+    },
+  };
+}
+
+const toolshedBaked = bakedToolshed("default");
+const toolshedBakedOpposite = bakedToolshed("opposite");
 
 /**
  * The compiled background-piece-service binary used by its deployed-topology
@@ -539,6 +625,7 @@ export const CAPABILITIES: ReadonlyMap<CapabilityId, Capability> = new Map(
     browser,
     gitHistory,
     toolshed,
+    toolshedBaked,
     toolshedBakedOpposite,
     bgPieceServiceBinary,
     cf,
@@ -582,8 +669,17 @@ export function resolveCapabilities(
 
 /** What opening a set of capabilities produced. */
 export interface OpenedCapabilities {
-  /** The environment every batch runs with, the requests merged in order. */
-  env: Record<string, string>;
+  /**
+   * The environment the capabilities a suite asked for export, merged in
+   * the order they opened.
+   *
+   * Two capabilities may export the same name and mean different things
+   * by it. The two Toolshed servers are the case: each exports the
+   * address its own server is listening on, and the default and opposite
+   * server-execution arms can share a lane. A batch reaching the other
+   * arm's server passes and reports that the arm it named works.
+   */
+  envFor(requested: Iterable<CapabilityId>): Record<string, string>;
 
   /** Seconds each capability's setup took, in the order they opened. */
   timings: Array<{ capability: CapabilityId; seconds: number }>;
@@ -603,7 +699,7 @@ export async function openCapabilities(
   context: CapabilityContext,
   registry: ReadonlyMap<CapabilityId, Capability> = CAPABILITIES,
 ): Promise<OpenedCapabilities> {
-  const env: Record<string, string> = {};
+  const exported = new Map<CapabilityId, Record<string, string>>();
   const timings: Array<{ capability: CapabilityId; seconds: number }> = [];
   const opened: OpenCapability[] = [];
   const close = async (): Promise<void> => {
@@ -622,7 +718,7 @@ export async function openCapabilities(
       const startedAt = performance.now();
       const open = await capability.open(context);
       opened.push(open);
-      Object.assign(env, open.env);
+      exported.set(id, open.env);
       timings.push({
         capability: id,
         seconds: (performance.now() - startedAt) / 1000,
@@ -632,5 +728,17 @@ export async function openCapabilities(
     await close();
     throw error;
   }
-  return { env, timings, close };
+  return {
+    envFor: (requested) => {
+      const env: Record<string, string> = {};
+      // Resolved rather than taken as given, so that a suite naming a
+      // capability gets what the capabilities under it export too.
+      for (const id of resolveCapabilities(requested, registry)) {
+        Object.assign(env, exported.get(id) ?? {});
+      }
+      return env;
+    },
+    timings,
+    close,
+  };
 }

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -5,6 +5,7 @@ import {
   testIdentityKey,
   type TestRecord,
 } from "@commonfabric/test-support/records";
+import type { CapabilityId } from "./ci-capabilities.ts";
 import { loadTopology } from "./test-topology.ts";
 
 import {
@@ -1649,6 +1650,74 @@ describe("what a lane does with the batches it was given", () => {
 
   it("passes when every batch passed", async () => {
     expect(await run([Deno.execPath(), "eval", "0"])).toBe(true);
+  });
+
+  it("gives each batch the environment its own suite asked for", async () => {
+    // `cf` exports the root it puts its command line under, and `deno`
+    // exports nothing. A lane opens the union of what its batches asked
+    // for, so both suites here run in a lane that opened `cf`, and only
+    // the one that asked for it may see what it exports.
+    const dir = await Deno.makeTempDir({ prefix: "lane-env-" });
+    const reporting = (id: string, needs: readonly CapabilityId[]) =>
+      suite({
+        id,
+        needs,
+        units: [`packages/bakery/${id}.test.ts`],
+        command: (_units, context) =>
+          Promise.resolve([{
+            command: [
+              Deno.execPath(),
+              "eval",
+              `Deno.writeTextFileSync(${
+                JSON.stringify(`${dir}/${id}`)
+              }, Deno.env.get("CF_LABS_ROOT") ?? "");`,
+            ],
+            cwd: context.root,
+          }]),
+      });
+    const log = console.log;
+    console.log = () => {};
+    try {
+      await runLane(
+        {
+          lane: 1,
+          of: 1,
+          full: false,
+          dryRun: false,
+          laneCount: false,
+          root: REPOSITORY,
+          at: "2026-09-01T00:00:00Z",
+        },
+        {
+          manifest: () =>
+            Promise.resolve({
+              manifest: manifestOf([
+                {
+                  test: { k: "unit", s: "bakery", n: "asked > runs" },
+                  suite: "asked",
+                  unit: "packages/bakery/asked.test.ts",
+                },
+                {
+                  test: { k: "unit", s: "bakery", n: "did-not > runs" },
+                  suite: "did-not",
+                  unit: "packages/bakery/did-not.test.ts",
+                },
+              ]),
+              objectName: "manifest-fixture.json.gz",
+            }),
+          topology: () =>
+            Promise.resolve([
+              reporting("asked", ["deno", "cf"]),
+              reporting("did-not", ["deno"]),
+            ]),
+        },
+      );
+      expect(await Deno.readTextFile(`${dir}/asked`)).toBe(REPOSITORY);
+      expect(await Deno.readTextFile(`${dir}/did-not`)).toBe("");
+    } finally {
+      console.log = log;
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
   });
 
   it("fails when a batch failed, having run it", async () => {

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -809,11 +809,19 @@ export async function runLane(
 
   const workDir = await Deno.makeTempDir({ prefix: "ci-lane-" });
   const spool = recordsDir();
-  const opened = await openCapabilities([...needs], {
-    root: options.root,
-    dryRun: false,
-    workDir,
-  });
+  // The directory belongs to the lane from the moment it exists, and a
+  // capability that refuses to open is one of the ways the lane ends.
+  let opened;
+  try {
+    opened = await openCapabilities([...needs], {
+      root: options.root,
+      dryRun: false,
+      workDir,
+    });
+  } catch (error) {
+    await Deno.remove(workDir, { recursive: true }).catch(() => {});
+    throw error;
+  }
   if (spool !== undefined) {
     spoolRecords(
       spool,
@@ -833,7 +841,16 @@ export async function runLane(
       // A failure never stops the lane: one failing batch would otherwise
       // hide every batch and every repeat after it, and the point of a
       // lane is what it measured.
-      const result = await runBatch(batch, options, workDir, spool, opened.env);
+      const result = await runBatch(
+        batch,
+        options,
+        workDir,
+        spool,
+        // Two capabilities may export the same name and mean different
+        // things by it, and the two server-execution arms can share a
+        // lane.
+        opened.envFor(batch.suite.needs),
+      );
       if (!result.ok) ok = false;
       conflicts.push(...result.conflicts);
     }

--- a/tasks/server-execution-ci.ts
+++ b/tasks/server-execution-ci.ts
@@ -94,6 +94,32 @@ export function assertServerExecutionCiPosture(
   }
 }
 
+/**
+ * Reads a running Toolshed server's posture and holds it to the role it
+ * was started for. A server on the other arm passes the tests it was
+ * given and proves the wrong thing, which is a green run that measured
+ * nothing anybody asked for.
+ */
+export async function verifyServerExecutionPosture(
+  role: ServerExecutionCiRole,
+  baseUrl: string,
+  fetcher: typeof fetch = fetch,
+): Promise<void> {
+  const url = baseUrl.replace(/\/$/, "");
+  const [metaResponse, statsResponse] = await Promise.all([
+    fetcher(`${url}/api/meta`),
+    fetcher(`${url}/api/health/stats`),
+  ]);
+  if (!metaResponse.ok || !statsResponse.ok) {
+    throw new Error(
+      `Posture probe failed: meta=${metaResponse.status}, stats=${statsResponse.status}`,
+    );
+  }
+  const meta = await metaResponse.json() as Record<string, unknown>;
+  const stats = await statsResponse.json() as Record<string, unknown>;
+  assertServerExecutionCiPosture(role, meta, stats);
+}
+
 /** Runs the small workflow-facing CLI. Exported so its error paths stay tested. */
 export async function runServerExecutionCiCommand(
   args: readonly string[],
@@ -109,19 +135,7 @@ export async function runServerExecutionCiCommand(
   if (command === "env") {
     log(serverExecutionCiEnvironment(role).join("\n"));
   } else if (command === "probe" && baseUrl !== undefined) {
-    const url = baseUrl.replace(/\/$/, "");
-    const [metaResponse, statsResponse] = await Promise.all([
-      fetcher(`${url}/api/meta`),
-      fetcher(`${url}/api/health/stats`),
-    ]);
-    if (!metaResponse.ok || !statsResponse.ok) {
-      throw new Error(
-        `Posture probe failed: meta=${metaResponse.status}, stats=${statsResponse.status}`,
-      );
-    }
-    const meta = await metaResponse.json() as Record<string, unknown>;
-    const stats = await statsResponse.json() as Record<string, unknown>;
-    assertServerExecutionCiPosture(role, meta, stats);
+    await verifyServerExecutionPosture(role, baseUrl, fetcher);
     log(
       `Verified ${role} server-execution lane (${
         serverExecutionCiLane(role).label


### PR DESCRIPTION
PROBLEM

A suite says what setup it needs and the lane opens it: a Deno toolchain, a browser, a FUSE mount, a Toolshed server, the compile byte cache. The lane then hands every batch one environment, the union of what it opened. Both Toolshed capabilities export `API_URL`, so a lane holding the default server-execution arm and the opposite arm gives the first arm's suites the second arm's address; they pass, and report that the arm they named works. Nothing on that path asks a server which arm it is serving. `API_URL` carries a trailing slash the shell suites cannot compose a path onto, and the FUSE probe asks after a command rather than the library the mount opens.

SOLUTION

`envFor` answers with the names one suite's own capabilities export, closed over what those are built on, and the lane asks it once per batch. `API_URL` carries the origin with no trailing slash, which is the form the workflow already hands the shell suites; the Deno suites read it through `packages/integration/env.ts`, which adds one of its own.

A Toolshed capability names the arm it was started for, reads the running server's posture back, and refuses a server on the other arm. The environment it builds and runs under carries the define its role names, and none where the role names none, so an ambient define cannot reach the default arm.

`toolshed-baked` joins the registry, because the browser shell is a bundle compiled into the binary and a server run from source serves no shell.

The FUSE probe asks `pkg-config --exists fuse3`, which answers about the file the tests link against, and every package the capability installs has a probe.

DESIGN DISCUSSION

The posture probe a deleted job used to run moves into the capability that starts the server, so it holds a server the lane started rather than one a workflow step started. `CapabilityContext` gains `fetch` for it: a caller says what the server answers, the way `exec` says what the machine answers, so a test runs the real check rather than one it supplied.

A probe is a command line. A package that puts a command on the path is probed with `onPath`, which writes `sh -c "command -v <name>"`; a package whose point is a file is probed with whatever answers about that file.

The binary a baked capability runs is named by role rather than by the flag value, because the default role leaves the flag unset and that is a third state rather than a synonym for `false`. Nothing outside this module names the file.

`docs/plans/pull-request-test-selection.md` carries the third way of providing a Toolshed server, and says the reason is the shell rather than the compile-time define.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

