### PR TITLE
perf(memory): a graph state keeps its own schema-ref scans

### DIFF
--- a/packages/memory/test/v2-refresh-schema-ref-scans.test.ts
+++ b/packages/memory/test/v2-refresh-schema-ref-scans.test.ts
@@ -1,0 +1,98 @@
+// A refresh re-validates the schema-document closure over everything the
+// graph has delivered, and must not re-scan what did not change. The
+// engine-wide scan cache covers only canonical space-scoped versions and
+// clears when it overflows, so a session whose delivered set is large or
+// per-user was scanned whole on every commit; the graph state's own record
+// (`TrackedGraphState.schemaRefs`) answers the established set instead.
+
+import { assertEquals, assertExists } from "@std/assert";
+import { toFileUrl } from "@std/path";
+import { applyCommit, close, open } from "../v2/engine.ts";
+import { refreshTrackedGraph, toDirtyKey, trackGraph } from "../v2/query.ts";
+
+const identity = { principal: "did:key:alice", sessionId: "session:alice" };
+
+Deno.test("refresh scans only the changed documents, per-user ones included", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engine = await open({ url: toFileUrl(path) });
+  const space = "did:key:z6Mk-memory-v2-refresh-scans";
+  const root = "of:refresh-scans-root";
+  const argument = "of:refresh-scans-argument";
+  const profile = "of:refresh-scans-profile";
+  const argumentSchema = {
+    type: "object",
+    properties: { label: { type: "string" } },
+    required: ["label"],
+  };
+  const rootWith = (title: string) => ({
+    value: { title },
+    argument: {
+      "/": { "link@1": { id: argument, path: [], schema: argumentSchema } },
+    },
+  });
+  const query = {
+    roots: [
+      { id: root, selector: { path: [], schema: false as const } },
+      {
+        id: profile,
+        scope: "user" as const,
+        selector: { path: [], schema: false as const },
+      },
+    ],
+  };
+  try {
+    applyCommit(engine, {
+      sessionId: identity.sessionId,
+      principal: identity.principal,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [
+          { op: "set", id: argument, value: { value: { label: "shared" } } },
+          { op: "set", id: root, value: rootWith("first") },
+          {
+            op: "set",
+            id: profile,
+            scope: "user",
+            value: { value: { name: "alice" } },
+          },
+        ],
+      },
+    });
+
+    const tracked = trackGraph(space, engine, query, undefined, identity);
+    // Every delivered document is scanned once on the first evaluation,
+    // and the state records each version it scanned.
+    assertEquals(tracked.state.entities.size, 3);
+    assertEquals(tracked.stats.schemaRefScans, 3);
+    assertEquals(tracked.state.schemaRefs.size, 3);
+
+    applyCommit(engine, {
+      sessionId: identity.sessionId,
+      principal: identity.principal,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id: root, value: rootWith("second") }],
+      },
+    });
+
+    const refreshed = refreshTrackedGraph(
+      space,
+      engine,
+      tracked.state,
+      new Set([toDirtyKey(root)]),
+    );
+    assertExists(refreshed);
+    assertEquals([...refreshed.updates.values()].map((e) => e.id), [root]);
+    // The closure was re-validated over all three delivered documents,
+    // but only the one that changed was scanned again: the unchanged
+    // space-scoped argument and the per-user profile — which no
+    // engine-wide cache may hold — were answered from the state's record.
+    assertEquals(refreshed.stats.schemaRefScans, 1);
+    assertEquals(tracked.state.schemaRefs.size, 3);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});

--- a/packages/memory/test/v2-refresh-schema-ref-scans.test.ts
+++ b/packages/memory/test/v2-refresh-schema-ref-scans.test.ts
@@ -1,98 +1,220 @@
-// A refresh re-validates the schema-document closure over everything the
-// graph has delivered, and must not re-scan what did not change. The
-// engine-wide scan cache covers only canonical space-scoped versions and
-// clears when it overflows, so a session whose delivered set is large or
-// per-user was scanned whole on every commit; the graph state's own record
-// (`TrackedGraphState.schemaRefs`) answers the established set instead.
+/**
+ * A refresh re-validates the schema-document closure over everything the
+ * graph has delivered. The scans that feed it are answered from the graph
+ * state's own per-version record — every scope, the closure's own documents
+ * included — so the documents a refresh scans again are the ones that
+ * changed.
+ */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
 import { toFileUrl } from "@std/path";
-import { applyCommit, close, open } from "../v2/engine.ts";
-import { refreshTrackedGraph, toDirtyKey, trackGraph } from "../v2/query.ts";
+import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";
+import { applyCommit, close, type Engine, open } from "../v2/engine.ts";
+import {
+  refreshTrackedGraph,
+  toDirtyKey,
+  type TrackedGraphState,
+  trackGraph,
+} from "../v2/query.ts";
 
 const identity = { principal: "did:key:alice", sessionId: "session:alice" };
 
-Deno.test("refresh scans only the changed documents, per-user ones included", async () => {
+const withEngine = async (
+  fn: (engine: Engine) => Promise<void>,
+): Promise<void> => {
   const path = await Deno.makeTempFile({ suffix: ".sqlite" });
   const engine = await open({ url: toFileUrl(path) });
-  const space = "did:key:z6Mk-memory-v2-refresh-scans";
-  const root = "of:refresh-scans-root";
-  const argument = "of:refresh-scans-argument";
-  const profile = "of:refresh-scans-profile";
-  const argumentSchema = {
-    type: "object",
-    properties: { label: { type: "string" } },
-    required: ["label"],
-  };
-  const rootWith = (title: string) => ({
-    value: { title },
-    argument: {
-      "/": { "link@1": { id: argument, path: [], schema: argumentSchema } },
-    },
-  });
-  const query = {
-    roots: [
-      { id: root, selector: { path: [], schema: false as const } },
-      {
-        id: profile,
-        scope: "user" as const,
-        selector: { path: [], schema: false as const },
-      },
-    ],
-  };
   try {
-    applyCommit(engine, {
-      sessionId: identity.sessionId,
-      principal: identity.principal,
-      commit: {
-        localSeq: 1,
-        reads: { confirmed: [], pending: [] },
-        operations: [
-          { op: "set", id: argument, value: { value: { label: "shared" } } },
-          { op: "set", id: root, value: rootWith("first") },
-          {
-            op: "set",
-            id: profile,
-            scope: "user",
-            value: { value: { name: "alice" } },
-          },
-        ],
-      },
-    });
-
-    const tracked = trackGraph(space, engine, query, undefined, identity);
-    // Every delivered document is scanned once on the first evaluation,
-    // and the state records each version it scanned.
-    assertEquals(tracked.state.entities.size, 3);
-    assertEquals(tracked.stats.schemaRefScans, 3);
-    assertEquals(tracked.state.schemaRefs.size, 3);
-
-    applyCommit(engine, {
-      sessionId: identity.sessionId,
-      principal: identity.principal,
-      commit: {
-        localSeq: 2,
-        reads: { confirmed: [], pending: [] },
-        operations: [{ op: "set", id: root, value: rootWith("second") }],
-      },
-    });
-
-    const refreshed = refreshTrackedGraph(
-      space,
-      engine,
-      tracked.state,
-      new Set([toDirtyKey(root)]),
-    );
-    assertExists(refreshed);
-    assertEquals([...refreshed.updates.values()].map((e) => e.id), [root]);
-    // The closure was re-validated over all three delivered documents,
-    // but only the one that changed was scanned again: the unchanged
-    // space-scoped argument and the per-user profile — which no
-    // engine-wide cache may hold — were answered from the state's record.
-    assertEquals(refreshed.stats.schemaRefScans, 1);
-    assertEquals(tracked.state.schemaRefs.size, 3);
+    await fn(engine);
   } finally {
     close(engine);
     await Deno.remove(path);
   }
+};
+
+/** Every delivered document has a scan record at its delivered version. */
+const expectRecordPerVersion = (state: TrackedGraphState) => {
+  expect(state.schemaRefs.size).toBe(state.entities.size);
+  for (const [key, snapshot] of state.entities) {
+    expect(state.schemaRefs.get(key)?.seq).toBe(snapshot.seq);
+  }
+};
+
+describe("v2-refresh-schema-ref-scans", () => {
+  describe("refreshTrackedGraph()", () => {
+    it("scans only the changed documents, per-user ones included", async () => {
+      await withEngine((engine) => {
+        const space = "did:key:z6Mk-memory-v2-refresh-scans";
+        const root = "of:refresh-scans-root";
+        const argument = "of:refresh-scans-argument";
+        const profile = "of:refresh-scans-profile";
+        const argumentSchema = {
+          type: "object",
+          properties: { label: { type: "string" } },
+          required: ["label"],
+        };
+        const rootWith = (title: string) => ({
+          value: { title },
+          argument: {
+            "/": {
+              "link@1": { id: argument, path: [], schema: argumentSchema },
+            },
+          },
+        });
+        const query = {
+          roots: [
+            { id: root, selector: { path: [], schema: false as const } },
+            {
+              id: profile,
+              scope: "user" as const,
+              selector: { path: [], schema: false as const },
+            },
+          ],
+        };
+        applyCommit(engine, {
+          sessionId: identity.sessionId,
+          principal: identity.principal,
+          commit: {
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            operations: [
+              {
+                op: "set",
+                id: argument,
+                value: { value: { label: "shared" } },
+              },
+              { op: "set", id: root, value: rootWith("first") },
+              {
+                op: "set",
+                id: profile,
+                scope: "user",
+                value: { value: { name: "alice" } },
+              },
+            ],
+          },
+        });
+
+        const tracked = trackGraph(space, engine, query, undefined, identity);
+        // Every delivered document is scanned once on the first evaluation.
+        expect(tracked.state.entities.size).toBe(3);
+        expect(tracked.stats.schemaRefScans).toBe(3);
+        expectRecordPerVersion(tracked.state);
+
+        applyCommit(engine, {
+          sessionId: identity.sessionId,
+          principal: identity.principal,
+          commit: {
+            localSeq: 2,
+            reads: { confirmed: [], pending: [] },
+            operations: [{ op: "set", id: root, value: rootWith("second") }],
+          },
+        });
+
+        const refreshed = refreshTrackedGraph(
+          space,
+          engine,
+          tracked.state,
+          new Set([toDirtyKey(root)]),
+        );
+        expect(refreshed).not.toBeNull();
+        expect([...refreshed!.updates.values()].map((entity) => entity.id))
+          .toEqual([root]);
+        // The closure was re-validated over all three delivered documents,
+        // but only the one that changed was scanned again: the unchanged
+        // space-scoped argument and the per-user profile — which no
+        // engine-wide cache holds — were answered from the state's record.
+        expect(refreshed!.stats.schemaRefScans).toBe(1);
+        expectRecordPerVersion(tracked.state);
+        return Promise.resolve();
+      });
+    });
+
+    it("records the schema documents the closure delivered, so an unchanged refresh scans nothing", async () => {
+      await withEngine((engine) => {
+        const space = "did:key:z6Mk-memory-v2-refresh-scans-closure";
+        const root = "of:refresh-scans-closure-root";
+        const target = "of:refresh-scans-closure-target";
+        // `outer` references `leaf`, so the root's one link schema delivers
+        // two schema documents through the closure.
+        const leafSchema = { type: "string", title: "scans-leaf" } as const;
+        const leafHash = internSchemaAsTaggedHashString(leafSchema);
+        const outerSchema = {
+          type: "object",
+          properties: { x: { $ref: `cid:${leafHash}` } },
+        } as const;
+        const outerHash = internSchemaAsTaggedHashString(outerSchema);
+        applyCommit(engine, {
+          sessionId: identity.sessionId,
+          principal: identity.principal,
+          commit: {
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            operations: [
+              {
+                op: "set",
+                id: `cid:${leafHash}`,
+                value: { value: leafSchema },
+              },
+              {
+                op: "set",
+                id: `cid:${outerHash}`,
+                value: { value: outerSchema },
+              },
+              { op: "set", id: target, value: { value: { n: 1 } } },
+              {
+                op: "set",
+                id: root,
+                value: {
+                  value: {
+                    x: {
+                      "/": {
+                        "link@1": {
+                          id: target,
+                          path: [],
+                          schema: { $ref: `cid:${outerHash}` },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        });
+
+        const tracked = trackGraph(
+          space,
+          engine,
+          {
+            roots: [{ id: root, selector: { path: [], schema: false } }],
+          },
+          undefined,
+          identity,
+        );
+        // The root was scanned; the two schema documents its closure
+        // delivered were verified, and recorded at their versions without
+        // a scan of their own.
+        expect(tracked.state.entities.has(`${space}/space/cid:${leafHash}`))
+          .toBe(true);
+        expect(tracked.state.entities.has(`${space}/space/cid:${outerHash}`))
+          .toBe(true);
+        expect(tracked.stats.schemaRefScans).toBe(1);
+        expectRecordPerVersion(tracked.state);
+
+        // A refresh over the unchanged root re-validates the whole closure
+        // from the record and scans nothing.
+        const refreshed = refreshTrackedGraph(
+          space,
+          engine,
+          tracked.state,
+          new Set([toDirtyKey(root)]),
+        );
+        expect(refreshed).not.toBeNull();
+        expect(refreshed!.stats.schemaRefScans).toBe(0);
+        expectRecordPerVersion(tracked.state);
+        return Promise.resolve();
+      });
+    });
+  });
 });

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -106,7 +106,26 @@ export type TrackedGraphState = {
    * query that names a document requires its key here too: reach without
    * family is not coverage for a root (see isGraphQueryCoveredByState). */
   chased: Set<string>;
+
+  /** Per-version scans of this state's delivered documents for embedded
+   * schema refs (`docKey -> { seq, refs }`), consulted when the closure is
+   * re-validated over the established set on every refresh. It lives with
+   * the state whose entities it describes: exactly one entry per delivered
+   * version, so it is as large as the state and no larger, dies with it,
+   * and — being one identity's — caches every scope, where the engine-wide
+   * cache below can hold only canonical space-scoped versions. Without it
+   * a refresh scanned the whole established set again whenever that set
+   * outgrew the engine-wide cache: a session holding the Topics board
+   * (some 18k delivered documents against a 4,096-entry cache) rescanned
+   * everything on every commit anyone made. */
+  schemaRefs: SchemaRefScans;
 };
+
+/** See TrackedGraphState.schemaRefs. */
+export type SchemaRefScans = Map<
+  QueryDocKey,
+  { seq: number; refs: ReadonlySet<string> }
+>;
 
 /**
  * The costliest single root of one query evaluation.
@@ -181,6 +200,14 @@ const walkStatsDelta = (
 export type QueryTraversalStats = GraphQueryWalkStats & {
   managerReads: number;
 
+  /** Documents whose value this evaluation scanned for embedded schema
+   * refs while assembling the delivered set's schema-document closure. A
+   * version scanned before — by this state, or by any session that
+   * delivered the same space-scoped version — costs no scan, so on a
+   * refresh this counts the documents that actually changed, not the
+   * established set the closure was re-validated over. */
+  schemaRefScans: number;
+
   /** Roots this evaluation visited. A cache hit visits none. */
   rootsVisited: number;
 
@@ -198,6 +225,7 @@ export type QueryTraversalStats = GraphQueryWalkStats & {
 
 const createQueryTraversalStats = (): QueryTraversalStats => ({
   managerReads: 0,
+  schemaRefScans: 0,
   rootsVisited: 0,
   rootsElapsedMs: 0,
   ...createGraphQueryWalkStats(),
@@ -876,6 +904,7 @@ export const cloneTrackedGraphState = (
     manager,
     roots: new Set(state.roots),
     chased: new Set(state.chased),
+    schemaRefs: new Map(state.schemaRefs),
   };
 };
 
@@ -949,13 +978,15 @@ const entitiesFromTracker = (
   return entities;
 };
 
-// Per-version cache of document scans for embedded schema refs, so a
-// version delivered again — by another session, query, or refresh — is
-// not rescanned. Only canonical `"space"`-scoped snapshots are cached: a
+// Engine-wide per-version cache of document scans for embedded schema
+// refs, so a version delivered again by ANOTHER session or query is not
+// rescanned. Only canonical `"space"`-scoped snapshots are cached: a
 // user- or session-scoped doc key names different content per principal,
 // and sharing scans across principals could hand one principal's refs to
 // another. Bounded; on overflow the cache clears and repopulates from
-// live deliveries.
+// live deliveries. A refresh does not depend on it: the established set
+// is answered from the graph state's own record
+// (`TrackedGraphState.schemaRefs`), which this cache only seeds.
 const SCHEMA_REF_SCAN_CACHE_MAX_ENTRIES = 4096;
 const schemaRefScanCaches = new WeakMap<
   Engine.Engine,
@@ -987,7 +1018,15 @@ const scanSnapshotSchemaRefs = (
   engine: Engine.Engine,
   key: QueryDocKey,
   snapshot: EntitySnapshot,
+  scans: SchemaRefScans,
+  stats: QueryTraversalStats,
 ): ReadonlySet<string> => {
+  // The state's own record first: it covers every scope, and on a refresh
+  // it is where the whole established set is answered from.
+  const own = scans.get(key);
+  if (own !== undefined && own.seq === snapshot.seq) {
+    return own.refs;
+  }
   const cacheable = (snapshot.scope ?? DEFAULT_SCOPE) === DEFAULT_SCOPE;
   let cache = schemaRefScanCaches.get(engine);
   if (cache === undefined) {
@@ -997,9 +1036,11 @@ const scanSnapshotSchemaRefs = (
   if (cacheable) {
     const cached = cache.get(key);
     if (cached !== undefined && cached.seq === snapshot.seq) {
+      scans.set(key, cached);
       return cached.refs;
     }
   }
+  stats.schemaRefScans += 1;
   const refs = new Set<string>();
   const doc = snapshot.document;
   if (isObjectNotArray(doc)) {
@@ -1032,9 +1073,11 @@ const scanSnapshotSchemaRefs = (
     }
   }
   const result = refs.size === 0 ? EMPTY_SCHEMA_REFS : refs;
+  const entry = { seq: snapshot.seq, refs: result };
+  scans.set(key, entry);
   if (cacheable) {
     if (cache.size >= SCHEMA_REF_SCAN_CACHE_MAX_ENTRIES) cache.clear();
-    cache.set(key, { seq: snapshot.seq, refs: result });
+    cache.set(key, entry);
   }
   return result;
 };
@@ -1089,6 +1132,8 @@ const assembleSchemaDocClosures = (
   branch: string,
   tracker: MapSetStringToPathSelectors,
   delivered: ReadonlyMap<QueryDocKey, EntitySnapshot>,
+  scans: SchemaRefScans,
+  stats: QueryTraversalStats,
   established?: ReadonlyMap<QueryDocKey, EntitySnapshot>,
 ): {
   trackerAdds: QueryDocKey[];
@@ -1103,14 +1148,24 @@ const assembleSchemaDocClosures = (
     }
   };
   for (const [key, snapshot] of delivered) {
-    for (const hash of scanSnapshotSchemaRefs(engine, key, snapshot)) {
+    for (
+      const hash of scanSnapshotSchemaRefs(engine, key, snapshot, scans, stats)
+    ) {
       enqueue(hash);
     }
   }
   if (established !== undefined) {
     for (const [key, snapshot] of established) {
       if (delivered.has(key)) continue;
-      for (const hash of scanSnapshotSchemaRefs(engine, key, snapshot)) {
+      for (
+        const hash of scanSnapshotSchemaRefs(
+          engine,
+          key,
+          snapshot,
+          scans,
+          stats,
+        )
+      ) {
         enqueue(hash);
       }
     }
@@ -1467,6 +1522,7 @@ export const trackGraph = (
   for (const key of walk.chasedFamilyKeys) chased.add(key);
 
   const entities = entitiesFromTracker(space, schemaTracker, manager, branch);
+  const schemaRefs: SchemaRefScans = new Map();
   const staged = assembleSchemaDocClosures(
     space,
     engine,
@@ -1474,6 +1530,8 @@ export const trackGraph = (
     branch,
     schemaTracker,
     entities,
+    schemaRefs,
+    stats,
   );
   for (const key of staged.trackerAdds) {
     schemaTracker.add(key, REJECTING_SELECTOR);
@@ -1494,6 +1552,7 @@ export const trackGraph = (
     manager,
     roots,
     chased,
+    schemaRefs,
   };
   if (
     cache !== undefined && cacheKeys !== undefined &&
@@ -1608,6 +1667,8 @@ export const extendTrackedGraph = (
     state.branch,
     state.tracker,
     updates,
+    state.schemaRefs,
+    stats,
   );
   for (const key of staged.trackerAdds) {
     state.tracker.add(key, REJECTING_SELECTOR);
@@ -1929,6 +1990,8 @@ export const refreshTrackedGraph = (
       state.branch,
       state.tracker,
       updates,
+      state.schemaRefs,
+      stats,
       state.entities,
     );
     phases.enter("merge");

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -108,16 +108,12 @@ export type TrackedGraphState = {
   chased: Set<string>;
 
   /** Per-version scans of this state's delivered documents for embedded
-   * schema refs (`docKey -> { seq, refs }`), consulted when the closure is
-   * re-validated over the established set on every refresh. It lives with
-   * the state whose entities it describes: exactly one entry per delivered
-   * version, so it is as large as the state and no larger, dies with it,
-   * and — being one identity's — caches every scope, where the engine-wide
-   * cache below can hold only canonical space-scoped versions. Without it
-   * a refresh scanned the whole established set again whenever that set
-   * outgrew the engine-wide cache: a session holding the Topics board
-   * (some 18k delivered documents against a 4,096-entry cache) rescanned
-   * everything on every commit anyone made. */
+   * schema refs (`docKey -> { seq, refs }`): the record the closure's
+   * re-validation over the established set is answered from on every
+   * refresh. One entry per delivered version, the schema documents the
+   * closure itself delivered included; reused by document key and sequence;
+   * every scope, since the state is one identity's; the state's lifetime.
+   * The engine-wide cache of space-scoped scans only seeds it. */
   schemaRefs: SchemaRefScans;
 };
 
@@ -1073,13 +1069,32 @@ const scanSnapshotSchemaRefs = (
     }
   }
   const result = refs.size === 0 ? EMPTY_SCHEMA_REFS : refs;
-  const entry = { seq: snapshot.seq, refs: result };
-  scans.set(key, entry);
-  if (cacheable) {
-    if (cache.size >= SCHEMA_REF_SCAN_CACHE_MAX_ENTRIES) cache.clear();
-    cache.set(key, entry);
-  }
+  recordSchemaRefScan(engine, key, snapshot, result, scans);
   return result;
+};
+
+/**
+ * Records what a scan of `snapshot` finds — in the state's own record
+ * always, and in the engine-wide cache when the version is space-scoped, so
+ * another session delivering it is spared the scan.
+ */
+const recordSchemaRefScan = (
+  engine: Engine.Engine,
+  key: QueryDocKey,
+  snapshot: EntitySnapshot,
+  refs: ReadonlySet<string>,
+  scans: SchemaRefScans,
+): void => {
+  const entry = { seq: snapshot.seq, refs };
+  scans.set(key, entry);
+  if ((snapshot.scope ?? DEFAULT_SCOPE) !== DEFAULT_SCOPE) return;
+  let cache = schemaRefScanCaches.get(engine);
+  if (cache === undefined) {
+    cache = new Map();
+    schemaRefScanCaches.set(engine, cache);
+  }
+  if (cache.size >= SCHEMA_REF_SCAN_CACHE_MAX_ENTRIES) cache.clear();
+  cache.set(key, entry);
 };
 
 /**
@@ -1211,6 +1226,11 @@ const assembleSchemaDocClosures = (
       if (verified.size >= SCHEMA_REF_SCAN_CACHE_MAX_ENTRIES) verified.clear();
       verified.set(key, snapshot.seq);
     }
+    // The document just verified is the schema document its id names,
+    // which is all a scan of it finds: its own hash. Recording that here
+    // keeps the state's record at one entry per delivered version, so a
+    // later refresh answers the closure's documents without scanning them.
+    recordSchemaRefScan(engine, key, snapshot, new Set([hash]), scans);
     for (const dep of collectExternalSchemaRefHashes(registered)) {
       enqueue(dep);
     }


### PR DESCRIPTION
## What

A watch refresh re-validates the schema-document closure over everything the graph has delivered (so a corrupted dependency fails the refresh even when its referrer did not change). The document scans feeding that step were cached engine-wide, per version, in a map capped at 4,096 entries that **clears when it overflows**, and only for canonical space-scoped versions.

A session holding the Topics board had ~18k delivered documents when measured (12k of them the lazily registered derived cells #7132 has since dropped from the rail; the space-scoped remainder is still several times the cap). Its established set alone is four times the cap, so every refresh cleared the cache, rescanned the whole set, and cleared it again for the next session. With the phase rows from #7158 that showed as 189 ms of a touched session's 243 ms per commit.

This PR gives each tracked graph state its own record of the versions it scanned (`TrackedGraphState.schemaRefs`): one entry per delivered version, so it is as large as the state and no larger, it dies with the state, and — being one identity's — it covers every scope, where the engine-wide cache can hold only space-scoped versions. The engine-wide cache stays for what it is good for (a version another session already scanned costs the newcomer nothing) and now only seeds the record. A `schemaRefScans` traversal stat counts what an evaluation actually scanned. The schema documents the closure assembly verifies enter the record at their versions without a scan of their own (a scan of a schema document finds only its own hash, which the verification just established).

## Measured

Measured before #7132 landed (its removal of the lazy-registration rail shrinks the `tracked` row on today's main; the closure figures do not depend on it).

Same served clone of the Topics space, six sessions holding the board with its UI demanded, one document rewritten once a second for 60 s (harness in the tracking topic):

| per touched session | before (#7158) | after |
|---|---|---|
| end to end | 243 ms | 19 ms |
| `walk/closure` | 189 ms | 4 ms |
| `tracked` (wake-set rebuild) | 50 ms | 15 ms |
| whole fan-out pass, 6 sessions | 1,466 ms | 116 ms |
| the committer's commit latency, p50 | 788 ms | 2 ms |

The wake-set rebuild (`tracked/undelivered` over 12k lazy keys, `tracked/entries` over 18k entities) is now the largest remaining term and is the next PR.

## Test

`packages/memory/test/v2-refresh-schema-ref-scans.test.ts`, in the repository's `describe`/`it`/`expect` shape. Two cases: a space-scoped root with a linked argument and a **per-user** root, where changing only the space root leaves one document scanned on refresh; and a root whose one link schema names an outer schema document that references a leaf, where the initial evaluation scans one document and records three, and a refresh over the unchanged root scans nothing. Both assert the invariant directly: one record per delivered entity, at that entity's version. With the state's record not consulted the per-user document is rescanned; with the closure's documents not recorded the closure case rescans two.

## Memory

One map entry per delivered version per graph state (key string + `{ seq, refs }`, with an empty-refs singleton shared). For the board session above that is ~18k entries; the entities map it sits beside already holds those keys and their snapshots.

Stacked on #7158 (the phase rows this was measured with).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



