### PR TITLE
ci: keep the nightly CFC job out of test records

### DIFF
--- a/.claude/rules/github-workflows.md
+++ b/.claude/rules/github-workflows.md
@@ -60,21 +60,26 @@ steps wrap their command in `deno task run-recorded <kind> <scope> <name>
 without the ship step runs fine and records nothing — which is how a new
 job silently falls out of the flake and duration history.
 
-A job whose every test another workflow already records against the same
-commit is the exception, and it records nothing: no spool directory, no
-`run-recorded` wrapper, no ship step. Recording there would file each of
+A job or step whose every test another workflow already records against
+the same commit is the exception, and it records nothing: no spool
+directory, no `run-recorded` wrapper, no ship step. Recording there would file each of
 those tests twice against one commit. The Dashboard workflow's tests job
-is the one such job, and the relay does not follow that workflow. The
-exemption covers tests, not jobs, so a test that runs only in such a job
-is recorded there.
+and the CFC Property Suite's test step are the two, and the relay follows
+neither workflow. The exemption covers tests, not jobs, so a test that
+runs only in such a job is recorded there.
 
 A check that no lane can be asked to run is the other exception, and it
 records nothing either: no spool directory, no `run-recorded` wrapper, no
 ship step. `docs/specs/test-records.md` under "Recording" holds the
-criterion. The `Coverage Check` job in `deno.yml` is the one such job,
-because it reads the coverage artifacts of every test job in its own run.
-A gate comparing against a base ref is not this: `check-baselines-append-only`
-and `check-test-aliases` each resolve a merge base, and both record.
+criterion. The `Coverage Check` job in `deno.yml` is one, because it reads
+the coverage artifacts of every test job in its own run; the CFC Property
+Suite's audit step is the other, because it reads the corpus the suite in
+the step before it has just written. A gate comparing against a base ref
+is not this: `check-baselines-append-only` and `check-test-aliases` each
+resolve a merge base, and both record.
+
+Both exceptions land on the CFC Property Suite, one on each of its two
+steps, so that workflow takes no part in test records at all.
 
 ## Before splitting or rebalancing jobs
 

--- a/.claude/rules/github-workflows.md
+++ b/.claude/rules/github-workflows.md
@@ -60,13 +60,13 @@ steps wrap their command in `deno task run-recorded <kind> <scope> <name>
 without the ship step runs fine and records nothing — which is how a new
 job silently falls out of the flake and duration history.
 
-A job or step whose every test another workflow already records against
-the same commit is the exception, and it records nothing: no spool
-directory, no `run-recorded` wrapper, no ship step. Recording there would file each of
+A job whose every test another workflow already records against the same
+commit is the exception, and it records nothing: no spool directory, no
+`run-recorded` wrapper, no ship step. Recording there would file each of
 those tests twice against one commit. The Dashboard workflow's tests job
-and the CFC Property Suite's test step are the two, and the relay follows
-neither workflow. The exemption covers tests, not jobs, so a test that
-runs only in such a job is recorded there.
+is the one such job, and the relay does not follow that workflow. The
+exemption covers tests, not jobs, so a test that runs only in such a job
+is recorded there.
 
 A check that no lane can be asked to run is the other exception, and it
 records nothing either: no spool directory, no `run-recorded` wrapper, no
@@ -78,8 +78,16 @@ the step before it has just written. A gate comparing against a base ref
 is not this: `check-baselines-append-only` and `check-test-aliases` each
 resolve a merge base, and both record.
 
-Both exceptions land on the CFC Property Suite, one on each of its two
-steps, so that workflow takes no part in test records at all.
+Which of a job's steps are wrapped is a separate question from either
+exemption. A wrapper records the command under it, so it belongs on a
+command that is itself the check and not on one whose own tests are the
+checks — the wrapper passes recording through, so a wrapped test command
+files a summary of the invocation beside whatever its tests record. The
+CFC Property Suite's test step is the case to learn from: it runs
+`deno test` directly, which without a `--junit-path` to ingest records
+nothing, so its wrapper's line was the job's only record of a step whose
+tests CI records through `workspace-unit`. That step and the audit step
+together leave that workflow taking no part in test records at all.
 
 ## Before splitting or rebalancing jobs
 

--- a/.github/workflows/cfc-properties.yml
+++ b/.github/workflows/cfc-properties.yml
@@ -30,16 +30,19 @@ name: CFC Property Suite
 # does.
 #
 # The job takes no part in test records: no spool directory, no
-# `run-recorded` wrapper, no ship step. Its two steps sit outside what a
-# record is for, for the two reasons `docs/specs/test-records.md` gives
-# under "Recording". Each test file the suite step runs is a unit of
-# `workspace-unit`, which the per-PR job runs and records against the same
-# commit, so recording them here files each one twice; a wrapper around
-# the invocation as a whole summarizes it rather than recording one test
-# execution. The audit reads the corpus the step before it wrote, so no
-# lane can be asked to run it. The audit's verdict is the job's own
-# conclusion, and the findings behind a red one are in the uploaded
-# artifacts and in `audit/expected-failures.json`.
+# `run-recorded` wrapper, no ship step. `docs/specs/test-records.md`
+# under "Recording" holds why, and the two steps get there differently.
+# The suite step runs `deno test` directly, and a bare run records
+# nothing: records for such a suite come from a JUnit report ingested at
+# shipping time, which the workspace runner arranges by appending
+# `--junit-path` and the registration preload, and neither is here. Its
+# tests are units of `workspace-unit` and record when CI runs them. So a
+# wrapper here files one line summarizing the invocation and nothing
+# else, which is not one execution of one test. The audit step reads the
+# corpus the step before it wrote, so no lane can be asked to run it. The
+# audit's verdict is the job's own conclusion, and the findings behind a
+# red one are in the uploaded artifacts and in
+# `audit/expected-failures.json`.
 on:
   schedule:
     - cron: "0 5 * * *" # Nightly, 05:00 UTC

--- a/.github/workflows/cfc-properties.yml
+++ b/.github/workflows/cfc-properties.yml
@@ -28,6 +28,18 @@ name: CFC Property Suite
 # historic session corpus cannot be re-run, so a check can only ever report
 # what those runs happened to record; this one reports what the current code
 # does.
+#
+# The job takes no part in test records: no spool directory, no
+# `run-recorded` wrapper, no ship step. Its two steps sit outside what a
+# record is for, for the two reasons `docs/specs/test-records.md` gives
+# under "Recording". Each test file the suite step runs is a unit of
+# `workspace-unit`, which the per-PR job runs and records against the same
+# commit, so recording them here files each one twice; a wrapper around
+# the invocation as a whole summarizes it rather than recording one test
+# execution. The audit reads the corpus the step before it wrote, so no
+# lane can be asked to run it. The audit's verdict is the job's own
+# conclusion, and the findings behind a red one are in the uploaded
+# artifacts and in `audit/expected-failures.json`.
 on:
   schedule:
     - cron: "0 5 * * *" # Nightly, 05:00 UTC
@@ -37,8 +49,6 @@ jobs:
   cfc-properties:
     name: "CFC properties and the audit over them"
     runs-on: ubuntu-latest
-    env:
-      CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,27 +64,17 @@ jobs:
         working-directory: packages/cf-harness
         env:
           CF_HARNESS_PROPERTY_ARTIFACT_ROOT: ${{ runner.temp }}/cfc-properties
-        run: >-
-          deno task run-recorded test cf-harness cfc-properties --
-          deno test -A test/cfc-properties/
+        run: deno test -A test/cfc-properties/
 
       - name: 🔎 Audit the artifacts the suite just wrote
         working-directory: packages/cf-harness
         run: |
-          deno task run-recorded gate cf-harness cfc-audit-properties -- \
-            deno task cfc-audit "${{ runner.temp }}/cfc-properties" \
+          deno task cfc-audit "${{ runner.temp }}/cfc-properties" \
             --corpus \
             --expect-refusals \
             --expected-posture audit/profiles/max-enforcement.json \
             --fail-on warn \
             --expected-failures audit/expected-failures.json
-
-      - name: 📤 Ship test records
-        if: always()
-        uses: ./.github/actions/test-records-ship
-        with:
-          artifact: cfc-properties
-          job: CFC properties and the audit over them
 
       # Kept whether or not the audit passed: a red run's findings are the
       # reason to look, so the evidence behind them has to outlive the job.

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -173,6 +173,16 @@ second workflow running those tests on that commit would give each of
 them two entries in its history. The exemption covers tests rather than
 jobs: a test that runs only in such a job is recorded there.
 
+`run-recorded` records the command it wraps, as one line carrying the
+identity the wrapper was given. It is therefore for a command that is
+itself the check — a formatter, a linter, a gate. A command whose own
+tests are the checks is not wrapped: its tests record through their own
+runner, and the wrapper's line would summarize an invocation beside
+them rather than record one execution of one test. The wrapper passes
+recording through to what it runs either way, so wrapping such a
+command adds that summary without changing what the tests below it
+record.
+
 A run's owner — locally `deno task test`, `deno task integration`, or
 `deno task run-recorded` when a personal key is present — creates the
 spool under the per-user spool root (`CF_TEST_RECORDS_SPOOL_ROOT`, or the
@@ -341,7 +351,9 @@ make if a closed partition is ever shown to have lost something.
 
 ## CI movement
 
-Test jobs hold no credentials. Each job spools records (and its JUnit
+Test jobs hold no credentials. Each recording job — which is every job
+running tests that "Recording" above does not exempt — spools records
+(and its JUnit
 XML: leaf cases become records, container cases — one per describe level,
 with overlapping times — are dropped by a name-prefix rule) and uploads
 one credential-free `test-records-<job>-a<attempt>` artifact,

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -159,11 +159,19 @@ empty value is recording off, the same as an unset one.
 A check that no lane can be asked to run is not recorded. A record is one
 execution of one test, and every history built from records — flake rate,
 duration, and what a pull request selects — answers whether to run that
-test again. A check reading the artifacts of every job in its own run
-exists only as part of a whole run, so there is nothing to select and no
-suite in the test topology to claim its identity. The pull request
-coverage gate is the one such check; a gate resolving a merge base
+test again. A check reading what the run around it produced exists only
+as part of that run, so there is nothing to select and no suite in the
+test topology to claim its identity. Two checks are of this shape: the
+pull request coverage gate, which reads the coverage artifacts of every
+job in its own run, and the nightly audit over the CFC property corpus,
+which reads what the step before it wrote. A gate resolving a merge base
 against a base ref is not, and records normally.
+
+A test another workflow already records against the same commit is not
+recorded a second time. One execution of one test is one record, so a
+second workflow running those tests on that commit would give each of
+them two entries in its history. The exemption covers tests rather than
+jobs: a test that runs only in such a job is recorded there.
 
 A run's owner — locally `deno task test`, `deno task integration`, or
 `deno task run-recorded` when a personal key is present — creates the
@@ -362,10 +370,9 @@ the default branch. Otherwise the old relay drops the field before writing a
 create-only object that cannot be repaired in place.
 
 The relay workflow follows the completion of every workflow that records
-tests — success, failure, cancellation, and timeout alike. A workflow whose
-tests another workflow already records against the same commit records
-nothing of its own, and the relay does not follow it. It ships a
-same-repository run unconditionally, since only write access creates
+tests — success, failure, cancellation, and timeout alike — and follows
+no workflow that "Recording" above leaves recording nothing. The relay
+ships a same-repository run unconditionally, since only write access creates
 one, and a fork run only when the run's actor — read from the trusted
 payload — is on the team member list (`TEST_RECORDS_MEMBER_ACTOR_IDS`,
 an infra-managed variable of numeric actor ids): team members work from

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -693,6 +693,48 @@ Deno.test("the Coverage Check job records no tests", async () => {
   assertStringIncludes(job, "tasks/coverage-check.ts");
 });
 
+Deno.test("the CFC Property Suite workflow records no tests", async () => {
+  const suite = withoutComments(await workflow("cfc-properties.yml"));
+  const relay = withoutComments(await workflow("test-records-relay.yml"));
+
+  // Both of the job's steps fall outside what a record is for, and for the
+  // two different reasons `docs/specs/test-records.md` gives under
+  // "Recording". Each test file the suite step runs is a unit of
+  // `workspace-unit`, so CI runs and records them against the same commit,
+  // and a wrapper around the invocation as a whole summarizes it rather
+  // than recording one test execution. The audit step reads the corpus the
+  // step before it wrote, so no lane can be asked to run it. The workflow
+  // therefore takes no part in test records at either end: it spools
+  // nothing, and the relay does not follow it. Spooling again without the
+  // relay produces a run whose records are gathered and never shipped, and
+  // the relay assertion is what keeps its follow list honest about which
+  // workflows record.
+  assert(
+    !suite.includes("CF_TEST_RECORDS_DIR"),
+    "the workflow spools test records",
+  );
+  assert(
+    !suite.includes("run-recorded"),
+    "the workflow wraps a command in run-recorded",
+  );
+  assert(
+    !suite.includes("test-records-ship"),
+    "the workflow ships test records",
+  );
+  const name = suite.match(/^name: (.+)$/m);
+  assert(name, "the workflow has no name");
+  assertEquals(
+    workflowTriggers(relay).includes(name[1]),
+    false,
+    `the relay follows ${name[1]}, whose records nothing gathers`,
+  );
+
+  // Both checks themselves still run.
+  const job = jobBlock(suite, "cfc-properties");
+  assertStringIncludes(job, "run: deno test -A test/cfc-properties/\n");
+  assertStringIncludes(job, "deno task cfc-audit ");
+});
+
 Deno.test("One commit publishes one set of release artifacts", async () => {
   // A release artifact is named after the commit it was built from, and the
   // deploy hands the bastion a commit rather than a build. So a commit has one

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -699,16 +699,17 @@ Deno.test("the CFC Property Suite workflow records no tests", async () => {
 
   // Both of the job's steps fall outside what a record is for, and for the
   // two different reasons `docs/specs/test-records.md` gives under
-  // "Recording". Each test file the suite step runs is a unit of
-  // `workspace-unit`, so CI runs and records them against the same commit,
-  // and a wrapper around the invocation as a whole summarizes it rather
-  // than recording one test execution. The audit step reads the corpus the
-  // step before it wrote, so no lane can be asked to run it. The workflow
-  // therefore takes no part in test records at either end: it spools
-  // nothing, and the relay does not follow it. Spooling again without the
-  // relay produces a run whose records are gathered and never shipped, and
-  // the relay assertion is what keeps its follow list honest about which
-  // workflows record.
+  // "Recording". The suite step runs `deno test` directly, with no
+  // `--junit-path` to ingest and no registration preload, so nothing under
+  // it records; a wrapper passes recording through to what it runs, so one
+  // here would file a line summarizing the invocation and nothing else.
+  // Those tests are units of `workspace-unit` and record when CI runs
+  // them. The audit step reads the corpus the step before it wrote, so no
+  // lane can be asked to run it. The workflow therefore takes no part in
+  // test records at either end: it spools nothing, and the relay does not
+  // follow it. Spooling again without the relay produces a run whose
+  // records are gathered and never shipped, and the relay assertion is
+  // what keeps its follow list honest about which workflows record.
   assert(
     !suite.includes("CF_TEST_RECORDS_DIR"),
     "the workflow spools test records",


### PR DESCRIPTION
PROBLEM

The nightly CFC Property Suite workflow wraps both of its steps in `run-recorded`, sets a spool directory, and ships a `cfc-properties` artifact. The two identities it files are `["test","cf-harness", "cfc-properties"]` and `["gate","cf-harness","cfc-audit-properties"]`. No suite in the topology claims either: handed a record carrying them, `deno task check-test-topology --records` answers `no suite claims the recorded identity` for both. `test` is not among the kinds the specification lists.

Neither record reaches the store. The relay follows `workflows: ["CI"]`, and this workflow is named `CFC Property Suite`, so nothing downloads the artifact except a manual dispatch naming the run. The specification says the relay follows every workflow that records tests, and this is the only workflow that made that sentence false.

SOLUTION

The job now takes no part in test records: no spool directory, no wrapper on either step, no ship step. Both checks run exactly as before.

Each step falls under one of two exemptions. The suite step runs files that are each a unit of `workspace-unit`, which a pull request selects and CI records against the same commit, so a record here would file each of them twice; the wrapper's own line summarized an invocation rather than one test execution, which is the shape #7110 removed from the Dashboard workflow. The audit step reads the corpus the step before it wrote, so no lane can ever be asked to run it, which is the criterion #7123 wrote into the specification for the coverage gate.

Removing the audit's wrapper leaves the job's own conclusion as the signal that the corpus checks passed. That is the whole signal either way: the wrapper recorded the step's exit code, which is what the run already shows, and the history worth watching is
`audit/expected-failures.json` shrinking rather than a nightly boolean.

DESIGN DISCUSSION

No per-test records are lost, because the run produces none. Records for a `deno test` suite come from a JUnit report ingested at shipping time, which the workspace runner arranges by appending `--junit-path` and the registration preload. This step invokes `deno test` directly with neither. The import map does reach the records shim for `@std/testing/bdd`, but that shim re-exports the real `describe` and `it` until the preload installs a capture, nothing under `packages/cf-harness` writes to a spool, and `cfc-audit` runs without `--allow-write` and could not. A bare `deno test` with `CF_TEST_RECORDS_DIR` set writes no fragment. The two wrapper lines were the job's entire output, so the spool and the ship step go with them rather than staying to gather nothing.

Recording the nightly run's individual tests would be worth having, as a second execution against real runtimes in a different environment from the per-PR one. It is a larger change than this: the same identities recorded from a second configuration need a variant, and the relay needs to follow a second workflow.

Both exemptions now sit together in the specification under "Recording", which is where what counts as a record belongs. The duplicate-recording rule was in the relay paragraph, phrased as a fact about what the relay follows, where a reader sent to "Recording" for it would not find it. The relay paragraph refers to that section instead of restating half of it. `.claude/rules/github-workflows.md` carried one job under each exemption, and both now name this workflow's step as well.

A test in `tasks/ci-workflow.test.ts` holds the six properties: no spool directory, no wrapper, no ship step, no relay trigger on this workflow's name, and each of the two commands still invoked. Each assertion was checked by mutation, three of them failing with a message naming the construct that came back and three naming the condition they hold.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

