### PR TITLE
fix(cf-harness): read the session's flow-label rung from its preset

### DIFF
--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -49,6 +49,12 @@ export type HarnessFabricCfcEnforcementMode =
 
 export type HarnessFabricCfcFlowLabelsMode = CfcFlowLabelsMode;
 
+/** Where a fabric session's flow-label rung came from. */
+export type HarnessFabricCfcFlowLabelsSource =
+  | "configured"
+  | "posture"
+  | "default";
+
 /**
  * Connection settings for the trusted Fabric session behind the
  * `run_pattern` tool: the deployed API URL, a PKCS#8 identity keyfile path
@@ -371,6 +377,38 @@ export const fabricSessionCfcEnforcementMode = (
 ): CfcEnforcementMode =>
   resolveCfcDials(presetCfcOptions(fabricSessionPresetCfcDials(fabricSession)))
     .cfcEnforcementMode;
+
+/**
+ * The flow-label rung a fabric session propagates at, whether or not it
+ * stated one.
+ *
+ * `presetCfcOptions` resolves the dials the config states — the named posture
+ * bundle where one is selected, then the host dial over it — and the
+ * runtime's own dial defaults resolve whatever the preset leaves unset. A
+ * session's runtime is constructed through those same two steps over the same
+ * dials, so this is the rung it propagates at.
+ */
+export const fabricSessionCfcFlowLabels = (
+  fabricSession: HarnessFabricSessionConfig,
+): CfcFlowLabelsMode =>
+  resolveCfcDials(presetCfcOptions(fabricSessionPresetCfcDials(fabricSession)))
+    .cfcFlowLabels;
+
+/**
+ * Where that rung came from: `configured` when the config states the dial,
+ * `posture` when the named bundle the config selected moves the dial off what
+ * the preset resolves without it, and `default` when nothing the config states
+ * reaches this dial at all.
+ */
+export const fabricSessionCfcFlowLabelsSource = (
+  fabricSession: HarnessFabricSessionConfig,
+): HarnessFabricCfcFlowLabelsSource =>
+  fabricSession.cfcFlowLabels !== undefined
+    ? "configured"
+    : presetCfcOptions(fabricSessionPresetCfcDials(fabricSession))
+        .cfcFlowLabels === presetCfcOptions({}).cfcFlowLabels
+    ? "default"
+    : "posture";
 
 /** What the operator stated the harness's own dial to be, if anything. */
 const statedCfcEnforcementMode = (

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -24,6 +24,8 @@ import {
 } from "./artifacts.ts";
 import {
   fabricSessionCfcEnforcementMode,
+  fabricSessionCfcFlowLabels,
+  fabricSessionCfcFlowLabelsSource,
   type HarnessConfig,
   type ResolvedHarnessConfig,
   resolveHarnessConfig,
@@ -790,8 +792,8 @@ export class CfHarnessEngine {
       options.runState,
     );
     // The posture the fabric session's runtime will actually run at, resolved
-    // from the same config the session factory reads. The pin/default values
-    // restate what `runtimePresets.remoteClient` and the Runtime constructor
+    // from the same config the session factory reads. The enforcement pin
+    // restates what `runtimePresets.remoteClient` and the Runtime constructor
     // supply when the dial is unset (`coreOptions` in
     // `packages/runner/src/runtime-presets.ts`).
     // A host that supplies its own session factory overrides the config the
@@ -825,15 +827,10 @@ export class CfHarnessEngine {
           this.config.fabricSession.cfcEnforcementMode !== undefined
             ? "configured" as const
             : "preset-pin" as const,
-        flowLabels: this.config.fabricSession.cfcFlowLabels ??
-          (this.config.fabricSession.cfcPosture === "max-enforcement"
-            ? "persist" as const
-            : "off" as const),
-        flowLabelsSource: this.config.fabricSession.cfcFlowLabels !== undefined
-          ? "configured" as const
-          : this.config.fabricSession.cfcPosture === "max-enforcement"
-          ? "posture" as const
-          : "default" as const,
+        flowLabels: fabricSessionCfcFlowLabels(this.config.fabricSession),
+        flowLabelsSource: fabricSessionCfcFlowLabelsSource(
+          this.config.fabricSession,
+        ),
         ...(this.config.fabricSession.cfcPosture !== undefined
           ? { posture: this.config.fabricSession.cfcPosture }
           : {}),

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -1,6 +1,7 @@
 import type {
   CfcConfClause,
   CfcEnforcementMode,
+  CfcFlowLabelsMode,
   CfcPostureReport,
   CfcReadOnExceed,
 } from "@commonfabric/runner/cfc";
@@ -45,6 +46,7 @@ import type {
 } from "./diagnostics.ts";
 import { selectPrimaryHarnessFailure } from "./diagnostics.ts";
 import type {
+  HarnessFabricCfcFlowLabelsSource,
   HarnessModelAuthSource,
   HarnessModelProviderId,
 } from "./config.ts";
@@ -88,13 +90,14 @@ export interface HarnessFabricSessionCfcPosture {
   /** `configured` when the operator set the dial; `preset-pin` otherwise. */
   enforcementModeSource: "configured" | "preset-pin";
 
-  flowLabels: "off" | "observe" | "persist";
+  /** The rung the session's runtime resolves to, from the whole ladder. */
+  flowLabels: CfcFlowLabelsMode;
 
   /**
    * `configured` when the operator set the dial; `posture` when the named
    * bundle below supplied it; `default` otherwise.
    */
-  flowLabelsSource: "configured" | "default" | "posture";
+  flowLabelsSource: HarnessFabricCfcFlowLabelsSource;
 
   /**
    * The named CFC posture bundle the session's runtime opted into, when the

--- a/packages/cf-harness/test/cfc-posture.test.ts
+++ b/packages/cf-harness/test/cfc-posture.test.ts
@@ -7,26 +7,48 @@
  * record in — an ungated sink that did not reach the output is a gap nobody
  * reads about.
  *
- * The itemized enforcement dial belongs here too. A run records it beside the
+ * The itemized dials belong here too — the enforcement rung, the flow-label
+ * rung, and where the flow-label rung came from. A run records each beside the
  * record, from the same configuration, and an audit reads both.
  */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { presetCfcOptions } from "@commonfabric/runner";
+import { RUNTIME_CFC_DIAL_DEFAULTS } from "@commonfabric/runner/cfc";
 
 import {
   harnessFabricSessionPosture,
   harnessFabricSessionPostureBanner,
   renderCfcPostureReport,
 } from "../src/cfc-posture.ts";
-import { fabricSessionCfcEnforcementMode } from "../src/config.ts";
+import {
+  fabricSessionCfcEnforcementMode,
+  fabricSessionCfcFlowLabels,
+  fabricSessionCfcFlowLabelsSource,
+  type HarnessFabricCfcFlowLabelsMode,
+} from "../src/config.ts";
 
 const SESSION = {
   apiUrl: "https://toolshed.example/",
   identityKeyPath: "/keys/agent.pkcs8",
   space: "my-space",
 } as const;
+
+/**
+ * Every configuration of the two dials that decide a session's flow-label
+ * rung: the named bundle it selects, and the rung it states itself.
+ */
+const SESSIONS = ([undefined, "max-enforcement"] as const).flatMap(
+  (cfcPosture) =>
+    ([undefined, "off", "observe", "persist"] as const).map((
+      cfcFlowLabels,
+    ) => ({
+      ...SESSION,
+      ...(cfcPosture !== undefined ? { cfcPosture } : {}),
+      ...(cfcFlowLabels !== undefined ? { cfcFlowLabels } : {}),
+    })),
+);
 
 describe("cfc-posture", () => {
   describe("harnessFabricSessionPosture()", () => {
@@ -119,6 +141,94 @@ describe("cfc-posture", () => {
           harnessFabricSessionPosture(session).enforcementMode.rung,
         );
       }
+    });
+  });
+
+  describe("fabricSessionCfcFlowLabels()", () => {
+    it("returns the rung the named bundle supplies", () => {
+      expect(
+        fabricSessionCfcFlowLabels({
+          ...SESSION,
+          cfcPosture: "max-enforcement",
+        }),
+      ).toBe(presetCfcOptions({ cfcPosture: "max-enforcement" }).cfcFlowLabels);
+    });
+
+    it("returns the runtime's own default when nothing states the dial", () => {
+      expect(fabricSessionCfcFlowLabels(SESSION)).toBe(
+        RUNTIME_CFC_DIAL_DEFAULTS.cfcFlowLabels,
+      );
+    });
+
+    it("returns the rung the session states over the bundle's", () => {
+      expect(
+        fabricSessionCfcFlowLabels({
+          ...SESSION,
+          cfcPosture: "max-enforcement",
+          // `off` is the rung the assertion below reads back.
+          cfcFlowLabels: "off",
+        }),
+      ).toBe("off");
+    });
+
+    it("throws naming the ladder for a rung outside it", () => {
+      // A value outside the ladder reaches a session config only from a
+      // caller the type checker never saw. The record has no rung to state
+      // for it, and the run that would carry one is refused instead. Where
+      // the run holds the whole record beside this dial, the record's own
+      // resolution refuses first; where a host supplied the session factory,
+      // there is no record and this is the only reader.
+
+      expect(() =>
+        fabricSessionCfcFlowLabels({
+          ...SESSION,
+          cfcFlowLabels: "persistt" as HarnessFabricCfcFlowLabelsMode,
+        })
+      ).toThrow("off, observe, persist");
+    });
+
+    it("returns the rung the record projected from that configuration carries", () => {
+      // A run records both from the same configuration: the itemized dial an
+      // audit compares against, and the whole record beside it. Every
+      // configuration of the two dials that reach this one, rather than a
+      // chosen few.
+
+      for (const session of SESSIONS) {
+        expect(fabricSessionCfcFlowLabels(session)).toBe(
+          harnessFabricSessionPosture(session).flowLabels.rung,
+        );
+      }
+    });
+  });
+
+  describe("fabricSessionCfcFlowLabelsSource()", () => {
+    it("returns `configured` when the session states the dial", () => {
+      // `off` is what the runtime also defaults to, so a source read off the
+      // rung rather than the configuration would say `default` here. Both
+      // ways round on the bundle, which the stated dial outranks either way.
+
+      for (const bundle of [{}, { cfcPosture: "max-enforcement" as const }]) {
+        expect(
+          fabricSessionCfcFlowLabelsSource({
+            ...SESSION,
+            ...bundle,
+            cfcFlowLabels: "off",
+          }),
+        ).toBe("configured");
+      }
+    });
+
+    it("returns `posture` when only the named bundle supplies the dial", () => {
+      expect(
+        fabricSessionCfcFlowLabelsSource({
+          ...SESSION,
+          cfcPosture: "max-enforcement",
+        }),
+      ).toBe("posture");
+    });
+
+    it("returns `default` when neither the session nor a bundle states the dial", () => {
+      expect(fabricSessionCfcFlowLabelsSource(SESSION)).toBe("default");
     });
   });
 


### PR DESCRIPTION
PROBLEM

A run records the flow-label rung its fabric session propagates at, as `fabricSessionCfc.flowLabels`, and `engine.ts` wrote it from two literals:

    flowLabels: cfcFlowLabels ??
      (cfcPosture === "max-enforcement" ? "persist" : "off"),

`"persist"` is a hand-copy of
`MAX_ENFORCEMENT_CFC_OPTIONS.cfcFlowLabels` and `"off"` a hand-copy of `RUNTIME_CFC_DIAL_DEFAULTS.cfcFlowLabels`, both owned by the runner. Nothing connected either copy to its original. The same record's `record` field comes from `harnessFabricSessionPosture`, which resolves through `presetCfcOptions`, so moving either runner value leaves one posture record carrying two different answers for one dial. `flowLabelsSource` beside it named the bundle in the same way.

SOLUTION

`fabricSessionCfcFlowLabels` resolves the dial through the two steps the session's runtime resolves it through: `presetCfcOptions` for the named posture bundle and the host dial over it, then `resolveCfcDials` for the runtime's default table behind that. That is what
`fabricSessionCfcEnforcementMode` beside it already does.

`fabricSessionCfcFlowLabelsSource` compares what the preset resolves for this configuration against what it resolves for a configuration stating nothing. The dial came from the bundle when the two differ, and from nothing the configuration states when they agree.

The engine calls both. Values are unchanged today.

DESIGN DISCUSSION

Only `configured` is a fact about the configuration rather than about a resolved value, and cf-harness holds the configuration, so that arm stays a comparison against the config's own field.

The other two arms could have been one test of whether the preset states this dial at all, since the bundle is the only thing inside the preset that sets it. That reading stops being true the moment the preset pins the dial the way it already pins `cfcEnforcementMode`, which `coreOptions` says is deferred until a first-party rollout begins: a session naming no bundle would then record `flowLabelsSource: "posture"` with no `posture` beside it, and AUD-15a returns `not-applicable` for a run claiming no bundle, so nothing would catch it. Under a preset pin the comparison records `default` instead, which is the remaining honest word — the record's three source words have no name for a preset pin, and giving this dial a fourth would add a member nothing can reach.

`HarnessFabricSessionCfcPosture.flowLabels` is a rung of the dial's ladder, `CfcFlowLabelsMode`, rather than the three rung names written out again; a ladder that gains a rung would otherwise need a cast on the way into the record. `flowLabelsSource` is
`HarnessFabricCfcFlowLabelsSource`, which the function that decides it returns.

Verified by moving both runner values — the bundle to `observe`, the runtime default to `persist` — and reading a run's recorded posture back. The old code left the itemized dial at `off` beside a record reading `persist` for a session stating nothing, and at `persist` beside a record reading `observe` under the bundle. The new code agrees with the record in both, and three of the cases below fail if the literal comes back. Verified the source by adding a `cfcFlowLabels` pin to `presetCfcOptions`, where it reads `default`, and by dropping `cfcFlowLabels` from the bundle, where it reads `default` and the literal it replaced read `posture`. The runner files were restored from copies; they are unmodified here.

Eight cases in `test/cfc-posture.test.ts`, whose subject is the posture a run records and which is already written in the BDD form: the bundle's rung, the runtime's default, a stated rung over the bundle's, the itemized dial against the record's rung across every configuration of the two dials that decide it, one per source word, and the refusal a rung outside the ladder now meets. That last one is a behavior change: where a host supplies its own session factory there is no record, so this dial is the only reader, and a value off the ladder used to be recorded as it stood.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

