### PR TITLE
fix(cfc): stop retrying a link refusal the state in hand settles

### DIFF
--- a/docs/specs/space-model/5-transactions.md
+++ b/docs/specs/space-model/5-transactions.md
@@ -197,8 +197,12 @@ evaluated the transaction's own reads and writes and refused them before
 storage saw them — and did so on EVERY recorded reason. A refusal is terminal
 only when every reason is a verdict; a reason is a verdict only when its
 producer tags it as one (`cfc/verdict-reason.ts`), so anything untagged — an
-unavailable input, a failed resolution, a prepared state a caller disturbed —
-stays retryable. It carries both channels: `reasons`, the prose one per rule
+input the transaction does not have, a failed resolution, a prepared state a
+caller disturbed — stays retryable. A verdict covers the input a re-run cannot
+change as well as the data policy refused: an input absent from stored state
+the transaction already holds reads the same on every attempt, and its
+producer leaves the run depending on the state whose arrival would decide
+otherwise. It carries both channels: `reasons`, the prose one per rule
 that refused, and `refusals`, the structured descriptions
 (`cfc/refusal-detail.ts`) naming the boundary, the offending label atoms, and
 the reads that carried them — which is what lets a consumer state a remedy

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -155,6 +155,19 @@ const INTERNAL_VERIFIER_META = {
   ...internalVerifierRead,
 };
 
+// The link-source schema read, which reactivity SEES. Prepare's other reads
+// carry `ignoreReadForScheduling` and are invisible to it. This one decides
+// whether a link write can be labeled at all, and the commit boundary ends
+// the retries on a refusal it cannot answer, so the run is re-triggered when
+// the member it went looking for lands. The stored `["cfc"]` envelope, the
+// other half of that decision, is a dependency of the writer already, through
+// `readStoredCfcMetadata` (cfc/metadata.ts, called from data-updating.ts when
+// the link is written). The read is a commit-time precondition either way:
+// `ignoreReadForScheduling` gates reactivity alone.
+const LINK_SOURCE_SCHEMA_META = {
+  ...internalVerifierRead,
+};
+
 const isPrefix = (
   prefix: readonly string[],
   path: readonly string[],
@@ -1108,8 +1121,11 @@ const storedMetadataFor = (
   // layer-naming half was fixed (verification-coverage.md OW47's
   // re-close; the name-draft triage's arm (c), the path half of the
   // ruled arm (b)). The read is marked as a runtime-internal verifier
-  // read, so it stays in the journal and drives reactivity while the
-  // commit's conflict set drops it (spec §18.6.2, §8.9.4).
+  // read, so the commit's conflict set drops it (spec §18.6.2, §8.9.4);
+  // it carries `ignoreReadForScheduling` besides, so reactivity skips it
+  // like every other read this pass makes. A writer that depends on the
+  // envelope reads it through `readStoredCfcMetadata` (cfc/metadata.ts),
+  // whose meta omits that marker.
   const metadata = tx.readOrThrow({
     space,
     id,
@@ -1140,6 +1156,34 @@ const storedMetadataFor = (
   }
   return metadata;
 };
+
+// Whether this transaction's view of the document has a root value.
+//
+// `storedMetadataFor` answers `undefined` both for a document that stores no
+// CFC metadata and for one whose root the transaction cannot see, and the two
+// differ in whether reading again can change the answer. `readOrThrow`
+// collapses them; the storage layer separates them by the error rather than
+// the value, so the same read is issued again here to see it: a document with
+// no root value answers every read below the root with `NotFoundError`, while
+// one with a root answers a missing `["cfc"]` slot with a successful read of
+// `undefined`. A root that cannot carry the path answers with a type mismatch
+// and counts as no root.
+//
+// The view a read resolves against includes this transaction's own writes, so
+// a document the replica never pulled reads as having a root once this
+// transaction writes into it. The address and the meta are the ones
+// `storedMetadataFor` already read, so this adds nothing to the transaction's
+// read set.
+const documentRootIsReadable = (
+  tx: IExtendedStorageTransaction,
+  space: MemorySpace,
+  id: URI,
+  scope: ReturnType<typeof normalizeCellScope>,
+  type: MediaType,
+): boolean =>
+  tx.read({ space, id, scope, type, path: ["cfc"] }, {
+    meta: INTERNAL_VERIFIER_META,
+  }).ok !== undefined;
 
 /**
  * This returns a map whose values are always interned schemas.
@@ -4792,7 +4836,7 @@ const setupResultSchemaFor = (
     type: "application/json",
     path: ["schema"],
   }, {
-    meta: INTERNAL_VERIFIER_META,
+    meta: LINK_SOURCE_SCHEMA_META,
   });
   return schema === undefined || schema === null
     ? undefined
@@ -4867,13 +4911,35 @@ const derivePersistedLinkLabel = (
     sourceMetadata === undefined && pendingSourceSchema === undefined &&
     !hasLabelValues(linkSchemaLabel) && !hasCarriedLabel
   ) {
-    return {
-      // Untagged, so retryable: the source document's metadata is not
-      // available in this transaction. It loads, and the re-run decides.
-      reason: `missing link source metadata for ${input.target.id} at /${
-        input.target.path.join("/")
-      }`,
-    };
+    // Name the SOURCE document, which is the one carrying no metadata, and
+    // the target location the link was being written into.
+    const reason = `missing link source metadata for ${input.source.id} at /${
+      input.source.path.join("/")
+    }, linked into ${input.target.id} at /${input.target.path.join("/")}`;
+    // A source whose root this transaction cannot see is what the untagged
+    // default is for: reading the document is what decides, so the reason
+    // stays retryable.
+    //
+    // Where the root IS readable, two of its members decided — `["cfc"]`
+    // above and `["schema"]` through `setupResultSchemaFor` — and the rest of
+    // the decision is the link value and the writer's own schema inputs,
+    // which a re-run reconstructs identically. So an immediate re-run refuses
+    // over the same absence, which is a verdict.
+    //
+    // Those immediate attempts are what end here, not the subscription. A
+    // later revision of the source can carry either member, and the run
+    // depends on both: `["cfc"]` through the writer's `readStoredCfcMetadata`
+    // and `["schema"]` through this pass's `LINK_SOURCE_SCHEMA_META` read. The
+    // arriving member re-triggers the reader, with the full retry budget the
+    // terminal disposition clears.
+    const sourceRootIsReadable = documentRootIsReadable(
+      tx,
+      input.source.space,
+      input.source.id as URI,
+      input.source.scope,
+      "application/json",
+    );
+    return { reason: sourceRootIsReadable ? verdictReason(reason) : reason };
   }
   if (
     sourceMetadata === undefined && pendingSourceSchema === undefined &&

--- a/packages/runner/src/cfc/verdict-reason.ts
+++ b/packages/runner/src/cfc/verdict-reason.ts
@@ -1,20 +1,32 @@
 // Why: a CFC prepare rejection is not one thing, and only one kind of it may
 // stop the scheduler.
 //
-// A VERDICT is policy evaluating this transaction's data and refusing it — a
+// A VERDICT is a refusal an immediate re-run reproduces, and two shapes
+// qualify. Policy evaluated this transaction's data and refused it — a
 // writer-fit misfit, an unprivileged write to a protected `cfc` path, an
-// exact-copy or monotonicity violation. Re-running recomputes the identical
-// refused write, so a verdict is terminal: never retried, surfaced.
+// exact-copy or monotonicity violation. Or the input the evaluation needed is
+// absent from stored state the transaction already has, so reading it again
+// returns the same absence — a link source document in hand that carries
+// neither an envelope nor a result schema. Either way re-running recomputes
+// the identical refused write, so a verdict is terminal: never retried,
+// surfaced.
+//
+// The second shape carries an obligation the first does not. It is terminal
+// over the state in hand rather than over the data, so its producer leaves the
+// run DEPENDING on the state that would change the answer. The value arriving
+// there re-triggers the reader, which is a fresh trigger with a fresh budget
+// rather than a retry. A producer that cannot establish that dependency has no
+// verdict to claim.
 //
 // Everything else that lands in `reasons` is NOT a verdict, whatever it looks
 // like. Prepare may have been unable to EVALUATE because an input was not
-// available in this transaction (a link's source metadata, a schema's
-// write-policy input, an unreadable stored envelope, a policy manifest that
-// did not resolve). The prepared state may have DRIFTED — `invalidateCfc`
-// records a read after prepare, a changed policy input — which says the
-// verdict was never reached, not that it went against the data. Both clear on
-// a fresh attempt, and terminating them strands a write that would have
-// landed.
+// available in this transaction (a link source document this replica does not
+// hold, a schema's write-policy input, an unreadable stored envelope, a policy
+// manifest that did not resolve). The prepared state may have DRIFTED —
+// `invalidateCfc` records a read after prepare, a changed policy input — which
+// says the verdict was never reached, not that it went against the data. Both
+// clear on a fresh attempt, and terminating them strands a write that would
+// have landed.
 //
 // WATCH(cfc-verdict): THE DEFAULT IS "NOT A VERDICT", AND THAT IS DELIBERATE.
 //
@@ -55,10 +67,11 @@
 
 /**
  * Stable machine token marking a CFC prepare reason as a VERDICT — policy
- * evaluated this transaction's data and refused it, so re-running recomputes
- * the identical refused write. Emitted into the prepare `reason` (see
- * `prepare.ts`) so it survives into the commit-rejection message, and read at
- * the commit boundary to decide that the rejection is terminal.
+ * evaluated this transaction's data and refused it, or the input it needed is
+ * absent from stored state the transaction already has, so re-running
+ * recomputes the identical refused write. Emitted into the prepare `reason`
+ * (see `prepare.ts`) so it survives into the commit-rejection message, and
+ * read at the commit boundary to decide that the rejection is terminal.
  */
 export const CFC_VERDICT_REASON = "cfc-verdict";
 

--- a/packages/runner/test/cfc-missing-link-source-metadata.test.ts
+++ b/packages/runner/test/cfc-missing-link-source-metadata.test.ts
@@ -1,0 +1,248 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { Action } from "../src/scheduler.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-missing-source");
+const space: MemorySpace = signer.did();
+
+const LABEL = "personal-space";
+
+const labeledSchema: JSONSchema = {
+  type: "object",
+  properties: { title: { type: "string" } },
+  ifc: { confidentiality: [LABEL] },
+};
+
+const createRuntime = () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+    cfcEnforcementMode: "enforce-explicit",
+    cfcFlowLabels: "off",
+    cfcWriteFloor: "off",
+    cfcTriggerReadGating: false,
+    cfcDecomposedEnvelopes: false,
+    cfcPolicyEvaluation: "off",
+    cfcLabelMetadataProtection: "off",
+    cfcDeclaredMonotonicity: "off",
+  });
+  return { runtime, storageManager };
+};
+
+const idFor = (runtime: Runtime, name: string): string =>
+  runtime.getCell(space, name).getAsNormalizedFullLink().id;
+
+/** Commits a labeled target and, when named, an unlabeled source beside it. */
+const seedTarget = async (
+  runtime: Runtime,
+  targetName: string,
+  sourceName?: string,
+) => {
+  const tx = runtime.edit();
+  tx.setCfcEnforcementMode("enforce-explicit");
+  runtime.getCell(space, targetName, {
+    type: "object",
+    ifc: { confidentiality: [LABEL] },
+  }, tx).set({ existing: true });
+  if (sourceName !== undefined) {
+    // Written with no schema, so the commit stores no `cfc` member on this
+    // document and nothing later in the test writes one unasked.
+    runtime.getCell(space, sourceName, undefined, tx).set({ title: "plain" });
+  }
+  tx.prepareCfc();
+  expect((await tx.commit()).ok).toBeDefined();
+};
+
+/** Commits one write to `name`, under `schema` when one is given. */
+const commitWrite = async (
+  runtime: Runtime,
+  name: string,
+  value: unknown,
+  schema?: JSONSchema,
+) => {
+  const tx = runtime.edit();
+  tx.setCfcEnforcementMode("enforce-explicit");
+  runtime.getCell(space, name, schema, tx).set(value);
+  tx.prepareCfc();
+  expect((await tx.commit()).ok).toBeDefined();
+};
+
+/**
+ * Subscribes an action that links `sourceName` into a labeled target, counting
+ * its runs and collecting every commit rejection they earn.
+ */
+const subscribeLink = (
+  runtime: Runtime,
+  sourceName: string,
+  targetName: string,
+) => {
+  const state = {
+    runs: 0,
+    errors: [] as { name?: string; message?: string }[],
+  };
+  const link: Action = (tx) => {
+    state.runs++;
+    tx.setCfcEnforcementMode("enforce-explicit");
+    tx.addVerdictCallback((_tx, result) => {
+      if (result.error) state.errors.push(result.error);
+    });
+    runtime.getCell(space, targetName, undefined, tx).set(
+      runtime.getCell(space, sourceName, undefined, tx),
+    );
+  };
+  runtime.scheduler.subscribe(link, { isEffect: true });
+  return state;
+};
+
+describe("cfc-missing-link-source-metadata", () => {
+  // The cases here are a pair, and each is worth as much as the other. A
+  // refusal the state in hand settles has to stop retrying, and one that
+  // reading the source would settle has to keep retrying, since mislabelling
+  // in the second direction strands a write that would have landed. Two
+  // members of the source document decide the refusal — its `["cfc"]`
+  // envelope and its `["schema"]` meta — and the run depends on both, so a
+  // case covers each one arriving.
+
+  it("stops retrying when the source is here and stores no metadata", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      await seedTarget(runtime, "held-target", "held-source");
+      const state = subscribeLink(runtime, "held-source", "held-target");
+      await runtime.scheduler.idleWithPendingCommits();
+
+      expect(state.runs).toBe(1);
+      expect(state.errors.length).toBe(1);
+      expect(state.errors[0].name).toBe("CfcCommitRefusalError");
+      expect(state.errors[0].message).toContain("missing link source metadata");
+
+      // Idling again finds no queued retry.
+      await runtime.scheduler.idleWithPendingCommits();
+      expect(state.runs).toBe(1);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("names the source document and the target the link was written to", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      await seedTarget(runtime, "named-target", "named-source");
+      const sourceId = idFor(runtime, "named-source");
+      const targetId = idFor(runtime, "named-target");
+      expect(sourceId).not.toBe(targetId);
+
+      const state = subscribeLink(runtime, "named-source", "named-target");
+      await runtime.scheduler.idleWithPendingCommits();
+
+      const message = state.errors[0]?.message ?? "";
+      expect(message).toContain(`missing link source metadata for ${sourceId}`);
+      expect(message).toContain(`linked into ${targetId}`);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("re-runs the refused action, and lands it, when the source gains metadata", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      await seedTarget(runtime, "healed-target", "healed-source");
+      const state = subscribeLink(runtime, "healed-source", "healed-target");
+      await runtime.scheduler.idleWithPendingCommits();
+      expect(state.runs).toBe(1);
+
+      // A change to the source's VALUE does not re-trigger the run: the
+      // refusal read the source's metadata, not its value.
+      await commitWrite(runtime, "healed-source", { title: "bumped" });
+      await runtime.scheduler.idleWithPendingCommits();
+      expect(state.runs).toBe(1);
+
+      // Declaring the source's label stores the metadata the refusal went
+      // looking for, at the path it read.
+      await commitWrite(runtime, "healed-source", { title: "labeled" }, {
+        ...labeledSchema,
+      });
+      await runtime.scheduler.idleWithPendingCommits();
+
+      expect(state.runs).toBeGreaterThan(1);
+      // No second rejection: the re-run derived the source's label and the
+      // link landed.
+      expect(state.errors.length).toBe(1);
+      expect(
+        runtime.getCell(space, "healed-target").getAsQueryResult(),
+      ).toMatchObject({ title: "labeled" });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("re-runs the refused action, and lands it, when the source gains a schema", async () => {
+    // The stored `["cfc"]` envelope is not the only member the derivation
+    // consults: `setupResultSchemaFor` reads the source's `["schema"]` meta,
+    // which a piece's setup writes and which can land after the link write
+    // was refused. The refusal is terminal over the revision in hand, so the
+    // arrival has to re-trigger the run the same way metadata does.
+    const { runtime, storageManager } = createRuntime();
+    try {
+      await seedTarget(runtime, "schema-target", "schema-source");
+      const state = subscribeLink(runtime, "schema-source", "schema-target");
+      await runtime.scheduler.idleWithPendingCommits();
+      expect(state.runs).toBe(1);
+      expect(state.errors[0].name).toBe("CfcCommitRefusalError");
+
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      runtime.getCell(space, "schema-source", undefined, tx).setMetaRaw(
+        "schema",
+        labeledSchema,
+        rawMetaWriteAuthorization,
+      );
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+      await runtime.scheduler.idleWithPendingCommits();
+
+      expect(state.runs).toBeGreaterThan(1);
+      expect(state.errors.length).toBe(1);
+      expect(
+        runtime.getCell(space, "schema-target").getAsQueryResult(),
+      ).toMatchObject({ title: "plain" });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps retrying when this replica does not hold the source", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      await seedTarget(runtime, "unheld-target");
+      const state = subscribeLink(runtime, "unheld-source", "unheld-target");
+      await runtime.scheduler.idleWithPendingCommits();
+
+      // Every attempt is refused, for the same reason, and the reason keeps
+      // the retryable name.
+      expect(state.runs).toBeGreaterThan(1);
+      expect(state.errors.length).toBe(state.runs);
+      expect(new Set(state.errors.map((error) => error.name)))
+        .toEqual(new Set(["StorageTransactionAborted"]));
+      expect(new Set(state.errors.map((error) => error.message))).toEqual(
+        new Set([state.errors[0].message]),
+      );
+      expect(state.errors[0].message).toContain("missing link source metadata");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-verdict-reason.test.ts
+++ b/packages/runner/test/cfc-verdict-reason.test.ts
@@ -29,7 +29,7 @@ describe("cfc-verdict-reason", () => {
 
   it("recognizes a tagged reason and rejects an untagged one", () => {
     expect(isVerdictReason(verdictReason("exact-copy violated"))).toBe(true);
-    expect(isVerdictReason("missing link source metadata for of:x"))
+    expect(isVerdictReason("missing schema write-policy input for of:x"))
       .toBe(false);
   });
 
@@ -51,7 +51,7 @@ describe("cfc-verdict-reason", () => {
       verdictReason("writer-fit confidentiality misfit at /body"),
       "missing schema write-policy input for of:y",
     ])).toBe(false);
-    expect(isTerminalRefusal(["missing link source metadata for of:x"]))
+    expect(isTerminalRefusal(["missing schema write-policy input for of:x"]))
       .toBe(false);
     expect(isTerminalRefusal([])).toBe(false);
   });

--- a/packages/runner/test/speculation-arrival-gate.test.ts
+++ b/packages/runner/test/speculation-arrival-gate.test.ts
@@ -95,6 +95,92 @@ const PER_USER_PATTERN = [
   "});",
 ].join("\n");
 
+/**
+ * The overlay destination under a scripted pair of writers, for the
+ * supersede-by-newer cases below.
+ *
+ * The replica double seals natively and reports a retirement view that
+ * retires nothing, so an entry leaves the destination only when the supersede
+ * rule drops it. `seal` hands the destination whatever operations a case
+ * names, under whichever writer it names.
+ */
+const supersedeHarness = () => {
+  let nextLocalSeq = 10;
+  const replica = {
+    sealNative: (
+      native: { operations: Array<Record<string, unknown>> },
+      _source: unknown,
+      verdict: Promise<unknown>,
+    ) => {
+      const localSeq = nextLocalSeq++;
+      return {
+        localSeq,
+        commit: {
+          localSeq,
+          reads: { confirmed: [], pending: [] },
+          operations: native.operations,
+        },
+        settled: verdict.then(() => undefined, () => undefined),
+      };
+    },
+    speculationRetirementView: () => ({
+      confirmedSeq: 0,
+      pendingLocalSeqs: [] as number[],
+    }),
+    ackedSeqOf: () => undefined,
+    speculationAckObserver: undefined as (() => void) | undefined,
+  };
+  const runtime = {
+    storageManager: { open: () => ({ replica }) },
+    getCellFromLink: () => ({ sink: () => () => {} }),
+  } as unknown as Runtime;
+  const destination = new SpeculationOverlayDestination(runtime);
+  const seal = (
+    writer: object,
+    operations: Array<Record<string, unknown>>,
+  ) => {
+    const tx = {
+      tx: {
+        sourceAction: writer,
+        // These doubles hand-build the ops they seal, so the mark has
+        // nothing to shape; it is present because the seal refuses a
+        // transaction that cannot take it.
+        markWholeDocumentWrites: () => {},
+        sealInto: (collector: {
+          sealSpaceCommit: (
+            space: MemorySpace,
+            native: unknown,
+            source: unknown,
+          ) => Promise<unknown>;
+        }) =>
+          collector.sealSpaceCommit(
+            space,
+            { operations, preconditions: [] },
+            { sourceAction: writer },
+          ).then(() => ({ ok: {} })),
+      },
+    } as unknown as IExtendedStorageTransaction;
+    stampSpeculationRunContext(tx, {
+      actionId: "supersede",
+      kind: "derivation",
+    });
+    return destination.seal(tx);
+  };
+  const setOf = (id: string) => ({
+    op: "set",
+    id,
+    scope: "user",
+    value: { value: 1 },
+  });
+  return {
+    destination,
+    seal,
+    setOf,
+    writerA: { name: "writer-a" },
+    writerB: { name: "writer-b" },
+  };
+};
+
 describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () => {
   let server: MemoryV2Server.Server;
   let managers: EmulatedStorageManager[];
@@ -420,71 +506,9 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
   });
 
   it("supersede-by-newer (destination-level): a newer whole-doc entry of the same writer retires the older entry over the same instances at seal; a patch does not; another writer does not", async () => {
-    const doc = "of:supersede" as never;
-    let nextLocalSeq = 10;
-    const replica = {
-      sealNative: (
-        native: { operations: Array<Record<string, unknown>> },
-        _source: unknown,
-        verdict: Promise<unknown>,
-      ) => {
-        const localSeq = nextLocalSeq++;
-        return {
-          localSeq,
-          commit: {
-            localSeq,
-            reads: { confirmed: [], pending: [] },
-            operations: native.operations,
-          },
-          settled: verdict.then(() => undefined, () => undefined),
-        };
-      },
-      speculationRetirementView: () => ({
-        confirmedSeq: 0,
-        pendingLocalSeqs: [] as number[],
-      }),
-      ackedSeqOf: () => undefined,
-      speculationAckObserver: undefined as (() => void) | undefined,
-    };
-    const runtime = {
-      storageManager: { open: () => ({ replica }) },
-      getCellFromLink: () => ({ sink: () => () => {} }),
-    } as unknown as Runtime;
-    const destination = new SpeculationOverlayDestination(runtime);
-    const writerA = { name: "writer-a" };
-    const writerB = { name: "writer-b" };
-    const seal = (
-      writer: object,
-      operations: Array<Record<string, unknown>>,
-    ) => {
-      const tx = {
-        tx: {
-          sourceAction: writer,
-          // These doubles hand-build the ops they seal, so the mark has
-          // nothing to shape; it is present because the seal refuses a
-          // transaction that cannot take it.
-          markWholeDocumentWrites: () => {},
-          sealInto: (collector: {
-            sealSpaceCommit: (
-              space: MemorySpace,
-              native: unknown,
-              source: unknown,
-            ) => Promise<unknown>;
-          }) =>
-            collector.sealSpaceCommit(
-              space,
-              { operations, preconditions: [] },
-              { sourceAction: writer },
-            ).then(() => ({ ok: {} })),
-        },
-      } as unknown as IExtendedStorageTransaction;
-      stampSpeculationRunContext(tx, {
-        actionId: "supersede",
-        kind: "derivation",
-      });
-      return destination.seal(tx);
-    };
-    const set = { op: "set", id: doc, scope: "user", value: { value: 1 } };
+    const { destination, seal, setOf, writerA, writerB } = supersedeHarness();
+    const doc = "of:supersede";
+    const set = setOf(doc);
     const patch = {
       op: "patch",
       id: doc,
@@ -511,6 +535,32 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
     // invisible); B's entry stays.
     expect((await seal(writerA, [set])).ok).toBeDefined();
     expect(destination.entryCount(space)).toBe(2);
+    destination.close();
+  });
+
+  it("supersede-by-newer keeps an older entry the newer one covers only in part", async () => {
+    // The rule drops an older entry only when the newer entry's whole-doc
+    // ops cover EVERY doc the older one wrote. An older entry over two
+    // instances, met by a newer entry over one of them, keeps its own: the
+    // uncovered instance still reads through the older layer, and dropping
+    // it would take that speculation with it.
+    const { destination, seal, setOf, writerA } = supersedeHarness();
+    const first = setOf("of:supersede-part-1");
+    const second = setOf("of:supersede-part-2");
+
+    // Entry 1 (A) over both instances.
+    expect((await seal(writerA, [first, second])).ok).toBeDefined();
+    expect(destination.entryCount(space)).toBe(1);
+
+    // Entry 2 (A) over the first instance alone: entry 1 wrote the second
+    // as well, so it is KEPT.
+    expect((await seal(writerA, [first])).ok).toBeDefined();
+    expect(destination.entryCount(space)).toBe(2);
+
+    // Entry 3 (A) over both instances covers every doc each older entry
+    // wrote, so both go.
+    expect((await seal(writerA, [first, second])).ok).toBeDefined();
+    expect(destination.entryCount(space)).toBe(1);
     destination.close();
   });
 


### PR DESCRIPTION
PROBLEM

CFC prepare refuses a link write when it cannot derive a label for the link's source, and leaves that reason untagged, which the commit boundary reads as retryable. Some of those refusals can never converge. Where the source document's stored state is in hand and carries neither a `cfc` envelope nor a result schema, no immediate re-attempt finds either: the reactive scheduler runs the action ten times, each run reconstructing the identical write and being refused identically, then abandons it with the budget spent. That is the doomed-retry loop the commit-retry allow-list exists to prevent. The refusal message also names the target document rather than the source that was actually unreadable.

SOLUTION

Split the refusal by whether the transaction can see the source document's root. Reading `["cfc"]` answers `undefined` for both causes, but the storage layer separates them by the error: a document with no root value answers any read below the root with `NotFoundError`, while one with a root answers the missing slot with a successful read. A source whose root is out of reach keeps the untagged, retryable reason, which is what that default is for. A source whose root is readable is tagged with `verdictReason`, so the boundary refuses terminally and the scheduler stops after one run.

Two members of the source decide the refusal, and the run now depends on both, so either one arriving re-triggers the action with the full retry budget the terminal disposition clears. The `["cfc"]` envelope is already a dependency through the writer's `readStoredCfcMetadata`; the `["schema"]` member gains one by moving `setupResultSchemaFor`'s read to a metadata marker reactivity sees. Commit treatment is unchanged, since the conflict-set exemption covers `["cfc"]` paths alone.

The message now names the source document and the target location the link was written into.

DESIGN DISCUSSION

The tagging sits with the producer, in `prepare.ts`, rather than at the commit boundary: `cfc/verdict-reason.ts` asks each producer to claim what it can say about itself, and `isTerminalRefusal` is left alone.

The other shape considered was force-syncing the source before refusing, so the question is answered rather than inferred. It costs a synchronous prepare pass a wait on the network, and still cannot separate a document that is absent from one that is absent forever. The read this uses is the address and the marker `storedMetadataFor` already read, so the classification costs nothing.

Tagging in the direction that ends retries is the direction `verdict-reason.ts` warns about, since a mislabelled reason strands a write that would have landed. What bounds it is the dependency above: the events that change the answer re-trigger the reader, and a re-triggered run gets a full budget where an exhausted one keeps its spent counter. `verdict-reason.ts` states that as the obligation the shape carries — a producer that cannot establish the dependency has no verdict to claim — and the transaction spec's account of the refusal follows.

The tests count the reactive runs on each side: one run for a source whose root is readable, more than one for a source whose is not, with every attempt on the retryable side refused for the same reason. Two more pin the recovery, one per member, each landing the write the refusal dropped. A value change to the held source is committed first and does not re-trigger the run, which is what makes the re-run attributable to the metadata.

Two neighbouring reasons are unchanged. `verifyWriteFloor` discards this reason rather than recording it, so the floor's own untagged failure is unaffected; and a transaction refused for both this verdict and an untagged reason stays retryable, since `isTerminalRefusal` requires every reason to be a verdict.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

