### PR TITLE
docs(runner): say which name each CFC commit refusal carries

### DIFF
--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -36,12 +36,14 @@ export function isPermanentRejection(
  *   before storage ever saw the commit (`rejectCommitBeforeStorage` in
  *   extended-storage-transaction.ts). Carries the prepare refusal reasons
  *   as a structured `reasons` array. Never crosses the wire either.
- *   VERDICTS only, and every recorded reason must be one. A reason is a
- *   verdict when its producer tags it (`cfc/verdict-reason.ts`); an
- *   untagged reason — an input prepare could not evaluate, a resolution
- *   that failed, a prepared state a caller disturbed through
- *   `invalidateCfc` — keeps the retryable `StorageTransactionAborted`
- *   name, because a fresh attempt can decide differently.
+ *   The name is reserved for a refusal that recorded reasons and tagged
+ *   every one of them a verdict (`cfc/verdict-reason.ts`). The retryable
+ *   `StorageTransactionAborted` name goes to reasons that are not all
+ *   verdicts, to an enforcing transaction whose prepared digest changed
+ *   under it, and to a relevant transaction that reaches commit
+ *   unprepared, which records no reasons at all. A crash inside commit
+ *   preparation takes `CommitPreparationError`, checked before the
+ *   reasons are read.
  */
 const TERMINAL_REJECTION_NAMES: ReadonlySet<string> = new Set([
   "RowLabelCommitError",
@@ -317,9 +319,10 @@ export function isCfcEnforcementRejection<
  * genuinely new attempt, and — unlike every other rejection class — a
  * discarded attempt costs no round-trip and no `finalizeRejection`, so
  * retrying one is local work rather than churn against the server. The CFC
- * boundary refusal shares the never-reached-storage shape but NOT the
- * convergence argument — the refusal is deterministic — so it carries its own
- * name (`CfcCommitRefusalError`) and classifies as terminal, not discarded.
+ * boundary aborts before storage too, and a refusal it produces reaches this
+ * predicate under the same name. That refusal takes the terminal
+ * `CfcCommitRefusalError` name instead when prepare recorded reasons and
+ * tagged every one of them a verdict (see {@link TERMINAL_REJECTION_NAMES}).
  *
  * NOTE the asymmetry with a callback that THROWS: `editWithRetry` aborts that
  * transaction and returns immediately without retrying, because a thrown


### PR DESCRIPTION
PROBLEM

`packages/runner/src/storage/rejection.ts` decides which commit rejections a caller may retry, and two of its doc comments describe the CFC boundary incompletely. The `CfcCommitRefusalError` bullet requires that "every recorded reason must be one" verdict, which a refusal recording no reasons vacuously satisfies, and it does not mention the digest arm at all. The doc on `isDiscardedAttemptRejection` says the CFC boundary refusal "carries its own name (`CfcCommitRefusalError`) and classifies as terminal, not discarded" — false for the two shapes that carry the very name that predicate matches, and that predicate is what puts a rejection on the retry allow-list.

SOLUTION

Say which name each shape carries. `CfcCommitRefusalError` is reserved for a refusal that recorded reasons and tagged every one a verdict. The retryable `StorageTransactionAborted` name goes to reasons that are not all verdicts, to an enforcing transaction whose prepared digest changed, and to a relevant transaction reaching commit unprepared, which records no reasons at all. A crash inside commit preparation takes `CommitPreparationError`, checked before the reasons are read. The `isDiscardedAttemptRejection` doc says the CFC boundary aborts before storage too, so a refusal it produces reaches that predicate under the same name.

Neither comment repeats the argument for why an untagged reason defaults to retryable. That stays at the branch in
`extended-storage-transaction.ts` and in the header of `cfc/verdict-reason.ts`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

