### PR TITLE
fix(schema-generator): preserve empty record defaults

### DIFF
--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -51,7 +51,7 @@ here is what it does to a verb's author:
 | Mark a verb `@deprecated` | allowed, and it disappears from listings |
 | Turn a verb into data, or data into a verb | refused |
 | Add an optional field to a verb's input | allowed |
-| Add a required field to a verb's input | refused, unless the field already carried a default |
+| Add a required field to a verb's input | refused, unless the field carries a default |
 | Make a field of a verb's input optional | allowed |
 | Remove or retype a field of a verb's input | refused |
 | Change anything about a verb's **output** | allowed, and nothing checks it |
@@ -72,11 +72,15 @@ the change does.
 **Required-ness of a verb's input is settled** ([#5663]). It reads as the
 argument side's rule, stated in the result comparison's direction, because a
 verb's event is an argument in every respect but where it is declared. Adding
-a newly required field is refused; the default that would rescue it has to be
-one the field already carried, since descending through a stream marker
-withdraws permission to introduce a default below it. Relaxing a field to
-optional is allowed for the same reason it is allowed of an argument: every
-call already written still sent it, so every one still validates.
+a newly required field is refused unless the field carries a default, which
+materializes for every call that omits it. The default may be one the field
+already carried or one the candidate introduces, and a default that changes
+value is accepted as it is of an argument: a stream marker is cell metadata,
+and cell metadata is default-stable ([#7166]) — it does not constrain the
+value beneath it, so it withdraws no permission to introduce or change a
+default there. Relaxing a field to optional is allowed for the same reason it
+is allowed of an argument: every call already written still sent it, so every
+one still validates.
 
 **A verb's output is not checked at all.** The shape records a verb's input
 and discards its output, so renaming a field of what a verb hands back
@@ -705,3 +709,4 @@ Five smaller calls belong to whoever does the work:
 
 [#5663]: https://github.com/commontoolsinc/labs/issues/5663
 [#5746]: https://github.com/commontoolsinc/labs/pull/5746
+[#7166]: https://github.com/commontoolsinc/labs/pull/7166

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -51,7 +51,7 @@ here is what it does to a verb's author:
 | Mark a verb `@deprecated` | allowed, and it disappears from listings |
 | Turn a verb into data, or data into a verb | refused |
 | Add an optional field to a verb's input | allowed |
-| Add a required field to a verb's input | refused, unless the field carries a default |
+| Add a required field to a verb's input | refused, unless the field carries a valid default |
 | Make a field of a verb's input optional | allowed |
 | Remove or retype a field of a verb's input | refused |
 | Change anything about a verb's **output** | allowed, and nothing checks it |
@@ -72,8 +72,9 @@ the change does.
 **Required-ness of a verb's input is settled** ([#5663]). It reads as the
 argument side's rule, stated in the result comparison's direction, because a
 verb's event is an argument in every respect but where it is declared. Adding
-a newly required field is refused unless the field carries a default, which
-materializes for every call that omits it. The default may be one the field
+a newly required field is refused unless the field carries a valid default,
+which fills a missing field in a present event object. An entirely absent
+event payload stays absent. The default may be one the field
 already carried or one the candidate introduces, and a default that changes
 value is accepted as it is of an argument: a stream marker is cell metadata,
 and cell metadata is default-stable ([#7166]) — it does not constrain the

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -117,6 +117,12 @@ candidate pattern generates it during setup. This admits the forward migration;
 add a result default as well when an older concurrently running generation must
 still be able to write its previous result shape.
 
+Unchanged cell wrappers (`asCell`) and storage scopes (`scope`) permit default
+insertion, including an empty-object default on a record reached through a
+`$ref`. The metadata itself must still compare equal across an update. Value
+constraints that default insertion can invalidate, such as `maxProperties`,
+continue to require equal defaults beneath them.
+
 A verb's event is the one place inside a result where that reasoning does not
 hold, and the direction is decided by which side supplies the value rather
 than by where the node sits. A verb declares its event below a stream marker

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -130,15 +130,18 @@ itself must still compare equal across an update: a changed `asCell` or
 invalidate, such as `maxProperties`, continue to require equal defaults
 beneath them.
 
-A verb's event is the one place inside a result where that reasoning does not
-hold, and the direction is decided by which side supplies the value rather
-than by where the node sits. A verb declares its event below a stream marker
-in the result, but the pattern does not generate the event — a caller does. So
-a field the candidate event newly requires is a demand on every call already
-written. Below a verb node a newly required field therefore needs a valid
-default, exactly as an argument does. Dispatch fills missing fields in a
-present event object from defaults; an entirely absent event payload remains
-absent.
+The semantic-extension classification is conservative: `readOnly`, `writeOnly`,
+and `ifc` still require equal defaults beneath them. Extending default-stability
+to these markers requires a separate proof of their default-materialization
+behavior; the classification does not assert that default insertion through
+them is inherently unsafe.
+
+A verb's event follows argument compatibility rules even when declared in a
+result. A caller supplies the event, so it does not receive the result-side
+exemption for newly required fields that a pattern generates itself. A field
+the candidate event newly requires therefore needs a valid default, exactly
+as an argument does. Dispatch fills missing fields in a present event object
+from defaults; an entirely absent event payload remains absent.
 
 ## Tier 2 — state continuity
 

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -117,24 +117,24 @@ candidate pattern generates it during setup. This admits the forward migration;
 add a result default as well when an older concurrently running generation must
 still be able to write its previous result shape.
 
-Cell wrappers (`asCell`) and storage scopes (`scope`) are default-stable: they
-say how a value is delivered or stored, not what shape it has, so a default
-beneath one may be introduced or changed under the same rules as beneath a
-plain object node. That covers an empty-object default on a record reached
-through a `$ref`, a default that changes value on an unchanged cell, a verb's
-event below its stream marker (a newly required event field is rescued by a
-valid default the candidate carries, including a newly introduced one), and a
+Cell wrappers (`asCell`), storage scopes (`scope`), and the write markers
+(`readOnly`, `writeOnly`) are default-stable: they say how a value is
+delivered, stored, or written, not what shape it has, so a default beneath one
+may be introduced or changed under the same rules as beneath a plain object
+node. That covers an empty-object default on a record reached through a
+`$ref`, a default that changes value on an unchanged cell, a verb's event
+below its stream marker (a newly required event field is rescued by a valid
+default the candidate carries, including a newly introduced one), and a
 durable-link proof whose target declares a default below a cell. The metadata
-itself must still compare equal across an update: a changed `asCell` or
-`scope` is refused on its own. Value constraints that default insertion can
-invalidate, such as `maxProperties`, continue to require equal defaults
-beneath them.
+itself must still compare equal across an update: a changed `asCell`, `scope`,
+`readOnly`, or `writeOnly` is refused on its own. Value constraints that
+default insertion can invalidate, such as `maxProperties`, continue to require
+equal defaults beneath them.
 
-The semantic-extension classification is conservative: `readOnly`, `writeOnly`,
-and `ifc` still require equal defaults beneath them. Extending default-stability
-to these markers requires a separate proof of their default-materialization
-behavior; the classification does not assert that default insertion through
-them is inherently unsafe.
+`ifc` is the one semantic extension deliberately not on that list: a label is
+policy the write-authority comparison reasons about, and whether a materialized
+default satisfies a labeled node's floor is that comparison's question, so a
+changed default beneath an `ifc` stays refused until it is decided there.
 
 A verb's event follows argument compatibility rules even when declared in a
 result. A caller supplies the event, so it does not receive the result-side

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -122,8 +122,8 @@ say how a value is delivered or stored, not what shape it has, so a default
 beneath one may be introduced or changed under the same rules as beneath a
 plain object node. That covers an empty-object default on a record reached
 through a `$ref`, a default that changes value on an unchanged cell, a verb's
-event below its stream marker (a newly required event field is rescued by any
-default the candidate carries, not only one the field carried before), and a
+event below its stream marker (a newly required event field is rescued by a
+valid default the candidate carries, including a newly introduced one), and a
 durable-link proof whose target declares a default below a cell. The metadata
 itself must still compare equal across an update: a changed `asCell` or
 `scope` is refused on its own. Value constraints that default insertion can
@@ -135,11 +135,10 @@ hold, and the direction is decided by which side supplies the value rather
 than by where the node sits. A verb declares its event below a stream marker
 in the result, but the pattern does not generate the event — a caller does. So
 a field the candidate event newly requires is a demand on every call already
-written, and each one omitting it is refused at dispatch after the update has
-landed. Below a verb node a newly required field therefore needs a default,
-exactly as an argument does. A field that carried the same default before and
-after may become required, because a caller that omits it still materializes
-one.
+written. Below a verb node a newly required field therefore needs a valid
+default, exactly as an argument does. Dispatch fills missing fields in a
+present event object from defaults; an entirely absent event payload remains
+absent.
 
 ## Tier 2 — state continuity
 

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -117,11 +117,18 @@ candidate pattern generates it during setup. This admits the forward migration;
 add a result default as well when an older concurrently running generation must
 still be able to write its previous result shape.
 
-Unchanged cell wrappers (`asCell`) and storage scopes (`scope`) permit default
-insertion, including an empty-object default on a record reached through a
-`$ref`. The metadata itself must still compare equal across an update. Value
-constraints that default insertion can invalidate, such as `maxProperties`,
-continue to require equal defaults beneath them.
+Cell wrappers (`asCell`) and storage scopes (`scope`) are default-stable: they
+say how a value is delivered or stored, not what shape it has, so a default
+beneath one may be introduced or changed under the same rules as beneath a
+plain object node. That covers an empty-object default on a record reached
+through a `$ref`, a default that changes value on an unchanged cell, a verb's
+event below its stream marker (a newly required event field is rescued by any
+default the candidate carries, not only one the field carried before), and a
+durable-link proof whose target declares a default below a cell. The metadata
+itself must still compare equal across an update: a changed `asCell` or
+`scope` is refused on its own. Value constraints that default insertion can
+invalidate, such as `maxProperties`, continue to require equal defaults
+beneath them.
 
 A verb's event is the one place inside a result where that reasoning does not
 hold, and the direction is decided by which side supplies the value rather

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -473,9 +473,9 @@ not take the alias path. (Contrast §11: CFC detection has no source check.)
    declarations, and empty records. A record with no named properties or call
    or construct signatures, and at least one index signature, yields `{}` when
    every index value type is `never`. This includes `Record<string, never>`,
-   `Record<PropertyKey, never>`, and aliases of these types, in both
-   `T | Default<V>` and `Default<T, V>`. The record check does not require a
-   symbol value declaration. A propertyless record with `string` or `unknown`
+   `Record<PropertyKey, never>`, their intersections, and aliases of these types,
+   in both `T | Default<V>` and `Default<T, V>`. The record check does not require
+   a symbol value declaration. A propertyless record with `string` or `unknown`
    values does not qualify for this check.
 3. **Brand-payload fallback**: `Default<T,V>` carries V in a
    `DEFAULT_MARKER`-branded payload; when the alias is resolved away

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -465,7 +465,7 @@ not take the alias path. (Contrast §11: CFC detection has no source check.)
 1. **Node-based** (`extractDefaultValueFromNode` + expression walk,
    `common-fabric-formatter.ts`; union-side twin
    `union-formatter.ts`): literal nodes, tuple nodes, object-literal
-   type nodes, `Record<K, never>` → `{}`, and `typeof CONST` queries resolved
+   type nodes, and `typeof CONST` queries resolved
    through import aliases to the variable initializer (unwrapping
    `as`/`satisfies`/parens/type assertions; shorthand properties via
    `getShorthandAssignmentValueSymbol`).
@@ -477,6 +477,11 @@ not take the alias path. (Contrast §11: CFC detection has no source check.)
    in both `T | Default<V>` and `Default<T, V>`. The record check does not require
    a symbol value declaration. A propertyless record with `string` or `unknown`
    values does not qualify for this check.
+   Nor does a type that merely carries a `never` type argument:
+   `Record<"required", never>` has a named property and `Array<never>` has no
+   index signature, so both yield no default. An inline `Record<K, never>` in
+   `Default<T, V>` reaches this rule through the node route's type fallback;
+   there is no name-based shortcut.
 3. **Brand-payload fallback**: `Default<T,V>` carries V in a
    `DEFAULT_MARKER`-branded payload; when the alias is resolved away
    (`T | (T & DefaultMarker<V>)`), the payload is read back type-structurally

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -475,11 +475,12 @@ not take the alias path. (Contrast §11: CFC detection has no source check.)
    every index value type is `never`. This includes `Record<string, never>`,
    `Record<PropertyKey, never>`, their intersections, and aliases of these types,
    in both `T | Default<V>` and `Default<T, V>`. The record check does not require
-   a symbol value declaration. A propertyless record with `string` or `unknown`
-   values does not qualify for this check.
+   a symbol value declaration. Every intersection constituent must be an object
+   type; a primitive intersected with an empty record does not qualify. A
+   propertyless record with `string` or `unknown` values does not qualify either.
    Nor does a type that merely carries a `never` type argument:
-   `Record<"required", never>` has a named property and `Array<never>` has no
-   index signature, so both yield no default. An inline `Record<K, never>` in
+   `Record<"required", never>` and `Array<never>` both have named properties, so
+   neither yields a default. An inline `Record<K, never>` in
    `Default<T, V>` reaches this rule through the node route's type fallback;
    there is no name-based shortcut.
 3. **Brand-payload fallback**: `Default<T,V>` carries V in a

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -469,7 +469,15 @@ not take the alias path. (Contrast §11: CFC detection has no source check.)
    through import aliases to the variable initializer (unwrapping
    `as`/`satisfies`/parens/type assertions; shorthand properties via
    `getShorthandAssignmentValueSymbol`).
-2. **Brand-payload fallback**: `Default<T,V>` carries V in a
+2. **Type-based extraction** (both formatters): literal values, symbol value
+   declarations, and empty records. A record with no named properties or call
+   or construct signatures, and at least one index signature, yields `{}` when
+   every index value type is `never`. This includes `Record<string, never>`,
+   `Record<PropertyKey, never>`, and aliases of these types, in both
+   `T | Default<V>` and `Default<T, V>`. The record check does not require a
+   symbol value declaration. A propertyless record with `string` or `unknown`
+   values does not qualify for this check.
+3. **Brand-payload fallback**: `Default<T,V>` carries V in a
    `DEFAULT_MARKER`-branded payload; when the alias is resolved away
    (`T | (T & DefaultMarker<V>)`), the payload is read back type-structurally
    (`type-utils.ts`). Union-distributed brands must **agree**;

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1930,6 +1930,12 @@ Special path:
   schema).
 - `unknown` is emitted distinctly as `{ type: "unknown" }`; `any` remains `true`
 - arrays of `unknown` emit `items: { type: "unknown" }`
+- empty-record defaults emit `default: {}` in pattern argument schemas,
+  including inside `Writable`. Both `Record<string, unknown> | Default<V>`
+  and `Default<Record<string, unknown>, V>` support `V` written as `{}`,
+  `Record<string, never>`, `Record<PropertyKey, never>`, or an alias of either
+  record (`test/default-empty-record-schema.test.ts`). The extraction rules
+  live in §7 of the schema-generator mapping spec.
 - the node-based generator analyzes through a `readonly` type operator to
   its wrapped array type. A pattern-scope `.get()` on a `Cell<unknown[]>`
   lowers to a lift with result type `readonly unknown[]` and result schema

--- a/packages/patterns/baselines/factory-outputs/lot-watch/main.tsx/20260909T184755Z-xqd5hiiStuGcy7O3.json
+++ b/packages/patterns/baselines/factory-outputs/lot-watch/main.tsx/20260909T184755Z-xqd5hiiStuGcy7O3.json
@@ -1,0 +1,870 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Classification": {
+        "enum": [
+          "ours",
+          "guest",
+          "offender",
+          "unknown"
+        ]
+      },
+      "KnownVehicle": {
+        "properties": {
+          "category": {
+            "enum": [
+              "guest",
+              "offender"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState",
+          "description",
+          "category",
+          "org",
+          "label"
+        ],
+        "type": "object"
+      },
+      "LotWatchAdminList": {
+        "ifc": {
+          "addIntegrity": [
+            "lot-watch-admin"
+          ],
+          "requiredIntegrity": [
+            "lot-watch-admin"
+          ],
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/factory-outputs/lot-watch/main.tsx",
+              "moduleIdentity": "QDn_GfsqBmE6_hHxKPc4Cwa4QW3TXzepVR08SdmGP6s",
+              "path": [
+                "commitLotWatchAdminChange"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/LotWatchAdminRole"
+        },
+        "type": "array"
+      },
+      "LotWatchAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/LotWatchAdminList"
+          }
+        },
+        "type": "object"
+      },
+      "LotWatchAdminRegistryValue": {
+        "$ref": "#/$defs/LotWatchAdminRegistryStoredValue",
+        "default": {}
+      },
+      "LotWatchAdminRole": {
+        "$ref": "#/$defs/LotWatchAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "lot-watch-admin"
+          ]
+        }
+      },
+      "LotWatchAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/LotWatchAdminSubject"
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "LotWatchAdminSubject": {
+        "properties": {
+          "personName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personName"
+        ],
+        "type": "object"
+      },
+      "ParkingSpot": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label"
+        ],
+        "type": "object"
+      },
+      "PersonWithVehicles": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "vehicles": {
+            "items": {
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "make": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "plateId": {
+                  "type": "string"
+                },
+                "plateState": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "plateId",
+                "plateState"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "Sighting": {
+        "properties": {
+          "capturedAt": {
+            "type": "number"
+          },
+          "classification": {
+            "$ref": "#/$defs/Classification"
+          },
+          "description": {
+            "type": "string"
+          },
+          "extractionError": {
+            "type": "string"
+          },
+          "extractionPending": {
+            "type": "boolean"
+          },
+          "humanCorrected": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/$defs/SightingImage"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          },
+          "reportedBy": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "spotNumber",
+          "capturedAt",
+          "reportedBy",
+          "image",
+          "description",
+          "plateNumber",
+          "plateState",
+          "extractionPending",
+          "extractionError",
+          "humanCorrected",
+          "classification",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "SightingImage": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "adminRegistry": {
+        "$ref": "#/$defs/LotWatchAdminRegistryValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "knownVehicles": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/KnownVehicle"
+        },
+        "type": "array"
+      },
+      "people": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/PersonWithVehicles"
+        },
+        "type": "array"
+      },
+      "sightings": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Sighting"
+        },
+        "type": "array"
+      },
+      "spots": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [
+          {
+            "label": "Near entrance",
+            "spotNumber": "1"
+          },
+          {
+            "label": "",
+            "spotNumber": "5"
+          },
+          {
+            "label": "Compact only",
+            "spotNumber": "12"
+          },
+          {
+            "label": "",
+            "spotNumber": "13"
+          }
+        ],
+        "items": {
+          "$ref": "#/$defs/ParkingSpot"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "factory-outputs/lot-watch/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Classification": {
+        "enum": [
+          "ours",
+          "guest",
+          "offender",
+          "unknown"
+        ]
+      },
+      "ImageData": {
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "exif": {
+            "properties": {
+              "dateTime": {
+                "type": "string"
+              },
+              "exposureTime": {
+                "type": "string"
+              },
+              "fNumber": {
+                "type": "number"
+              },
+              "focalLength": {
+                "type": "number"
+              },
+              "gpsAltitude": {
+                "type": "number"
+              },
+              "gpsLatitude": {
+                "type": "number"
+              },
+              "gpsLongitude": {
+                "type": "number"
+              },
+              "iso": {
+                "type": "number"
+              },
+              "make": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "orientation": {
+                "type": "number"
+              },
+              "pixelXDimension": {
+                "type": "number"
+              },
+              "pixelYDimension": {
+                "type": "number"
+              },
+              "raw": {
+                "additionalProperties": true,
+                "properties": {},
+                "type": "object"
+              },
+              "software": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "height": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "width": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "url",
+          "data",
+          "timestamp",
+          "size",
+          "type"
+        ],
+        "type": "object"
+      },
+      "KnownVehicle": {
+        "properties": {
+          "category": {
+            "enum": [
+              "guest",
+              "offender"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState",
+          "description",
+          "category",
+          "org",
+          "label"
+        ],
+        "type": "object"
+      },
+      "PersonWithVehicles": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "vehicles": {
+            "items": {
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "make": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "plateId": {
+                  "type": "string"
+                },
+                "plateState": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "plateId",
+                "plateState"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "Sighting": {
+        "properties": {
+          "capturedAt": {
+            "type": "number"
+          },
+          "classification": {
+            "$ref": "#/$defs/Classification"
+          },
+          "description": {
+            "type": "string"
+          },
+          "extractionError": {
+            "type": "string"
+          },
+          "extractionPending": {
+            "type": "boolean"
+          },
+          "humanCorrected": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/$defs/SightingImage"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          },
+          "reportedBy": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "spotNumber",
+          "capturedAt",
+          "reportedBy",
+          "image",
+          "description",
+          "plateNumber",
+          "plateState",
+          "extractionPending",
+          "extractionError",
+          "humanCorrected",
+          "classification",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "SightingImage": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "assignToPerson": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "becomeCurator": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "cancelAssign": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "cancelGuest": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "captureSighting": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/$defs/ImageData"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "image",
+          "description",
+          "plateNumber",
+          "plateState",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "deleteSighting": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "enableAdminManager": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "knownVehicles": {
+        "items": {
+          "$ref": "#/$defs/KnownVehicle"
+        },
+        "type": "array"
+      },
+      "markVehicle": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "category": {
+            "enum": [
+              "guest",
+              "offender"
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState",
+          "category",
+          "org"
+        ],
+        "type": "object"
+      },
+      "openAssign": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "openGuest": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "people": {
+        "items": {
+          "$ref": "#/$defs/PersonWithVehicles"
+        },
+        "type": "array"
+      },
+      "removeKnownVehicle": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState"
+        ],
+        "type": "object"
+      },
+      "saveGuest": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "selectTab": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "tab": {
+            "enum": [
+              "capture",
+              "sightings",
+              "report"
+            ]
+          }
+        },
+        "required": [
+          "tab"
+        ],
+        "type": "object"
+      },
+      "setReporterName": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "sightings": {
+        "items": {
+          "$ref": "#/$defs/Sighting"
+        },
+        "type": "array"
+      },
+      "stepDownCurator": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "toggleAdminMode": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "togglePersonAdmin": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "sightings",
+      "knownVehicles",
+      "people",
+      "captureSighting",
+      "deleteSighting",
+      "selectTab",
+      "setReporterName",
+      "markVehicle",
+      "removeKnownVehicle",
+      "openAssign",
+      "cancelAssign",
+      "assignToPerson",
+      "openGuest",
+      "cancelGuest",
+      "saveGuest",
+      "enableAdminManager",
+      "togglePersonAdmin",
+      "becomeCurator",
+      "stepDownCurator",
+      "toggleAdminMode",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/factory-outputs/parking-coordinator/main.tsx/20260909T184755Z-soDh0eM4uUL1tYyU.json
+++ b/packages/patterns/baselines/factory-outputs/parking-coordinator/main.tsx/20260909T184755Z-soDh0eM4uUL1tYyU.json
@@ -1,0 +1,912 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "CommuteMode": {
+        "enum": [
+          "drive",
+          "transit",
+          "bike",
+          "wfh",
+          "other"
+        ]
+      },
+      "ParkingAdminList": {
+        "ifc": {
+          "addIntegrity": [
+            "parking-admin"
+          ],
+          "requiredIntegrity": [
+            "parking-admin"
+          ],
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/factory-outputs/parking-coordinator/main.tsx",
+              "moduleIdentity": "z0wCo9uDBvy4ucSqVDmk8LeSqEpLBdHFnZ4n2xfJGJs",
+              "path": [
+                "commitParkingAdminChange"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ParkingAdminRole"
+        },
+        "type": "array"
+      },
+      "ParkingAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/ParkingAdminList"
+          }
+        },
+        "type": "object"
+      },
+      "ParkingAdminRegistryValue": {
+        "$ref": "#/$defs/ParkingAdminRegistryStoredValue",
+        "default": {}
+      },
+      "ParkingAdminRole": {
+        "$ref": "#/$defs/ParkingAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "parking-admin"
+          ]
+        }
+      },
+      "ParkingAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/ParkingProfile",
+            "asCell": [
+              "cell"
+            ]
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "ParkingProfile": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ParkingSpot": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label",
+          "notes",
+          "active"
+        ],
+        "type": "object"
+      },
+      "ParkingSpotEntry": {
+        "$ref": "#/$defs/ParkingSpot",
+        "ifc": {
+          "addIntegrity": [
+            "parking-admin"
+          ]
+        }
+      },
+      "ParkingSpotList": {
+        "ifc": {
+          "addIntegrity": [
+            "parking-admin"
+          ],
+          "requiredIntegrity": [
+            "parking-admin"
+          ]
+        },
+        "items": {
+          "$ref": "#/$defs/ParkingSpotEntry"
+        },
+        "type": "array"
+      },
+      "ParkingViewerClaim": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "#/$defs/ParkingProfile",
+            "asCell": [
+              "cell"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "Person": {
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "profile": {
+            "$ref": "#/$defs/ParkingProfile",
+            "asCell": [
+              "cell"
+            ],
+            "description": "The Fabric identity that claimed this row, once someone has. A person with\nno profile is a name on a roster: they can hold a parking spot, and they\ncannot hold a parking-admin role, because nothing identifies them."
+          },
+          "spotPreferences": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "commuteMode",
+          "spotPreferences",
+          "defaultSpot",
+          "priorityRank"
+        ],
+        "type": "object"
+      },
+      "RequestStatus": {
+        "enum": [
+          "pending",
+          "allocated",
+          "denied",
+          "cancelled"
+        ]
+      },
+      "SpotRequest": {
+        "properties": {
+          "assignedSpot": {
+            "type": "string"
+          },
+          "autoAllocated": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/$defs/RequestStatus"
+          }
+        },
+        "required": [
+          "id",
+          "personName",
+          "date",
+          "status",
+          "assignedSpot",
+          "autoAllocated"
+        ],
+        "type": "object"
+      },
+      "Vehicle": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "make": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "plateId": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateId",
+          "plateState",
+          "color",
+          "make",
+          "model"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "adminRegistry": {
+        "$ref": "#/$defs/ParkingAdminRegistryValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "people": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Person"
+        },
+        "type": "array"
+      },
+      "requests": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SpotRequest"
+        },
+        "type": "array"
+      },
+      "spots": {
+        "$ref": "#/$defs/ParkingSpotList",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [
+          {
+            "active": true,
+            "label": "Near entrance",
+            "notes": "",
+            "spotNumber": "1"
+          },
+          {
+            "active": true,
+            "label": "",
+            "notes": "",
+            "spotNumber": "5"
+          },
+          {
+            "active": true,
+            "label": "Compact only",
+            "notes": "Tight, no large vehicles",
+            "spotNumber": "12"
+          }
+        ]
+      },
+      "viewer": {
+        "$ref": "#/$defs/ParkingViewerClaim",
+        "description": "Stands a particular viewer up in place of the `#profile` wish, for a test\nor a composing pattern that already holds one. A claim always carries a\nname: the name is what says the claim is real, because a cell-typed field\ncannot say so (see `hasViewerClaim` below).",
+        "tags": [
+          "profile"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "factory-outputs/parking-coordinator/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "CommuteMode": {
+        "enum": [
+          "drive",
+          "transit",
+          "bike",
+          "wfh",
+          "other"
+        ]
+      },
+      "ParkingAdminChangeEvent": {
+        "properties": {
+          "displayName": {
+            "description": "Name to record on a granted role, for display where the cell is offline.",
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "#/$defs/ParkingProfile",
+            "description": "The identity whose role changes."
+          }
+        },
+        "type": "object"
+      },
+      "ParkingAdminList": {
+        "ifc": {
+          "addIntegrity": [
+            "parking-admin"
+          ],
+          "requiredIntegrity": [
+            "parking-admin"
+          ],
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/factory-outputs/parking-coordinator/main.tsx",
+              "moduleIdentity": "z0wCo9uDBvy4ucSqVDmk8LeSqEpLBdHFnZ4n2xfJGJs",
+              "path": [
+                "commitParkingAdminChange"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ParkingAdminRole"
+        },
+        "type": "array"
+      },
+      "ParkingAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/ParkingAdminList"
+          }
+        },
+        "type": "object"
+      },
+      "ParkingAdminRegistryValue": {
+        "$ref": "#/$defs/ParkingAdminRegistryStoredValue",
+        "default": {}
+      },
+      "ParkingAdminRole": {
+        "$ref": "#/$defs/ParkingAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "parking-admin"
+          ]
+        }
+      },
+      "ParkingAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/ParkingProfile"
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "ParkingProfile": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ParkingSpot": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label",
+          "notes",
+          "active"
+        ],
+        "type": "object"
+      },
+      "Person": {
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "profile": {
+            "$ref": "#/$defs/ParkingProfile",
+            "description": "The Fabric identity that claimed this row, once someone has. A person with\nno profile is a name on a roster: they can hold a parking spot, and they\ncannot hold a parking-admin role, because nothing identifies them."
+          },
+          "spotPreferences": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "commuteMode",
+          "spotPreferences",
+          "defaultSpot",
+          "priorityRank"
+        ],
+        "type": "object"
+      },
+      "RequestStatus": {
+        "enum": [
+          "pending",
+          "allocated",
+          "denied",
+          "cancelled"
+        ]
+      },
+      "SpotRequest": {
+        "properties": {
+          "assignedSpot": {
+            "type": "string"
+          },
+          "autoAllocated": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/$defs/RequestStatus"
+          }
+        },
+        "required": [
+          "id",
+          "personName",
+          "date",
+          "status",
+          "assignedSpot",
+          "autoAllocated"
+        ],
+        "type": "object"
+      },
+      "Vehicle": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "make": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "plateId": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateId",
+          "plateState",
+          "color",
+          "make",
+          "model"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addPerson": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "preferences": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "commuteMode",
+          "priorityRank",
+          "defaultSpot",
+          "preferences"
+        ],
+        "type": "object"
+      },
+      "addSpot": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "adminMode": {
+        "type": "boolean"
+      },
+      "adminOverride": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "date",
+          "personName"
+        ],
+        "type": "object"
+      },
+      "adminRegistry": {
+        "$ref": "#/$defs/ParkingAdminRegistryValue"
+      },
+      "cancelRequest": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "requestId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "requestId"
+        ],
+        "type": "object"
+      },
+      "claimPerson": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "currentPersonIsAdmin": {
+        "type": "boolean"
+      },
+      "currentUserCanManageAdmins": {
+        "type": "boolean"
+      },
+      "editPerson": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "originalName": {
+            "type": "string"
+          },
+          "preferences": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "originalName",
+          "name",
+          "email",
+          "commuteMode",
+          "priorityRank",
+          "defaultSpot",
+          "preferences"
+        ],
+        "type": "object"
+      },
+      "editSpot": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "originalNumber": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "originalNumber",
+          "spotNumber",
+          "label",
+          "notes",
+          "active"
+        ],
+        "type": "object"
+      },
+      "enableAdminManager": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "movePersonDown": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "movePersonUp": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "people": {
+        "items": {
+          "$ref": "#/$defs/Person"
+        },
+        "type": "array"
+      },
+      "removePerson": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "removeSpot": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber"
+        ],
+        "type": "object"
+      },
+      "requestDate": {
+        "type": "string"
+      },
+      "requestResult": {
+        "type": "string"
+      },
+      "requests": {
+        "items": {
+          "$ref": "#/$defs/SpotRequest"
+        },
+        "type": "array"
+      },
+      "selectedPersonName": {
+        "type": "string"
+      },
+      "spots": {
+        "items": {
+          "$ref": "#/$defs/ParkingSpot"
+        },
+        "type": "array"
+      },
+      "submitRequest": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personName",
+          "date"
+        ],
+        "type": "object"
+      },
+      "toggleAdminMode": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "togglePersonAdmin": {
+        "$ref": "#/$defs/ParkingAdminChangeEvent",
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "spots",
+      "people",
+      "requests",
+      "adminMode",
+      "selectedPersonName",
+      "requestDate",
+      "requestResult",
+      "adminRegistry",
+      "currentPersonIsAdmin",
+      "currentUserCanManageAdmins",
+      "enableAdminManager",
+      "claimPerson",
+      "togglePersonAdmin",
+      "toggleAdminMode",
+      "submitRequest",
+      "cancelRequest",
+      "addPerson",
+      "editPerson",
+      "removePerson",
+      "movePersonUp",
+      "movePersonDown",
+      "addSpot",
+      "editSpot",
+      "removeSpot",
+      "adminOverride",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/gideon-tests/test-record-key-set-56.tsx/20260909T184755Z-QZ4cJsoyx7tEUM6E.json
+++ b/packages/patterns/baselines/gideon-tests/test-record-key-set-56.tsx/20260909T184755Z-QZ4cJsoyx7tEUM6E.json
@@ -1,0 +1,138 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Item": {
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value",
+          "count"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "emptyRecord": {
+        "additionalProperties": {
+          "$ref": "#/$defs/Item"
+        },
+        "default": {},
+        "properties": {},
+        "type": "object"
+      },
+      "logs": {
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "populatedRecord": {
+        "additionalProperties": {
+          "$ref": "#/$defs/Item"
+        },
+        "default": {
+          "existing": {
+            "count": 0,
+            "value": "preset"
+          }
+        },
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "required": [
+      "emptyRecord",
+      "populatedRecord",
+      "logs"
+    ],
+    "type": "object"
+  },
+  "pattern": "gideon-tests/test-record-key-set-56.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Item": {
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value",
+          "count"
+        ],
+        "type": "object"
+      },
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "#/$defs/JSXElement"
+      },
+      "emptyRecord": {
+        "additionalProperties": {
+          "$ref": "#/$defs/Item"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "logs": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "populatedRecord": {
+        "additionalProperties": {
+          "$ref": "#/$defs/Item"
+        },
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI",
+      "emptyRecord",
+      "populatedRecord",
+      "logs"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/core/experimental/gmail-agentic-search.tsx/20260909T184755Z-sg-Ns3ZECcKelvw9.json
+++ b/packages/patterns/baselines/google/core/experimental/gmail-agentic-search.tsx/20260909T184755Z-sg-Ns3ZECcKelvw9.json
@@ -1,0 +1,789 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      },
+      "DebugLogEntry": {
+        "properties": {
+          "details": true,
+          "message": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "info",
+              "search_start",
+              "search_result",
+              "error",
+              "summary"
+            ]
+          }
+        },
+        "required": [
+          "timestamp",
+          "type",
+          "message"
+        ],
+        "type": "object"
+      },
+      "LocalQuery": {
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "effectiveness": {
+            "type": "number"
+          },
+          "foundItems": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastUsed": {
+            "type": "number"
+          },
+          "query": {
+            "type": "string"
+          },
+          "shareStatus": {
+            "enum": [
+              "private",
+              "pending_review",
+              "submitted"
+            ]
+          },
+          "useCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "query",
+          "createdAt",
+          "useCount",
+          "effectiveness",
+          "shareStatus"
+        ],
+        "type": "object"
+      },
+      "PendingSubmission": {
+        "properties": {
+          "generalizabilityIssues": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "localQueryId": {
+            "type": "string"
+          },
+          "originalQuery": {
+            "type": "string"
+          },
+          "piiWarnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "recommendation": {
+            "enum": [
+              "share",
+              "share_with_edits",
+              "do_not_share",
+              "pending"
+            ]
+          },
+          "sanitizedQuery": {
+            "type": "string"
+          },
+          "submittedAt": {
+            "type": "number"
+          },
+          "userApproved": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "localQueryId",
+          "originalQuery",
+          "sanitizedQuery",
+          "piiWarnings",
+          "generalizabilityIssues",
+          "recommendation",
+          "userApproved"
+        ],
+        "type": "object"
+      },
+      "SearchProgress": {
+        "properties": {
+          "authError": {
+            "type": "string"
+          },
+          "completedQueries": {
+            "items": {
+              "properties": {
+                "emailCount": {
+                  "type": "number"
+                },
+                "query": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "query",
+                "emailCount",
+                "timestamp"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "currentQuery": {
+            "type": "string"
+          },
+          "searchCount": {
+            "type": "number"
+          },
+          "status": {
+            "enum": [
+              "idle",
+              "searching",
+              "analyzing",
+              "limit_reached",
+              "auth_error"
+            ]
+          }
+        },
+        "required": [
+          "currentQuery",
+          "completedQueries",
+          "status",
+          "searchCount"
+        ],
+        "type": "object"
+      },
+      "ToolDefinition": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "handler": {
+            "asCell": [
+              "stream"
+            ]
+          },
+          "inputSchema": true
+        },
+        "required": [
+          "description",
+          "handler"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "accountType": {
+        "default": "default",
+        "enum": [
+          "default",
+          "personal",
+          "work"
+        ],
+        "type": "string"
+      },
+      "additionalTools": {
+        "additionalProperties": {
+          "$ref": "#/$defs/ToolDefinition"
+        },
+        "default": {},
+        "properties": {},
+        "type": "object"
+      },
+      "agentGoal": {
+        "default": "",
+        "type": "string"
+      },
+      "agentTypeUrl": {
+        "default": "",
+        "type": "string"
+      },
+      "auth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      },
+      "debugLog": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/DebugLogEntry"
+        },
+        "type": "array"
+      },
+      "enableCommunityQueries": {
+        "default": true,
+        "type": "boolean"
+      },
+      "isScanning": {
+        "default": false,
+        "type": "boolean"
+      },
+      "itemFoundSignal": {
+        "default": 0,
+        "type": "number"
+      },
+      "lastScanAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "localQueries": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/LocalQuery"
+        },
+        "type": "array"
+      },
+      "maxSearches": {
+        "default": 0,
+        "type": "number"
+      },
+      "onlySaveQueriesWithItems": {
+        "default": false,
+        "type": "boolean"
+      },
+      "pendingSubmissions": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/PendingSubmission"
+        },
+        "type": "array"
+      },
+      "resultSchema": {
+        "additionalProperties": true,
+        "default": {},
+        "type": "object"
+      },
+      "scanButtonLabel": {
+        "default": "Scan",
+        "type": "string"
+      },
+      "searchProgress": {
+        "$ref": "#/$defs/SearchProgress",
+        "default": {
+          "completedQueries": [],
+          "currentQuery": "",
+          "searchCount": 0,
+          "status": "idle"
+        }
+      },
+      "suggestedQueries": {
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "systemPrompt": {
+        "default": "",
+        "type": "string"
+      },
+      "title": {
+        "default": "Gmail Agentic Search",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/core/experimental/gmail-agentic-search.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      },
+      "DebugLogEntry": {
+        "properties": {
+          "details": true,
+          "message": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "info",
+              "search_start",
+              "search_result",
+              "error",
+              "summary"
+            ]
+          }
+        },
+        "required": [
+          "timestamp",
+          "type",
+          "message"
+        ],
+        "type": "object"
+      },
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "LocalQuery": {
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "effectiveness": {
+            "type": "number"
+          },
+          "foundItems": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastUsed": {
+            "type": "number"
+          },
+          "query": {
+            "type": "string"
+          },
+          "shareStatus": {
+            "enum": [
+              "private",
+              "pending_review",
+              "submitted"
+            ]
+          },
+          "useCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "query",
+          "createdAt",
+          "useCount",
+          "effectiveness",
+          "shareStatus"
+        ],
+        "type": "object"
+      },
+      "PendingSubmission": {
+        "properties": {
+          "generalizabilityIssues": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "localQueryId": {
+            "type": "string"
+          },
+          "originalQuery": {
+            "type": "string"
+          },
+          "piiWarnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "recommendation": {
+            "enum": [
+              "share",
+              "share_with_edits",
+              "do_not_share",
+              "pending"
+            ]
+          },
+          "sanitizedQuery": {
+            "type": "string"
+          },
+          "submittedAt": {
+            "type": "number"
+          },
+          "userApproved": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "localQueryId",
+          "originalQuery",
+          "sanitizedQuery",
+          "piiWarnings",
+          "generalizabilityIssues",
+          "recommendation",
+          "userApproved"
+        ],
+        "type": "object"
+      },
+      "SearchProgress": {
+        "properties": {
+          "authError": {
+            "type": "string"
+          },
+          "completedQueries": {
+            "items": {
+              "properties": {
+                "emailCount": {
+                  "type": "number"
+                },
+                "query": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "query",
+                "emailCount",
+                "timestamp"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "currentQuery": {
+            "type": "string"
+          },
+          "searchCount": {
+            "type": "number"
+          },
+          "status": {
+            "enum": [
+              "idle",
+              "searching",
+              "analyzing",
+              "limit_reached",
+              "auth_error"
+            ]
+          }
+        },
+        "required": [
+          "currentQuery",
+          "completedQueries",
+          "status",
+          "searchCount"
+        ],
+        "type": "object"
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Reusable Gmail agentic search base pattern. #gmailAgenticSearch",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "#/$defs/JSXElement"
+      },
+      "agentPending": {
+        "type": "boolean"
+      },
+      "agentResult": true,
+      "auth": {
+        "anyOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/$defs/Auth"
+          }
+        ]
+      },
+      "authSource": {
+        "enum": [
+          "direct",
+          "wish",
+          "none"
+        ]
+      },
+      "debugLog": {
+        "items": {
+          "$ref": "#/$defs/DebugLogEntry"
+        },
+        "type": "array"
+      },
+      "deleteLocalQuery": {
+        "asCell": [
+          "stream"
+        ]
+      },
+      "hasGmailScope": {
+        "type": "boolean"
+      },
+      "isAuthenticated": {
+        "type": "boolean"
+      },
+      "isScanning": {
+        "type": "boolean"
+      },
+      "itemFoundSignal": {
+        "type": "number"
+      },
+      "lastScanAt": {
+        "type": "number"
+      },
+      "localQueries": {
+        "items": {
+          "$ref": "#/$defs/LocalQuery"
+        },
+        "type": "array"
+      },
+      "pendingSubmissions": {
+        "items": {
+          "$ref": "#/$defs/PendingSubmission"
+        },
+        "type": "array"
+      },
+      "rateQuery": {
+        "asCell": [
+          "stream"
+        ]
+      },
+      "searchProgress": {
+        "$ref": "#/$defs/SearchProgress"
+      },
+      "startScan": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "stopScan": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "ui": {
+        "properties": {
+          "auth": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "controls": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "debugLog": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "extras": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "localQueries": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "pendingSubmissions": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "progress": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "stats": {
+            "$ref": "#/$defs/JSXElement"
+          }
+        },
+        "required": [
+          "auth",
+          "controls",
+          "progress",
+          "stats",
+          "extras",
+          "debugLog",
+          "localQueries",
+          "pendingSubmissions"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "ui",
+      "auth",
+      "isAuthenticated",
+      "hasGmailScope",
+      "authSource",
+      "agentResult",
+      "agentPending",
+      "isScanning",
+      "searchProgress",
+      "debugLog",
+      "lastScanAt",
+      "startScan",
+      "stopScan",
+      "localQueries",
+      "pendingSubmissions",
+      "rateQuery",
+      "deleteLocalQuery",
+      "itemFoundSignal",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "gmailagenticsearch"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/core/experimental/google-docs-comment-orchestrator.tsx/20260909T184755Z-iFMFDZvFEEzKrzPf.json
+++ b/packages/patterns/baselines/google/core/experimental/google-docs-comment-orchestrator.tsx/20260909T184755Z-iFMFDZvFEEzKrzPf.json
@@ -1,0 +1,425 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "CommentState": {
+        "properties": {
+          "regenerateNonce": {
+            "type": "number"
+          },
+          "status": {
+            "enum": [
+              "pending",
+              "generating",
+              "ready",
+              "accepted",
+              "skipped"
+            ]
+          }
+        },
+        "required": [
+          "regenerateNonce",
+          "status"
+        ],
+        "type": "object"
+      },
+      "GoogleComment": {
+        "properties": {
+          "anchor": {
+            "type": "string"
+          },
+          "author": {
+            "$ref": "#/$defs/GoogleCommentAuthor"
+          },
+          "content": {
+            "type": "string"
+          },
+          "createdTime": {
+            "type": "string"
+          },
+          "htmlContent": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "type": "string"
+          },
+          "quotedFileContent": {
+            "properties": {
+              "mimeType": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "type": "object"
+          },
+          "replies": {
+            "items": {
+              "$ref": "#/$defs/GoogleCommentReply"
+            },
+            "type": "array"
+          },
+          "resolved": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "author",
+          "content",
+          "createdTime",
+          "resolved"
+        ],
+        "type": "object"
+      },
+      "GoogleCommentAuthor": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "emailAddress": {
+            "type": "string"
+          },
+          "photoLink": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "GoogleCommentReply": {
+        "properties": {
+          "action": {
+            "enum": [
+              "resolve",
+              "reopen"
+            ]
+          },
+          "author": {
+            "$ref": "#/$defs/GoogleCommentAuthor"
+          },
+          "content": {
+            "type": "string"
+          },
+          "createdTime": {
+            "type": "string"
+          },
+          "htmlContent": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "author",
+          "content",
+          "createdTime"
+        ],
+        "type": "object"
+      },
+      "PendingCommentAction": {
+        "properties": {
+          "commentAuthor": {
+            "type": "string"
+          },
+          "commentContent": {
+            "type": "string"
+          },
+          "commentId": {
+            "type": "string"
+          },
+          "docUrl": {
+            "type": "string"
+          },
+          "fileId": {
+            "type": "string"
+          },
+          "quotedText": {
+            "type": "string"
+          },
+          "responseText": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "reply-resolve",
+              "reply"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "docUrl",
+          "fileId",
+          "commentId",
+          "commentAuthor",
+          "commentContent",
+          "responseText"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "commentStates": {
+        "additionalProperties": {
+          "$ref": "#/$defs/CommentState"
+        },
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "properties": {},
+        "type": "object"
+      },
+      "comments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/GoogleComment"
+        },
+        "type": "array"
+      },
+      "docContent": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "docUrl": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "expandedCommentId": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null
+      },
+      "globalPrompt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "isExecuting": {
+        "asCell": [
+          "cell"
+        ],
+        "default": false,
+        "type": "boolean"
+      },
+      "isFetching": {
+        "asCell": [
+          "cell"
+        ],
+        "default": false,
+        "type": "boolean"
+      },
+      "lastError": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null
+      },
+      "pendingAction": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/PendingCommentAction"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null
+      },
+      "showGlobalPrompt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": false,
+        "type": "boolean"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/core/experimental/google-docs-comment-orchestrator.tsx",
+  "resultSchema": {
+    "$defs": {
+      "GoogleComment": {
+        "properties": {
+          "anchor": {
+            "type": "string"
+          },
+          "author": {
+            "$ref": "#/$defs/GoogleCommentAuthor"
+          },
+          "content": {
+            "type": "string"
+          },
+          "createdTime": {
+            "type": "string"
+          },
+          "htmlContent": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "type": "string"
+          },
+          "quotedFileContent": {
+            "properties": {
+              "mimeType": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "type": "object"
+          },
+          "replies": {
+            "items": {
+              "$ref": "#/$defs/GoogleCommentReply"
+            },
+            "type": "array"
+          },
+          "resolved": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "author",
+          "content",
+          "createdTime",
+          "resolved"
+        ],
+        "type": "object"
+      },
+      "GoogleCommentAuthor": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "emailAddress": {
+            "type": "string"
+          },
+          "photoLink": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "GoogleCommentReply": {
+        "properties": {
+          "action": {
+            "enum": [
+              "resolve",
+              "reopen"
+            ]
+          },
+          "author": {
+            "$ref": "#/$defs/GoogleCommentAuthor"
+          },
+          "content": {
+            "type": "string"
+          },
+          "createdTime": {
+            "type": "string"
+          },
+          "htmlContent": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "author",
+          "content",
+          "createdTime"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Google Docs Comment Orchestrator. AI-powered comment responses. #googleDocsComments",
+    "properties": {
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "comments": {
+        "items": {
+          "$ref": "#/$defs/GoogleComment"
+        },
+        "type": "array"
+      },
+      "docUrl": {
+        "type": "string"
+      },
+      "openCommentCount": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "docUrl",
+      "comments",
+      "openCommentCount",
+      "$UI"
+    ],
+    "tags": [
+      "googledocscomments"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/berkeley-library.tsx/20260909T184755Z-8nuN4L8VEsW6UX5D.json
+++ b/packages/patterns/baselines/google/extractors/berkeley-library.tsx/20260909T184755Z-8nuN4L8VEsW6UX5D.json
@@ -1,0 +1,281 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "dismissedHolds": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "dueDateOverrides": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "properties": {},
+        "type": "object"
+      },
+      "manuallyReturned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      },
+      "selectedItems": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/berkeley-library.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ItemStatus": {
+        "enum": [
+          "hold_ready",
+          "checked_out",
+          "overdue",
+          "renewed",
+          "returned"
+        ]
+      },
+      "ItemType": {
+        "enum": [
+          "other",
+          "book",
+          "audiobook",
+          "dvd",
+          "magazine",
+          "ebook"
+        ]
+      },
+      "TrackedItem": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "daysUntilDue": {
+            "type": "number"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "emailDate": {
+            "type": "string"
+          },
+          "fineAmount": {
+            "type": "number"
+          },
+          "isManuallyReturned": {
+            "type": "boolean"
+          },
+          "itemType": {
+            "$ref": "#/$defs/ItemType"
+          },
+          "key": {
+            "type": "string"
+          },
+          "renewalsRemaining": {
+            "type": "number"
+          },
+          "status": {
+            "$ref": "#/$defs/ItemStatus"
+          },
+          "title": {
+            "type": "string"
+          },
+          "urgency": {
+            "$ref": "#/$defs/UrgencyLevel"
+          }
+        },
+        "required": [
+          "key",
+          "title",
+          "status",
+          "urgency",
+          "daysUntilDue",
+          "emailDate",
+          "isManuallyReturned"
+        ],
+        "type": "object"
+      },
+      "UrgencyLevel": {
+        "enum": [
+          "overdue",
+          "urgent_1day",
+          "warning_3days",
+          "notice_7days",
+          "ok"
+        ]
+      }
+    },
+    "description": "Berkeley Public Library book tracker. #berkeleyLibrary",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "checkedOutCount": {
+        "type": "number"
+      },
+      "dismissHold": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "holdsReady": {
+        "items": {
+          "$ref": "#/$defs/TrackedItem"
+        },
+        "type": "array"
+      },
+      "holdsReadyCount": {
+        "type": "number"
+      },
+      "markAsReturned": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "overdueCount": {
+        "type": "number"
+      },
+      "trackedItems": {
+        "items": {
+          "$ref": "#/$defs/TrackedItem"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "trackedItems",
+      "holdsReady",
+      "overdueCount",
+      "checkedOutCount",
+      "holdsReadyCount",
+      "markAsReturned",
+      "dismissHold",
+      "$NAME",
+      "$UI",
+      "$TILE_UI"
+    ],
+    "tags": [
+      "berkeleylibrary"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/lobby/main.tsx/20260909T184755Z-cx1Z_vlIBmAlVPDa.json
+++ b/packages/patterns/baselines/lobby/main.tsx/20260909T184755Z-cx1Z_vlIBmAlVPDa.json
@@ -1,0 +1,384 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "LobbyAdminBootstrapRole": {
+        "$ref": "#/$defs/LobbyAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "lobby-admin"
+          ]
+        }
+      },
+      "LobbyAdminList": {
+        "ifc": {
+          "addIntegrity": [
+            "lobby-admin"
+          ],
+          "requiredIntegrity": [
+            "lobby-admin"
+          ],
+          "uiContract": {
+            "action": "TrustedLobbyAction",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedLobbySurface"
+            ],
+            "trustedPattern": "TrustedLobbySurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/lobby/main.tsx",
+              "moduleIdentity": "eW8FvC-wGHt9fpSoonbXTefmn13NsfIsGjtVrC0MZYk",
+              "path": [
+                "commitTrustedLobbyAction"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/LobbyAdminRole"
+        },
+        "type": "array"
+      },
+      "LobbyAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/LobbyAdminList"
+          },
+          "bootstrapAdmin": {
+            "$ref": "#/$defs/LobbyAdminBootstrapRole"
+          },
+          "everyoneIsAdmin": {
+            "$ref": "#/$defs/LobbyEveryoneAdminFlag"
+          }
+        },
+        "type": "object"
+      },
+      "LobbyAdminRegistryValue": {
+        "$ref": "#/$defs/LobbyAdminRegistryStoredValue",
+        "default": {}
+      },
+      "LobbyAdminRole": {
+        "$ref": "#/$defs/LobbyAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "lobby-admin"
+          ]
+        }
+      },
+      "LobbyAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/LobbyProfile",
+            "asCell": [
+              "cell"
+            ]
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "LobbyEveryoneAdminFlag": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedLobbyAction",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedLobbySurface"
+            ],
+            "trustedPattern": "TrustedLobbySurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/lobby/main.tsx",
+              "moduleIdentity": "eW8FvC-wGHt9fpSoonbXTefmn13NsfIsGjtVrC0MZYk",
+              "path": [
+                "commitTrustedLobbyAction"
+              ]
+            }
+          }
+        },
+        "type": "boolean"
+      },
+      "LobbyExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "LobbyParticipant": {
+        "properties": {
+          "name": {
+            "description": "Durable fallback label for policy rows if the live profile is offline.",
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "#/$defs/LobbyProfile",
+            "asCell": [
+              "cell"
+            ]
+          }
+        },
+        "required": [
+          "profile",
+          "name"
+        ],
+        "type": "object"
+      },
+      "LobbyParticipantList": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/LobbyParticipant"
+        },
+        "type": "array"
+      },
+      "LobbyProfile": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "bio": {
+            "type": "string"
+          },
+          "externalLinks": {
+            "description": "Connector-facing identity hints retained on the stored profile link.",
+            "items": {
+              "$ref": "#/$defs/LobbyExternalProfileLink"
+            },
+            "type": "array"
+          },
+          "initialNameApplied": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "verifiedIdentities": {
+            "description": "Transport original assertion cells; consumers validate their integrity.",
+            "items": {
+              "asCell": [
+                "cell"
+              ],
+              "type": "unknown"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "LobbyRoster": {
+        "properties": {
+          "participants": {
+            "$ref": "#/$defs/LobbyParticipantList"
+          }
+        },
+        "required": [
+          "participants"
+        ],
+        "type": "object"
+      },
+      "LobbyRosterValue": {
+        "$ref": "#/$defs/LobbyRoster",
+        "default": {
+          "participants": []
+        }
+      }
+    },
+    "properties": {
+      "adminRegistry": {
+        "$ref": "#/$defs/LobbyAdminRegistryValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "description": "Shared durable trusted-admin policy."
+      },
+      "roster": {
+        "$ref": "#/$defs/LobbyRosterValue",
+        "description": "Shared durable presence list.",
+        "scope": "space"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "lobby/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "LobbyExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "LobbyParticipantView": {
+        "properties": {
+          "isAdmin": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "isAdmin"
+        ],
+        "type": "object"
+      },
+      "LobbyProfile": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "bio": {
+            "type": "string"
+          },
+          "externalLinks": {
+            "description": "Connector-facing identity hints retained on the stored profile link.",
+            "items": {
+              "$ref": "#/$defs/LobbyExternalProfileLink"
+            },
+            "type": "array"
+          },
+          "initialNameApplied": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "verifiedIdentities": {
+            "description": "Transport original assertion cells; consumers validate their integrity.",
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "LobbyTrustedActionEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "checked": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "everyoneIsAdmin": {
+            "type": "boolean"
+          },
+          "profile": {
+            "$ref": "#/$defs/LobbyProfile",
+            "description": "Headless/test seam; real UI bindings supply profile cells as state."
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addSelf": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Agent-facing action: add the active Fabric profile, with no payload."
+      },
+      "allParticipants": {
+        "description": "Agent-facing, profile-free snapshot for downstream processing.",
+        "items": {
+          "$ref": "#/$defs/LobbyParticipantView"
+        },
+        "type": "array"
+      },
+      "currentUserIsAdmin": {
+        "type": "boolean"
+      },
+      "everyoneIsAdmin": {
+        "type": "boolean"
+      },
+      "join": {
+        "$ref": "#/$defs/LobbyTrustedActionEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "participantCount": {
+        "type": "number"
+      },
+      "participants": {
+        "description": "Backward-compatible alias for `allParticipants`.",
+        "items": {
+          "$ref": "#/$defs/LobbyParticipantView"
+        },
+        "type": "array"
+      },
+      "removeParticipant": {
+        "$ref": "#/$defs/LobbyTrustedActionEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "setEveryoneIsAdmin": {
+        "$ref": "#/$defs/LobbyTrustedActionEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "toggleParticipantAdmin": {
+        "$ref": "#/$defs/LobbyTrustedActionEvent",
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "addSelf",
+      "allParticipants",
+      "participants",
+      "participantCount",
+      "currentUserIsAdmin",
+      "everyoneIsAdmin",
+      "join",
+      "removeParticipant",
+      "toggleParticipantAdmin",
+      "setEveryoneIsAdmin",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/scoped-group-chat/main-plain-inputs.tsx/20260909T184756Z-M530BSuyTtIuZ_9J.json
+++ b/packages/patterns/baselines/scoped-group-chat/main-plain-inputs.tsx/20260909T184756Z-M530BSuyTtIuZ_9J.json
@@ -1,0 +1,258 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ChatMessage": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "sentAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "author",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "Conversation": {
+        "properties": {
+          "rooms": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Room"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rooms"
+        ],
+        "type": "object"
+      },
+      "Room": {
+        "properties": {
+          "messages": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages"
+        ],
+        "type": "object"
+      },
+      "SelectedRoom": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "conversation": {
+        "$ref": "#/$defs/Conversation",
+        "default": {
+          "rooms": []
+        },
+        "scope": "space"
+      },
+      "draft": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "name": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "newRoomName": {
+        "default": "",
+        "scope": "session",
+        "type": "string"
+      },
+      "selectedRoom": {
+        "$ref": "#/$defs/SelectedRoom",
+        "default": {},
+        "scope": "session"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "scoped-group-chat/main-plain-inputs.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddRoomEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ChatMessage": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "sentAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "author",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "Conversation": {
+        "properties": {
+          "rooms": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Room"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rooms"
+        ],
+        "type": "object"
+      },
+      "Room": {
+        "properties": {
+          "messages": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages"
+        ],
+        "type": "object"
+      },
+      "SelectRoomEvent": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      },
+      "SelectedRoom": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      },
+      "SendMessageEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addRoom": {
+        "$ref": "#/$defs/AddRoomEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "conversation": {
+        "$ref": "#/$defs/Conversation",
+        "default": {
+          "rooms": []
+        },
+        "scope": "space"
+      },
+      "draft": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "messageCount": {
+        "type": "number"
+      },
+      "name": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "newRoomName": {
+        "default": "",
+        "scope": "session",
+        "type": "string"
+      },
+      "roomCount": {
+        "type": "number"
+      },
+      "selectRoom": {
+        "$ref": "#/$defs/SelectRoomEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "selectedRoom": {
+        "$ref": "#/$defs/SelectedRoom",
+        "default": {},
+        "scope": "session"
+      },
+      "sendMessage": {
+        "$ref": "#/$defs/SendMessageEvent",
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "name",
+      "selectedRoom",
+      "conversation",
+      "draft",
+      "newRoomName",
+      "messageCount",
+      "roomCount",
+      "sendMessage",
+      "addRoom",
+      "selectRoom",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/scoped-group-chat/main-with-writable-inputs.tsx/20260909T184756Z-NMt89YDsQnt_urES.json
+++ b/packages/patterns/baselines/scoped-group-chat/main-with-writable-inputs.tsx/20260909T184756Z-NMt89YDsQnt_urES.json
@@ -1,0 +1,283 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ChatMessage": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "sentAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "author",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "Conversation": {
+        "properties": {
+          "rooms": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Room"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rooms"
+        ],
+        "type": "object"
+      },
+      "Room": {
+        "properties": {
+          "messages": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages"
+        ],
+        "type": "object"
+      },
+      "SelectedRoom": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "conversation": {
+        "$ref": "#/$defs/Conversation",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": {
+          "rooms": []
+        }
+      },
+      "draft": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "name": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "newRoomName": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "session"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "selectedRoom": {
+        "$ref": "#/$defs/SelectedRoom",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "session"
+          }
+        ],
+        "default": {}
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "scoped-group-chat/main-with-writable-inputs.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddRoomEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ChatMessage": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "sentAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "author",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "Conversation": {
+        "properties": {
+          "rooms": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Room"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rooms"
+        ],
+        "type": "object"
+      },
+      "Room": {
+        "properties": {
+          "messages": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages"
+        ],
+        "type": "object"
+      },
+      "SelectRoomEvent": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      },
+      "SelectedRoom": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      },
+      "SendMessageEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addRoom": {
+        "$ref": "#/$defs/AddRoomEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "conversation": {
+        "$ref": "#/$defs/Conversation",
+        "default": {
+          "rooms": []
+        },
+        "scope": "space"
+      },
+      "draft": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "messageCount": {
+        "type": "number"
+      },
+      "name": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "newRoomName": {
+        "default": "",
+        "scope": "session",
+        "type": "string"
+      },
+      "roomCount": {
+        "type": "number"
+      },
+      "selectRoom": {
+        "$ref": "#/$defs/SelectRoomEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "selectedRoom": {
+        "$ref": "#/$defs/SelectedRoom",
+        "default": {},
+        "scope": "session"
+      },
+      "sendMessage": {
+        "$ref": "#/$defs/SendMessageEvent",
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "name",
+      "selectedRoom",
+      "conversation",
+      "draft",
+      "newRoomName",
+      "messageCount",
+      "roomCount",
+      "sendMessage",
+      "addRoom",
+      "selectRoom",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/scoped-user-directory/main.tsx/20260909T184756Z-yTVjwgRtsxta3qAA.json
+++ b/packages/patterns/baselines/scoped-user-directory/main.tsx/20260909T184756Z-yTVjwgRtsxta3qAA.json
@@ -1,0 +1,161 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Directory": {
+        "properties": {
+          "users": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/User"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "users"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "UserPointer": {
+        "properties": {
+          "user": {
+            "$ref": "#/$defs/User"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "directory": {
+        "$ref": "#/$defs/Directory",
+        "default": {
+          "users": []
+        },
+        "scope": "space"
+      },
+      "me": {
+        "$ref": "#/$defs/UserPointer",
+        "default": {},
+        "scope": "user"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "scoped-user-directory/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Directory": {
+        "properties": {
+          "users": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/User"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "users"
+        ],
+        "type": "object"
+      },
+      "JoinAsEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "RenameEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "UserPointer": {
+        "properties": {
+          "user": {
+            "$ref": "#/$defs/User"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "directory": {
+        "$ref": "#/$defs/Directory",
+        "default": {
+          "users": []
+        },
+        "scope": "space"
+      },
+      "joinAs": {
+        "$ref": "#/$defs/JoinAsEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "me": {
+        "$ref": "#/$defs/UserPointer",
+        "default": {},
+        "scope": "user"
+      },
+      "rename": {
+        "$ref": "#/$defs/RenameEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "userCount": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "directory",
+      "me",
+      "userCount",
+      "joinAs",
+      "rename",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/suggestable/budget-planner.tsx/20260909T184756Z-eQJfMoestskLex5_.json
+++ b/packages/patterns/baselines/suggestable/budget-planner.tsx/20260909T184756Z-eQJfMoestskLex5_.json
@@ -1,0 +1,78 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "context": {
+        "additionalProperties": true,
+        "default": {},
+        "properties": {},
+        "type": "object"
+      },
+      "maxAmount": {
+        "default": 1000,
+        "type": "number"
+      },
+      "topic": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "suggestable/budget-planner.tsx",
+  "resultSchema": {
+    "$defs": {
+      "BudgetItem": {
+        "properties": {
+          "amount": {
+            "default": 0,
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "amount"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/BudgetItem"
+        },
+        "type": "array"
+      },
+      "pending": {
+        "type": "boolean"
+      },
+      "remaining": {
+        "type": "number"
+      },
+      "topic": {
+        "type": "string"
+      },
+      "total": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "topic",
+      "items",
+      "total",
+      "remaining",
+      "pending",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/suggestable/checklist.tsx/20260909T184756Z-RjX0xlprzWwtVBfb.json
+++ b/packages/patterns/baselines/suggestable/checklist.tsx/20260909T184756Z-RjX0xlprzWwtVBfb.json
@@ -1,0 +1,66 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "context": {
+        "additionalProperties": true,
+        "default": {},
+        "properties": {},
+        "type": "object"
+      },
+      "topic": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "suggestable/checklist.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ChecklistItem": {
+        "properties": {
+          "done": {
+            "default": false,
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "done"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/ChecklistItem"
+        },
+        "type": "array"
+      },
+      "pending": {
+        "type": "boolean"
+      },
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic",
+      "items",
+      "pending",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/suggestable/diagram.tsx/20260909T184756Z-Y6BCkytIw3nSu3Fk.json
+++ b/packages/patterns/baselines/suggestable/diagram.tsx/20260909T184756Z-Y6BCkytIw3nSu3Fk.json
@@ -1,0 +1,45 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "context": {
+        "additionalProperties": true,
+        "default": {},
+        "properties": {},
+        "type": "object"
+      },
+      "topic": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "suggestable/diagram.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "diagram": {
+        "type": "string"
+      },
+      "pending": {
+        "type": "boolean"
+      },
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic",
+      "diagram",
+      "pending",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/suggestable/question.tsx/20260909T184756Z-0jHTpMevIGGkL4Q-.json
+++ b/packages/patterns/baselines/suggestable/question.tsx/20260909T184756Z-0jHTpMevIGGkL4Q-.json
@@ -1,0 +1,56 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "context": {
+        "additionalProperties": true,
+        "default": {},
+        "properties": {},
+        "type": "object"
+      },
+      "topic": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "suggestable/question.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "answer": {
+        "type": "string"
+      },
+      "options": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "pending": {
+        "type": "boolean"
+      },
+      "question": {
+        "type": "string"
+      },
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic",
+      "question",
+      "options",
+      "answer",
+      "pending",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/suggestable/summary.tsx/20260909T184756Z-yaRR_E4DoQowBTU-.json
+++ b/packages/patterns/baselines/suggestable/summary.tsx/20260909T184756Z-yaRR_E4DoQowBTU-.json
@@ -1,0 +1,45 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "context": {
+        "additionalProperties": true,
+        "default": {},
+        "properties": {},
+        "type": "object"
+      },
+      "topic": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "suggestable/summary.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "pending": {
+        "type": "boolean"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic",
+      "summary",
+      "pending",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/suggestable/svg-diagram.tsx/20260909T184756Z-Y6BCkytIw3nSu3Fk.json
+++ b/packages/patterns/baselines/suggestable/svg-diagram.tsx/20260909T184756Z-Y6BCkytIw3nSu3Fk.json
@@ -1,0 +1,45 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "context": {
+        "additionalProperties": true,
+        "default": {},
+        "properties": {},
+        "type": "object"
+      },
+      "topic": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "suggestable/svg-diagram.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "diagram": {
+        "type": "string"
+      },
+      "pending": {
+        "type": "boolean"
+      },
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic",
+      "diagram",
+      "pending",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -852,6 +852,10 @@ function schemaSubsetIssue(
 
 const DEFAULT_STABLE_SCHEMA_KEYS = new Set([
   ...ANNOTATION_KEYS,
+  // Cell wrappers and storage scopes do not constrain descendant values.
+  // Changes to the metadata itself are checked by `SEMANTIC_EXTENSION_KEYS`.
+  "asCell",
+  "scope",
   "$ref",
   "additionalProperties",
   "exclusiveMaximum",
@@ -1038,15 +1042,10 @@ function objectSubsetIssue(
     // refused at dispatch once the update has landed. Below a verb node the
     // rule is the argument side's, stated in this comparison's direction:
     // `source` is the candidate here, where `target` is the candidate there.
-    // The rescue turns on the field's own default and not on
-    // `allowEvolutionDefaults`, which the verb node above has already set
-    // false: `asCell` is not default-stable, so descending through one
-    // withdraws permission to introduce a default anywhere below. That
-    // withdrawal is about defaults that CHANGE, which the check above decides
-    // on its own. A field that carried the same default before and after
-    // changes nothing and still materializes for a caller that omits it, so
-    // reusing the flag here would refuse the one evolution this rule means to
-    // allow.
+    // The rescue uses the field's own default even when an ancestor forbids
+    // changed defaults. An unchanged default still materializes the field for
+    // a caller that omits it; the default-comparison check separately rejects
+    // changed defaults beneath constraints that are not default-stable.
     if (context.verbEvent) {
       for (const property of sourceRequired) {
         if (

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -853,6 +853,9 @@ function schemaSubsetIssue(
 const DEFAULT_STABLE_SCHEMA_KEYS = new Set([
   ...ANNOTATION_KEYS,
   // Cell wrappers and storage scopes do not constrain descendant values.
+  // The classification is conservative: `readOnly`, `writeOnly`, and `ifc`
+  // remain default-unstable until their compatibility with default insertion
+  // is verified.
   // Changes to the metadata itself are checked by `SEMANTIC_EXTENSION_KEYS`.
   "asCell",
   "scope",
@@ -1037,15 +1040,15 @@ function objectSubsetIssue(
     // A verb's event is the exception, and it is one of location rather than of
     // principle. The node sits in the result, so this covariant comparison
     // reaches it — but the pattern does not produce the event, the CALLER
-    // supplies it. Requiring a field the previous event did not is therefore a
-    // demand made of every call already written, and each one that omits it is
-    // refused at dispatch once the update has landed. Below a verb node the
-    // rule is the argument side's, stated in this comparison's direction:
-    // `source` is the candidate here, where `target` is the candidate there.
-    // The rescue uses the field's own default even when an ancestor forbids
-    // changed defaults. An unchanged default still materializes the field for
-    // a caller that omits it; the default-comparison check separately rejects
-    // changed defaults beneath constraints that are not default-stable.
+    // supplies it. Requiring a field the previous event did not adds a demand
+    // on callers. Below a verb node the rule is the argument side's, stated in
+    // this comparison's direction: `source` is the candidate here, where
+    // `target` is the candidate there.
+    // A valid default on the candidate field rescues the new requirement,
+    // whether that default is retained, introduced, or changed. The stream
+    // marker permits default insertion, and dispatch fills missing fields in
+    // a present event object from defaults. Other ancestor constraints still
+    // apply their own default-stability checks.
     if (context.verbEvent) {
       for (const property of sourceRequired) {
         if (

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -852,13 +852,18 @@ function schemaSubsetIssue(
 
 const DEFAULT_STABLE_SCHEMA_KEYS = new Set([
   ...ANNOTATION_KEYS,
-  // Cell wrappers and storage scopes do not constrain descendant values.
-  // The classification is conservative: `readOnly`, `writeOnly`, and `ifc`
-  // remain default-unstable until their compatibility with default insertion
-  // is verified.
-  // Changes to the metadata itself are checked by `SEMANTIC_EXTENSION_KEYS`.
+  // Four of the five `SEMANTIC_EXTENSION_KEYS` say how a value is delivered,
+  // stored, or written, not what shape it has, so a default inserted beneath
+  // one cannot falsify it. A change to the marker itself is still refused by
+  // the exact comparison in `objectSubsetIssue`. `ifc` is left out on
+  // purpose: a label is policy the write-authority comparison reasons about
+  // (`comparableIfc`), and whether a materialized default satisfies a
+  // labeled node's floor is that comparison's question, not this one's, so
+  // a changed default beneath an `ifc` stays refused until it is decided.
   "asCell",
+  "readOnly",
   "scope",
+  "writeOnly",
   "$ref",
   "additionalProperties",
   "exclusiveMaximum",

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -1395,6 +1395,43 @@ describe("piece schema compatibility", () => {
     }
   });
 
+  it("treats a default beneath unchanged cell metadata as beneath a plain node", () => {
+    // Stable means the plain-node rule applies, not only insertion: a
+    // changed default value is accepted, and a durable-link proof accepts a
+    // target default declared below a cell.
+    const cell = (value: Record<string, number>): JSONSchema => ({
+      type: "object",
+      properties: {
+        settings: {
+          type: "object",
+          additionalProperties: { type: "number" },
+          asCell: ["cell"],
+          default: value,
+        },
+      },
+    });
+    const resultSchema: JSONSchema = { type: "object" };
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(cell({ a: 1 }), resultSchema),
+        pattern(cell({ a: 2 }), resultSchema),
+      )
+    ).not.toThrow();
+
+    const linked = (x: JSONSchema): JSONSchema => ({
+      type: "object",
+      properties: {
+        s: { type: "object", asCell: ["cell"], properties: { x } },
+      },
+    });
+    expect(() =>
+      assertSchemaSubset(
+        linked({ type: "number" }),
+        linked({ type: "number", default: 5 }),
+      )
+    ).not.toThrow();
+  });
+
   it("rejects cell and scope changes when a record gains a default", () => {
     for (
       const [before, after, message] of [
@@ -3345,6 +3382,65 @@ describe("verb event required-field transitions", () => {
       assertPatternSchemasBackwardCompatible(
         verbInResult(withDefault(["label"])),
         verbInResult(withDefault(["label", "color"])),
+      )
+    ).not.toThrow();
+  });
+
+  it("accepts an event field that becomes required with a newly added default", () => {
+    // The rescue is any default the candidate carries, not only one the
+    // field carried before. A stream marker is cell metadata, and cell
+    // metadata is default-stable (#7166): it says how the value arrives, not
+    // what shape it has, so it withdraws no permission to introduce a
+    // default beneath it. The default materializes for every call that
+    // omits the field, which is what makes the new requirement safe.
+    const before: JSONSchema = {
+      type: "object",
+      properties: { label: { type: "string" }, color: { type: "string" } },
+      required: ["label"],
+    };
+    const after: JSONSchema = {
+      type: "object",
+      properties: {
+        label: { type: "string" },
+        color: { type: "string", default: "none" },
+      },
+      required: ["label", "color"],
+    };
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        verbInResult(before),
+        verbInResult(after),
+      )
+    ).not.toThrow();
+  });
+
+  it("accepts a changed default on an event field, as on an argument", () => {
+    const withDefault = (color: string): JSONSchema => ({
+      type: "object",
+      properties: {
+        label: { type: "string" },
+        color: { type: "string", default: color },
+      },
+      required: ["label"],
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        verbInResult(withDefault("none")),
+        verbInResult(withDefault("blue")),
+      )
+    ).not.toThrow();
+    // The same verb declared in the argument, where the event was already
+    // compared in the argument's direction.
+    const verbInArgument = (event: JSONSchema): Pattern =>
+      pattern({
+        type: "object",
+        properties: { setLabel: { $ref: "#/$defs/Ev", asCell: ["stream"] } },
+        $defs: { Ev: event },
+      }, { type: "object", properties: {} });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        verbInArgument(withDefault("none")),
+        verbInArgument(withDefault("blue")),
       )
     ).not.toThrow();
   });

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -3387,12 +3387,9 @@ describe("verb event required-field transitions", () => {
   });
 
   it("accepts an event field that becomes required with a newly added default", () => {
-    // The rescue is any default the candidate carries, not only one the
-    // field carried before. A stream marker is cell metadata, and cell
-    // metadata is default-stable (#7166): it says how the value arrives, not
-    // what shape it has, so it withdraws no permission to introduce a
-    // default beneath it. The default materializes for every call that
-    // omits the field, which is what makes the new requirement safe.
+    // A stream marker permits default insertion. Dispatch fills a present
+    // event object's missing fields from valid defaults, so a new requirement
+    // with a default remains compatible with callers that omit the field.
     const before: JSONSchema = {
       type: "object",
       properties: { label: { type: "string" }, color: { type: "string" } },

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -1348,6 +1348,95 @@ describe("piece schema compatibility", () => {
       .toThrow(/not stable under default insertion/);
   });
 
+  it("accepts record defaults with unchanged cell and scope metadata", () => {
+    const resultSchema: JSONSchema = { type: "object" };
+    for (
+      const metadata of [
+        { asCell: ["cell"] },
+        { asCell: [{ kind: "cell", scope: "space" }] },
+        { scope: "user" },
+      ] as const
+    ) {
+      const record: JSONSchema = {
+        type: "object",
+        additionalProperties: { type: "string" },
+      };
+      const source: JSONSchema = {
+        type: "object",
+        properties: { settings: { ...record, ...metadata } },
+      };
+      const target: JSONSchema = {
+        ...source,
+        properties: { settings: { ...record, ...metadata, default: {} } },
+      };
+
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(source, resultSchema),
+          pattern(target, resultSchema),
+        )
+      ).not.toThrow();
+      expect(() => assertSchemaSubset(source, target)).not.toThrow();
+
+      const withRef: JSONSchema = {
+        type: "object",
+        properties: { settings: { $ref: "#/$defs/Settings", ...metadata } },
+        $defs: { Settings: record },
+      };
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(withRef, resultSchema),
+          pattern({
+            ...withRef,
+            $defs: { Settings: { ...record, default: {} } },
+          }, resultSchema),
+        )
+      ).not.toThrow();
+    }
+  });
+
+  it("rejects cell and scope changes when a record gains a default", () => {
+    for (
+      const [before, after, message] of [
+        [{ asCell: ["cell"] }, { asCell: ["readonly"] }, "asCell changed"],
+        [{ scope: "user" }, { scope: "space" }, "scope changed"],
+      ] as const
+    ) {
+      const record: JSONSchema = {
+        type: "object",
+        additionalProperties: { type: "string" },
+      };
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern({ ...record, ...before }, true),
+          pattern({ ...record, ...after, default: {} }, true),
+        )
+      ).toThrow(message);
+    }
+  });
+
+  it("rejects descendant defaults under a cell with a property-count constraint", () => {
+    const source: JSONSchema = {
+      type: "object",
+      asCell: ["cell"],
+      properties: { settings: { type: "object" } },
+      maxProperties: 0,
+    };
+    const target: JSONSchema = {
+      ...source,
+      properties: { settings: { type: "object", default: {} } },
+    };
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(source, true),
+        pattern(target, true),
+      )
+    ).toThrow(/not stable under default insertion/);
+    expect(() => assertSchemaSubset(source, target)).toThrow(
+      /not stable under default insertion/,
+    );
+  });
+
   it("rejects changed migration defaults below default-unstable constraints", () => {
     const resultSchema: JSONSchema = {
       type: "object",

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -1432,6 +1432,64 @@ describe("piece schema compatibility", () => {
     ).not.toThrow();
   });
 
+  it("treats a default beneath unchanged readOnly or writeOnly as beneath a plain node", () => {
+    // The same principle as cells and scopes: the marker says how the value
+    // is written, not what shape it has. The marker itself must still match.
+    for (const marker of [{ readOnly: true }, { writeOnly: true }] as const) {
+      const field = (value: string): JSONSchema => ({
+        type: "object",
+        properties: { note: { type: "string", ...marker, default: value } },
+      });
+      const resultSchema: JSONSchema = { type: "object" };
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(field("none"), resultSchema),
+          pattern(field("blue"), resultSchema),
+        )
+      ).not.toThrow();
+    }
+    const flipped = (marker: { readOnly: boolean }): JSONSchema => ({
+      type: "object",
+      properties: { note: { type: "string", ...marker, default: "none" } },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(flipped({ readOnly: true }), { type: "object" }),
+        pattern(flipped({ readOnly: false }), { type: "object" }),
+      )
+    ).toThrow("readOnly changed");
+  });
+
+  it("still refuses a changed default beneath an ifc label", () => {
+    // `ifc` is the one semantic extension left out of the default-stable set
+    // on purpose: whether a materialized default satisfies a labeled node's
+    // floor is the write-authority comparison's question.
+    const labeled = (value: boolean): JSONSchema => ({
+      type: "object",
+      properties: {
+        flag: {
+          type: "boolean",
+          ifc: {
+            writeAuthorizedBy: {
+              __ctWriterIdentityOf: {
+                file: "/packages/patterns/demo/main.tsx",
+                path: ["setFlag"],
+                moduleIdentity: "UVJh2ChHuLkknYrVet0Iu",
+              },
+            },
+          },
+          default: value,
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(labeled(false), { type: "object" }),
+        pattern(labeled(true), { type: "object" }),
+      )
+    ).toThrow(/not stable under default insertion/);
+  });
+
   it("rejects cell and scope changes when a record gains a default", () => {
     for (
       const [before, after, message] of [

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -1837,23 +1837,6 @@ export class CommonFabricFormatter implements TypeFormatter {
       return this.#extractValueFromTypeQuery(typeNode, context);
     }
 
-    // Handle type references that represent empty objects
-    // This includes Record<string, never>, Record<K, never>, and similar mapped types
-    if (ts.isTypeReferenceNode(typeNode) && typeNode.typeArguments) {
-      // For mapped types like Record<K, V>, if V is never, the result is an empty object
-      // Check the last type argument (the value type in mapped types)
-      const lastTypeArg =
-        typeNode.typeArguments[typeNode.typeArguments.length - 1];
-      if (lastTypeArg) {
-        const lastType = context.typeRegistry?.get(lastTypeArg) ??
-          context.typeChecker.getTypeFromTypeNode(lastTypeArg);
-        // If the value type is never, this represents an empty object
-        if (lastType.flags & ts.TypeFlags.Never) {
-          return {};
-        }
-      }
-    }
-
     // Handle literal types
     if (ts.isLiteralTypeNode(typeNode)) {
       const literal = typeNode.literal;

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -18,6 +18,7 @@ import {
   extractDefaultBrandPayloadValue,
   getArrayElementInfo,
   getPropertyNameText,
+  isEmptyRecordType,
   resolveWrapperNode,
   type TypeWithInternals,
 } from "../type-utils.ts";
@@ -1922,6 +1923,11 @@ export class CommonFabricFormatter implements TypeFormatter {
       return undefined;
     }
 
+    // Mapped records have type declarations but no `.valueDeclaration`.
+    if (isEmptyRecordType(type, context.typeChecker)) {
+      return {};
+    }
+
     // For complex values (arrays/objects), try to extract from the type's symbol
     // This is a simplified approach that works for many cases
     const symbol = type.getSymbol();
@@ -1971,7 +1977,6 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     // Check if this is an empty object type (no properties, object type)
-    // This handles cases like Record<string, never>
     if (
       (type.flags & ts.TypeFlags.Object) !== 0 &&
       context.typeChecker.getPropertiesOfType(type).length === 0

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -15,6 +15,7 @@ import {
   getNativeTypeSchema,
   getPropertyNameText,
   isDefaultBrandedMember,
+  isEmptyRecordType,
   resolveWrapperNode,
   TypeWithInternals,
 } from "../type-utils.ts";
@@ -897,6 +898,10 @@ export class UnionFormatter implements TypeFormatter {
     }
     if (type.flags & ts.TypeFlags.Undefined) {
       return undefined;
+    }
+
+    if (isEmptyRecordType(type, context.typeChecker)) {
+      return {};
     }
 
     const symbol = type.getSymbol();

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -913,6 +913,8 @@ export function isEmptyRecordType(
 ): boolean {
   if (
     (type.flags & (ts.TypeFlags.Object | ts.TypeFlags.Intersection)) === 0 ||
+    type.isIntersection() &&
+      type.types.some((member) => (member.flags & ts.TypeFlags.Object) === 0) ||
     typeChecker.getPropertiesOfType(type).length !== 0 ||
     type.getCallSignatures().length !== 0 ||
     type.getConstructSignatures().length !== 0

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -904,6 +904,26 @@ function followAliasToWrapperNode(
 }
 
 /**
+ * Returns whether a record has no named properties and only `never`-valued
+ * index signatures, so its default can be represented by `{}`.
+ */
+export function isEmptyRecordType(
+  type: ts.Type,
+  typeChecker: ts.TypeChecker,
+): boolean {
+  if (
+    (type.flags & ts.TypeFlags.Object) === 0 ||
+    typeChecker.getPropertiesOfType(type).length !== 0 ||
+    type.getCallSignatures().length !== 0 ||
+    type.getConstructSignatures().length !== 0
+  ) return false;
+
+  const indexes = typeChecker.getIndexInfosOfType(type);
+  return indexes.length > 0 &&
+    indexes.every((index) => (index.type.flags & ts.TypeFlags.Never) !== 0);
+}
+
+/**
  * Convert a purely literal-shaped Type to its JSON value: string/number/
  * boolean literals, null, literal tuples, and object-literal types whose
  * members are themselves literal-shaped. Returns the value wrapped (so a

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -912,7 +912,7 @@ export function isEmptyRecordType(
   typeChecker: ts.TypeChecker,
 ): boolean {
   if (
-    (type.flags & ts.TypeFlags.Object) === 0 ||
+    (type.flags & (ts.TypeFlags.Object | ts.TypeFlags.Intersection)) === 0 ||
     typeChecker.getPropertiesOfType(type).length !== 0 ||
     type.getCallSignatures().length !== 0 ||
     type.getConstructSignatures().length !== 0

--- a/packages/schema-generator/test/schema/default-empty-record.test.ts
+++ b/packages/schema-generator/test/schema/default-empty-record.test.ts
@@ -47,6 +47,8 @@ describe("default-empty-record", () => {
           'Record<"required", never>',
           "Record<string, never[]>",
           "Record<string, never> & Record<symbol, string>",
+          "true & Record<string, never>",
+          "string & Record<string, never>",
           "{ [K in PropertyKey]: K extends string ? never : string }",
         ]
       ) {

--- a/packages/schema-generator/test/schema/default-empty-record.test.ts
+++ b/packages/schema-generator/test/schema/default-empty-record.test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
+import ts from "typescript";
 
 import { SchemaGenerator } from "../../src/schema-generator.ts";
 import { asObjectSchema, getTypeFromCode } from "../utils.ts";
@@ -71,6 +72,57 @@ describe("default-empty-record", () => {
           expect(schema).not.toHaveProperty("default");
         });
       }
+
+      it("omits primitive-intersection defaults without boxed primitive members", () => {
+        // A custom type library need not declare `Boolean.valueOf`. Primitive
+        // intersections must be rejected independently of those named members.
+        const fileName = "default.ts";
+        const wrapped = form === "union member"
+          ? "{ [key: string]: unknown } | Default<Value>"
+          : "Default<{ [key: string]: unknown }, Value>";
+        const sourceFile = ts.createSourceFile(
+          fileName,
+          `
+          interface Array<T> { [index: number]: T; }
+          interface Boolean {}
+          interface CallableFunction {}
+          interface Function {}
+          interface IArguments {}
+          interface NewableFunction {}
+          interface Number {}
+          interface Object {}
+          interface RegExp {}
+          interface String {}
+          interface Default<T, V extends T = T> {}
+          type Value = true & { [key: string]: never };
+          type SchemaRoot = ${wrapped};
+          `,
+          ts.ScriptTarget.ES2023,
+          true,
+        );
+        const options: ts.CompilerOptions = { noLib: true, strict: true };
+        const host = ts.createCompilerHost(options);
+        host.getSourceFile = (name) =>
+          name === fileName ? sourceFile : undefined;
+        const program = ts.createProgram([fileName], options, host);
+        expect(ts.getPreEmitDiagnostics(program)).toEqual([]);
+        const checker = program.getTypeChecker();
+        const root = sourceFile.statements.find((node) =>
+          ts.isTypeAliasDeclaration(node) && node.name.text === "SchemaRoot"
+        );
+        if (!root || !ts.isTypeAliasDeclaration(root)) {
+          throw new Error("SchemaRoot type alias is missing");
+        }
+        const schema = asObjectSchema(
+          new SchemaGenerator().generateSchema(
+            checker.getTypeFromTypeNode(root.type),
+            checker,
+            root.type,
+          ),
+        );
+
+        expect(schema).not.toHaveProperty("default");
+      });
     });
   }
 

--- a/packages/schema-generator/test/schema/default-empty-record.test.ts
+++ b/packages/schema-generator/test/schema/default-empty-record.test.ts
@@ -1,0 +1,72 @@
+/** Checks default extraction from aliased records through both formatters. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { SchemaGenerator } from "../../src/schema-generator.ts";
+import { asObjectSchema, getTypeFromCode } from "../utils.ts";
+
+describe("default-empty-record", () => {
+  for (const form of ["union member", "two arguments"]) {
+    describe(form, () => {
+      for (
+        const value of [
+          "Record<string, never>",
+          "Record<number, never>",
+          "Record<symbol, never>",
+          "Record<PropertyKey, never>",
+          "{ [K in PropertyKey]: never }",
+          "{ [key: string]: never }",
+        ]
+      ) {
+        it(`emits an empty object default for an alias of \`${value}\``, async () => {
+          const wrapped = form === "union member"
+            ? "Record<string, unknown> | Default<Value>"
+            : "Default<Record<string, unknown>, Value>";
+          const { type, checker, typeNode } = await getTypeFromCode(
+            `
+            interface Default<T, V extends T = T> {}
+            type Value = ${value};
+            type SchemaRoot = ${wrapped};
+            `,
+            "SchemaRoot",
+          );
+          const schema = asObjectSchema(
+            new SchemaGenerator().generateSchema(type, checker, typeNode),
+          );
+
+          expect(schema.default).toEqual({});
+        });
+      }
+
+      for (
+        const value of [
+          "Record<string, string>",
+          "Record<string, unknown>",
+          'Record<"required", never>',
+          "Record<string, never[]>",
+          "{ [K in PropertyKey]: K extends string ? never : string }",
+        ]
+      ) {
+        it(`omits the default for an alias of \`${value}\``, async () => {
+          const wrapped = form === "union member"
+            ? "Record<string, unknown> | Default<Value>"
+            : "Default<Record<string, unknown>, Value>";
+          const { type, checker, typeNode } = await getTypeFromCode(
+            `
+            interface Default<T, V extends T = T> {}
+            type Value = ${value};
+            type SchemaRoot = ${wrapped};
+            `,
+            "SchemaRoot",
+          );
+          const schema = asObjectSchema(
+            new SchemaGenerator().generateSchema(type, checker, typeNode),
+          );
+
+          expect(schema).not.toHaveProperty("default");
+        });
+      }
+    });
+  }
+});

--- a/packages/schema-generator/test/schema/default-empty-record.test.ts
+++ b/packages/schema-generator/test/schema/default-empty-record.test.ts
@@ -15,6 +15,7 @@ describe("default-empty-record", () => {
           "Record<number, never>",
           "Record<symbol, never>",
           "Record<PropertyKey, never>",
+          "Record<string, never> & Record<number, never>",
           "{ [K in PropertyKey]: never }",
           "{ [key: string]: never }",
         ]
@@ -45,6 +46,7 @@ describe("default-empty-record", () => {
           "Record<string, unknown>",
           'Record<"required", never>',
           "Record<string, never[]>",
+          "Record<string, never> & Record<symbol, string>",
           "{ [K in PropertyKey]: K extends string ? never : string }",
         ]
       ) {
@@ -69,4 +71,20 @@ describe("default-empty-record", () => {
       }
     });
   }
+
+  it("emits an empty object default for an aliased `typeof` value", async () => {
+    const { type, checker, typeNode } = await getTypeFromCode(
+      `
+      interface Default<T, V extends T = T> {}
+      const emptyObject = {};
+      type EmptyObject = typeof emptyObject;
+      type SchemaRoot = Default<Record<string, unknown>, EmptyObject>;
+      `,
+      "SchemaRoot",
+    );
+    const schema = asObjectSchema(
+      new SchemaGenerator().generateSchema(type, checker, typeNode),
+    );
+    expect(schema.default).toEqual({});
+  });
 });

--- a/packages/ts-transformers/test/default-empty-record-schema.test.ts
+++ b/packages/ts-transformers/test/default-empty-record-schema.test.ts
@@ -1,0 +1,58 @@
+/** Pins empty-record defaults in schemas emitted for pattern arguments. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { parseModule, patternSchemas } from "./transformed-ast.ts";
+import { transformSource } from "./utils.ts";
+
+describe("default-empty-record-schema", () => {
+  for (const form of ["union member", "two arguments"]) {
+    it(`emits empty object defaults for the ${form} form`, async () => {
+      const defaults = {
+        literal: "{}",
+        stringKeys: "Record<string, never>",
+        propertyKeys: "Record<PropertyKey, never>",
+        alias: "EmptyRecord",
+      };
+      const properties = Object.entries(defaults).map(([name, value]) => {
+        const type = form === "union member"
+          ? `Record<string, unknown> | Default<${value}>`
+          : `Default<Record<string, unknown>, ${value}>`;
+        return `${name}: Writable<${type}>;`;
+      }).join("\n");
+      const output = await transformSource(
+        `/// <cts-enable />
+        import { Default, pattern, Writable } from "commonfabric";
+        type EmptyRecord = Record<string, never>;
+        interface Input { ${properties} }
+        export default pattern<Input>((state) => ({
+          literal: state.literal,
+          stringKeys: state.stringKeys,
+          propertyKeys: state.propertyKeys,
+          alias: state.alias,
+        }));
+        `,
+        { types: COMMONFABRIC_TYPES },
+      );
+      const { input } = patternSchemas(parseModule(output));
+      const schemas = input.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+
+      for (const name of Object.keys(defaults)) {
+        expect(schemas[name]).toMatchObject({
+          type: "object",
+          asCell: ["cell"],
+        });
+      }
+      expect(Object.fromEntries(
+        Object.keys(defaults).map((name) => [name, schemas[name]?.default]),
+      )).toEqual(Object.fromEntries(
+        Object.keys(defaults).map((name) => [name, {}]),
+      ));
+    });
+  }
+});

--- a/packages/ts-transformers/test/default-empty-record-schema.test.ts
+++ b/packages/ts-transformers/test/default-empty-record-schema.test.ts
@@ -34,7 +34,7 @@ describe("default-empty-record-schema", () => {
           alias: state.alias,
         }));
         `,
-        { types: COMMONFABRIC_TYPES },
+        { types: COMMONFABRIC_TYPES, typeCheck: true },
       );
       const { input } = patternSchemas(parseModule(output));
       const schemas = input.properties as Record<
@@ -57,15 +57,14 @@ describe("default-empty-record-schema", () => {
   }
 
   it("omits the default for never-valued types that are not empty records", async () => {
-    // A named property or a missing index signature disqualifies the type:
-    // `{}` is not its only inhabitant. The two-argument form once returned
-    // `{}` for any type reference whose last type argument was `never`.
+    // Named properties disqualify arrays and finite-key records from
+    // representing empty-object defaults, even when their value type is `never`.
     const output = await transformSource(
       `/// <cts-enable />
       import { Default, pattern, Writable } from "commonfabric";
       interface Input {
         namedNever: Writable<Default<Record<string, unknown>, Record<"required", never>>>;
-        neverArray: Writable<Default<Record<string, unknown>, Array<never>>>;
+        neverArray: Writable<Default<object, Array<never>>>;
         unionNamedNever: Writable<Record<string, unknown> | Default<Record<"required", never>>>;
       }
       export default pattern<Input>((state) => ({
@@ -74,7 +73,7 @@ describe("default-empty-record-schema", () => {
         unionNamedNever: state.unionNamedNever,
       }));
       `,
-      { types: COMMONFABRIC_TYPES },
+      { types: COMMONFABRIC_TYPES, typeCheck: true },
     );
     const { input } = patternSchemas(parseModule(output));
     const schemas = input.properties as Record<string, Record<string, unknown>>;

--- a/packages/ts-transformers/test/default-empty-record-schema.test.ts
+++ b/packages/ts-transformers/test/default-empty-record-schema.test.ts
@@ -55,4 +55,33 @@ describe("default-empty-record-schema", () => {
       ));
     });
   }
+
+  it("omits the default for never-valued types that are not empty records", async () => {
+    // A named property or a missing index signature disqualifies the type:
+    // `{}` is not its only inhabitant. The two-argument form once returned
+    // `{}` for any type reference whose last type argument was `never`.
+    const output = await transformSource(
+      `/// <cts-enable />
+      import { Default, pattern, Writable } from "commonfabric";
+      interface Input {
+        namedNever: Writable<Default<Record<string, unknown>, Record<"required", never>>>;
+        neverArray: Writable<Default<Record<string, unknown>, Array<never>>>;
+        unionNamedNever: Writable<Record<string, unknown> | Default<Record<"required", never>>>;
+      }
+      export default pattern<Input>((state) => ({
+        namedNever: state.namedNever,
+        neverArray: state.neverArray,
+        unionNamedNever: state.unionNamedNever,
+      }));
+      `,
+      { types: COMMONFABRIC_TYPES },
+    );
+    const { input } = patternSchemas(parseModule(output));
+    const schemas = input.properties as Record<string, Record<string, unknown>>;
+
+    for (const name of ["namedNever", "neverArray", "unionNamedNever"]) {
+      expect(schemas[name]).toMatchObject({ type: "object", asCell: ["cell"] });
+      expect(schemas[name]).not.toHaveProperty("default");
+    }
+  });
 });

--- a/tasks/pattern-compat-accepted-breaks.ts
+++ b/tasks/pattern-compat-accepted-breaks.ts
@@ -253,19 +253,19 @@ export const ACCEPTED_CONTRACT_BREAKS: readonly AcceptedContractBreak[] = [
     // The lunch poll's identity moved from display names to profile cells
     // (see docs/history/lunch-poll-identity-break.md). The proof reports two
     // paths here: the published name-keyed admin result went away, and the
-    // visit array's nested defaults changed when legacy roster links were
-    // replaced by optional profile links. The latter cannot be proven stable
-    // under default insertion even though the vintage replay preserves the
-    // stored visit rows.
+    // visit array's legacy roster links were replaced by optional profile
+    // links. Cell metadata is stable under default insertion, so the proof
+    // identifies the incompatible link at `loggedBy`. The
+    // vintage replay still preserves the stored visit rows.
     pattern: "lunch-poll/main.tsx",
     baselines: ["20260729T022742Z-5bjUubcOZ-gpvz7F"],
-    paths: ["argument.visits[]", "result.adminName"],
+    paths: ["argument.visits[].loggedBy", "result.adminName"],
     reason: "Lunch-poll identity moved from display names to profile cells. " +
       "The published `adminName` result cannot survive the removal of " +
-      "name-keyed identity; `argument.visits[]` is the proof's summary path " +
-      "for nested default changes introduced while legacy roster links became " +
-      "optional profile links. The vintage replay preserves those rows, but " +
-      "the root argument contract cannot be updated in place.",
+      "name-keyed identity; `argument.visits[].loggedBy` identifies the " +
+      "legacy roster link that became an optional profile link. The vintage " +
+      "replay preserves those rows, but the root argument contract cannot " +
+      "be updated in place.",
     record: "docs/history/lunch-poll-identity-break.md",
   },
   {
@@ -398,9 +398,10 @@ export const ACCEPTED_CONTRACT_BREAKS: readonly AcceptedContractBreak[] = [
     ],
     // The one spelling seen from the two roles a contract has: an optional
     // property carries no default, so the demand's defaults move, and the
-    // published row stops requiring the name.
+    // published row stops requiring the name. Stable cell metadata lets the
+    // proof identify the incompatible type at `shortName`.
     paths: [
-      "argument.items[]",
+      "argument.items[].shortName",
       "result.index[].shortName",
     ],
     reason:


### PR DESCRIPTION
`Default<Record<string, never>>` and `Default<Record<PropertyKey, never>>` could compile without emitting a default in a pattern argument, so replacing `{}` with a lint-friendly record type silently changed runtime behavior. Both the union-member and two-argument forms now preserve `default: {}`, including record aliases inside `Writable`.

**Schema generator.** A structural empty-record check is shared between CommonFabricFormatter and UnionFormatter: no named properties or call/construct signatures, at least one index signature, every index value type `never`. It accepts intersections of empty records and refuses an intersection with a primitive constituent. The node route's name-based shortcut (any type reference whose last type argument is `never` → `{}`) is deleted: the structural check now reaches the node route through its type fallback, so the shortcut was redundant where it was right and wrong where it was not — `Default<T, Record<"required", never>>` and `Default<T, Array<never>>` emitted `default: {}` in the two-argument form while the union form emitted none. Both misfires are pinned on the real compiler path.

**Compatibility gate.** The restored defaults change the recorded contract of 16 shipped patterns, and the gate refused 19 (pattern, baseline) pairs: `asCell` was not a default-stable key, so a cell-wrapped argument gaining a default read as "defaults changed below a constraint that is not stable under default insertion". `asCell`, `scope`, `readOnly`, and `writeOnly` are now default-stable. They say how a value is delivered, stored, or written, not what shape it has, and a change to the marker itself is still refused by the exact metadata comparison; value constraints such as `maxProperties` still require equal defaults beneath them. `ifc` is the one semantic extension deliberately left out: a label is policy the write-authority comparison reasons about, and whether a materialized default satisfies a labeled node's floor is that comparison's question, so a changed default beneath an `ifc` stays refused (pinned).

This reaches further than inserting an empty-object default, and the reach is deliberate and pinned. Beneath unchanged cell metadata the plain-node rule now applies in every direction the gate compares:

- a changed default value on a cell-wrapped argument;
- a changed default on a verb's event field, in either role;
- a newly required verb-event field rescued by a default the candidate introduces, not only one the field already carried;
- a durable-link proof whose target declares a default below a cell.

The verb-event rows reverse the reading #6662 recorded (descending through a stream marker withdrew permission to introduce a default below it). That reading was a consequence of `asCell`'s classification rather than a rule of its own; `docs/plans/verb-evolution.md`, `docs/specs/pattern-update-testing.md`, and the rescue's own comment in `schema-compatibility.ts` now say what the gate does. Dispatch fills a present event object's missing fields from valid defaults, which is what keeps every call already written valid; an entirely absent event payload stays absent.

16 baselines are appended whose only schema change is an added `{}` default. Two existing accepted-break entries are narrowed to the child fields the proof now identifies; their pattern/baseline pairs are unchanged.

Validation:
- Schema-generator, transformer, and piece package test suites passed in full, and each new test was mutation-checked against the code it pins (main's sources, the deleted node-route branch, main's piece gate, and the stable-key set with `readOnly`/`writeOnly` removed).
- Full pattern compatibility gate (409 patterns) and append-only baseline check passed.
- Per-package type checks, repo-wide `deno task check`, `deno fmt --check`, `deno lint`, and `git diff --check` passed.
