### PR TITLE
runner: the naming gate logs a spent probe budget, and says why it holds wide pieces

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -226,6 +226,23 @@ const triggerFlowLogger = getLogger("runner.trigger-flow", {
  */
 const RESULT_SHORTCUT_LIMIT = 4096;
 
+/**
+ * Presence probes `Runner.#patternToNameBeforeRun` may spend before it stops
+ * looking and holds the run for a name-sync. Each probe is one read of the
+ * local replica, so the budget bounds the walk's cost and not its verdict: a
+ * spent budget reads as absent, and the run pays one name-sync it may not
+ * have needed. A wide argument — one whose links, and the values behind
+ * them, fan out past the budget within the walk's depth — is therefore held
+ * once per runtime per pattern identity even when its whole family is
+ * local. That is the cheaper error. Narrowing the walk to the argument's own
+ * links would skip the links a linked document's value holds, which the
+ * name-sync's argument-link-target wave exists to warm; a missed absence
+ * costs a conflicting first commit, a spurious hold costs a re-sync the
+ * client answers from coverage it already has. The gate logs a spent budget
+ * so a wide piece held for it is diagnosable.
+ */
+const NAMING_PROBE_BUDGET = 256;
+
 const EAGER_RESULT_BUILTIN_REFS = new Set([
   "fetchBinary",
   "fetchJson",
@@ -2069,6 +2086,14 @@ export class Runner {
    * landed for. A run under another pattern probes again: an upgrade can add
    * an internal cell the crossing never delivered. Bounded like the other
    * result shortcuts; an evicted entry costs a probe, never a wrong verdict.
+   *
+   * A name-sync that rejects lands all the same. The run then degrades to
+   * what it was before the gate existed — over what is local, its own
+   * subscriptions fetching the rest, the rejection logged as the signal —
+   * and a later run under the same pattern is not held again for this
+   * runner's lifetime, a transient rejection included. Withholding the
+   * landing would name the piece again on every run, and the deferred run's
+   * own re-check of the gate would loop on the same rejection.
    */
   readonly #namedFamilies = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,
@@ -2133,6 +2158,9 @@ export class Runner {
    */
   #dependencySyncer: DependencySyncer | undefined = undefined;
 
+  /** `NAMING_PROBE_BUDGET`, lowered by a test to reach the spent-budget hold. */
+  #namingProbeBudget = NAMING_PROBE_BUDGET;
+
   /**
    * The committer a test supplies around a commit-gated start's commit;
    * `undefined` means the runner's own.
@@ -2183,6 +2211,7 @@ export class Runner {
     readonly activeStartAttempts: Set<StartAttempt>;
     dependencySyncer: DependencySyncer | undefined;
     deferredStartCommitter: DeferredStartCommitter | undefined;
+    namingProbeBudget: number;
     createStorageSubscription(): IStorageSubscription;
     setupInternal<T, R>(
       providedTx: IExtendedStorageTransaction | undefined,
@@ -2255,6 +2284,12 @@ export class Runner {
       },
       set deferredStartCommitter(value) {
         outerThis.#deferredStartCommitter = value;
+      },
+      get namingProbeBudget() {
+        return outerThis.#namingProbeBudget;
+      },
+      set namingProbeBudget(value) {
+        outerThis.#namingProbeBudget = value;
       },
       createStorageSubscription: () => this.#createStorageSubscription(),
       setupInternal: (
@@ -5227,24 +5262,49 @@ export class Runner {
     // schema, which answers an absent document with the schema's default.
     // A cell nothing has written yet — a derived cell whose producer never
     // ran — reads absent here too, and holds the run once; the probes stop
-    // at a budget, and a budget spent reads absent as well: a hold costs one
-    // name-sync, a wrong local verdict costs a conflicting commit.
+    // at a budget (`NAMING_PROBE_BUDGET`), and a budget spent reads absent
+    // as well: a hold costs one name-sync, a wrong local verdict costs a
+    // conflicting commit.
     const readTx = this.#runtime.readTx();
     const cell = resultCell.withTx(readTx);
-    let probes = 256;
-    const present = (link: NormalizedFullLink): boolean =>
-      probes-- > 0 &&
-      readTx.readOrThrow(
-          {
-            space: link.space,
-            id: link.id,
-            path: ["value"],
-            ...(link.scope !== undefined && { scope: link.scope }),
-          },
-          { meta: ignoreReadForScheduling },
-        ) !== undefined;
+    let probes = this.#namingProbeBudget;
+    let budgetSpent = false;
+    const present = (link: NormalizedFullLink): boolean => {
+      if (probes === 0) {
+        budgetSpent = true;
+        return false;
+      }
+      probes--;
+      return readTx.readOrThrow(
+        {
+          space: link.space,
+          id: link.id,
+          path: ["value"],
+          ...(link.scope !== undefined && { scope: link.scope }),
+        },
+        { meta: ignoreReadForScheduling },
+      ) !== undefined;
+    };
     const held = { pattern: resolved.pattern, entryKey };
-    if (!present(argumentLink)) return held;
+    // The hold, with what decided it: a document of `stage` read absent, or
+    // the budget ran out on a probe of that stage — the case worth a log,
+    // since a piece held for its width and not for an absence looks, from
+    // outside, like any other named run.
+    const hold = (stage: string): { pattern: Pattern; entryKey: string } => {
+      if (budgetSpent) {
+        logger.debug("named-run-gate", () => [
+          "probe budget spent; holding the run for a name-sync",
+          {
+            resultCell: resultCell.getAsNormalizedFullLink().id,
+            pattern: entryKey,
+            budget: this.#namingProbeBudget,
+            stage,
+          },
+        ]);
+      }
+      return held;
+    };
+    if (!present(argumentLink)) return hold("the argument document");
     // What the run reads through the argument: every document the caller's
     // argument and the stored argument link to, followed through the
     // targets those links resolve into — a coordinator's element link is a
@@ -5280,7 +5340,9 @@ export class Runner {
       }
       return false;
     };
-    if (linksAbsent(argument, 4)) return held;
+    if (linksAbsent(argument, 4)) {
+      return hold("a document the caller's argument links to");
+    }
     if (
       linksAbsent(
         readTx.readOrThrow(
@@ -5296,7 +5358,7 @@ export class Runner {
         4,
       )
     ) {
-      return held;
+      return hold("a document the stored argument links to");
     }
     // The owned cells the run reads: the pattern's derived internal cells
     // and, through each nested sub-pattern's result spot, those of the
@@ -5311,7 +5373,9 @@ export class Runner {
       readTx,
     );
     for (const ownedCell of owned) {
-      if (!present(ownedCell.getAsNormalizedFullLink())) return held;
+      if (!present(ownedCell.getAsNormalizedFullLink())) {
+        return hold("an owned cell");
+      }
     }
     return undefined;
   }
@@ -5407,6 +5471,11 @@ export class Runner {
             toName = again;
             continue;
           }
+          // The run consults the gate once more on its way in and gets the
+          // answer the re-check just got: the landing that satisfied it is
+          // recorded, and nothing runs between the two that could evict it —
+          // an eviction takes a name-sync landing for another piece, and this
+          // stretch is synchronous.
           started = this.#runWithStartOwnership(
             startTx,
             patternOrModule,

--- a/packages/runner/test/piece-named-before-start.test.ts
+++ b/packages/runner/test/piece-named-before-start.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { getLogger } from "@commonfabric/utils/logger";
 import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import type { Pattern } from "../src/builder/types.ts";
 import type { Cell } from "../src/cell.ts";
@@ -95,7 +96,7 @@ const CARDS_ITEM_SCHEMA = {
   },
 } as const;
 // One card per case, each cold on the replica that runs it.
-const CARD_COUNT = 10;
+const CARD_COUNT = 11;
 
 type EventCommitMarker = {
   type: "scheduler.event.commit";
@@ -139,6 +140,40 @@ function countPendingDeferredStarts(
     runtime.telemetry.removeEventListener("telemetry", listener);
     return count;
   };
+}
+
+type Emission = { key: string; parts: unknown[] };
+
+/**
+ * Records every `debug` the runner's logger emits while `fn` runs, resolving
+ * each call's lazy message thunk the way the logger itself does. Captured at
+ * the logger, not the console: the runner logger's configured level is
+ * `warn`, so its debug calls never reach the console at all.
+ */
+async function captureRunnerDebug(
+  fn: () => Promise<void>,
+): Promise<Emission[]> {
+  const logger = getLogger("runner") as unknown as {
+    debug: (key: string, ...messages: unknown[]) => void;
+  };
+  const emissions: Emission[] = [];
+  const original = logger.debug;
+  logger.debug = (key: string, ...messages: unknown[]) => {
+    emissions.push({
+      key,
+      parts: messages.flatMap((message) => {
+        const resolved = typeof message === "function" ? message() : message;
+        return Array.isArray(resolved) ? resolved : [resolved];
+      }),
+    });
+    original.call(logger, key, ...messages);
+  };
+  try {
+    await fn();
+  } finally {
+    logger.debug = original;
+  }
+  return emissions;
 }
 
 /** Resolves with the next deferred-start marker of `type` for `key`. */
@@ -719,5 +754,51 @@ describe("piece-named-before-start", () => {
     expect(String((failures[0].error as Error).message)).toContain(
       "Unknown pattern",
     );
+  });
+  it("holds the run once when the probe budget is spent, and says so", async () => {
+    const { cardB, itemB, argumentId, key } = locateCard(10);
+    // The family is local, as in the case that runs without a hold, so only
+    // the budget can hold this run.
+    await nameLinkChain(argumentId, 4);
+    await itemB.sync();
+    await quiesce(b);
+    const access = b.runner.accessForTestingOnly;
+    expect(access.namingProbeBudget).toBe(256);
+    // One probe. The argument document spends it, and the first link the
+    // caller's argument holds finds the budget gone.
+    access.namingProbeBudget = 1;
+    const settled = waitForDeferredStart(
+      b,
+      "runner.deferred-start.settled",
+      key,
+    );
+    const emissions = await captureRunnerDebug(async () => {
+      await runCard(cardB, itemB);
+      expect((await settled).outcome).toBe("installed");
+      await quiesce(b);
+    });
+    const spent = emissions.filter((emission) =>
+      emission.key === "named-run-gate"
+    );
+    expect(spent.length).toBe(1);
+    expect(spent[0].parts[0]).toBe(
+      "probe budget spent; holding the run for a name-sync",
+    );
+    expect(spent[0].parts[1]).toMatchObject({
+      resultCell: cardB.getAsNormalizedFullLink().id,
+      budget: 1,
+      stage: "a document the caller's argument links to",
+    });
+    // Landed: a later run under the same pattern is not held, and spends no
+    // probes to find that out.
+    let heldAgain = false;
+    waitForDeferredStart(b, "runner.deferred-start.pending", key).then(() => {
+      heldAgain = true;
+    });
+    await runCard(cardB, itemB);
+    await quiesce(b);
+    expect(heldAgain).toBe(false);
+    expect(await bump(cardB)).toBe(1);
+    expect(errors.get(b)!.map((error) => error.message)).toEqual([]);
   });
 });


### PR DESCRIPTION
Follow-up to #7132 from its review ([comment](https://github.com/commontoolsinc/labs/pull/7132#issuecomment-5606684347)), addressing the four non-blocking findings. No behavior change on the happy path; one new log line on a path that was silent.

## What

- **The probe budget is named and its trade stated.** `NAMING_PROBE_BUDGET` (256) carries the rationale: each probe is a local read, so the budget bounds cost, not the verdict; a spent budget reads as absent and holds the run for one name-sync. A wide argument is therefore held once per runtime per pattern identity even when its family is local. The review suggested narrowing the walk to the argument's own links; on reading the name-sync's argument-link-target wave I withdrew that: the wave warms the links a linked document's value holds, and a missed absence costs a conflicting first commit where a spurious hold costs a re-sync the client answers from coverage it already has. The conservative walk stays.
- **A spent budget is logged.** `logger.debug("named-run-gate", …)` with the piece, the pattern identity, the budget, and the probe stage (the argument document, a document the caller's or the stored argument links to, an owned cell) that ran out, so a wide piece held for its width is diagnosable.
- **`accessForTestingOnly.namingProbeBudget`** lets a test lower the budget; the counter stops at zero instead of counting past it.
- **Two doc notes.** `#namedFamilies` says why a name-sync that rejects still lands (the run degrades to the pre-gate posture; withholding the landing would re-name on every run and loop the deferred run's own re-check). The deferred run's inner `#runWithStartOwnership` call says why the gate cannot fire again there: the stretch between the re-check and the call is synchronous, and an eviction takes another piece's name-sync landing in between.

## Test

`piece-named-before-start` gains one case: a card whose family is local is held once under a budget of one, the log names the stage the budget ran out on, and the next run under the same pattern is not held. With the emission disabled the case fails on the emission count.

## Gates

`deno fmt`, `deno lint`, `deno task check` (workspace), `piece-named-before-start` 11/11, runner 1391/0 (8430 steps), all under the pinned Deno 2.9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

