### PR TITLE
fix(runner): let a refused wish report its refusal

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -2258,11 +2258,9 @@ export function wish(
 
   /**
    * Write `{error, [UI]}` into the wish state doc in its own committed
-   * bookkeeping transaction, SCHEMALESS on purpose: the failed commit was
-   * refused with the full wish-state schema in play (the served-wish shape
-   * dies in CFC prep on that envelope), and re-presenting the same envelope
-   * would meet the same refusal. A bare value write against the stored
-   * envelope does not.
+   * bookkeeping transaction, presenting the two fields it writes and nothing
+   * else. The commit it reports was refused with the whole wish-state
+   * envelope in play, and that envelope is the document's stored one.
    *
    * Bounded retries for the transient classes only: a stale-basis conflict
    * or a local inconsistency converges when re-run against settled state —
@@ -2293,20 +2291,47 @@ export function wish(
         : {}),
     });
     const { schema: _schema, ...bareLink } = stateLink;
-    // RAW value writes on purpose, not cell writes: a cell write against a
-    // doc with stored CFC metadata records the stored schema as the write's
-    // candidate envelope, and the candidate/stored merge re-meets exactly
-    // the refusal being reported (observed live: the divergent /result
-    // envelope refuses the error report too — the "Can't report …" loop).
-    // A raw value write records no candidate; prep keeps the stored
-    // envelope as-is, and the runtime-authored `error`/`$UI` fields carry
-    // no policy of their own (`true` in the wish-state schema).
-    errorTx.writeValueOrThrow(
-      { ...bareLink, path: [...stateLink.path, "error"] },
-      message,
-    );
-    errorTx.writeValueOrThrow(
-      { ...bareLink, path: [...stateLink.path, UI] },
+    // One field of the report: the value, and the schema it is authored
+    // against, written and named together.
+    //
+    // The write is a raw value rather than a cell write, which would record
+    // the document's STORED schema as this write's candidate envelope.
+    //
+    // A value write reaching a path the stored label map reaches is refused
+    // unless something names the schema it was authored against. A resolved
+    // wish whose result carries no `[UI]` of its own emits a `cf-cell-link`
+    // there, and that link persists a label entry under `[UI]/props/$cell`,
+    // so on such a document `[UI]` is one of those paths.
+    //
+    // The schema named is `true`, which is what the wish-state schema says
+    // at both paths. It declares nothing, so a stored claim at either path
+    // is not checked against this write; and a candidate declaring nothing
+    // is covered by whatever the document has stored, which keeps the report
+    // out of the schema merge.
+    //
+    // The requirement is decided per document rather than per path. What
+    // bounds the report is this transaction: it is created here, carries
+    // these two writes and no others, and the transaction whose refusal it
+    // reports is a separate one that has already settled.
+    const report = (
+      path: readonly string[],
+      value: Parameters<IExtendedStorageTransaction["writeValueOrThrow"]>[1],
+    ) => {
+      errorTx.writeValueOrThrow({ ...bareLink, path }, value);
+      errorTx.recordCfcWritePolicyInput({
+        kind: "schema",
+        target: {
+          space: stateLink.space,
+          id: stateLink.id,
+          scope: stateLink.scope,
+          path,
+        },
+        schema: true,
+      });
+    };
+    report([...stateLink.path, "error"], message);
+    report(
+      [...stateLink.path, UI],
       errorUI(message) as unknown as Parameters<
         IExtendedStorageTransaction["writeValueOrThrow"]
       >[1],

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1400,12 +1400,31 @@ const schemasEqualIgnoringWriterStamp = (
     stripWriterIdentityStamp(right),
   );
 
+const candidateDeclaresNothing = (
+  candidate: JSONSchema | undefined,
+): boolean =>
+  candidate === true ||
+  (isObjectNotArray(candidate) && Object.keys(candidate).length === 0);
+
 // Exported for unit testing of the merge-skip decision. Not part of the
 // public CFC surface.
 export const storedSchemaCoversCandidateEnvelope = (
   stored: JSONSchema | undefined,
   candidate: JSONSchema | undefined,
 ): boolean => {
+  // A candidate that declares nothing — JSON Schema `true`, or the empty
+  // object schema `getSchemaAtPath` returns for it — carries no label, no
+  // policy claim and no shape, so folding it into a stored schema that
+  // admits values leaves that schema as it stands. `false` admits none, and
+  // the merge refuses that form, so it is not one of those.
+  //
+  // The reading is narrower than `cfcSchemaIsTrue`, which also admits a
+  // schema whose only keys are `ifc`, `asCell`, `asStream`, `scope`,
+  // `default` or `$defs`. Each of those carries something the merge folds
+  // in.
+  if (stored !== false && candidateDeclaresNothing(candidate)) {
+    return true;
+  }
   if (stored === undefined || candidate === undefined) {
     return false;
   }
@@ -1424,12 +1443,25 @@ export const storedSchemaCoversCandidateEnvelope = (
       return false;
     }
     const storedProperties = stored.properties;
+    // What a stored `additionalProperties` governs is every key the STORED
+    // side does not name, and the merge pulls that claim down onto a key the
+    // candidate names (`leftClaim` in `mergeCfcSchemaEnvelopes`). So a
+    // candidate key absent from the stored properties is covered only where
+    // no such claim stands to be pulled down; otherwise the merge is what
+    // mints the label for it.
+    const storedGovernsUnnamedKeys = stored.additionalProperties !== undefined;
     if (
       !Object.entries(candidate.properties).every(([key, child]) =>
-        storedSchemaCoversCandidateEnvelope(
-          storedProperties[key] as JSONSchema | undefined,
-          child as JSONSchema,
-        )
+        Object.hasOwn(storedProperties, key)
+          ? storedSchemaCoversCandidateEnvelope(
+            storedProperties[key] as JSONSchema | undefined,
+            child as JSONSchema,
+          )
+          : !storedGovernsUnnamedKeys &&
+            storedSchemaCoversCandidateEnvelope(
+              undefined,
+              child as JSONSchema,
+            )
       )
     ) {
       return false;

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -1181,6 +1181,87 @@ describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
   // branch while their tuple slots differed, dropping the candidate's slot info
   // instead of merging it (fail-open: coverage=true skips the merge).
 
+  it("covers a candidate that declares nothing", () => {
+    // `true` and the empty object schema carry no label, no policy claim and
+    // no shape, so a merge leaves the stored envelope as it stands. The
+    // stored side saying nothing about the path is the case that matters
+    // most: the merge reads the STORED envelope, so a writer naming nothing
+    // would otherwise be refused for a defect in a schema it neither wrote
+    // nor touches.
+    const stored = {
+      type: "object",
+      properties: { name: { type: "string", ifc: { confidentiality: ["s"] } } },
+    } as const;
+    expect(storedSchemaCoversCandidateEnvelope(stored, true)).toBe(true);
+    expect(storedSchemaCoversCandidateEnvelope(stored, {})).toBe(true);
+    expect(storedSchemaCoversCandidateEnvelope(undefined, true)).toBe(true);
+    expect(storedSchemaCoversCandidateEnvelope(undefined, {})).toBe(true);
+    expect(
+      storedSchemaCoversCandidateEnvelope(stored, {
+        type: "object",
+        properties: { error: true },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not cover a candidate carrying only `ifc`, `default` or `$defs`", () => {
+    // `cfcSchemaIsTrue` admits all three as true schemas. Each carries
+    // something the merge has to fold in, so none of them is a schema that
+    // declares nothing.
+    const stored = { type: "object" } as const;
+    expect(
+      storedSchemaCoversCandidateEnvelope(stored, {
+        ifc: { confidentiality: ["s"] },
+      }),
+    ).toBe(false);
+    expect(storedSchemaCoversCandidateEnvelope(stored, { default: 1 })).toBe(
+      false,
+    );
+    expect(
+      storedSchemaCoversCandidateEnvelope(stored, { $defs: { a: true } }),
+    ).toBe(false);
+    expect(
+      storedSchemaCoversCandidateEnvelope(undefined, { default: 1 }),
+    ).toBe(false);
+  });
+
+  it("does not cover a nothing-declaring candidate against a stored `false`", () => {
+    // `false` admits no value, so there is nothing for a candidate to be
+    // folded into: `mergeCfcSchemaEnvelopes` refuses the form, and the write
+    // with it.
+    expect(storedSchemaCoversCandidateEnvelope(false, true)).toBe(false);
+    expect(
+      storedSchemaCoversCandidateEnvelope(
+        { type: "object", properties: { error: false } },
+        { type: "object", properties: { error: true } },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not cover a candidate key a stored rest claim would govern", () => {
+    // The merge pulls an object-valued `additionalProperties` claim down
+    // onto a key the candidate names, which is what mints that key's label.
+    // Skipping the merge would land the value unlabeled.
+    const stored = {
+      type: "object",
+      properties: { a: { type: "string", ifc: { confidentiality: ["seed"] } } },
+      additionalProperties: { ifc: { confidentiality: ["secret"] } },
+    } as const;
+    expect(
+      storedSchemaCoversCandidateEnvelope(stored, {
+        type: "object",
+        properties: { error: true },
+      }),
+    ).toBe(false);
+    // A key the stored side names itself is judged on that named schema.
+    expect(
+      storedSchemaCoversCandidateEnvelope(stored, {
+        type: "object",
+        properties: { a: true },
+      }),
+    ).toBe(true);
+  });
+
   it("differing tuple slots are not judged covered by matching items", () => {
     const stored = {
       type: "array",

--- a/packages/runner/test/wish-failure-report-write-policy.test.ts
+++ b/packages/runner/test/wish-failure-report-write-policy.test.ts
@@ -1,0 +1,335 @@
+/**
+ * What makes the report the subject here decidable at all is the document it
+ * writes to. A resolved wish emits a `cf-cell-link` as its `[UI]`, whose
+ * `$cell` prop is a link to the wished-for cell, so the stored label map
+ * carries a link-origin entry under `[UI]`. A value write reaching a path
+ * the stored label map reaches is refused unless something names the schema
+ * it was authored against, and that refusal reads `missing schema
+ * write-policy input`.
+ *
+ * The dials are the shell's (`packages/lib-shell/src/runtime.ts`), stated
+ * rather than inherited because the refusal is the subject. The runner's own
+ * flow-label default is `off`, and under `off` a transaction carrying only
+ * raw value writes is never CFC-relevant, so the report commits without the
+ * boundary looking at it.
+ *
+ * A wish-state document is addressed by a content-derived id, so a
+ * throwaway runtime is what learns the address the cases then seed.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { defer } from "@commonfabric/utils/defer";
+import { resolveLink } from "../src/link-resolution.ts";
+import { type JSONSchema, UI } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase(
+  "wish failure report write policy",
+);
+const space = signer.did();
+
+/** The requested wish view: one labeled field, as the profile consumer view. */
+const profileViewSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    name: { type: "string", ifc: { confidentiality: ["secret"] } },
+  },
+} as JSONSchema;
+
+const altProfileViewSchema: JSONSchema = {
+  type: "string",
+  ifc: { confidentiality: ["other"] },
+} as JSONSchema;
+
+/**
+ * The stored envelope that refuses the wish's own state commit: TWO
+ * ifc-carrying branches under `/result` is the ambiguity
+ * `assertNoDivergentIfcBranches` refuses when a later writer's candidate
+ * merges with it.
+ *
+ * The two variants are the two shapes a wish-state document is found in. The
+ * first declares the report's own fields, as the real wish-state schema
+ * does, and holds the `cf-cell-link` a resolved wish emits — so its stored
+ * label map reaches `[UI]` and the report needs a name for what it writes.
+ * The second says nothing about those fields, so the label map does not
+ * reach them and the report needs no name; it is there because a report that
+ * needs no name must not be refused for offering one.
+ */
+const ambiguousWishShapedSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    result: { anyOf: [profileViewSchema, altProfileViewSchema] },
+    candidates: { type: "array", items: profileViewSchema },
+    error: true,
+    [UI]: true,
+  },
+} as JSONSchema;
+
+const ambiguousSchemaSilentAboutTheReport: JSONSchema = {
+  type: "object",
+  properties: {
+    result: { anyOf: [profileViewSchema, altProfileViewSchema] },
+    candidates: { type: "array", items: profileViewSchema },
+  },
+} as JSONSchema;
+
+describe("wish commit-failure reporting", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  const makeRuntime = () => {
+    const manager = StorageManager.emulate({ as: signer });
+    return {
+      manager,
+      runtime: new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager: manager,
+        // The two rungs every case here reads: `persist` is what makes a
+        // transaction of raw value writes CFC-relevant, and
+        // `enforce-explicit` is what turns a prepare reason into a refused
+        // commit.
+        cfcFlowLabels: "persist",
+        cfcEnforcementMode: "enforce-explicit",
+      }),
+    };
+  };
+
+  beforeEach(() => {
+    const made = makeRuntime();
+    storageManager = made.manager;
+    runtime = made.runtime;
+  });
+
+  afterEach(async () => {
+    await runtime.idle();
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  /** Point the space cell's `/secret` at a document carrying a labeled name. */
+  const seedWishTarget = async (rt: Runtime, name: string) => {
+    const spaceCell = rt.getCell<{ secret?: unknown }>(space, space);
+    await spaceCell.pull();
+    const tx = rt.edit();
+    const target = rt.getCell(space, "wish-target", profileViewSchema, tx);
+    target.set({ name });
+    spaceCell.withTx(tx).key("secret").set(target.withTx(tx));
+    rt.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await rt.idle();
+  };
+
+  /** Run the wish and hand back the document its state lives in. */
+  const runWish = async (rt: Runtime) => {
+    const { commonfabric } = createTrustedBuilder(rt);
+    const { wish, pattern } = commonfabric;
+    const tx = rt.edit();
+    const wishPattern = pattern(() => ({
+      secretWish: wish({
+        query: "/secret",
+        schema: profileViewSchema as Record<string, unknown>,
+      }),
+    }));
+    const resultCell = rt.getCell<{ secretWish?: unknown }>(
+      space,
+      "wish failure report result",
+      undefined,
+      tx,
+    );
+    const result = rt.run(tx, wishPattern, {}, resultCell);
+    rt.prepareTxForCommit(tx);
+    await tx.commit();
+    await result.pull().catch(() => {});
+    await rt.idle();
+    const readTx = rt.edit();
+    const resolved = resolveLink(
+      rt,
+      readTx,
+      result.key("secretWish").getAsNormalizedFullLink(),
+    );
+    readTx.abort();
+    return { id: resolved.id, scope: resolved.scope };
+  };
+
+  /** The paths the document's stored label map carries entries at. */
+  const storedLabelPaths = (
+    rt: Runtime,
+    doc: { id: string; scope: string | undefined },
+  ): string[][] => {
+    const tx = rt.edit();
+    const stored = tx.read({
+      space,
+      id: doc.id,
+      scope: doc.scope,
+      type: "application/json",
+      path: ["cfc"],
+    } as never);
+    tx.abort();
+    const entries =
+      (stored.ok?.value as { labelMap?: { entries?: { path: string[] }[] } })
+        ?.labelMap?.entries ?? [];
+    return entries.map((entry) => entry.path);
+  };
+
+  const stateCellAt = (
+    rt: Runtime,
+    doc: { id: string; scope: string | undefined },
+  ) =>
+    rt.getCellFromLink(
+      { id: doc.id, space, scope: doc.scope, path: [] } as never,
+      undefined,
+      undefined,
+    );
+
+  it("persists a link-origin label entry under `[UI]` when a wish resolves", async () => {
+    await seedWishTarget(runtime, "classified");
+    const doc = await runWish(runtime);
+
+    expect(
+      storedLabelPaths(runtime, doc).some((path) => path[0] === UI),
+    ).toBe(true);
+  });
+
+  /**
+   * Seed the state document with an envelope the wish's own candidate cannot
+   * merge with, run the wish against it, and hand back what the document
+   * reads once the refusal has been reported.
+   */
+  const refusedWishReport = async (
+    seedSchema: JSONSchema,
+    withUILink: boolean,
+  ) => {
+    // Learn the state document's address: it is derived from the space, the
+    // pattern and the result cell, so a throwaway runtime names the same one.
+    const discovery = makeRuntime();
+    let doc: { id: string; scope: string | undefined };
+    try {
+      await seedWishTarget(discovery.runtime, "classified");
+      doc = await runWish(discovery.runtime);
+    } finally {
+      await discovery.runtime.idle();
+      await discovery.runtime.dispose();
+      await discovery.manager.close();
+    }
+
+    await seedWishTarget(runtime, "classified");
+    {
+      const tx = runtime.edit();
+      const linked = runtime.getCell(
+        space,
+        "wish-ui-link-source",
+        profileViewSchema,
+        tx,
+      );
+      linked.set({ name: "classified" });
+      const state = runtime.getCellFromLink(
+        { id: doc.id, space, scope: doc.scope, path: [] } as never,
+        seedSchema,
+        tx,
+      );
+      state.set({
+        result: { name: "Bob" },
+        candidates: [{ name: "Bob" }],
+        ...(withUILink
+          ? {
+            [UI]: {
+              type: "vnode",
+              name: "cf-cell-link",
+              props: { $cell: linked.withTx(tx) },
+              children: [],
+            },
+          }
+          : {}),
+      });
+      runtime.prepareTxForCommit(tx);
+      expect((await tx.commit()).error).toBeUndefined();
+      await runtime.idle();
+    }
+
+    // The report ends one of two ways, and each announces itself: the
+    // document gains an `error`, or the surfacing gives up and prints
+    // "Can't report …". Waiting on both is what makes the failing run say
+    // which happened instead of never returning. Neither wait has a timer
+    // under it — the surfacing chain is deliberately untracked by the
+    // scheduler, so `idle()` can return a beat before the report lands.
+    const settled = defer<void>();
+    const reports: string[] = [];
+    const realConsoleError = console.error;
+    console.error = (...args: unknown[]) => {
+      // Render the reason a commit rejection carries: it arrives as a plain
+      // record rather than an Error, and `String()` on it says nothing.
+      const line = args.map((arg) =>
+        typeof arg === "object" && arg !== null && "message" in arg
+          ? String((arg as { message: unknown }).message)
+          : String(arg)
+      ).join(" ");
+      reports.push(line);
+      if (line.includes("Can't report")) settled.resolve();
+    };
+    const state = stateCellAt(runtime, doc);
+    const readState = () =>
+      state.get() as {
+        error?: unknown;
+        result?: unknown;
+        candidates?: unknown;
+        [key: string]: unknown;
+      } | undefined;
+    const cancel = state.sink(() => {
+      if (readState()?.error !== undefined) settled.resolve();
+    });
+    try {
+      await runWish(runtime);
+      await settled.promise;
+      await runtime.idle();
+      return { doc, reports, value: readState() ?? {} };
+    } finally {
+      cancel();
+      console.error = realConsoleError;
+    }
+  };
+
+  it("lands a refusal on the state document rather than only on the console", async () => {
+    const { doc, reports, value } = await refusedWishReport(
+      ambiguousWishShapedSchema,
+      true,
+    );
+    // First, because it names what went wrong when it goes wrong: the
+    // console fallback is where the reason goes when the report is refused.
+    expect(reports.filter((line) => line.includes("Can't report"))).toEqual([]);
+    expect(String(value.error)).toMatch(/divergent anyOf|commit-prep/);
+    expect(value[UI]).toBeDefined();
+    // The report carries the refusal and nothing else. The wish resolved
+    // "classified" and its write of that was refused; the document still
+    // reads what stood there before, so no part of the refused write rode
+    // outward inside the account of its refusal.
+    expect(value.result).toEqual({ name: "Bob" });
+    expect(value.candidates).toEqual([{ name: "Bob" }]);
+    // Nor did the report launder the document's labels. It replaces the
+    // `[UI]` subtree, so the entries describing the link that used to sit
+    // there go with the value they described; every entry at a path the
+    // report does not write stands.
+    const labelled = storedLabelPaths(runtime, doc);
+    expect(labelled).toContainEqual(["result", "name"]);
+    expect(labelled).toContainEqual(["candidates", "0"]);
+    expect(labelled.filter((path) => path[0] === UI)).toEqual([]);
+  });
+
+  it("lands a refusal on a document whose stored envelope says nothing about the report's own fields", async () => {
+    // The report names a schema for the fields it writes. That name must not
+    // drag the write into a merge with the stored envelope, because the merge
+    // reads that envelope — and the envelope refusing the wish is exactly the
+    // one a report follows.
+    const { reports, value } = await refusedWishReport(
+      ambiguousSchemaSilentAboutTheReport,
+      false,
+    );
+    expect(reports.filter((line) => line.includes("Can't report"))).toEqual([]);
+    expect(String(value.error)).toMatch(/divergent anyOf|commit-prep/);
+    expect(value[UI]).toBeDefined();
+    expect(value.result).toEqual({ name: "Bob" });
+  });
+});


### PR DESCRIPTION
PROBLEM

When a wish's state commit is refused by the commit boundary, the wish writes the reason into its own state document so the surface shows it instead of silently never mounting. That write is refused too. A resolved wish emits a `cf-cell-link` as its `[UI]`, whose `$cell` prop is a link to the wished-for cell, so the document's stored label map carries a link-origin entry under `[UI]`. A value write reaching a path the stored label map reaches is refused unless something names the schema it was authored against, and the report wrote raw values naming nothing:

    CFC enforcement rejected commit: relevant transaction was not
    prepared: missing schema write-policy input for of:fid1:RWYYYl9t...

The reason then reaches `console.error` and nowhere else, once per scheduler retry, while the surface stays blank. An error-reporting channel refused by the conditions it reports on fails exactly when it is needed.

SOLUTION

The report names the schema each of its two fields is authored against: `true` at `error` and at `[UI]`, which is what the wish-state schema says at both paths. It declares nothing, so a stored claim at either path is not checked against this write, and every other commit-boundary decision runs on the transaction unchanged.

Naming alone leaves the report in the schema merge, whose entry assert reads the stored envelope — and an envelope that refuses a wish is the one a report follows. So the merge-skip decision now covers a candidate that declares nothing: JSON Schema `true`, or the empty object `getSchemaAtPath` returns for it. Folding such a candidate in leaves the stored envelope as it stands, and running the merge only exposes the writer to that envelope's own defects.

A suite drives the real wish under the shell's dials against a stored envelope the wish's own candidate cannot merge with, and pins that the reason lands on the document rather than only on the console, that the refused wish's own value does not land with it, and that every label entry at a path the report does not write stands.

DESIGN DISCUSSION

Under the runner's default `cfcFlowLabels: "off"` a transaction carrying only raw value writes is never CFC-relevant, so the report commits without the boundary looking at it. The shell runs `persist` (`packages/lib-shell/src/runtime.ts`), which is why this reaches a deployment and no test before this one.

Two mechanisms in the tree already carry a runtime-authored write past gating meant for pattern-authored ones, and neither fits. The privileged system-write scope suppresses the recorders for writes to a document's `["cfc"]` label map and to the meta seam, and the per-write identity capture; the schema write-policy requirement is decided in `valueWriteTargets`, which selects by document id and raw path rather than by that scope, so a report written inside it meets the same refusal. That scope is also ECMAScript-private to the transaction class and unreachable from a builtin. `Runtime.prepareTxForCommit` decides what a transaction's commit needs from the transaction's own state, and which two fields the wish's error channel writes is the wish builtin's knowledge. Recording a write-policy input beside the write is not a third mechanism; it is the one the gate reads, and the one `runner.ts`, `runtime-owned-store.ts` and `cell.ts` already use.

The merge-skip rule takes two guards, each of which fails open without them. A stored `additionalProperties` claim governs every key the stored side does not name, and the merge is what pulls it down onto a key the candidate names, so a candidate key absent from the stored properties is covered only where no such claim stands; without that, a write lands with no label at all. And a stored `false` admits no value, so there is nothing to fold into: `mergeCfcSchemaEnvelopes` refuses that form, and the rule holds only against a stored schema that admits values. The reading of "declares nothing" is also narrower than `cfcSchemaIsTrue`, which admits a schema whose only keys are `ifc`, `asCell`, `asStream`, `scope`, `default` or `$defs`; each of those carries something the merge folds in.

What stops a refused wish write from riding outward inside a report: the transaction is created inside the reporting function, carries exactly the two writes it makes, and is prepared and committed there; the refused wish's transaction is a separate object that has already settled, and the only thing carried across is the message string. The requirement itself is decided per document rather than per path, so a candidate recorded for one path lifts it for every path on that document — what bounds the report is its transaction's contents. Measured on the reproduction the suite carries: after the report lands, the stored label map loses only the entries under the `[UI]` subtree it overwrote, while the declared confidentiality at `/result/name` and the link entry at `/candidates/0` both stand.

Measured before the change, on that same reproduction: the wish's state commit is refused, the report is refused with `missing schema write-policy input`, and the "Can't report ... in the surface it belongs to" line is printed ten times, the reactive retry budget, while the document's `error` field stays absent.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

