### PR TITLE
feat(ci): the topology declares the suites a lane runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,8 @@ If you are developing runtime code, start with:
   poll is the honest tool
 - `docs/development/COVERAGE.md` - The two coverage mechanisms (V8 runtime
   coverage and transformer-based pattern coverage), which CI job collects which,
-  and why the pattern integration jobs do not set `CF_PATTERN_COVERAGE_DIR`
+  and why only one of the two pattern integration arms collects authored-pattern
+  coverage
 - `docs/development/debugging/` - Runtime errors, type errors, and
   troubleshooting
 - `docs/development/DEPENDENCIES.md` - Adding and rolling dependencies, required

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -15,8 +15,9 @@ directly, so Deno's built-in V8 coverage can record which of their lines ran. A
 CI job turns this on by setting the `DENO_COVERAGE_DIR` environment variable.
 After the tests finish, `tasks/write-coverage-lcov.ts` converts the raw V8
 profile into an LCOV file, and the job uploads it as a `coverage-profile-*`
-artifact. Most test jobs set `DENO_COVERAGE_DIR`, including both pattern
-integration jobs.
+artifact. Most test jobs set `DENO_COVERAGE_DIR`. The pattern and package
+integration jobs do; the two that run the opposite server-execution arm do
+not.
 
 A focused `*.browser.test.ts` file run through `deno-web-test` executes its
 application module inside Chrome. That browser execution proves DOM behavior,
@@ -953,6 +954,13 @@ The pattern unit job runs each `packages/patterns/**/*.test.tsx` file through
 `cf test` in-process. The two integration jobs run browser-driven `deno test`
 files against a running Toolshed server. Both kinds of authored-pattern coverage
 feed the same gated metric.
+
+The pattern integration job runs in two server-execution arms, and only the
+arm with the flag off collects authored-pattern coverage. The instrumentation
+records what the browser's runtime worker compiles, which is the whole of what
+ran only where that worker is the sole compiler; the arm with server execution
+on has a second compiler on the server. The arm with it off measures the same
+pattern files, so nothing goes unmeasured.
 
 The compile byte cache is available to `cf test` through
 `CF_COMPILE_CACHE_FILE`. Coverage and non-coverage compiles use different cache

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -16,8 +16,8 @@ CI job turns this on by setting the `DENO_COVERAGE_DIR` environment variable.
 After the tests finish, `tasks/write-coverage-lcov.ts` converts the raw V8
 profile into an LCOV file, and the job uploads it as a `coverage-profile-*`
 artifact. Most test jobs set `DENO_COVERAGE_DIR`. The pattern and package
-integration jobs do; the two that run the opposite server-execution arm do
-not.
+integration jobs set it. The two workflow jobs running the opposite
+server-execution arm set none.
 
 A focused `*.browser.test.ts` file run through `deno-web-test` executes its
 application module inside Chrome. That browser execution proves DOM behavior,

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -386,14 +386,14 @@ table is the migration's checklist.
 | `pattern-compat` | `Pattern Update Compatibility (1..3)` | — | `deno` |
 | `pattern-vintage` | `Pattern Update State and Baseline Integrity` | — | `deno`, `git-history` |
 | `generated-patterns` | `Generated Patterns Integration Tests (1..2)` | — | `deno`, `compile-cache` |
-| `package-integration` | `Package Integration Tests (3 suites)` | — | `deno`, `toolshed`, `browser` |
+| `package-integration` | `Package Integration Tests (3 suites)` | — | `deno`, `toolshed-baked`, `browser` |
 | `package-integration-opposite` | the posture opposite the server-execution default | resolved arm variant | `deno`, `toolshed-baked-opposite`, `browser` |
 | `deployed-topology` | the background-service and cf-harness default-posture gates | — | `deno`, `toolshed`, `bg-piece-service-binary` |
 | `cli-core` | `CLI Integration Tests (3 suites)` | — | `deno`, `toolshed`, `cf`, `jq` |
 | `cli-fuse` | the FUSE steps of the third CLI suite | — | `deno`, `toolshed`, `cf`, `fuse` |
 | `cli-deno` | the Deno-based CLI integration step | — | `deno`, `toolshed`, `cf` |
-| `pattern-integration` | `Pattern Integration Tests (1..10)` | — | `deno`, `toolshed`, `browser`, `compile-cache` |
-| `pattern-integration-opposite` | the posture opposite the server-execution default | resolved arm variant | `deno`, `toolshed-baked-opposite`, `browser` |
+| `pattern-integration` | `Pattern Integration Tests (1..10)` | — | `deno`, `toolshed-baked`, `browser`, `compile-cache` |
+| `pattern-integration-opposite` | the posture opposite the server-execution default | resolved arm variant | `deno`, `toolshed-baked-opposite`, `browser`, `compile-cache` |
 | `pattern-reload` | `Pattern Reload Integration Tests` | — | `deno`, `local-dev-servers`, `browser` |
 | `pattern-unit` | `Pattern Unit Tests (1..4)` | — | `deno`, `cf`, `compile-cache` |
 | `binaries` | the compile inside `Build Binary (toolshed)` and the two beside it | — | `deno` |
@@ -1037,7 +1037,8 @@ from source with `deno run` skips both. The dependency graph is already in
 the Deno cache that the `deno` capability restores, so starting from
 source costs a few seconds. The full run on `main` keeps the
 compiled-binary path, because it needs the binary anyway for attestation
-and deployment.
+and deployment. A suite that only talks to the server's API takes this
+one, which is why the CLI suites and the deployed-topology gates do.
 
 **The baked capabilities cannot.** The browser shell is a bundle compiled
 into the binary, so a server run from source answers the API and serves no

--- a/tasks/test-topology.test.ts
+++ b/tasks/test-topology.test.ts
@@ -1,4 +1,6 @@
 import { expect } from "@std/expect";
+import { parse as parseJsonc } from "@std/jsonc";
+import * as path from "@std/path";
 import { describe, it } from "@std/testing/bdd";
 import {
   capabilitiesBySuite,
@@ -11,14 +13,88 @@ import {
 import { CAPABILITIES } from "./ci-capabilities.ts";
 import { serverExecutionCiLane } from "./server-execution-ci.ts";
 
-const suites = await loadTopology(
-  new URL("..", import.meta.url).pathname.replace(/\/$/, ""),
-);
+const root = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const suites = await loadTopology(root);
+
+/** The Deno subcommands a suite's runner is allowed to be. */
+const SUBCOMMANDS = new Set(["task", "test", "run", "check", "fmt", "lint"]);
+
+/** The task names the manifest in a directory defines, if it has one. */
+async function tasksOf(dir: string): Promise<Set<string>> {
+  for (const name of ["deno.json", "deno.jsonc"]) {
+    const text = await Deno.readTextFile(path.join(dir, name)).catch(
+      () => undefined,
+    );
+    if (text === undefined) continue;
+    const manifest = parseJsonc(text) as { tasks?: Record<string, unknown> };
+    return new Set(Object.keys(manifest.tasks ?? {}));
+  }
+  return new Set();
+}
 
 describe("the test topology", () => {
   it("names each suite once", () => {
     const ids = suites.map((suite) => suite.id);
     expect(ids.length).toBe(new Set(ids).size);
+  });
+
+  it("names a task every manifest it runs in defines", async () => {
+    // `deno fmt` and `deno lint` are subcommands rather than tasks of this
+    // repository, and a command asking for one as a task prints the list
+    // of tasks that do exist and exits one. A lane reports that the way it
+    // reports any failed unit, by exiting one itself, with no failing test
+    // under it to say what broke. So every task a suite runs is held to
+    // being one Deno can find: defined where the command runs, or in the
+    // root manifest, which is where Deno looks next.
+
+    const outputDir = await Deno.makeTempDir({ prefix: "topology-commands-" });
+    const rootTasks = await tasksOf(root);
+    const missing: string[] = [];
+    const named: string[] = [];
+    for (const suite of suites) {
+      const requests = suite.units.map((unit) => ({ unit, skip: [] }));
+      for (
+        const invocation of await suite.command(requests, {
+          root,
+          outputDir,
+          baseRef: "origin/main",
+        })
+      ) {
+        // A suite whose runner is a script of its own runs no Deno
+        // subcommand and names no task.
+        if (invocation.command[0] !== Deno.execPath()) continue;
+        // What the command runs, which for a gate is what the recorder
+        // was handed rather than the recorder's own task.
+        const separator = invocation.command.indexOf("--");
+        const run = separator < 0
+          ? invocation.command.slice(1)
+          : invocation.command.slice(separator + 2);
+        if (!SUBCOMMANDS.has(run[0]!)) {
+          missing.push(`${suite.id}: ${run[0]} is no subcommand of Deno`);
+          continue;
+        }
+        if (run[0] !== "task") continue;
+        named.push(run[1]!);
+        const where = invocation.cwd ?? root;
+        const local = await tasksOf(where);
+        if (!local.has(run[1]!) && !rootTasks.has(run[1]!)) {
+          missing.push(`${suite.id}: no task named ${run[1]} in ${where}`);
+        }
+      }
+    }
+    await Deno.remove(outputDir, { recursive: true });
+    expect(missing).toEqual([]);
+
+    // A run that read nothing satisfies the check above, and so does one
+    // that stopped at the recorder instead of reaching what the recorder
+    // was handed. Every gate whose name begins `check-` runs a task of
+    // that name, so the two counts agree only where each of them was
+    // reached and read past the recorder.
+    const gates = ["repo-gates", "repo-history-gates"]
+      .flatMap((id) => suiteById(suites, id)!.units)
+      .filter((unit) => unit.startsWith("check-"));
+    expect(named.filter((task) => task.startsWith("check-")).toSorted())
+      .toEqual(gates.toSorted());
   });
 
   it("asks only for capabilities the registry declares", () => {

--- a/tasks/test-topology/deno-task.test.ts
+++ b/tasks/test-topology/deno-task.test.ts
@@ -4,6 +4,7 @@ import {
   memberTasks,
   memberTestFiles,
   parseTestTask,
+  taskEnvironment,
   unquote,
 } from "./deno-task.ts";
 
@@ -89,6 +90,56 @@ describe("reading a member's test task", () => {
   it("refuses a task that is not a deno test at all", () => {
     expect(parseTestTask("deno run test/runner.ts")).toBeUndefined();
     expect(parseTestTask("echo 'No tests defined.'")).toBeUndefined();
+  });
+});
+
+describe("reading the environment a task sets", () => {
+  it("takes the assignments standing before the command", async () => {
+    const dir = await member({
+      tasks: { integration: "LOG_LEVEL=warn TEST_HTTP=1 deno test -A" },
+    });
+    expect(await taskEnvironment(dir, "integration")).toEqual({
+      LOG_LEVEL: "warn",
+      TEST_HTTP: "1",
+    });
+  });
+
+  it("answers for a command the test-task parser declines", async () => {
+    // Every `integration` task in the workspace names a shell variable
+    // among its flags, and a shell variable is a metacharacter that
+    // `parseTestTask` stops at. The environment is readable regardless,
+    // and it is the whole of what the suites want from these tasks.
+
+    const command =
+      'LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS "./integration/*.test.ts"';
+    expect(parseTestTask(command)).toBeUndefined();
+    const dir = await member({ tasks: { integration: command } });
+    expect(await taskEnvironment(dir, "integration")).toEqual({
+      LOG_LEVEL: "warn",
+    });
+  });
+
+  it("stops at the command, so a later argument is not environment", async () => {
+    const dir = await member({
+      tasks: { integration: "deno test -A --env=LOG_LEVEL=debug" },
+    });
+    expect(await taskEnvironment(dir, "integration")).toEqual({});
+  });
+
+  it("gives nothing for a task the manifest does not define", async () => {
+    const dir = await member({ tasks: { test: "deno test" } });
+    expect(await taskEnvironment(dir, "integration")).toEqual({});
+  });
+
+  it("reads a task written as an object with dependencies", async () => {
+    const dir = await member({
+      tasks: {
+        integration: { command: "LOG_LEVEL=warn deno test", dependencies: [] },
+      },
+    });
+    expect(await taskEnvironment(dir, "integration")).toEqual({
+      LOG_LEVEL: "warn",
+    });
   });
 });
 

--- a/tasks/test-topology/deno-task.ts
+++ b/tasks/test-topology/deno-task.ts
@@ -295,6 +295,33 @@ async function readTasks(
 }
 
 /**
+ * The environment a named task sets, from the assignments standing
+ * before its command. A task the manifest does not define, and a task
+ * setting nothing, both give an empty environment.
+ *
+ * This reads only the assignments, so it answers for a task whose
+ * command {@link parseTestTask} declines — every `integration` task in
+ * the workspace names a shell variable in its flags, which is a
+ * metacharacter that parser stops at.
+ */
+export async function taskEnvironment(
+  memberDir: string,
+  name: string,
+): Promise<Record<string, string>> {
+  const tasks = await readTasks(memberDir);
+  const task = tasks[name];
+  const command = typeof task === "string" ? task : task?.command;
+  if (command === undefined) return {};
+  const env: Record<string, string> = {};
+  for (const word of command.trim().split(/\s+/)) {
+    const assignment = ASSIGNMENT.exec(word);
+    if (assignment === null) break;
+    env[assignment[1]!] = unquote(assignment[2]!);
+  }
+  return env;
+}
+
+/**
  * A member's test tasks as the topology needs them.
  *
  * The Deno-only half is `deno-test` where a member names one and `test`

--- a/tasks/test-topology/gates.test.ts
+++ b/tasks/test-topology/gates.test.ts
@@ -238,6 +238,28 @@ describe("the repository's gate suites", () => {
     expect(invocation!.cwd).toBe("/repo");
   });
 
+  it("runs the two Deno subcommands as subcommands", async () => {
+    // `fmt` and `lint` are subcommands of Deno rather than tasks this
+    // repository defines, so a command asking for either as a task
+    // prints the list of tasks that do exist and exits one. The tail of
+    // the command line is what the recorder runs, and it is the whole of
+    // what decides this.
+
+    const suite = byId("repo-gates");
+    for (
+      const [unit, run] of [
+        ["deno-fmt", ["fmt", "--check"]],
+        ["deno-lint", ["lint"]],
+      ] as const
+    ) {
+      const [invocation] = await suite.command([{ unit, skip: [] }], context);
+      expect(invocation!.command.slice(-run.length - 1)).toEqual([
+        Deno.execPath(),
+        ...run,
+      ]);
+    }
+  });
+
   it("gives a gate that compares against a base the base to use", async () => {
     const [invocation] = await byId("repo-history-gates").command(
       [{ unit: "check-test-aliases", skip: [] }],

--- a/tasks/test-topology/gates.ts
+++ b/tasks/test-topology/gates.ts
@@ -39,10 +39,10 @@ export interface Gate {
   /** The record kind, which is `gate` for all but formatting and linting. */
   kind: string;
 
-  /** The task that runs it. */
-  task: string;
+  /** What runs it, as the arguments Deno takes beyond its own path. */
+  run: readonly string[];
 
-  /** Arguments the task takes beyond its own. */
+  /** Further arguments, for a gate that reads the base revision. */
   args?: (context: { baseRef: string }) => string[];
 
   /** Where it runs, repository-relative, when that is not the root. */
@@ -75,22 +75,21 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "deno-fmt",
     kind: "format",
-    task: "fmt",
-    args: () => ["--check"],
+    run: ["fmt", "--check"],
     // Reads every file the root configuration does not exclude.
     reachedBy: [],
   },
   {
     name: "deno-lint",
     kind: "lint",
-    task: "lint",
+    run: ["lint"],
     // The same, over the extensions the linter opens.
     reachedBy: [],
   },
   {
     name: "check-test-topology",
     kind: "gate",
-    task: "check-test-topology",
+    run: ["task", "check-test-topology"],
     // Walks every tree this repository keeps source in for anything
     // that looks like a test, and holds the topology to what it finds.
     // The topology enumerates from those same trees, so a set stated
@@ -101,7 +100,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-skill-facts",
     kind: "gate",
-    task: "check-skill-facts",
+    run: ["task", "check-skill-facts"],
     // Holds every path a skill, an `AGENTS.md` or a rule cites to
     // resolving against the tree, so a file moved or removed anywhere
     // can fail it.
@@ -110,7 +109,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-tripwires",
     kind: "gate",
-    task: "check-tripwires",
+    run: ["task", "check-tripwires"],
     // Probes the weakness each tripwire asserts is still present, and
     // reads the test file carrying the same assertion. A tripwire added
     // against another package widens this list.
@@ -123,7 +122,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-docs",
     kind: "gate",
-    task: "check-docs",
+    run: ["task", "check-docs"],
     // The documents holding the blocks, and the import map they
     // compile through. The historical tree is walked past: those blocks
     // reflect the API of their era. A block also compiles against this
@@ -134,13 +133,13 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-docs-history-index",
     kind: "gate",
-    task: "check-docs-history-index",
+    run: ["task", "check-docs-history-index"],
     reachedBy: ["docs/history/", "tasks/check-docs-history-index.ts"],
   },
   {
     name: "check-no-waitfor",
     kind: "gate",
-    task: "check-no-waitfor",
+    run: ["task", "check-no-waitfor"],
     // The `integration` directories under `packages`, less the package
     // declaring the polling helper, which is out of the check's scope.
     reachedBy: [
@@ -152,7 +151,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-conflict-markers",
     kind: "gate",
-    task: "check-conflict-markers",
+    run: ["task", "check-conflict-markers"],
     // Reads every tracked file: a marker left behind is a mistake
     // wherever it lands.
     reachedBy: [],
@@ -160,7 +159,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-control-characters",
     kind: "gate",
-    task: "check-control-characters",
+    run: ["task", "check-control-characters"],
     // The same, over every tracked file the extension list does not
     // call binary.
     reachedBy: [],
@@ -168,7 +167,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-verb-session-sync",
     kind: "gate",
-    task: "check-verb-session-sync",
+    run: ["task", "check-verb-session-sync"],
     reachedBy: [
       "docs/common/verbs/",
       "docs/common/workflows/",
@@ -179,7 +178,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-pattern-tiers",
     kind: "gate",
-    task: "check-pattern-tiers",
+    run: ["task", "check-pattern-tiers"],
     // The pattern sources, the tier tables, and the collector deciding
     // which files take a marker at all. The baselines are data beside
     // the patterns and carry no marker.
@@ -194,7 +193,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-unused-deps",
     kind: "gate",
-    task: "check-unused-deps",
+    run: ["task", "check-unused-deps"],
     // Reads every tracked code file, since the import that justifies a
     // declared dependency can sit in any of them.
     reachedBy: [],
@@ -202,7 +201,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-deno-pins",
     kind: "gate",
-    task: "check-deno-pins",
+    run: ["task", "check-deno-pins"],
     reachedBy: [
       ".github/actions/deno-setup/action.yml",
       "Dockerfile.dashboard",
@@ -215,19 +214,19 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-action-pins",
     kind: "gate",
-    task: "check-action-pins",
+    run: ["task", "check-action-pins"],
     reachedBy: [".github/", "tasks/check-action-pins.ts"],
   },
   {
     name: "check-single-copy-deps",
     kind: "gate",
-    task: "check-single-copy-deps",
+    run: ["task", "check-single-copy-deps"],
     reachedBy: ["deno.lock", "tasks/check-single-copy-deps.ts"],
   },
   {
     name: "check-package-cycles",
     kind: "gate",
-    task: "check-package-cycles",
+    run: ["task", "check-package-cycles"],
     // Reads every production module under `packages/` for its imports,
     // which is most of the repository, and no smaller part of it
     // decides the verdict.
@@ -236,7 +235,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-local-program",
     kind: "gate",
-    task: "check-local-program",
+    run: ["task", "check-local-program"],
     // Reads every tracked TypeScript file, since the resolver it looks
     // for can be named from any of them.
     reachedBy: [],
@@ -244,7 +243,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-completion-slots",
     kind: "gate",
-    task: "check-completion-slots",
+    run: ["task", "check-completion-slots"],
     // The command tree it walks and the two provider tables it
     // subtracts against.
     reachedBy: [
@@ -256,7 +255,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-command-docs",
     kind: "gate",
-    task: "check-command-docs",
+    run: ["task", "check-command-docs"],
     // The command tree and the shuttle verbs, against the documents
     // that could describe them: the documentation tree less the two
     // parts of it no live document sits in, the authored skills, and
@@ -276,7 +275,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-cfc-types",
     kind: "gate",
-    task: "check-cfc-types",
+    run: ["task", "check-cfc-types"],
     cwd: "packages/static",
     reachedBy: [
       "packages/api/",
@@ -287,7 +286,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-commonfabric-types",
     kind: "gate",
-    task: "check-commonfabric-types",
+    run: ["task", "check-commonfabric-types"],
     cwd: "packages/static",
     // The pattern API and the workspace modules it re-exports, whose
     // text this one inlines.
@@ -301,7 +300,7 @@ export const WORKING_TREE_GATES: readonly Gate[] = [
   {
     name: "check-withheld-globals",
     kind: "gate",
-    task: "check-withheld-globals",
+    run: ["task", "check-withheld-globals"],
     cwd: "packages/static",
     // The type libraries, and the sandbox contract naming the globals
     // to be stripped from them.
@@ -322,7 +321,7 @@ export const HISTORY_GATES: readonly Gate[] = [
   {
     name: "check-baselines-append-only",
     kind: "gate",
-    task: "check-baselines-append-only",
+    run: ["task", "check-baselines-append-only"],
     args: ({ baseRef }) => [baseRef],
     // The baselines. A deleted pattern file is what excuses deleting
     // the baselines beside it, so it can turn this gate's verdict from
@@ -337,7 +336,7 @@ export const HISTORY_GATES: readonly Gate[] = [
   {
     name: "check-test-aliases",
     kind: "gate",
-    task: "check-test-aliases",
+    run: ["task", "check-test-aliases"],
     args: ({ baseRef }) => [baseRef],
     // The file, and the module holding the line format it parses and
     // the graph rules it applies; the task itself is a `git show`
@@ -401,8 +400,7 @@ function gateSuite(
             gate.name,
             "--",
             Deno.execPath(),
-            "task",
-            gate.task,
+            ...gate.run,
             ...gate.args?.({ baseRef }) ?? [],
           ],
           cwd: gate.cwd === undefined

--- a/tasks/test-topology/package-integration.test.ts
+++ b/tasks/test-topology/package-integration.test.ts
@@ -1,0 +1,103 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { serverExecutionCiLane } from "../server-execution-ci.ts";
+import type {
+  ServerExecutionOnSkip,
+  ServerExecutionSuite,
+} from "../server-execution-on-skips.ts";
+import { loadPackageIntegrationSuites } from "./package-integration.ts";
+import { type Suite, unavailableUnits } from "./suite.ts";
+
+const root = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
+
+/** The suites as they stand with a stated first-party default. */
+async function suitesWith(
+  defaultEnabled: boolean,
+  skips: Record<ServerExecutionSuite, ServerExecutionOnSkip[]> = {
+    patterns: [],
+    runner: [],
+    "runtime-client": [],
+    shell: [],
+  },
+): Promise<Suite[]> {
+  return await loadPackageIntegrationSuites(root, defaultEnabled, skips);
+}
+
+/** One suite by name, from a set. */
+function byId(suites: readonly Suite[], id: string): Suite {
+  return suites.find((suite) => suite.id === id)!;
+}
+
+describe("the package integration suites", () => {
+  it("gives each arm the server that arm needs", async () => {
+    // The opposite arm is a compile-time define baked into the browser
+    // shell inside a binary, which a server run from source cannot
+    // reproduce. Naming a capability is how a suite says which of the two
+    // it needs without either the workflow or the other suites knowing
+    // that there are two.
+
+    const suites = await suitesWith(serverExecutionCiLane("default").enabled);
+    // Both arms take a compiled binary. The shell's tests drive a browser
+    // at the server, and the shell is a bundle inside the binary; the
+    // opposite arm needs one for a second reason, its posture being a
+    // define baked into that same shell.
+    expect(byId(suites, "package-integration").needs).toContain(
+      "toolshed-baked",
+    );
+    expect(byId(suites, "package-integration-opposite").needs).toContain(
+      "toolshed-baked-opposite",
+    );
+    expect(byId(suites, "package-integration").variant).toBeUndefined();
+  });
+
+  it("carries the ON-arm skip list on whichever arm resolves ON", async () => {
+    // The skip list belongs to the arm that is ON rather than to a role, so
+    // a flip of the first-party default moves it between the two suites. A
+    // list that stayed with one of them would take tests out of the arm
+    // that can run them and leave them in the arm that cannot. The list is
+    // stated here rather than read from the repository, which holds an
+    // empty one whenever the ON arm is complete.
+
+    const file = "packages/runner/integration/reconnection.test.ts";
+    const skips = {
+      patterns: [],
+      runner: [{
+        file: "integration/reconnection.test.ts",
+        phase: "phase-2" as const,
+        reason: "a stated skip, so the property has something to move",
+      }],
+      "runtime-client": [],
+      shell: [],
+    };
+
+    for (const defaultEnabled of [true, false]) {
+      const suites = await suitesWith(defaultEnabled, skips);
+      const on = byId(
+        suites,
+        defaultEnabled ? "package-integration" : "package-integration-opposite",
+      );
+      const off = byId(
+        suites,
+        defaultEnabled ? "package-integration-opposite" : "package-integration",
+      );
+      expect([...unavailableUnits(on)]).toEqual([file]);
+      expect([...unavailableUnits(off)]).toEqual([]);
+      expect(on.units).not.toContain(file);
+      expect(off.units).toContain(file);
+    }
+  });
+
+  it("runs the shell's integration tests without a visible browser", async () => {
+    const suites = await suitesWith(serverExecutionCiLane("default").enabled);
+    const suite = byId(suites, "package-integration");
+    const unit = suite.units.find((name) =>
+      name.startsWith("packages/shell/")
+    )!;
+    const [invocation] = await suite.command([{ unit, skip: [] }], {
+      root,
+      outputDir: await Deno.makeTempDir({ prefix: "package-integration-" }),
+    });
+    expect(invocation!.env?.HEADLESS).toBe("1");
+    expect(invocation!.junit?.[0]?.scope).toBe("shell");
+  });
+});

--- a/tasks/test-topology/package-integration.ts
+++ b/tasks/test-topology/package-integration.ts
@@ -17,6 +17,7 @@ import {
   type ServerExecutionSuite,
 } from "../server-execution-on-skips.ts";
 import { serverExecutionCiLane } from "../server-execution-ci.ts";
+import { taskEnvironment } from "./deno-task.ts";
 import {
   type FilePart,
   fileSuite,
@@ -71,11 +72,12 @@ export async function loadPackageIntegrationSuites(
     const packageDir = `packages/${scope}`;
     const files = await integrationFiles(root, packageDir);
     const junit = { kind: "integration", scope, filePrefix: packageDir };
-    // `LOG_LEVEL` is what each package's own `integration` task runs
-    // these with, and running them at the default level is running them
-    // differently from the way they are meant to run.
+    // The environment the package's own `integration` task sets, so the
+    // suite a lane runs and the suite somebody runs by hand are the same
+    // run. `HEADLESS` is not part of it: the task leaves the browser
+    // visible and CI hides it.
     const env: Record<string, string> = {
-      LOG_LEVEL: "warn",
+      ...await taskEnvironment(`${root}/${packageDir}`, "integration"),
       ...(headless ? { HEADLESS: "1" } : {}),
     };
     const on = unavailableFrom(skips[scope], packageDir);

--- a/tasks/test-topology/package-integration.ts
+++ b/tasks/test-topology/package-integration.ts
@@ -13,6 +13,7 @@
 
 import {
   SERVER_EXECUTION_ON_SKIPS,
+  type ServerExecutionOnSkip,
   type ServerExecutionSuite,
 } from "../server-execution-on-skips.ts";
 import { serverExecutionCiLane } from "../server-execution-ci.ts";
@@ -59,6 +60,8 @@ async function integrationFiles(
 export async function loadPackageIntegrationSuites(
   root: string,
   defaultEnabled = serverExecutionCiLane("default").enabled,
+  skips: Record<ServerExecutionSuite, readonly ServerExecutionOnSkip[]> =
+    SERVER_EXECUTION_ON_SKIPS,
 ): Promise<Suite[]> {
   const defaults: FilePart[] = [];
   const opposites: FilePart[] = [];
@@ -68,11 +71,14 @@ export async function loadPackageIntegrationSuites(
     const packageDir = `packages/${scope}`;
     const files = await integrationFiles(root, packageDir);
     const junit = { kind: "integration", scope, filePrefix: packageDir };
-    const env: Record<string, string> = headless ? { HEADLESS: "1" } : {};
-    const on = unavailableFrom(
-      SERVER_EXECUTION_ON_SKIPS[scope],
-      packageDir,
-    );
+    // `LOG_LEVEL` is what each package's own `integration` task runs
+    // these with, and running them at the default level is running them
+    // differently from the way they are meant to run.
+    const env: Record<string, string> = {
+      LOG_LEVEL: "warn",
+      ...(headless ? { HEADLESS: "1" } : {}),
+    };
+    const on = unavailableFrom(skips[scope], packageDir);
     defaults.push({
       packageDir,
       flags: ["-A"],
@@ -135,7 +141,10 @@ export async function loadPackageIntegrationSuites(
   return [
     fileSuite({
       id: "package-integration",
-      needs: ["deno", "toolshed", "browser"],
+      // The baked server rather than one run from source: the shell's
+      // tests drive a browser at it, and the shell is a bundle inside
+      // the binary.
+      needs: ["deno", "toolshed-baked", "browser"],
       parts: defaults,
     }),
     fileSuite({

--- a/tasks/test-topology/patterns.test.ts
+++ b/tasks/test-topology/patterns.test.ts
@@ -4,18 +4,37 @@ import { SKIP_LIST_VARIABLE } from "@commonfabric/test-support/records";
 import { serverExecutionCiLane } from "../server-execution-ci.ts";
 import { loadPatternSuites } from "./patterns.ts";
 import { loadPackageIntegrationSuites } from "./package-integration.ts";
-import type { Suite } from "./suite.ts";
+import type { CommandContext, Suite } from "./suite.ts";
 
 const root = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
 const suites = [
   ...await loadPatternSuites(root),
   ...await loadPackageIntegrationSuites(root),
 ];
-const byId = (id: string): Suite => suites.find((s) => s.id === id)!;
+const pick = (from: readonly Suite[], id: string): Suite =>
+  from.find((suite) => suite.id === id)!;
+const byId = (id: string): Suite => pick(suites, id);
 
 /** A directory each case writes its reports and lists into. */
 async function outputDir(): Promise<string> {
   return await Deno.makeTempDir({ prefix: "patterns-suite-" });
+}
+
+/** A context that measures both streams, writing into stated directories. */
+function measured(outputDir: string): CommandContext {
+  return {
+    root,
+    outputDir,
+    coverageDir: "/cov",
+    patternCoverageDir: "/pattern",
+  };
+}
+
+/** The two pattern integration suites, named by the arm each resolves to. */
+function arms(defaultEnabled: boolean): { on: string; off: string } {
+  return defaultEnabled
+    ? { on: "pattern-integration", off: "pattern-integration-opposite" }
+    : { on: "pattern-integration-opposite", off: "pattern-integration" };
 }
 
 describe("the pattern and package suites", () => {
@@ -41,6 +60,82 @@ describe("the pattern and package suites", () => {
         { root, outputDir: await outputDir() },
       );
       expect(invocation!.command).toContain("--no-check");
+    }
+  });
+
+  it("gives every suite that measures a pattern somewhere to report it", async () => {
+    // Authored-pattern coverage is LCOV the instrumentation writes for
+    // itself rather than a V8 profile the lane converts, so it needs a
+    // directory of its own. It is the only source of coverage for the
+    // pattern files, and a suite that measured one and reported nowhere
+    // would take that coverage out of the repository-wide figure with
+    // nothing saying so.
+
+    const context = measured(await outputDir());
+    for (const defaultEnabled of [true, false]) {
+      const loaded = await loadPatternSuites(root, defaultEnabled);
+      const { off } = arms(defaultEnabled);
+      for (const id of [off, "pattern-unit", "pattern-reload"]) {
+        const suite = pick(loaded, id);
+        const [invocation] = await suite.command(
+          [{ unit: suite.units[0]!, skip: [] }],
+          context,
+        );
+        expect(invocation!.env?.CF_PATTERN_COVERAGE_DIR).toBe("/pattern");
+        expect(invocation!.env?.DENO_COVERAGE_DIR).toBeDefined();
+      }
+    }
+  });
+
+  it("leaves the pattern instrumentation off the arm that compiles twice", async () => {
+    // Instrumenting a pattern compiles it a second way, and what the
+    // browser worker records is the whole of what ran only where that
+    // worker does all the compiling. The arm running server execution
+    // has another compiler on the server, so it collects the V8 profile
+    // and leaves the authored-pattern report to the other arm.
+
+    const context = measured(await outputDir());
+    for (const defaultEnabled of [true, false]) {
+      const loaded = await loadPatternSuites(root, defaultEnabled);
+      const suite = pick(loaded, arms(defaultEnabled).on);
+      const [invocation] = await suite.command(
+        [{ unit: suite.units[0]!, skip: [] }],
+        context,
+      );
+      expect(invocation!.env?.CF_PATTERN_COVERAGE_DIR).toBeUndefined();
+      expect(invocation!.env?.DENO_COVERAGE_DIR).toBeDefined();
+    }
+  });
+
+  it("leaves the pattern report out where nothing measures the batch", async () => {
+    const suite = byId("pattern-unit");
+    const [invocation] = await suite.command(
+      [{ unit: suite.units[0]!, skip: [] }],
+      { root, outputDir: await outputDir() },
+    );
+    expect(invocation!.env?.CF_PATTERN_COVERAGE_DIR).toBeUndefined();
+    expect(invocation!.env?.DENO_COVERAGE_DIR).toBeUndefined();
+  });
+
+  it("runs an integration suite the way its own task runs it", async () => {
+    // Each package's `integration` task sets the log level, and running
+    // the same files at the default level is running them differently
+    // from the way they are meant to run.
+
+    for (
+      const id of [
+        "pattern-integration",
+        "pattern-integration-opposite",
+        "package-integration",
+        "package-integration-opposite",
+      ]
+    ) {
+      const suite = byId(id);
+      const [invocation] = await suite.command(
+        [{ unit: suite.units[0]!, skip: [] }],
+        { root, outputDir: await outputDir() },
+      );
+      expect(invocation!.env?.LOG_LEVEL).toBe("warn");
     }
   });
 

--- a/tasks/test-topology/patterns.ts
+++ b/tasks/test-topology/patterns.ts
@@ -14,6 +14,7 @@ import * as path from "@std/path";
 import { PATTERN_TREES } from "../pattern-files.ts";
 import { SERVER_EXECUTION_ON_SKIPS } from "../server-execution-on-skips.ts";
 import { serverExecutionCiLane } from "../server-execution-ci.ts";
+import { taskEnvironment } from "./deno-task.ts";
 import {
   type CommandContext,
   fileSuite,
@@ -91,11 +92,14 @@ async function patternIntegrationSuites(
     scope: "patterns",
     filePrefix: packageDir,
   };
-  // What the package's own `integration` task runs these with. Running
-  // them at the default level is running them differently from the way
-  // they are meant to run, and a browser suite at that level writes a
-  // great deal of it.
-  const env = { HEADLESS: "1", LOG_LEVEL: "warn" };
+  // The environment the package's own `integration` task sets, so the
+  // suite a lane runs and the suite somebody runs by hand are the same
+  // run. `HEADLESS` is not part of it: the task leaves the browser
+  // visible and CI hides it.
+  const env = {
+    ...await taskEnvironment(`${root}/${packageDir}`, "integration"),
+    HEADLESS: "1",
+  };
   const on = unavailableFrom(SERVER_EXECUTION_ON_SKIPS.patterns, packageDir);
   const defaultLane = serverExecutionCiLane("default", defaultEnabled);
   const oppositeLane = serverExecutionCiLane("opposite", defaultEnabled);

--- a/tasks/test-topology/patterns.ts
+++ b/tasks/test-topology/patterns.ts
@@ -15,6 +15,7 @@ import { PATTERN_TREES } from "../pattern-files.ts";
 import { SERVER_EXECUTION_ON_SKIPS } from "../server-execution-on-skips.ts";
 import { serverExecutionCiLane } from "../server-execution-ci.ts";
 import {
+  type CommandContext,
   fileSuite,
   type Invocation,
   type Location,
@@ -90,17 +91,31 @@ async function patternIntegrationSuites(
     scope: "patterns",
     filePrefix: packageDir,
   };
+  // What the package's own `integration` task runs these with. Running
+  // them at the default level is running them differently from the way
+  // they are meant to run, and a browser suite at that level writes a
+  // great deal of it.
+  const env = { HEADLESS: "1", LOG_LEVEL: "warn" };
   const on = unavailableFrom(SERVER_EXECUTION_ON_SKIPS.patterns, packageDir);
   const defaultLane = serverExecutionCiLane("default", defaultEnabled);
   const oppositeLane = serverExecutionCiLane("opposite", defaultEnabled);
   return [
     fileSuite({
       id: "pattern-integration",
-      needs: ["deno", "toolshed", "browser", "compile-cache"],
+      // The baked server rather than one run from source: these drive a
+      // browser at the shell, and the shell is a bundle inside the
+      // binary. A source run answers the API and serves no shell.
+      needs: ["deno", "toolshed-baked", "browser", "compile-cache"],
+      // Authored-pattern instrumentation compiles each pattern a second
+      // way, and what the browser worker records is the whole of what ran
+      // only where that worker is the sole compiler. Server execution puts
+      // another one on the server, so the arm running it leaves the
+      // authored-pattern measurement to the arm that does not.
+      patternCoverage: !defaultLane.enabled,
       parts: [{
         packageDir,
         flags,
-        env: { HEADLESS: "1" },
+        env,
         junit,
         files: defaultLane.enabled
           ? files.filter((file) => !on.whole.has(file))
@@ -111,6 +126,7 @@ async function patternIntegrationSuites(
     fileSuite({
       id: "pattern-integration-opposite",
       variant: oppositeLane.recordVariant,
+      patternCoverage: !oppositeLane.enabled,
       needs: [
         "deno",
         "toolshed-baked-opposite",
@@ -121,7 +137,7 @@ async function patternIntegrationSuites(
         packageDir,
         flags,
         env: {
-          HEADLESS: "1",
+          ...env,
           EXPERIMENTAL_SERVER_EXECUTION: String(oppositeLane.enabled),
         },
         junit,
@@ -132,6 +148,31 @@ async function patternIntegrationSuites(
       }],
     }),
   ];
+}
+
+/**
+ * Where a suite that builds its own invocation puts what it measures.
+ *
+ * Two streams, and they are not the same shape. Deno writes V8 profiles
+ * into `DENO_COVERAGE_DIR`, which the lane converts afterwards; the
+ * authored-pattern instrumentation writes LCOV straight into
+ * `CF_PATTERN_COVERAGE_DIR`, which the lane only has to carry. A suite
+ * whose runner is `deno test` over a file list gets both from
+ * `fileSuite`; these two build their own command lines, so they say it
+ * here.
+ */
+function coverageEnv(
+  context: CommandContext,
+  slug: string,
+): Record<string, string> {
+  return {
+    ...(context.coverageDir === undefined
+      ? {}
+      : { DENO_COVERAGE_DIR: path.join(context.coverageDir, slug) }),
+    ...(context.patternCoverageDir === undefined
+      ? {}
+      : { CF_PATTERN_COVERAGE_DIR: context.patternCoverageDir }),
+  };
 }
 
 /**
@@ -167,7 +208,10 @@ function patternReloadSuite(): Suite {
           "patterns-reload",
         ],
         cwd: context.root,
-        env: { HEADLESS: "1" },
+        env: {
+          HEADLESS: "1",
+          ...coverageEnv(context, "pattern-reload"),
+        },
         junit: [{
           path: path.join(context.outputDir, "patterns-reload.xml"),
           kind: "integration",
@@ -220,6 +264,7 @@ async function patternUnitSuite(root: string): Promise<Suite> {
           "pattern-tests",
         ],
         cwd: context.root,
+        env: coverageEnv(context, "pattern-unit"),
       }];
     },
   };

--- a/tasks/test-topology/suite.ts
+++ b/tasks/test-topology/suite.ts
@@ -112,6 +112,14 @@ export interface CommandContext {
   coverageDir?: string;
 
   /**
+   * Where a producer that writes a coverage report of its own puts it.
+   * The authored-pattern instrumentation writes LCOV rather than a V8
+   * profile, so it has nowhere to put one under `coverageDir`, which
+   * holds profiles and is converted from them.
+   */
+  patternCoverageDir?: string;
+
+  /**
    * What this change is measured against, as a git revision. The gates
    * that hold a file to being appended to compare against it.
    */
@@ -382,6 +390,14 @@ export interface FileSuiteOptions {
    * directory and its own record scope.
    */
   parts: readonly FilePart[];
+
+  /**
+   * Whether this suite's runner instruments authored patterns, which
+   * write a coverage report of their own rather than a V8 profile. A
+   * suite that says so is handed `CF_PATTERN_COVERAGE_DIR` wherever the
+   * batch is measured.
+   */
+  patternCoverage?: boolean;
 }
 
 /**
@@ -462,6 +478,12 @@ export function fileSuite(options: FileSuiteOptions): Suite {
         }
         if (context.coverageDir !== undefined) {
           env.DENO_COVERAGE_DIR = path.join(context.coverageDir, slug);
+        }
+        if (
+          options.patternCoverage === true &&
+          context.patternCoverageDir !== undefined
+        ) {
+          env.CF_PATTERN_COVERAGE_DIR = context.patternCoverageDir;
         }
         invocations.push({
           command: [

--- a/tasks/test-topology/unit.test.ts
+++ b/tasks/test-topology/unit.test.ts
@@ -232,6 +232,59 @@ describe("running a member that cannot be handed a subset", () => {
     expect(invocation!.env?.[SKIP_LIST_VARIABLE]).toBeDefined();
   });
 
+  it("accounts for the files the Deno-only half declines", async () => {
+    // A member that splits its halves by a name keeps the browser files
+    // out of the `deno test` run, and the browser half is one unit
+    // whatever it holds. Without saying so, those files would be test
+    // files no suite claims, and the drift guard would fail on them.
+
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: {
+          test: { dependencies: ["deno-test", "browser-test"] },
+          "deno-test": "deno test --allow-read --ignore='**/*.browser.test.ts'",
+          "browser-test": "deno run -A ../deno-web-test/cli.ts oven.test.ts",
+        },
+        files: ["test/glaze.test.ts", "test/oven.browser.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    expect(suite.units).toContain("packages/bakery/test/glaze.test.ts");
+    expect(suite.units).not.toContain(
+      "packages/bakery/test/oven.browser.test.ts",
+    );
+    expect(suite.sources).toEqual([
+      "packages/bakery/test/oven.browser.test.ts",
+    ]);
+  });
+
+  it("leaves out a file neither half of a split member runs", async () => {
+    // A task naming its own paths passes over everything outside them,
+    // and what it passes over is not what the browser half runs. Only
+    // the files an ignore took out belong to the browser half, so a file
+    // outside the task's paths is claimed by neither.
+
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: {
+          test: { dependencies: ["deno-test", "browser-test"] },
+          "deno-test":
+            "deno test --allow-read --ignore='**/*.browser.test.ts' test",
+          "browser-test": "deno run -A ../deno-web-test/cli.ts oven.test.ts",
+        },
+        files: [
+          "test/glaze.test.ts",
+          "test/oven.browser.test.ts",
+          "integration/proof.test.ts",
+        ],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    expect(suite.sources).toEqual([
+      "packages/bakery/test/oven.browser.test.ts",
+    ]);
+  });
+
   it("runs the browser half through the task that owns it", async () => {
     const root = await workspace({
       "./packages/bakery": {

--- a/tasks/test-topology/unit.ts
+++ b/tasks/test-topology/unit.ts
@@ -65,6 +65,13 @@ interface Member {
 
   /** Whether the member also names a browser half. */
   browserTest: boolean;
+
+  /**
+   * The test files the Deno-only half declines, which is what the
+   * browser half runs. The browser half is one unit whatever it holds,
+   * so these are files the topology accounts for without enumerating.
+   */
+  browserFiles: string[];
 }
 
 /** The record scope of a member: its path with `packages/` taken off. */
@@ -95,14 +102,32 @@ async function readMember(
     denoTestTask: tasks.denoTestTask ?? "test",
     denoHalf: tasks.denoHalf,
     browserTest: tasks.browserTest,
+    browserFiles: [],
   };
   if (tasks.denoTest === undefined) return member;
   // Normalized against the repository root, because a member's task may
   // name a file outside its own directory and a unit is a path anyone
   // else can resolve.
+  const relative = (file: string) =>
+    path.relative(root, path.resolve(memberDir, file));
   member.files = (await memberTestFiles(memberDir, tasks.denoTest))
-    .map((file) => path.relative(root, path.resolve(memberDir, file)));
+    .map(relative);
   member.run = { flags: tasks.denoTest.flags, env: tasks.denoTest.env };
+  if (member.browserTest) {
+    // What the Deno-only half ignores is what the browser half runs. A
+    // member that splits its halves by a name — `*.browser.test.ts` — is
+    // otherwise a member whose browser files no suite claims, because
+    // the browser unit is one unit rather than one per file. The same
+    // paths the task names, read without its ignores, so the difference
+    // is what an ignore took out rather than what the task never looked
+    // at. No member in the tree has that shape yet.
+    const everything = new Set(
+      (await memberTestFiles(memberDir, { ...tasks.denoTest, ignores: [] }))
+        .map(relative),
+    );
+    for (const file of member.files) everything.delete(file);
+    member.browserFiles = [...everything].sort();
+  }
   return member;
 }
 
@@ -150,12 +175,15 @@ function unitSuite(
     recordSurfaces.push({ kind: "browser", scope: member.scope });
   }
 
+  const sources = members.flatMap((member) => member.browserFiles);
+
   return {
     id,
     recordSurfaces,
     needs,
     units,
     unavailable: [],
+    ...(sources.length === 0 ? {} : { sources }),
 
     locate(record: LocatableRecord): Location | undefined {
       if (!claimsIdentity({ recordSurfaces }, record.test)) return undefined;


### PR DESCRIPTION
PROBLEM

`tasks/test-topology/` declares the test surfaces a lane runs, and it does not describe what the jobs it models run. The package integration suites sit inline among the pattern suites, though each is one package running its own task. Suites that drive a browser ask for a Toolshed run from source, which serves the API and no shell, so every such test fails on "Shell app not available". Two gates name `fmt` and `lint` as tasks; they are subcommands of Deno, and `deno task fmt` prints the list of tasks that do exist and exits one. Integration suites run at the default log level rather than the one their own task sets.

SOLUTION

The package integration suites move to `package-integration.ts`: one suite per package, each running that package's `integration` task, in two server-execution arms. A suite that drives a browser asks for `toolshed-baked`, the compiled binary the shell is bundled into. A gate carries the argument vector it runs rather than the name of a task, so `fmt` and `lint` are the subcommands they are. An integration suite runs with the environment its own task sets.

Three things the suites were not saying. Authored-pattern instrumentation goes on the arm whose browser worker is the only compiler, which is what the workflow does, and the only arm where what that worker records is the whole of what ran. The reload and unit suites name their own coverage directories rather than sharing one. A member splitting its halves by filename accounts for the files its Deno-only half declines, which the browser half runs and no unit enumerates.

DESIGN DISCUSSION

Each test holds a suite to the argument or the variable that decides the behavior rather than to something that merely accompanies it: the tail of a gate's command line, the log level on all four integration suites, and the per-arm coverage rule with the first-party default stated both ways. The task-name guard names the gates it reached, so a run that read nothing, or that stopped at the recorder rather than at what the recorder was handed, fails rather than passes.

The suite table in the test-selection plan names the capability each suite takes. `COVERAGE.md` states the per-arm coverage rule and why it holds, and the `AGENTS.md` line pointing at that file no longer describes its inverse.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

