### PR TITLE
Fail on a recorded step the test topology does not hold

### DIFF
--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -350,6 +350,15 @@ Anything else wraps its command:
 deno task run-recorded <kind> <scope> <name> -- <command...>
 ```
 
+A wrapped command in a workflow step also has its identity registered in
+the test topology. A lane runs what a suite enumerates, so the topology
+is what keeps the command running once a lane takes over the job. `deno
+task check-test-topology` reads every such step and fails on one no suite
+claims, which settles it on the pull request that adds the step. A
+command with no suite to register it under is one to leave unwrapped:
+"Recording" above says that a check no lane can be asked to run is not
+recorded.
+
 A harness that is also a library — one this repository's own tests drive
 over fixture files — takes the decision to record from its caller, not
 from the environment alone. Its entry point asks for records; a test

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -356,8 +356,8 @@ is what keeps the command running once a lane takes over the job. `deno
 task check-test-topology` reads every such step and fails on one no suite
 claims, which settles it on the pull request that adds the step. A
 command with no suite to register it under is one to leave unwrapped:
-"Recording" above says that a check no lane can be asked to run is not
-recorded.
+["Recording" in the specification](../specs/test-records.md#recording)
+says that a check no lane can be asked to run is not recorded.
 
 A harness that is also a library — one this repository's own tests drive
 over fixture files — takes the decision to record from its caller, not

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -909,7 +909,7 @@ being imposed.
 - Suites that are not `deno test` need no mechanism. Every one of their
   invocation units holds a single identity, so skipping it is declining to
   invoke it.
-- The drift guard is unchanged.
+- Skipping does not reach the drift guard.
 - A repeat names an identity and invokes its file with every other
   identity in that file skipped.
 

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -909,9 +909,7 @@ being imposed.
 - Suites that are not `deno test` need no mechanism. Every one of their
   invocation units holds a single identity, so skipping it is declining to
   invoke it.
-- The drift guard is unchanged: the tree half still claims files, the
-  workflow half still claims recording steps, and the store half still
-  claims identities.
+- The drift guard is unchanged.
 - A repeat names an identity and invokes its file with every other
   identity in that file skipped.
 

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -909,8 +909,9 @@ being imposed.
 - Suites that are not `deno test` need no mechanism. Every one of their
   invocation units holds a single identity, so skipping it is declining to
   invoke it.
-- Both halves of the drift guard are unchanged: the tree half still claims
-  files, the store half still claims identities.
+- The drift guard is unchanged: the tree half still claims files, the
+  workflow half still claims recording steps, and the store half still
+  claims identities.
 - A repeat names an identity and invokes its file with every other
   identity in that file skipped.
 
@@ -954,8 +955,8 @@ The topology is only worth having if it stays complete. A new test surface
 that nobody registers would silently vanish from the full run, which is a
 far worse failure than the workflow edit it replaced.
 
-`deno task check-test-topology` closes that, in two halves that catch the
-two different ways a surface goes missing.
+`deno task check-test-topology` closes that. A surface goes missing in
+three ways, and the guard answers each.
 
 The **tree half** needs no store, and is a unit of the `repo-gates` suite.
 It walks the tree for things that look like tests — `*.test.ts`,
@@ -970,6 +971,23 @@ leaves the unregistered surface to the full run on `main`, which is where
 the record of what this guard catches comes from. An entry in a
 configuration's declared skip registry accounts for its unavailable file or
 leaf without pretending it ran.
+
+The **workflow half** runs beside it, on the checkout alone, over the
+step definitions under `.github` — the workflows and the composite
+actions alike. A step can wrap a command in `deno task run-recorded
+<kind> <scope> <name>`. Those three words are the command's identity, and
+every record the command writes carries that identity. The topology is
+the other place an identity is written down. A lane builds its commands
+from the topology, so a step whose identity no suite holds runs while
+that step stands and stops when a lane takes over the job holding it.
+Nothing in the tree carries such an identity, which is what puts it out
+of the tree half's reach.
+
+The half admits no exceptions, because there is nothing for one to
+cover. `docs/specs/test-records.md` says under "Recording" that a check
+no lane can be asked to run is not recorded, so a recording step whose
+identity no suite claims is a defect either way round: the step should
+be registered, or it should not be recording.
 
 The **store half** runs on `main`. It reads the most recent successful
 `main` build's records and fails if any recorded identity is one that no
@@ -2927,6 +2945,7 @@ is pinned to the commit's date. And if none of that settles it,
 | The manifest is malformed or a newer schema | Rejected whole, treated as absent, same path as unreachable. |
 | A selected item no longer exists in the tree | Dropped with a line in the summary. A renamed test is simultaneously an unknown item, so it runs anyway. |
 | A new test surface nobody registered | `check-test-topology` fails on the next `main` run and names the unclaimed identities. |
+| A gate wired into a workflow job and into no suite | The workflow half of the drift guard fails on the pull request that adds the step, before the gate has ever run. |
 | A record's variant or record surface contradicts its batch | Kept as written and named in the lane summary. The identity then belongs to no suite, so the store half of the drift guard fails on the next `main` run. |
 | A suite gains a new variant with no records | Every available item in that variant is mandatory until a successful full `main` run accounts for every enumerated item under that exact variant, the store drift guard passes, and the next publisher cycle includes the run. Other variants do not stand in for it. |
 | A variant deliberately skips a file or leaf | The topology reads the existing skip registry and the manifest reports the test as unavailable with its phase and reason. It is not unknown. Removing the skip makes it mandatory until `main` records it. |
@@ -3315,7 +3334,7 @@ exercised on the branch on its own.
       test. A pull request runs its servers and its command line from
       source and compiles nothing, so without these a broken compile
       would be found only on `main`.
-- [x] `tasks/check-test-topology.ts`, both halves, wired into
+- [x] `tasks/check-test-topology.ts`, tree, workflow and store, wired into
       `repo-gates`, with exact variant matching and one source-item claim
       allowed per variant. Eight paths that look like tests and are not
       are declared as the fixtures they are: the five projects under
@@ -3429,6 +3448,18 @@ exercised on the branch on its own.
       convention: a package that mixes Deno-only tests with tests needing
       a browser names the Deno-only half `deno-test`, and that half is
       what the coverage gate measures.
+- [ ] The workflow half turned around, once the lanes carry the gates.
+      It asks today whether every recording step's identity is in the
+      topology, which is the right question while the workflows and the
+      topology both name gates. When a lane runs them, the question
+      becomes whether a recording step is one the topology could not run:
+      the declarations become the whole list of steps a workflow may
+      write, and a step outside that list fails whether or not a suite
+      claims it. That form also catches a gate a leftover step runs a
+      second time, which the current form passes over. Four recording
+      steps survive the switch, so the half does not go quiet on its own;
+      if a later change leaves none, the declarations fail as stale and
+      the half is then dead and should go.
 - [ ] This plan archived.
 
 ### What would force a split, and what to split first

--- a/tasks/check-test-topology.test.ts
+++ b/tasks/check-test-topology.test.ts
@@ -382,6 +382,24 @@ describe("what the workflow half looks at", () => {
     }
   });
 
+  it("reads a step a quoted hash sits ahead of on its line", async () => {
+    // A `#` the shell is handed as a character does not end the command,
+    // so the step after it on that line still records and still counts.
+    const root = await workflows({
+      "workflows/deno.yml": [
+        "      - run: |",
+        '          echo "count # of things" && deno task run-recorded gate repo icing -- deno task x',
+      ].join("\n"),
+    });
+    try {
+      expect((await workflowRecords(root)).map((found) => found.test)).toEqual([
+        { k: "gate", s: "repo", n: "icing" },
+      ]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
   it("reads an identity a workflow expression stands in the middle of", async () => {
     // A lane cannot be asked for an identity that is not settled until
     // the run resolves the expression, so the guard reads what is
@@ -465,6 +483,51 @@ describe("what the workflow half looks at", () => {
           ".github/workflows/deno.yml",
         ],
       );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("reads no step out of a file that is not a step definition", async () => {
+    // Only the YAML under `.github` defines steps. A document beside it
+    // quoting the wrapper is prose.
+    const root = await workflows({
+      "workflows/README.md":
+        "  run: deno task run-recorded gate repo prose -- deno task prose",
+      "workflows/deno.yml":
+        "  run: deno task run-recorded gate repo real -- deno task real",
+    });
+    try {
+      expect((await workflowRecords(root)).map((found) => found.test.n))
+        .toEqual(["real"]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("raises on a file ending in the middle of a recording step", async () => {
+    // Three words follow the wrapper or the identity is not there to
+    // read, and reading a shorter one would invent an identity.
+    const root = await workflows({
+      "workflows/deno.yml": "  run: deno task run-recorded gate repo",
+    });
+    try {
+      await expect(workflowRecords(root)).rejects.toThrow(
+        "ends in the middle of a recording step",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("raises rather than reading a shorter list of definitions", async () => {
+    // A directory that cannot be read is not a directory that holds no
+    // steps. Treating the two alike would report success over whatever
+    // it managed to reach.
+    const root = await Deno.makeTempDir({ prefix: "obstructed-" });
+    try {
+      await Deno.writeTextFile(`${root}/.github`, "not a directory");
+      await expect(workflowRecords(root)).rejects.toThrow();
     } finally {
       await Deno.remove(root, { recursive: true });
     }

--- a/tasks/check-test-topology.test.ts
+++ b/tasks/check-test-topology.test.ts
@@ -400,6 +400,24 @@ describe("what the workflow half looks at", () => {
     }
   });
 
+  it("reads a step a quoted hash with an escape in it sits ahead of", async () => {
+    // The backslash takes the quote with it, so the quoted run has not
+    // ended and the `#` inside it is still a character of the command.
+    const root = await workflows({
+      "workflows/deno.yml": [
+        "      - run: |",
+        '          echo "a \\" # b" && deno task run-recorded gate repo icing -- deno task x',
+      ].join("\n"),
+    });
+    try {
+      expect((await workflowRecords(root)).map((found) => found.test)).toEqual([
+        { k: "gate", s: "repo", n: "icing" },
+      ]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
   it("reads an identity a workflow expression stands in the middle of", async () => {
     // A lane cannot be asked for an identity that is not settled until
     // the run resolves the expression, so the guard reads what is

--- a/tasks/check-test-topology.test.ts
+++ b/tasks/check-test-topology.test.ts
@@ -5,10 +5,12 @@ import {
   check,
   checkStore,
   checkTree,
+  checkWorkflows,
   main,
   parseCheckArgs,
   readRecords,
   report,
+  workflowRecords,
 } from "./check-test-topology.ts";
 import type { Suite } from "./test-topology/suite.ts";
 
@@ -269,6 +271,212 @@ describe("what the tree half looks at", () => {
     });
     expect(findings.map((finding) => finding.fails)).toEqual([true]);
     expect(findings[0]!.message).toContain("still listed as a fixture");
+  });
+});
+
+describe("the workflow half of the drift guard", () => {
+  const gates = suite({
+    id: "repo-checks",
+    units: ["check-icing"],
+    locate: (record) =>
+      record.test.k === "gate" && record.test.s === "repo" &&
+        record.test.n === "check-icing"
+        ? { level: "unit", unit: record.test.n }
+        : undefined,
+  });
+
+  /** One step, written the way a workflow writes it. */
+  function step(k: string, s: string, n: string) {
+    return { test: { k, s, n }, where: ".github/workflows/deno.yml" };
+  }
+
+  it("passes a step exactly one suite claims", () => {
+    const findings = checkWorkflows([gates], [
+      step("gate", "repo", "check-icing"),
+    ]);
+    expect(findings).toEqual([]);
+  });
+
+  it("fails a step no suite claims", () => {
+    // A gate wired into a job and into no suite runs while its step
+    // stands and stops when a lane takes over the job.
+    const findings = checkWorkflows([gates], [
+      step("gate", "repo", "check-glaze"),
+    ]);
+    expect(findings.map((finding) => finding.fails)).toEqual([true]);
+    expect(findings[0]!.message).toContain(
+      'no suite claims ["gate","repo","check-glaze"], which ' +
+        ".github/workflows/deno.yml records",
+    );
+  });
+
+  it("fails a step two suites claim", () => {
+    const findings = checkWorkflows(
+      [gates, { ...gates, id: "repo-gates" }],
+      [step("gate", "repo", "check-icing")],
+    );
+    expect(findings.map((finding) => finding.fails)).toEqual([true]);
+    expect(findings[0]!.message).toContain("both claim");
+  });
+
+  it("counts one identity once, however many steps write it", () => {
+    const findings = checkWorkflows([gates], [
+      step("gate", "repo", "check-glaze"),
+      step("gate", "repo", "check-glaze"),
+    ]);
+    expect(findings.length).toBe(1);
+  });
+});
+
+describe("what the workflow half looks at", () => {
+  /** A tree holding the step definitions a case names. */
+  async function workflows(files: Record<string, string>): Promise<string> {
+    const root = await Deno.makeTempDir({ prefix: "workflows-" });
+    for (const [at, body] of Object.entries(files)) {
+      const file = `${root}/.github/${at}`;
+      await Deno.mkdir(file.slice(0, file.lastIndexOf("/")), {
+        recursive: true,
+      });
+      await Deno.writeTextFile(file, body);
+    }
+    return root;
+  }
+
+  it("reads the identity out of a step, however the step is wrapped", async () => {
+    const root = await workflows({
+      "workflows/deno.yml": [
+        "      - run: deno task run-recorded gate repo check-icing -- deno task x",
+        "      - run: >-",
+        "          deno task run-recorded lint repo deno-lint --",
+        "          deno lint",
+        "      - run: |",
+        "          deno task run-recorded test oven bake -- \\",
+        "            deno test",
+      ].join("\n"),
+    });
+    try {
+      expect((await workflowRecords(root)).map((found) => found.test)).toEqual([
+        { k: "gate", s: "repo", n: "check-icing" },
+        { k: "lint", s: "repo", n: "deno-lint" },
+        { k: "test", s: "oven", n: "bake" },
+      ]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("reads no step out of a comment naming the wrapper", async () => {
+    // Both shapes a comment takes: a line of its own, and the tail of a
+    // line that carries something else. Each holds a whole invocation,
+    // so what keeps them out is that they are comments.
+    const root = await workflows({
+      "workflows/deno.yml": [
+        "      # deno task run-recorded gate repo ghost -- deno task ghost",
+        "      - run: deno task check # deno task run-recorded gate repo old --",
+      ].join("\n"),
+    });
+    try {
+      expect(await workflowRecords(root)).toEqual([]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("reads an identity a workflow expression stands in the middle of", async () => {
+    // A lane cannot be asked for an identity that is not settled until
+    // the run resolves the expression, so the guard reads what is
+    // written and lets no suite claim it.
+    const root = await workflows({
+      "workflows/deno.yml":
+        "  run: deno task run-recorded unit ${{ matrix.scope }} test -- deno task test",
+    });
+    try {
+      expect((await workflowRecords(root)).map((found) => found.test)).toEqual([
+        { k: "unit", s: "${{ matrix.scope }}", n: "test" },
+      ]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("reads a step whose parts are quoted rather than passing over it", async () => {
+    const root = await workflows({
+      "workflows/deno.yml":
+        '  run: deno task run-recorded gate repo "check icing" -- deno task x',
+    });
+    try {
+      expect((await workflowRecords(root)).map((found) => found.test.n))
+        .toEqual(
+          ['"check'],
+        );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("names the workflow each step is written in", async () => {
+    const root = await workflows({
+      "workflows/nightly.yml":
+        "  run: deno task run-recorded gate repo audit -- deno task a",
+      "workflows/deno.yml":
+        "  run: deno task run-recorded gate repo check -- deno task b",
+    });
+    try {
+      expect((await workflowRecords(root)).map((found) => found.where)).toEqual(
+        [
+          ".github/workflows/deno.yml",
+          ".github/workflows/nightly.yml",
+        ],
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("reads a step across the line continuations that break it up", async () => {
+    const root = await workflows({
+      "workflows/deno.yml": [
+        "      - run: |",
+        "          deno task run-recorded gate \\",
+        "            repo check-icing -- \\",
+        "            deno task check-icing",
+      ].join("\n"),
+    });
+    try {
+      expect((await workflowRecords(root)).map((found) => found.test)).toEqual([
+        { k: "gate", s: "repo", n: "check-icing" },
+      ]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("reads a step a composite action runs as well as one a workflow runs", async () => {
+    const root = await workflows({
+      "actions/ship/action.yml":
+        "  run: deno task run-recorded gate repo ship -- deno task ship",
+      "workflows/deno.yml":
+        "  run: deno task run-recorded gate repo check -- deno task check",
+    });
+    try {
+      expect((await workflowRecords(root)).map((found) => found.where)).toEqual(
+        [
+          ".github/actions/ship/action.yml",
+          ".github/workflows/deno.yml",
+        ],
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("finds nothing in a tree that defines no steps", async () => {
+    const root = await Deno.makeTempDir({ prefix: "bare-" });
+    try {
+      expect(await workflowRecords(root)).toEqual([]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
   });
 });
 

--- a/tasks/check-test-topology.ts
+++ b/tasks/check-test-topology.ts
@@ -5,14 +5,24 @@
  *
  * The topology is only worth having if it stays complete: a test surface
  * nobody registered would vanish from the full run, which is a worse
- * failure than the workflow edit it replaced. Two halves catch the two
- * different ways a surface goes missing.
+ * failure than the workflow edit it replaced. A surface goes missing in
+ * three ways, and a check answers each.
  *
  * The tree half needs no store and runs on every pull request. It walks
  * the tree for things that look like tests and fails on any that no
  * suite accounts for, or that two suites claim under the same record
  * surface and variant. This is what catches a pull request adding a test
  * surface nobody registered, at the moment it is added.
+ *
+ * The workflow half runs beside it, over the step definitions under
+ * `.github`. A step can wrap a command in `run-recorded`. The three
+ * words after it are the command's identity, and every record the
+ * command writes carries that identity. The topology is the other place
+ * an identity is written down. A lane builds its commands from the
+ * topology, so a step whose identity no suite holds runs while that step
+ * stands and stops when a lane takes over the job holding it. Nothing in
+ * the tree carries such an identity, which is what puts it out of the
+ * tree half's reach.
  *
  * The store half runs on `main`. It reads a run's records and fails on
  * any identity no suite recognizes, or that more than one suite claims.
@@ -26,8 +36,8 @@
  * never runs or a mapping that is wrong, and both are worth knowing
  * about without blocking anybody.
  *
- *   deno task check-test-topology            # the tree half
- *   deno task check-test-topology --records <file>...   # both halves
+ *   deno task check-test-topology            # tree and workflows
+ *   deno task check-test-topology --records <file>...   # those and the store
  */
 
 import * as path from "@std/path";
@@ -37,6 +47,11 @@ import {
   type TestIdentity,
   testIdentityKey,
 } from "@commonfabric/test-support/records";
+import {
+  commandWords,
+  withoutComments,
+  withoutContinuations,
+} from "./ci-workflow.ts";
 import { isLaneMeasurement } from "./lane-measurement.ts";
 import { dayOf } from "./test-selection/build.ts";
 import { DENO_TEST_FILE } from "./test-topology/deno-task.ts";
@@ -142,6 +157,73 @@ const NOT_A_TEST_SURFACE: ReadonlyArray<{ path: string; reason: string }> = [
   },
 ];
 
+/** Where the steps continuous integration runs are defined. */
+const CI_DEFINITIONS = ".github";
+
+/** The words that introduce a recording step, in the order they read. */
+const RUN_RECORDED = ["deno", "task", "run-recorded"];
+
+/** One recording step: the identity it writes, and the file holding it. */
+export interface WorkflowRecord {
+  test: TestIdentity;
+  where: string;
+}
+
+/**
+ * The identities the words of one file record. `deno task run-recorded`
+ * is followed by the three parts of an identity, so the three words
+ * after it are the identity. A step whose parts are quoted, or whose
+ * identity holds a workflow expression the run resolves, gives an
+ * identity no suite claims, and the check that reads it fails.
+ */
+function recordedIdentities(text: string, where: string): WorkflowRecord[] {
+  const words = commandWords(withoutContinuations(withoutComments(text)));
+  const found: WorkflowRecord[] = [];
+  for (let at = 0; at + RUN_RECORDED.length < words.length; at++) {
+    if (RUN_RECORDED.some((word, index) => words[at + index] !== word)) {
+      continue;
+    }
+    const [k, s, n] = words.slice(at + RUN_RECORDED.length).slice(0, 3);
+    if (k === undefined || s === undefined || n === undefined) {
+      throw new Error(`${where} ends in the middle of a recording step`);
+    }
+    found.push({ test: { k, s, n }, where });
+  }
+  return found;
+}
+
+/** Every identity a step under `.github` records by hand. */
+export async function workflowRecords(
+  root: string,
+): Promise<WorkflowRecord[]> {
+  const found: WorkflowRecord[] = [];
+  const walk = async (relative: string): Promise<void> => {
+    // As in the tree walk, only the read of a directory's own entries
+    // answers "no such directory". A directory that vanishes deeper in
+    // the walk raises.
+    let entries: Deno.DirEntry[];
+    try {
+      entries = await Array.fromAsync(Deno.readDir(path.join(root, relative)));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return;
+      throw error;
+    }
+    entries.sort((left, right) => left.name < right.name ? -1 : 1);
+    for (const entry of entries) {
+      const at = `${relative}/${entry.name}`;
+      if (entry.isDirectory) {
+        await walk(at);
+        continue;
+      }
+      if (!entry.isFile || !/\.ya?ml$/.test(entry.name)) continue;
+      const text = await Deno.readTextFile(path.join(root, at));
+      found.push(...recordedIdentities(text, at));
+    }
+  };
+  await walk(CI_DEFINITIONS);
+  return found;
+}
+
 /** One thing the check found. */
 export interface Finding {
   /** Whether it fails the check or is only reported. */
@@ -239,6 +321,33 @@ export function checkTree(
     findings.push({
       fails: true,
       message: `${path} is listed as a fixture and the tree no longer holds it`,
+    });
+  }
+  return findings;
+}
+
+/**
+ * The workflow half: every identity a workflow step records by hand is
+ * claimed by exactly one suite.
+ */
+export function checkWorkflows(
+  suites: readonly Suite[],
+  records: readonly WorkflowRecord[],
+): Finding[] {
+  const findings: Finding[] = [];
+  const seen = new Set<string>();
+  for (const record of records) {
+    const key = testIdentityKey(record.test);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const claims = claimsFor(suites, record);
+    if (claims.length === 1) continue;
+    findings.push({
+      fails: true,
+      message: claims.length === 0
+        ? `no suite claims ${key}, which ${record.where} records`
+        : `${claims.map((claim) => claim.suite.id).join(" and ")} ` +
+          `both claim ${key}, which ${record.where} records`,
     });
   }
   return findings;
@@ -363,9 +472,9 @@ export function parseCheckArgs(
 }
 
 /**
- * Runs whichever halves the options ask for. The tree half always runs,
- * because it needs nothing but the checkout; the store half runs when a
- * run's records are named.
+ * Runs whichever halves the options ask for. The tree and workflow
+ * halves always run, because they need nothing but the checkout; the
+ * store half runs when a run's records are named.
  */
 export async function check(
   options: CheckOptions,
@@ -375,6 +484,9 @@ export async function check(
     suites,
     await candidateSurfaces(options.root),
     { fixtures: NOT_A_TEST_SURFACE },
+  );
+  findings.push(
+    ...checkWorkflows(suites, await workflowRecords(options.root)),
   );
   if (options.records !== undefined) {
     findings.push(...checkStore(suites, await readRecords(options.records)));

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -1,6 +1,7 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
 import { getBinary } from "@astral/astral";
+import { commandWords, withoutComments } from "./ci-workflow.ts";
 import { phaseOf } from "./ci-step-phases.ts";
 import { EXPECTED_COVERAGE_ARTIFACT_NAMES } from "./coverage-check.ts";
 import { PATTERN_INTEGRATION_SHARD_COUNT } from "./select-pattern-integration-files.ts";
@@ -130,26 +131,10 @@ function stepNames(contents: string): string[] {
   return [...contents.matchAll(/^ *- name: (.+)$/gm)].map((match) => match[1]);
 }
 
-// Drops YAML comments. A `#` after whitespace ends a plain scalar, so what is
-// left on a line is the value the workflow actually carries. Applied before
-// looking for commands, so that a comment naming a command is not read as one
-// and a comment after a command is not read as part of it.
-function withoutComments(contents: string): string {
-  return contents.replaceAll(/(^|\s)#.*$/gm, "$1");
-}
-
 function deployInvocations(contents: string): string[] {
   return [...contents.matchAll(/^ +script: (\/opt\/cf\/deploy\.sh.*)$/gm)].map(
     (match) => match[1],
   );
-}
-
-// Splits a command the way a shell would count its words, except that a
-// `${{ ... }}` workflow expression holds spaces and still stands for one word.
-// The expression is matched to its first `}}` so that one containing a brace,
-// as `${{ format('{0}', github.sha) }}` does, still comes out as one word.
-function commandWords(command: string): string[] {
-  return [...command.matchAll(/\$\{\{.*?\}\}|\S+/g)].map((match) => match[0]);
 }
 
 function workflowTriggers(contents: string): string {

--- a/tasks/ci-workflow.ts
+++ b/tasks/ci-workflow.ts
@@ -1,0 +1,38 @@
+/**
+ * Reading the workflow files as text.
+ *
+ * A workflow is a YAML document, and the checks over these files read
+ * them as text rather than as a parse tree, because what they ask about
+ * is the commands the steps run. Two things about that text are subtle
+ * enough to be worth writing once: where a comment ends, and where one
+ * word ends and the next begins.
+ */
+
+/**
+ * Drops YAML comments. A `#` after whitespace ends a plain scalar, so
+ * what is left on a line is the value the workflow carries. Applied
+ * before looking for commands, so that a comment naming a command is not
+ * read as one and a comment after a command is not read as part of it.
+ */
+export function withoutComments(contents: string): string {
+  return contents.replaceAll(/(^|\s)#.*$/gm, "$1");
+}
+
+/**
+ * Splits a command the way a shell would count its words, except that a
+ * `${{ ... }}` workflow expression holds spaces and still stands for one
+ * word. The expression is matched to its first `}}` so that one
+ * containing a brace, as `${{ format('{0}', github.sha) }}` does, still
+ * comes out as one word.
+ */
+export function commandWords(command: string): string[] {
+  return [...command.matchAll(/\$\{\{.*?\}\}|\S+/g)].map((match) => match[0]);
+}
+
+/**
+ * Joins the lines a shell continuation splits a command across, so that
+ * a command written over several lines counts its words as one command.
+ */
+export function withoutContinuations(contents: string): string {
+  return contents.replaceAll(/\\\n/g, " ");
+}

--- a/tasks/ci-workflow.ts
+++ b/tasks/ci-workflow.ts
@@ -26,7 +26,11 @@ function uncommented(line: string): string {
   for (let at = 0; at < line.length; at++) {
     const character = line[at]!;
     if (quote !== undefined) {
-      if (character === quote) quote = undefined;
+      // A backslash inside double quotes takes the next character with
+      // it, in the shell and in a double-quoted scalar alike. Inside
+      // single quotes both hand the backslash over as a character.
+      if (character === "\\" && quote === '"') at += 1;
+      else if (character === quote) quote = undefined;
       continue;
     }
     if (character === '"' || character === "'") {

--- a/tasks/ci-workflow.ts
+++ b/tasks/ci-workflow.ts
@@ -9,13 +9,34 @@
  */
 
 /**
- * Drops YAML comments. A `#` after whitespace ends a plain scalar, so
- * what is left on a line is the value the workflow carries. Applied
- * before looking for commands, so that a comment naming a command is not
- * read as one and a comment after a command is not read as part of it.
+ * Drops comments. A `#` after whitespace ends a plain scalar, and ends a
+ * command in the shell a block scalar hands its lines to. A `#` inside
+ * quotes is a character of the command, so the rest of that line stays.
+ * Applied before looking for commands, so that a comment naming a
+ * command is not read as one and a comment after a command is not read
+ * as part of it.
  */
 export function withoutComments(contents: string): string {
-  return contents.replaceAll(/(^|\s)#.*$/gm, "$1");
+  return contents.split("\n").map(uncommented).join("\n");
+}
+
+/** The part of one line that a comment does not take. */
+function uncommented(line: string): string {
+  let quote: string | undefined;
+  for (let at = 0; at < line.length; at++) {
+    const character = line[at]!;
+    if (quote !== undefined) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character !== "#") continue;
+    if (at === 0 || /\s/.test(line[at - 1]!)) return line.slice(0, at);
+  }
+  return line;
 }
 
 /**


### PR DESCRIPTION
A workflow step can wrap a command in `deno task run-recorded <kind> <scope> <name>`. Those three words are the command's identity. Every record the command writes carries that identity.

The test topology is the other place an identity is written down. A lane builds its commands from the topology. A lane therefore runs the identities the topology holds and no others.

Nothing held the two places to each other. A gate could be wired into a workflow job and into no suite. Two were, until #7109 registered them:

  ["gate","repo","check-pattern-tiers"]
  ["gate","repo","check-action-pins"]

Neither existing half of the drift guard reaches that. The tree half walks the tree for files that look like tests. Nothing in the tree carries a gate's identity. The store half fails on a recorded identity no suite claims, and would have named both. It runs nowhere, because nothing passes it a run's records.

A gate the topology does not hold runs today, because its workflow step runs it. It stops when a lane takes that job over. Nothing reports the change.

Add a third half to `deno task check-test-topology`. It reads the step definitions under `.github`, the composite actions alongside the workflows. It fails on an identity no suite claims. It needs no store and no network. Taking either gate back out of
`tasks/test-topology/gates.ts` makes it name that gate.

The steps are read as words rather than matched against a pattern. A step can name its scope through a matrix expression. A step can quote a part of its identity. A pattern matches neither shape and reports neither. Read as words, the three after `deno task run-recorded` are the identity. A step the guard cannot resolve yields an identity no suite claims, and the check fails on it.

Two functions in `tasks/ci-workflow.test.ts` already answer the two hard parts of that reading. `withoutComments` drops a YAML comment wherever on a line it starts. `commandWords` counts a `${{ ... }}` expression as one word. Both move to `tasks/ci-workflow.ts`. The guard and the test read them from there.

Two steps in the nightly CFC workflow record and belong to no lane: the property suite, and the audit over the corpus that suite writes. Each is declared with the reason no suite claims it. A declaration naming a step no workflow records fails, so the list cannot go stale. The store half reads the same list. A check no lane can be asked to run is a different case and never reaches the list, because `docs/specs/test-records.md` has it record nothing.

The plan carries what this half becomes once the lanes carry the gates. The question turns from whether a step's identity is in the topology into whether the topology could run the step at all.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

