### PR TITLE
fix(test-records): a leaf under the bdd root suite carries a file

### DIFF
--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -24,7 +24,12 @@ A test's identity has three required parts, scoped within a repository:
   repository-root-relative file path with forward slashes, a task name, a
   script's own name (`acl.sh`), a script step (`integration.sh
   piece-values`), or a task-plus-item pair (`cfcheck <file>`,
-  `pattern-compat <key>`, `pattern-vintage <testKey> <tier> <stamp>`).
+  `pattern-compat <key>`, `pattern-vintage <testKey> <tier> <stamp>`). A
+  bdd file declaring a hook outside every `describe` has a root suite
+  invented for it, named `global`, and every chain that file goes on to
+  run opens with that name. A suite it registers as ignored is reported
+  under its bare name. The runner keeps such a suite out of the root
+  suite and never runs its body.
 - **variant**, when present — a stable name for a non-default configuration
   that runs the same test. The default configuration has no variant. The
   server-execution deployed-topology lanes have stable `default` and
@@ -107,9 +112,13 @@ The registration preload is such a module, and it replaces what it takes:
 it writes a name-to-file map into the spool, and ingestion lays that over
 what the report says. The map holds each name `Deno.test` was called with
 and, for a file written with `describe` and `it`, the whole chain of each
-leaf. A suite title two files share says nothing about either and is
-dropped from the merged map; a leaf's whole chain is what usually
-survives that.
+leaf. A hook a file declares outside every `describe` has no suite to
+hold it, so the bdd runner makes one named `global` and every suite that
+file goes on to run sits inside it; the chain each leaf is named by opens
+with that name. A suite title two files share says nothing about either
+and is dropped from the merged map; a leaf's whole chain is what usually
+survives that, and `global` is a title every file declaring such a hook
+shares.
 
 The context line carries `schema` (this document describes version 1, the
 `v1` in object paths), a per-object ULID `reportId`, the canonical `repo`

--- a/packages/test-support/src/records/bdd.ts
+++ b/packages/test-support/src/records/bdd.ts
@@ -3,7 +3,9 @@
  * run one of them.
  *
  * A test's identity is the name its runner reports, which for a file
- * written this way is the describe chain joined with `" > "`.
+ * written this way is the describe chain joined with `" > "`, opening
+ * with the root suite the runner invents for a file whose hooks sit
+ * outside every `describe`.
  * Registration does not follow that shape: `describe` registers one
  * `Deno.test` and every `it` inside it is a step within that one test, so
  * the preload's wrapper around `Deno.test` sees the container and never
@@ -24,7 +26,16 @@
  * whole; see `capturing`.
  */
 
-import { describe as realDescribe, it as realIt } from "@std/testing/bdd/real";
+import {
+  after as realAfter,
+  afterAll as realAfterAll,
+  afterEach as realAfterEach,
+  before as realBefore,
+  beforeAll as realBeforeAll,
+  beforeEach as realBeforeEach,
+  describe as realDescribe,
+  it as realIt,
+} from "@std/testing/bdd/real";
 import {
   activeCapture,
   NAME_SEPARATOR,
@@ -32,15 +43,6 @@ import {
   registeringFile,
   type RegistrationCapture,
 } from "./registration.ts";
-
-export {
-  after,
-  afterAll,
-  afterEach,
-  before,
-  beforeAll,
-  beforeEach,
-} from "@std/testing/bdd/real";
 
 // A test registered through this module is the caller's, not this
 // module's, so the file attribution walks past these frames.
@@ -50,8 +52,19 @@ registerFrameworkModule(import.meta.url);
  * The describe chain enclosing whatever is being registered right now.
  * `describe` runs its body while it registers, so pushing the title
  * around that call is what makes the chain available to the `it`s inside.
+ * A hook declared outside every `describe` opens the chain with the root
+ * suite the runner invents for it, and nothing pops that one: the suite
+ * holds the rest of the file.
  */
 const chain: string[] = [];
+
+/**
+ * The name the bdd runner gives the root suite it invents. A hook
+ * declared outside every `describe` has no suite to hold it, so the
+ * runner makes one under this name and the suites the file goes on to
+ * run sit inside it.
+ */
+const ROOT_SUITE_NAME = "global";
 
 /** The name a bdd call was given, whichever way it was called. */
 export function nameOf(args: readonly unknown[]): string | undefined {
@@ -88,20 +101,25 @@ export function bodyOf(
   return undefined;
 }
 
+/** The shape every one of the bdd hooks shares. */
+type Hook = <T>(fn: (this: T) => void | Promise<void>) => void;
+
 /**
  * Wraps one `describe` entry point so the chain is pushed around the body
- * it registers. A shape this does not model reaches the real function
- * untouched, so an unfamiliar overload still runs and still reports its
- * own error.
+ * it registers. A call with no body registers nothing inside it and
+ * reaches the real function untouched, so an unfamiliar overload still
+ * runs and still reports its own error. A call carrying no title of its
+ * own is named after its body, so the wrapper answers to the body's own
+ * name and the suite is reported under it.
  *
  * Takes no capture: a wrapper is built only where one is installed, and
  * tracking the chain is the whole of what this does with it.
  */
 export function wrapDescribe(through: AnyFunction): AnyFunction {
   return (...args: unknown[]): unknown => {
-    const name = nameOf(args);
     const found = bodyOf(args);
-    if (name === undefined || found === undefined) return through(...args);
+    if (found === undefined) return through(...args);
+    const name = nameOf(args) ?? found.body.name;
     const wrapped = function (this: unknown, ...rest: unknown[]): unknown {
       chain.push(name);
       try {
@@ -110,6 +128,7 @@ export function wrapDescribe(through: AnyFunction): AnyFunction {
         chain.pop();
       }
     };
+    Object.defineProperty(wrapped, "name", { value: found.body.name });
     if (found.index >= 0) {
       const next = [...args];
       next[found.index] = wrapped;
@@ -215,3 +234,39 @@ export const it: typeof realIt = capture === undefined
 
 /** The alias `@std/testing/bdd` gives `it`. */
 export const test: typeof realIt = it;
+
+/**
+ * Wraps one hook where a capture is installed, and not otherwise.
+ *
+ * A call outside every `describe` is what makes the runner invent its
+ * root suite, so the chain opens with that suite's name from there on
+ * and every leaf is named inside it. The name goes on once the call has
+ * returned, so a hook the runner refuses — it refuses one declared after
+ * a test has started — leaves the naming alone. Deno gives each test
+ * file a realm of its own, so the chain is one file's.
+ */
+function hook(real: Hook): Hook {
+  if (capture === undefined) return real;
+  return (fn) => {
+    real(fn);
+    if (chain.length === 0) chain.push(ROOT_SUITE_NAME);
+  };
+}
+
+/** `beforeEach`, noticing a call that brings the root suite about. */
+export const beforeEach: typeof realBeforeEach = hook(realBeforeEach);
+
+/** `afterEach`, noticing the same. */
+export const afterEach: typeof realAfterEach = hook(realAfterEach);
+
+/** `beforeAll`, noticing the same. */
+export const beforeAll: typeof realBeforeAll = hook(realBeforeAll);
+
+/** `afterAll`, noticing the same. */
+export const afterAll: typeof realAfterAll = hook(realAfterAll);
+
+/** The alias `@std/testing/bdd` gives `beforeAll`. */
+export const before: typeof realBefore = hook(realBefore);
+
+/** The alias `@std/testing/bdd` gives `afterAll`. */
+export const after: typeof realAfter = hook(realAfter);

--- a/packages/test-support/test/records/preload.test.ts
+++ b/packages/test-support/test/records/preload.test.ts
@@ -144,6 +144,94 @@ describe("outer", () => {
 });
 `;
 
+// A file declaring a hook outside every `describe`. The bdd runner has
+// no suite to hold it, so it makes one of its own named `global` and
+// every suite the file registers after that is a step inside it, which
+// puts that name at the head of each leaf's chain.
+const HOOKED_FILE =
+  `import { beforeEach, describe, it } from "@std/testing/bdd";
+let ran = 0;
+beforeEach(() => {
+  ran++;
+});
+describe("hooked", () => {
+  it("kept", () => {
+    if (ran === 0) throw new Error("the hook did not run");
+  });
+  it("dropped", () => {});
+});
+`;
+
+// A second file doing the same, so the run holds two root suites under
+// the one name. That name says nothing about either file, and what
+// carries a file is the whole chain of each leaf beneath it.
+const SECOND_HOOKED_FILE =
+  `import { afterEach, describe, it } from "@std/testing/bdd";
+afterEach(() => {});
+describe("second", () => {
+  it("kept", () => {});
+});
+`;
+
+// A file declaring all six hooks the re-export hands out, inside a
+// `describe` rather than outside every one. Each hook writes its own
+// name as it fires, so what the file leaves behind is the order the
+// runner ran them in, and its leaves are named without a root suite.
+const EVERY_HOOK_FILE = `import {
+  after,
+  afterAll,
+  afterEach,
+  before,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "@std/testing/bdd";
+
+function note(what: string) {
+  Deno.writeTextFileSync("hooks.log", what + " ", {
+    append: true,
+    create: true,
+  });
+}
+
+describe("hooks", () => {
+  beforeAll(() => note("beforeAll"));
+  before(() => note("before"));
+  beforeEach(() => note("beforeEach"));
+  afterEach(() => note("afterEach"));
+  afterAll(() => note("afterAll"));
+  after(() => note("after"));
+  it("first", () => {});
+  it("second", () => {});
+});
+`;
+
+// A file whose outermost `describe` carries no title of its own. The
+// runner names such a suite after the body it was given.
+const TITLELESS_FILE = `import { describe, it } from "@std/testing/bdd";
+describe(function first() {
+  it("kept", () => {});
+});
+`;
+
+// A second file doing the same, so the run holds two such suites. Each
+// is named after its own body, and the two names are different.
+const SECOND_TITLELESS_FILE = `import { describe, it } from "@std/testing/bdd";
+describe(function second() {
+  it("kept", () => {});
+});
+`;
+
+// A file whose `describe` carries neither a title nor a body with a
+// name in it. The suite's name is empty, and the runner is what says
+// so.
+const NAMELESS_FILE = `import { describe, it } from "@std/testing/bdd";
+describe(() => {
+  it("kept", () => {});
+});
+`;
+
 // Two modules that register a suite for whoever calls them, one
 // declaring itself machinery and one not. What each leaf's file comes
 // out as is the whole of what the declaration does.
@@ -233,6 +321,122 @@ describe("preload", () => {
       const byName = new Map(records.map((r) => [r.test.n, r.file]));
       expect(byName.get("outer > kept")).toEqual("bdd.test.ts");
       expect(byName.get("outer > elsewhere")).toEqual("shared.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("names a leaf inside the root suite a file-scope hook brings about", async () => {
+    const fixture = await makeFixture({
+      "hooked.test.ts": HOOKED_FILE,
+      "second.test.ts": SECOND_HOOKED_FILE,
+      "bdd.test.ts": BDD_FILE,
+    });
+    try {
+      const run = await runFixture(fixture, [
+        "hooked.test.ts",
+        "second.test.ts",
+        "bdd.test.ts",
+      ]);
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const names = await readNameMaps(fixture.spool);
+      // Both hooked files register a root suite under the one name, so
+      // that name carries no file and each leaf carries its own.
+      expect(names.get("global")).toBeUndefined();
+      expect(names.get("global > hooked > kept")).toEqual("hooked.test.ts");
+      expect(names.get("global > second > kept")).toEqual("second.test.ts");
+      // The third file declares no hook, so the runner invents nothing
+      // for it and its leaves are named by their own chain.
+      expect(names.get("outer > kept")).toEqual("bdd.test.ts");
+      expect(names.get("global > outer > kept")).toBeUndefined();
+
+      // The names the report gives those leaves, so the map is joined
+      // onto them rather than sitting beside them.
+      const records = ingestJUnit(await Deno.readTextFile(fixture.junit), {
+        kind: "unit",
+        scope: "fixture",
+        fileByName: names,
+      });
+      const byName = new Map(records.map((r) => [r.test.n, r.file]));
+      expect(byName.get("global > hooked > kept")).toEqual("hooked.test.ts");
+      expect(byName.get("global > second > kept")).toEqual("second.test.ts");
+      expect(byName.get("outer > kept")).toEqual("bdd.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("hands out each hook, and one inside a describe invents no suite", async () => {
+    const fixture = await makeFixture({ "hooks.test.ts": EVERY_HOOK_FILE });
+    try {
+      const run = await runFixture(fixture, ["hooks.test.ts"]);
+      assert(run.success, new TextDecoder().decode(run.stderr));
+
+      // The order the runner ran them in. A binding reaching a function
+      // other than the one it names moves or drops a line here, which
+      // nothing else in this suite would notice.
+      const fired = await Deno.readTextFile(join(fixture.dir, "hooks.log"));
+      expect(fired.trim().split(" ")).toEqual([
+        "beforeAll",
+        "before",
+        "beforeEach",
+        "afterEach",
+        "beforeEach",
+        "afterEach",
+        "afterAll",
+        "after",
+      ]);
+
+      // The hooks sit inside a `describe`, so the runner has a suite to
+      // hold them and invents none of its own.
+      const names = await readNameMaps(fixture.spool);
+      expect(names.get("hooks > first")).toEqual("hooks.test.ts");
+      expect(names.get("global > hooks > first")).toBeUndefined();
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("names a suite whose call carries no title after its body", async () => {
+    const fixture = await makeFixture({
+      "first.test.ts": TITLELESS_FILE,
+      "second.test.ts": SECOND_TITLELESS_FILE,
+    });
+    try {
+      const run = await runFixture(fixture, [
+        "first.test.ts",
+        "second.test.ts",
+      ]);
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const names = await readNameMaps(fixture.spool);
+      expect(names.get("first > kept")).toEqual("first.test.ts");
+      expect(names.get("second > kept")).toEqual("second.test.ts");
+
+      // The name the report gives each leaf, which is the body's name and
+      // not the wrapper's. A wrapper name would be one name two files
+      // share, and neither leaf would carry a file.
+      const records = ingestJUnit(await Deno.readTextFile(fixture.junit), {
+        kind: "unit",
+        scope: "fixture",
+        fileByName: names,
+      });
+      const byName = new Map(records.map((r) => [r.test.n, r.file]));
+      expect(byName.get("first > kept")).toEqual("first.test.ts");
+      expect(byName.get("second > kept")).toEqual("second.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("leaves a suite with no name at all to the runner to refuse", async () => {
+    const fixture = await makeFixture({ "nameless.test.ts": NAMELESS_FILE });
+    try {
+      const run = await runFixture(fixture, ["nameless.test.ts"]);
+      expect(run.success).toBe(false);
+      // The runner's own report of the call it refused, which is what
+      // reaches a reader of the run rather than the wrapper's name.
+      const reported = new TextDecoder().decode(run.stdout);
+      expect(reported).toContain("The test name can't be empty");
     } finally {
       await Deno.remove(fixture.dir, { recursive: true });
     }
@@ -429,6 +633,21 @@ describe("preload", () => {
       const reported = await outcomes(fixture);
       expect(reported.get("outer > kept")).toEqual("pass");
       expect(reported.get("outer > dropped")).toEqual("skip");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("skips a leaf under the root suite by the name it is reported as", async () => {
+    const fixture = await makeFixture({ "hooked.test.ts": HOOKED_FILE });
+    try {
+      const run = await runFixture(fixture, ["hooked.test.ts"], {
+        "hooked.test.ts": ["global > hooked > dropped"],
+      });
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const reported = await outcomes(fixture);
+      expect(reported.get("global > hooked > kept")).toEqual("pass");
+      expect(reported.get("global > hooked > dropped")).toEqual("skip");
     } finally {
       await Deno.remove(fixture.dir, { recursive: true });
     }


### PR DESCRIPTION
PROBLEM

A test record with no source file has no unit in the topology, so every lane runs it, and a file declaring a hook outside every `describe` puts its leaves in that state. The runner has no suite to hold such a hook, so it makes one named `global` and every suite the file goes on to run sits inside it. Each leaf is reported as `global > <describe> > <it>`, while the chain the records re-export tracks opens at the file's own outermost `describe`, so the name it writes matches no leaf. The leaves rest on the `global` entry instead, which two such files in one report make ambiguous.

SOLUTION

Wrap the six hooks the re-export hands out, alongside `describe` and `it`. A call arriving outside every `describe` is what brings the root suite about, so the chain opens with that suite's name from there on and each leaf carries its own file rather than resting on a prefix it shares with every other leaf in the file.

The skip list is keyed by the identity the runner reports, so a leaf under the root suite can now be left out of an invocation, which it could not be before.

The wrapper `describe` substitutes for a body now answers to that body's own name. The runner takes a suite's name from its body where the call carries no title, so such a suite was reported under the wrapper's name, and a body with no name at all registered rather than being refused.

Measured over packages/toolshed, run the way the workspace runner runs it: 536 records, 33 of them carrying no file before this and none after.

DESIGN DISCUSSION

Deno gives each test file a realm of its own, so the chain covers exactly the file that declared the hook. The suite's name goes on the chain once the call has returned, so a hook the runner refuses — it refuses one declared after a test has started — leaves the naming alone. Nothing pops that name: the suite is the runner's and it holds the rest of the file.

The root suite's name is written out here rather than read from the runner. It comes from `addHook` in `@std/testing/bdd`, which the manifest pins with a caret, so a rename there would land as a failure of the test that names a leaf inside the root suite rather than as silence.

`wrapDescribe` no longer refuses a call carrying a body but no title of its own. The chain then holds an entry for that suite, so a hook inside its body is no longer read as one declared outside every `describe`.

Eight other files declare such a hook: three in packages/cli, two in packages/content-hash, and one each in packages/navigation, packages/shell and tasks. The same measurement over packages/shell and packages/navigation is unchanged, at no fileless records either way, because one file registering `global` leaves that entry unambiguous and every leaf beneath it reaches a file through it. What changes for those files is that a leaf's file stops depending on how many files in one report declare such a hook.

An ignored suite is the exception the specification now names: the runner keeps it out of the root suite and never runs its body, so it holds no leaf for the naming to reach.

The tests cover the naming of a leaf under the root suite, a skip list keyed by such a leaf's reported name, the six hook bindings and the guard that tells a file-scope hook from one inside a `describe`, a suite whose call carries no title, and one with no name to take at all.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

