### PR TITLE
perf(lunch-poll): the tally reads the vote list and the roster once

### DIFF
--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -88,6 +88,7 @@ import {
 import PollOptionCard from "./poll-option-card.tsx";
 import ParticipantIdentityCard from "./participant-identity-card.tsx";
 import { safeImageUrl } from "./generated-art.tsx";
+import { memoBy } from "./voter-memo.ts";
 
 /**
  * The minimal profile shape this pattern reads: the stable identity cell for
@@ -1017,15 +1018,31 @@ interface OptionTally {
 }
 
 /**
- * The key a voter's cell groups under, so that a lookup made for one of a
- * voter's votes serves the rest. A voter is compared with `equals()`, which
- * resolves both sides; this key only says which cells are the same link, so
- * two spellings of one voter cost one comparison each and never a wrong one.
+ * The key a voter's cell is looked up under, so that a lookup made for one of
+ * a voter's votes serves the rest. The key is a hint, not an identity: it is
+ * built from the entity id and path alone, and two profile cells in different
+ * spaces or scopes can share one. A remembered answer is served only to a
+ * voter whose link equals the one it was computed for; other voters under the
+ * same key are kept apart.
  */
 const voterKey = (voter: LunchProfileCell): string | undefined => {
   const id = getEntityId(voter);
   return id === undefined ? undefined : entityRefToString(id);
 };
+
+/**
+ * Remembers `compute(voter)` per voter, so a voter who cast several votes is
+ * looked up once. A hit is a remembered voter whose link equals this one, not
+ * merely one whose key matches.
+ */
+const memoByVoter = <T,>(
+  compute: (voter: LunchProfileCell) => T,
+): (voter: LunchProfileCell) => T =>
+  memoBy(
+    voterKey,
+    (remembered, voter) => remembered.equalLinks(voter),
+    compute,
+  );
 
 /** A vote as the tally holds it: read off the reactive list once. */
 type VoteRecord = Pick<Vote, "voter" | "voteType">;
@@ -1043,13 +1060,15 @@ const groupVotesByOption = (
 ): Map<string, VoteRecord[]> => {
   const byOption = new Map<string, VoteRecord[]>();
   for (const vote of votes) {
+    const voter = vote.voter;
+    const optionId = vote.optionId;
     const record: VoteRecord = {
       voteType: vote.voteType,
-      ...(vote.voter === undefined ? {} : { voter: vote.voter }),
+      ...(voter === undefined ? {} : { voter }),
     };
-    const group = byOption.get(vote.optionId);
+    const group = byOption.get(optionId);
     if (group === undefined) {
-      byOption.set(vote.optionId, [record]);
+      byOption.set(optionId, [record]);
     } else {
       group.push(record);
     }
@@ -1070,39 +1089,26 @@ const tallyOptions = (
   // are looked up from the roster by comparison. A voter who has left the
   // roster still tallies; they just render without a name. The roster is read
   // once, and each voter is compared once however many votes they cast.
-  const roster = users.map((u) => ({
-    name: u.name,
-    color: u.color,
-    ...(u.profile === undefined ? {} : { profile: u.profile }),
-  }));
+  const roster = users.map((u) => {
+    const profile = u.profile;
+    return {
+      name: u.name,
+      color: u.color,
+      ...(profile === undefined ? {} : { profile }),
+    };
+  });
   const participantNames = roster.map((u) => u.name);
   const initialsByName = getInitialsByName(participantNames);
-  const rosterByVoter = new Map<string, (typeof roster)[number] | undefined>();
+  const rosterEntryOf = memoByVoter((voter) =>
+    roster.find((u) => u.profile !== undefined && equals(u.profile, voter))
+  );
   const rosterOf = (
     voter: LunchProfileCell | undefined,
-  ): (typeof roster)[number] | undefined => {
-    if (voter === undefined) return undefined;
-    const key = voterKey(voter);
-    if (key !== undefined && rosterByVoter.has(key)) {
-      return rosterByVoter.get(key);
-    }
-    const entry = roster.find((u) =>
-      u.profile !== undefined && equals(u.profile, voter)
-    );
-    if (key !== undefined) rosterByVoter.set(key, entry);
-    return entry;
-  };
-  const selfByVoter = new Map<string, boolean>();
-  const isSelf = (voter: LunchProfileCell | undefined): boolean => {
-    if (viewer === undefined || voter === undefined) return false;
-    const key = voterKey(voter);
-    if (key !== undefined && selfByVoter.has(key)) {
-      return selfByVoter.get(key)!;
-    }
-    const same = equals(voter, viewer);
-    if (key !== undefined) selfByVoter.set(key, same);
-    return same;
-  };
+  ): (typeof roster)[number] | undefined =>
+    voter === undefined ? undefined : rosterEntryOf(voter);
+  const viewerIs = memoByVoter((voter) => equals(voter, viewer));
+  const isSelf = (voter: LunchProfileCell | undefined): boolean =>
+    viewer !== undefined && voter !== undefined && viewerIs(voter);
   const byOption = groupVotesByOption(votes);
   const tallies = options.map((option): OptionTally => {
     const optionVotes = byOption.get(option.id) ?? [];

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -1016,6 +1016,47 @@ interface OptionTally {
   }>;
 }
 
+/**
+ * The key a voter's cell groups under, so that a lookup made for one of a
+ * voter's votes serves the rest. A voter is compared with `equals()`, which
+ * resolves both sides; this key only says which cells are the same link, so
+ * two spellings of one voter cost one comparison each and never a wrong one.
+ */
+const voterKey = (voter: LunchProfileCell): string | undefined => {
+  const id = getEntityId(voter);
+  return id === undefined ? undefined : entityRefToString(id);
+};
+
+/** A vote as the tally holds it: read off the reactive list once. */
+type VoteRecord = Pick<Vote, "voter" | "voteType">;
+
+/**
+ * Reads each vote off the poll's list once and groups the records by option.
+ *
+ * Every element and property read on a reactive list is a runtime call — a
+ * link resolved and a labeled view built — so the tally takes its votes from
+ * this one pass rather than scanning the list once per option and again per
+ * color.
+ */
+const groupVotesByOption = (
+  votes: readonly Vote[],
+): Map<string, VoteRecord[]> => {
+  const byOption = new Map<string, VoteRecord[]>();
+  for (const vote of votes) {
+    const record: VoteRecord = {
+      voteType: vote.voteType,
+      ...(vote.voter === undefined ? {} : { voter: vote.voter }),
+    };
+    const group = byOption.get(vote.optionId);
+    if (group === undefined) {
+      byOption.set(vote.optionId, [record]);
+    } else {
+      group.push(record);
+    }
+  }
+  return byOption;
+};
+
 const tallyOptions = (
   options: readonly Option[],
   votes: readonly Vote[],
@@ -1027,20 +1068,57 @@ const tallyOptions = (
 ): OptionTally[] => {
   // A vote carries its voter's identity, so the display name and swatch colour
   // are looked up from the roster by comparison. A voter who has left the
-  // roster still tallies; they just render without a name.
-  const participantNames = users.map((u) => u.name);
+  // roster still tallies; they just render without a name. The roster is read
+  // once, and each voter is compared once however many votes they cast.
+  const roster = users.map((u) => ({
+    name: u.name,
+    color: u.color,
+    ...(u.profile === undefined ? {} : { profile: u.profile }),
+  }));
+  const participantNames = roster.map((u) => u.name);
   const initialsByName = getInitialsByName(participantNames);
-  const rosterOf = (voter: LunchProfileCell | undefined): User | undefined =>
-    voter === undefined
-      ? undefined
-      : users.find((u) => equals(u.profile, voter));
+  const rosterByVoter = new Map<string, (typeof roster)[number] | undefined>();
+  const rosterOf = (
+    voter: LunchProfileCell | undefined,
+  ): (typeof roster)[number] | undefined => {
+    if (voter === undefined) return undefined;
+    const key = voterKey(voter);
+    if (key !== undefined && rosterByVoter.has(key)) {
+      return rosterByVoter.get(key);
+    }
+    const entry = roster.find((u) =>
+      u.profile !== undefined && equals(u.profile, voter)
+    );
+    if (key !== undefined) rosterByVoter.set(key, entry);
+    return entry;
+  };
+  const selfByVoter = new Map<string, boolean>();
+  const isSelf = (voter: LunchProfileCell | undefined): boolean => {
+    if (viewer === undefined || voter === undefined) return false;
+    const key = voterKey(voter);
+    if (key !== undefined && selfByVoter.has(key)) {
+      return selfByVoter.get(key)!;
+    }
+    const same = equals(voter, viewer);
+    if (key !== undefined) selfByVoter.set(key, same);
+    return same;
+  };
+  const byOption = groupVotesByOption(votes);
   const tallies = options.map((option): OptionTally => {
-    const optionVotes = votes.filter((v) => v.optionId === option.id);
+    const optionVotes = byOption.get(option.id) ?? [];
+    let green = 0;
+    let yellow = 0;
+    let red = 0;
+    for (const v of optionVotes) {
+      if (v.voteType === "green") green++;
+      else if (v.voteType === "yellow") yellow++;
+      else if (v.voteType === "red") red++;
+    }
     return {
       option,
-      green: optionVotes.filter((v) => v.voteType === "green").length,
-      yellow: optionVotes.filter((v) => v.voteType === "yellow").length,
-      red: optionVotes.filter((v) => v.voteType === "red").length,
+      green,
+      yellow,
+      red,
       voters: optionVotes.map((v) => {
         const entry = rosterOf(v.voter);
         const name = entry?.name ?? "";
@@ -1050,7 +1128,7 @@ const tallyOptions = (
           color: entry?.color ?? "#888",
           initials: initialsByName.get(name) ??
             getInitials(name, participantNames),
-          isSelf: viewer !== undefined && equals(v.voter, viewer),
+          isSelf: isSelf(v.voter),
         };
       }),
     };

--- a/packages/patterns/lunch-poll/voter-memo.test.ts
+++ b/packages/patterns/lunch-poll/voter-memo.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { memoBy } from "./voter-memo.ts";
+
+/** A stand-in for a profile cell: an entity id, and the space it lives in. */
+interface Voter {
+  id: string;
+  space: string;
+}
+
+const keyOf = (voter: Voter) => voter.id;
+const sameLink = (a: Voter, b: Voter) => a.id === b.id && a.space === b.space;
+
+describe("voter-memo", () => {
+  describe("memoBy", () => {
+    it("computes once for a subject seen again", () => {
+      const computed: Voter[] = [];
+      const nameOf = memoBy(keyOf, sameLink, (voter: Voter) => {
+        computed.push(voter);
+        return `name of ${voter.id}`;
+      });
+      const alice: Voter = { id: "profile", space: "did:key:alice" };
+
+      expect(nameOf(alice)).toBe("name of profile");
+      expect(nameOf({ ...alice })).toBe("name of profile");
+      expect(computed).toHaveLength(1);
+    });
+
+    it("keeps apart two subjects that share a key but are not the same", () => {
+      const nameOf = memoBy(
+        keyOf,
+        sameLink,
+        (voter: Voter) => `${voter.id} in ${voter.space}`,
+      );
+      const alice: Voter = { id: "profile", space: "did:key:alice" };
+      const bob: Voter = { id: "profile", space: "did:key:bob" };
+
+      expect(nameOf(alice)).toBe("profile in did:key:alice");
+      expect(nameOf(bob)).toBe("profile in did:key:bob");
+      expect(nameOf(alice)).toBe("profile in did:key:alice");
+      expect(nameOf(bob)).toBe("profile in did:key:bob");
+    });
+
+    it("computes each time for a subject with no key", () => {
+      let computed = 0;
+      const answer = memoBy(
+        () => undefined,
+        sameLink,
+        (_voter: Voter) => ++computed,
+      );
+      const alice: Voter = { id: "profile", space: "did:key:alice" };
+
+      expect(answer(alice)).toBe(1);
+      expect(answer(alice)).toBe(2);
+    });
+
+    it("remembers a computed `undefined` as an answer", () => {
+      let computed = 0;
+      const rosterEntry = memoBy(keyOf, sameLink, (_voter: Voter) => {
+        computed++;
+        return undefined;
+      });
+      const stranger: Voter = { id: "gone", space: "did:key:stranger" };
+
+      expect(rosterEntry(stranger)).toBeUndefined();
+      expect(rosterEntry(stranger)).toBeUndefined();
+      expect(computed).toBe(1);
+    });
+  });
+});

--- a/packages/patterns/lunch-poll/voter-memo.ts
+++ b/packages/patterns/lunch-poll/voter-memo.ts
@@ -1,0 +1,46 @@
+/**
+ * A memo keyed by a hint, with each hit confirmed against the subject it was
+ * computed for.
+ *
+ * A key here is cheap to derive and may be shared by subjects that are not
+ * the same — a profile cell's entity id, say, which two cells in different
+ * spaces can share. So a key only narrows the search: a remembered answer is
+ * served to a subject the `same` comparison accepts, and subjects sharing a
+ * key are kept apart.
+ */
+
+/** An answer computed for one subject, remembered under a key others may share. */
+interface MemoEntry<Subject, Answer> {
+  subject: Subject;
+  answer: Answer;
+}
+
+/**
+ * Remembers `compute(subject)` per subject. `keyOf` narrows the search and a
+ * subject it cannot key is computed every time; `same` decides whether a
+ * remembered subject is this one.
+ */
+export const memoBy = <Subject, Answer>(
+  keyOf: (subject: Subject) => string | undefined,
+  same: (remembered: Subject, subject: Subject) => boolean,
+  compute: (subject: Subject) => Answer,
+): (subject: Subject) => Answer => {
+  const entries = new Map<string, MemoEntry<Subject, Answer>[]>();
+  return (subject) => {
+    const key = keyOf(subject);
+    if (key === undefined) return compute(subject);
+    const known = entries.get(key);
+    if (known !== undefined) {
+      for (const entry of known) {
+        if (same(entry.subject, subject)) return entry.answer;
+      }
+    }
+    const answer = compute(subject);
+    if (known === undefined) {
+      entries.set(key, [{ subject, answer }]);
+    } else {
+      known.push({ subject, answer });
+    }
+    return answer;
+  };
+};


### PR DESCRIPTION
## What

`tallyOptions` scanned the whole vote list once per option and three more times per option for the colors, then looked each vote's voter up in the roster by comparing cells against every row. Every element and property read on a reactive list is a runtime call — a link resolved and a labeled view built — so at 74 votes and 14 options that was a few thousand runtime reads per run, and the run was most of what a vote costs on the deployed poll.

The tally now reads each vote off the list once into plain records grouped by option, reads the roster once, and remembers each voter's roster entry and self-comparison, so a voter is compared once however many votes they cast. The memo is keyed by the voter's entity id, which is a hint rather than an identity (two profile cells in different spaces can share one), so a remembered answer is served only to a voter whose link equals the one it was computed for; the memo is its own module, `voter-memo.ts`. The tally's result, the graph, and the option cards are unchanged; the option cards' own scan is a separate change.

## Measured on a clone of the live space

Rehearsed per `docs/development/space-clone-rehearsal.md` on a snapshot of team-lunch taken 2026-09-09 18:11 UTC (74 votes, 8 users, 14 options), served locally with CFC `enforce-explicit` and server-execution OFF, the same posture as estuary. Votes were moved into the current day so the tally runs over all 74 as it did on estuary on 9/8; a throwaway participant cast and removed one vote per round through the real UI, with a V8 sampling profile around both clicks.

| | production source (min of 2) | this branch (min of 2) |
| --- | --- | --- |
| click → voter's own render, cast | 1,539 ms | 570 ms |
| click → voter's own render, removal | 1,356 ms | 570 ms |
| action bodies per cast+removal | 1,865 ms | 643 ms |
| slowest single action (the tally lift) | 483 ms | 55 ms |
| worker busy per click | 1,551 ms | 625 ms |
| `canonicalizeCfcLogicalPath` self time per click | 344 ms | 121 ms |

The remaining cost is the fourteen option cards each scanning the vote list for the viewer's own vote, and the tally's single pass; those are the next change.

## Why no local rig could show this

At the same size and posture the tally costs ~4 ms in the pattern-test runner and ~45 ms in the headless multi-runtime probe, against ~500 ms in the browser on real data, so neither local rig can resolve the change, and the runner's per-step stats do not count reactive-proxy accesses at all (#7155's Track A1). The clone reproduces the production cost, even though the voters' home spaces aren't in it.

One rehearsal note for the runbook: `setsrc --check` refuses any source on such a clone (`votes: 0: voter: value does not match type object`, including the deployed source itself) because the review judges an unreadable link strictly, while the apply's setup defers it as a placeholder; the apply path was used here.

## Verification

- All seven lunch-poll pattern tests pass (36, 13, 11, 14, 1, 4, 9 assertions); `voter-memo.test.ts` pins the shared-key case; `cf check` clean; `deno fmt`/`deno lint` clean.
- Rehearsal artifacts (profiles, per-round captures, the measurement script) are in the perf workline directory, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
