### PR TITLE
fix(test-records): the caller appending the preload grants the write

### DIFF
--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -310,17 +310,49 @@ leaves the map in the spool, and it applies `CF_TEST_SKIP_LIST`. Wrapping
 own, so a process with nothing to skip and no spool it may write leaves
 `Deno.test` alone and the report's own class names are read instead.
 
-Both of those need permissions the test task grants. Reading
-`CF_TEST_RECORDS_DIR` and `CF_TEST_SKIP_LIST` needs `--allow-env`, so a
-task naming a restricted list of variables names those two among them —
-`readEnv` swallows the refusal, so a task that leaves them out records
-nothing and skips nothing, silently.
+Both of those need permissions. Reading `CF_TEST_RECORDS_DIR` and
+`CF_TEST_SKIP_LIST` needs `--allow-env`, and that one the test task
+grants: a task naming a restricted list of variables names those two
+among them — `readEnv` swallows the refusal, so a task that leaves them
+out records nothing and skips nothing, silently.
+
 Writing the map needs `--allow-write` covering the directory the run
-owner put the spool in, which is a path only the environment knows: a
-task string cannot name it, because `deno task` expands `$VAR` but not
-`${VAR:-default}`, and `--allow-write=` with an unset variable ends the
-run with `Empty values are not allowed`. So a task that has to capture
-grants a write path wide enough to hold whatever spool a run hands it.
+owner put the spool in, and that one the task cannot grant, because it
+cannot name the path: `deno task` expands `$VAR` but not
+`${VAR:-default}`, `--allow-write=` with an unset variable ends the run
+with `Empty values are not allowed`, and a `$` costs its member the file
+granularity `tasks/test-topology/deno-task.ts` reads its task for —
+every `$` but the one command substitution that file resolves, which is
+the `deno eval` naming the executable that several tasks already carry.
+So the caller that appends the preload appends the permission beside it.
+`spoolWriteArgument()` from
+`@commonfabric/test-support/records` builds that argument, and it builds
+none for an invocation already permitted to write everywhere. Deno merges
+two `--allow-write` path lists, so an invocation naming a list of its own
+takes the spool on top of it. A blanket grant is the one that cannot take
+a list beside it: `-A` and `--allow-all` refuse the combination outright,
+ending the run with `the argument '--allow-all...' cannot be used with
+'--allow-write[=<PATH>...]'`, and a bare `--allow-write` or `-W` is cut
+down to whatever list joins it. Short flags cluster, so `-RW` is a
+blanket grant of both, and `-A` is one of everything.
+
+It builds none for an invocation that cannot read the filesystem either,
+and that is the case to hold on to. A writable spool is what makes the
+preload wrap `Deno.test`, and wrapping is what costs the report the class
+names ingestion reads each case's file from; the files that replace them
+come from climbing to the directory holding `.git`, which needs read
+permission. So the write and the read go together, and an invocation
+granted one without the other records no file for any of its tests.
+`tasks/test-topology/package-integration.ts` holds a part in that shape,
+with `--allow-env` and no `--allow-read`.
+
+Three callers append the preload. `tasks/workspace-tests.ts` appends it
+to each member's `deno task test`, and `tasks/test-topology/suite.ts`
+appends it to each invocation a batch runs; both take the write argument
+from `spoolWriteArgument()`. `tasks/integration.ts` appends it without
+one, because every invocation it builds runs under `-A`, so the helper
+would build nothing for any of them. A task there that ever narrows its
+permissions needs the argument too.
 
 A test task naming its own `--import-map` does not take the preload. That
 map governs every module of the invocation, the preload included, so a

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -346,13 +346,16 @@ granted one without the other records no file for any of its tests.
 `tasks/test-topology/package-integration.ts` holds a part in that shape,
 with `--allow-env` and no `--allow-read`.
 
-Three callers append the preload. `tasks/workspace-tests.ts` appends it
-to each member's `deno task test`, and `tasks/test-topology/suite.ts`
-appends it to each invocation a batch runs; both take the write argument
-from `spoolWriteArgument()`. `tasks/integration.ts` appends it without
-one, because every invocation it builds runs under `-A`, so the helper
-would build nothing for any of them. A task there that ever narrows its
-permissions needs the argument too.
+Four callers append the preload, and three of them append the write
+beside it. `tasks/workspace-tests.ts` appends both to each member's
+`deno task test`, taking the write from `spoolWriteArgument()` directly.
+The two topology suites append both to each invocation a batch runs —
+`fileSuite` in `tasks/test-topology/suite.ts` and `unitSuite` in
+`tasks/test-topology/unit.ts` — through `recordingArguments()`, which is
+where the helper is called for them. The fourth, `tasks/integration.ts`,
+appends the preload alone, because every invocation it builds runs under
+`-A` and the helper would build nothing for any of them. A task there
+that ever narrows its permissions needs the argument too.
 
 A test task naming its own `--import-map` does not take the preload. That
 map governs every module of the invocation, the preload included, so a

--- a/packages/test-support/src/records/mod.ts
+++ b/packages/test-support/src/records/mod.ts
@@ -78,7 +78,11 @@ export {
   SKIP_LIST_VARIABLE,
 } from "./registration.ts";
 export type { NameMap, RegistrationCapture, SkipList } from "./registration.ts";
-export { preloadArgument, preloadModulePath } from "./preload-path.ts";
+export {
+  preloadArgument,
+  preloadModulePath,
+  spoolWriteArgument,
+} from "./preload-path.ts";
 export {
   dropContainerCases,
   ingestJUnit,

--- a/packages/test-support/src/records/preload-path.test.ts
+++ b/packages/test-support/src/records/preload-path.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { preloadArgument, spoolWriteArgument } from "./preload-path.ts";
+
+describe("preload-path", () => {
+  it("names the preload by an absolute path", () => {
+    const argument = preloadArgument();
+    expect(argument.startsWith("--preload=/")).toBe(true);
+    expect(argument.endsWith("/preload.ts")).toBe(true);
+  });
+
+  it("grants the spool where the flags name a write list of their own", () => {
+    expect(
+      spoolWriteArgument(
+        ["--allow-read", "--allow-write=/tmp", "a.test.ts"],
+        "/s",
+      ),
+    ).toBe("--allow-write=/s");
+  });
+
+  it("grants the spool where the flags name no write at all", () => {
+    expect(spoolWriteArgument(["--allow-read", "a.test.ts"], "/s")).toBe(
+      "--allow-write=/s",
+    );
+  });
+
+  it("grants nothing where the flags already write anywhere", () => {
+    // Beside `-A` or `--allow-all` Deno refuses the combination and the
+    // run never starts. Beside a bare `--allow-write` or `-W` the list
+    // would cut that grant down to itself.
+    for (const flag of ["-A", "--allow-all", "-W", "--allow-write"]) {
+      expect(spoolWriteArgument([flag, "--allow-read", "a.test.ts"], "/s"))
+        .toBeUndefined();
+    }
+  });
+
+  it("grants nothing where the flags cannot read the tree", () => {
+    // A writable spool is what makes the preload wrap `Deno.test`, and
+    // the files that replace the class names it takes are found by
+    // climbing to `.git`, which the read permission is for.
+    expect(spoolWriteArgument(["--allow-env", "a.test.ts"], "/s"))
+      .toBeUndefined();
+    expect(spoolWriteArgument([], "/s")).toBeUndefined();
+  });
+
+  it("reads a cluster of short flags as each of its letters", () => {
+    // `-RW` grants read and write together, so it is a blanket write.
+    expect(spoolWriteArgument(["-RW", "a.test.ts"], "/s")).toBeUndefined();
+    expect(spoolWriteArgument(["-RN", "a.test.ts"], "/s")).toBe(
+      "--allow-write=/s",
+    );
+  });
+
+  it("reads a permission flag only as a whole word", () => {
+    expect(
+      spoolWriteArgument(["--allow-read", "--allow-write-elsewhere"], "/s"),
+    ).toBe("--allow-write=/s");
+  });
+
+  it("refuses a spool that is not an absolute path", () => {
+    // `--allow-write=` with an empty value ends the run, and a relative
+    // path names a different directory in each package the leaves run in.
+    expect(() => spoolWriteArgument(["--allow-read"], "")).toThrow();
+    expect(() => spoolWriteArgument(["--allow-read"], "spool")).toThrow();
+  });
+});

--- a/packages/test-support/src/records/preload-path.test.ts
+++ b/packages/test-support/src/records/preload-path.test.ts
@@ -63,4 +63,11 @@ describe("preload-path", () => {
     expect(() => spoolWriteArgument(["--allow-read"], "")).toThrow();
     expect(() => spoolWriteArgument(["--allow-read"], "spool")).toThrow();
   });
+
+  it("refuses a spool holding a comma", () => {
+    // A comma separates one path from the next inside `--allow-write=`,
+    // so such a spool is granted as two paths that are not it.
+    expect(() => spoolWriteArgument(["--allow-read"], "/a,b/spool"))
+      .toThrow();
+  });
 });

--- a/packages/test-support/src/records/preload-path.ts
+++ b/packages/test-support/src/records/preload-path.ts
@@ -1,11 +1,15 @@
 /**
- * Where the registration preload lives on disk. `deno test --preload`
- * takes a path rather than an import-map specifier, and a test task runs
- * with its own package as the working directory, so every caller needs an
- * absolute path rather than a relative one.
+ * What a caller appends to a `deno test` invocation to make it record:
+ * where the registration preload lives on disk, and the write permission
+ * that preload needs to leave its name map behind.
+ *
+ * `deno test --preload` takes a path rather than an import-map
+ * specifier, and a test task runs with its own package as the working
+ * directory, so every caller needs an absolute path rather than a
+ * relative one.
  */
 
-import { fromFileUrl } from "@std/path";
+import { fromFileUrl, isAbsolute } from "@std/path";
 
 /** Absolute path of the module `--preload` is pointed at. */
 export function preloadModulePath(): string {
@@ -15,4 +19,63 @@ export function preloadModulePath(): string {
 /** The `--preload=<path>` argument naming that module. */
 export function preloadArgument(): string {
   return `--preload=${preloadModulePath()}`;
+}
+
+/**
+ * Whether a flag list grants one permission over the whole filesystem,
+ * given the long flag naming it and the letter it takes as a short one.
+ * Short flags cluster, so `-RW` grants read and write together, and `-A`
+ * grants everything however it is written.
+ */
+function grantsEverything(
+  flags: readonly string[],
+  long: string,
+  letter: string,
+): boolean {
+  return flags.some((flag) => {
+    if (flag === long || flag === "--allow-all") return true;
+    if (!/^-[A-Za-z]+$/.test(flag)) return false;
+    return flag.includes(letter) || flag.includes("A");
+  });
+}
+
+/**
+ * The `--allow-write` an invocation needs so the preload can leave its
+ * name map in the spool, or undefined where the invocation would be no
+ * better for having one.
+ *
+ * The spool is wherever the run owner put it, which is a path only the
+ * environment knows and a test task cannot name: `deno task` expands
+ * `$VAR` but not `${VAR:-default}`, and `--allow-write=` with an unset
+ * variable ends the run. So the caller appending the preload appends the
+ * permission beside it, for the invocation that needs it and no other.
+ *
+ * Deno merges two `--allow-write` path lists, so an invocation carrying
+ * a list of its own takes this one on top of it and one carrying no
+ * write flag takes it alone. An invocation already permitted to write
+ * everywhere is given nothing. Beside `-A` or `--allow-all`, a path list
+ * ends the run before it starts, with `the argument '--allow-all...'
+ * cannot be used with '--allow-write[=<PATH>...]'`. Beside a bare
+ * `--allow-write`, `-W`, or a cluster holding one of them, it cuts that
+ * grant down to the list.
+ *
+ * An invocation that cannot read the filesystem is given nothing either.
+ * A writable spool is what makes the preload wrap `Deno.test`, and
+ * wrapping costs the report the class names it names each case's file
+ * by. What replaces them is found by climbing from each test file to the
+ * directory holding `.git`, and that climb needs read permission, so the
+ * write is worth granting only beside the read.
+ */
+export function spoolWriteArgument(
+  flags: readonly string[],
+  spool: string,
+): string | undefined {
+  if (!isAbsolute(spool)) {
+    throw new Error(
+      `test records: the spool to grant must be an absolute path: "${spool}"`,
+    );
+  }
+  if (grantsEverything(flags, "--allow-write", "W")) return undefined;
+  if (!grantsEverything(flags, "--allow-read", "R")) return undefined;
+  return `--allow-write=${spool}`;
 }

--- a/packages/test-support/src/records/preload-path.ts
+++ b/packages/test-support/src/records/preload-path.ts
@@ -75,6 +75,14 @@ export function spoolWriteArgument(
       `test records: the spool to grant must be an absolute path: "${spool}"`,
     );
   }
+  // A comma is what separates one path from the next inside
+  // `--allow-write=`, and Deno offers no way to write one that is part of a
+  // path, so a spool holding one is granted as two paths that are not it.
+  if (spool.includes(",")) {
+    throw new Error(
+      `test records: the spool to grant cannot hold a comma: "${spool}"`,
+    );
+  }
   if (grantsEverything(flags, "--allow-write", "W")) return undefined;
   if (!grantsEverything(flags, "--allow-read", "R")) return undefined;
   return `--allow-write=${spool}`;

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -413,6 +413,7 @@ export async function runBatch(
     const invocations = await batch.suite.command(batch.units, {
       root: options.root,
       outputDir,
+      spoolDir: batchSpool,
       ...(options.base === undefined ? {} : { baseRef: options.base }),
     });
     for (const invocation of invocations) {

--- a/tasks/test-topology.test.ts
+++ b/tasks/test-topology.test.ts
@@ -57,6 +57,7 @@ describe("the test topology", () => {
         const invocation of await suite.command(requests, {
           root,
           outputDir,
+          spoolDir: "/spool",
           baseRef: "origin/main",
         })
       ) {

--- a/tasks/test-topology/binaries.test.ts
+++ b/tasks/test-topology/binaries.test.ts
@@ -55,7 +55,7 @@ describe("the binary build suites", () => {
     // others to report for themselves.
     const invocations = byId("binaries").command(
       [{ unit: "cf", skip: [] }, { unit: "toolshed", skip: [] }],
-      { root: "/repo", outputDir: "/out" },
+      { root: "/repo", outputDir: "/out", spoolDir: "/spool" },
     );
     return invocations.then((made) => {
       expect(made.length).toBe(2);
@@ -68,7 +68,7 @@ describe("the binary build suites", () => {
     const opposite = serverExecutionCiLane("opposite");
     return byId("binaries-opposite").command(
       [{ unit: "toolshed", skip: [] }],
-      { root: "/repo", outputDir: "/out" },
+      { root: "/repo", outputDir: "/out", spoolDir: "/spool" },
     ).then((made) => {
       expect(made[0]!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe(
         String(opposite.enabled),

--- a/tasks/test-topology/cli.test.ts
+++ b/tasks/test-topology/cli.test.ts
@@ -10,7 +10,7 @@ import type { Suite } from "./suite.ts";
 const root = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
 const suites = await loadCliSuites(root);
 const byId = (id: string): Suite => suites.find((s) => s.id === id)!;
-const context = { root, outputDir: "/out" };
+const context = { root, outputDir: "/out", spoolDir: "/spool" };
 
 describe("the command-line suites", () => {
   it("names a unit for the record its step writes", () => {

--- a/tasks/test-topology/gates.test.ts
+++ b/tasks/test-topology/gates.test.ts
@@ -25,7 +25,7 @@ const root = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
 
 const suites = await loadGateSuites(root);
 const byId = (id: string): Suite => suites.find((s) => s.id === id)!;
-const context = { root: "/repo", outputDir: "/out" };
+const context = { root: "/repo", outputDir: "/out", spoolDir: "/spool" };
 
 describe("the repository's gate suites", () => {
   it("gives the base revision to the gates whose suite asks for history", async () => {

--- a/tasks/test-topology/package-integration.test.ts
+++ b/tasks/test-topology/package-integration.test.ts
@@ -96,6 +96,7 @@ describe("the package integration suites", () => {
     const [invocation] = await suite.command([{ unit, skip: [] }], {
       root,
       outputDir: await Deno.makeTempDir({ prefix: "package-integration-" }),
+      spoolDir: "/spool",
     });
     expect(invocation!.env?.HEADLESS).toBe("1");
     expect(invocation!.junit?.[0]?.scope).toBe("shell");

--- a/tasks/test-topology/patterns.test.ts
+++ b/tasks/test-topology/patterns.test.ts
@@ -42,7 +42,7 @@ describe("the pattern and package suites", () => {
     const suite = byId("pattern-integration");
     const [invocation] = await suite.command(
       [{ unit: suite.units[0]!, skip: [] }],
-      { root, outputDir: await outputDir() },
+      { root, outputDir: await outputDir(), spoolDir: "/spool" },
     );
     expect(invocation!.cwd).toBe(`${root}/packages/patterns`);
     expect(invocation!.env?.HEADLESS).toBe("1");
@@ -57,7 +57,7 @@ describe("the pattern and package suites", () => {
       const suite = byId(id);
       const [invocation] = await suite.command(
         [{ unit: suite.units[0]!, skip: [] }],
-        { root, outputDir: await outputDir() },
+        { root, outputDir: await outputDir(), spoolDir: "/spool" },
       );
       expect(invocation!.command).toContain("--no-check");
     }
@@ -144,7 +144,7 @@ describe("the pattern and package suites", () => {
     const suite = byId("pattern-integration-opposite");
     const [invocation] = await suite.command(
       [{ unit: suite.units[0]!, skip: [] }],
-      { root, outputDir: await outputDir() },
+      { root, outputDir: await outputDir(), spoolDir: "/spool" },
     );
     expect(invocation!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe(
       String(opposite.enabled),
@@ -169,7 +169,7 @@ describe("the pattern and package suites", () => {
       expect(suite.variant).toBe(opposite.recordVariant);
       const [invocation] = await suite.command(
         [{ unit: suite.units[0]!, skip: [] }],
-        { root, outputDir: await outputDir() },
+        { root, outputDir: await outputDir(), spoolDir: "/spool" },
       );
       expect(invocation!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe(
         String(opposite.enabled),
@@ -184,11 +184,12 @@ describe("the pattern and package suites", () => {
     const [whole] = await suite.command([{ unit, skip: [] }], {
       root,
       outputDir: out,
+      spoolDir: "/spool",
     });
     expect(whole!.env?.[SKIP_LIST_VARIABLE]).toBeUndefined();
     const [partial] = await suite.command(
       [{ unit, skip: ["counter > counts up"] }],
-      { root, outputDir: out },
+      { root, outputDir: out, spoolDir: "/spool" },
     );
     const listed = partial!.env?.[SKIP_LIST_VARIABLE];
     expect(listed).toBeDefined();
@@ -201,7 +202,12 @@ describe("the pattern and package suites", () => {
     const suite = byId("pattern-integration");
     const [invocation] = await suite.command(
       [{ unit: suite.units[0]!, skip: [] }],
-      { root, outputDir: await outputDir(), coverageDir: "/cov" },
+      {
+        root,
+        outputDir: await outputDir(),
+        coverageDir: "/cov",
+        spoolDir: "/spool",
+      },
     );
     expect(invocation!.env?.DENO_COVERAGE_DIR).toBe(
       "/cov/pattern-integration-patterns",
@@ -217,7 +223,7 @@ describe("the pattern and package suites", () => {
     const shell = suite.units.find((u) => u.startsWith("packages/shell/"))!;
     const made = await suite.command(
       [{ unit: runner, skip: [] }, { unit: shell, skip: [] }],
-      { root, outputDir: await outputDir() },
+      { root, outputDir: await outputDir(), spoolDir: "/spool" },
     );
     expect(made.length).toBe(2);
     expect(made.map((i) => i.junit?.[0]?.scope).toSorted())
@@ -234,7 +240,7 @@ describe("the pattern and package suites", () => {
     expect(suite.needs).toContain("toolshed");
     const made = await suite.command(
       suite.units.map((unit) => ({ unit, skip: [] })),
-      { root, outputDir: await outputDir() },
+      { root, outputDir: await outputDir(), spoolDir: "/spool" },
     );
     expect(made.map((invocation) => invocation.junit?.[0]?.scope)).toEqual([
       "background-piece-service",
@@ -250,10 +256,12 @@ describe("the pattern and package suites", () => {
     expect(suite.units).toEqual(["packages/patterns/integration/reload"]);
     const [invocation] = await suite.command(
       [{ unit: suite.units[0]!, skip: [] }],
-      { root, outputDir: "/out" },
+      { root, outputDir: "/out", spoolDir: "/spool" },
     );
     expect(invocation!.command).toContain("patterns-reload");
-    expect(await suite.command([], { root, outputDir: "/out" })).toEqual([]);
+    expect(
+      await suite.command([], { root, outputDir: "/out", spoolDir: "/spool" }),
+    ).toEqual([]);
   });
 
   it("locates a reload record by the directory it came from", () => {
@@ -282,7 +290,7 @@ describe("the pattern and package suites", () => {
     const chosen = suite.units.slice(0, 2);
     const [invocation] = await suite.command(
       chosen.map((unit) => ({ unit, skip: [] })),
-      { root, outputDir: out },
+      { root, outputDir: out, spoolDir: "/spool" },
     );
     const flag = invocation!.command.find((arg) => arg.startsWith("--files="))!;
     const listed = await Deno.readTextFile(flag.slice("--files=".length));
@@ -303,7 +311,13 @@ describe("the pattern and package suites", () => {
 
   it("builds nothing for a suite asked for no units", async () => {
     for (const id of ["pattern-unit", "generated-patterns"]) {
-      expect(await byId(id).command([], { root, outputDir: "/out" }))
+      expect(
+        await byId(id).command([], {
+          root,
+          outputDir: "/out",
+          spoolDir: "/spool",
+        }),
+      )
         .toEqual([]);
     }
   });

--- a/tasks/test-topology/patterns.test.ts
+++ b/tasks/test-topology/patterns.test.ts
@@ -27,6 +27,7 @@ function measured(outputDir: string): CommandContext {
     outputDir,
     coverageDir: "/cov",
     patternCoverageDir: "/pattern",
+    spoolDir: "/spool",
   };
 }
 
@@ -111,7 +112,7 @@ describe("the pattern and package suites", () => {
     const suite = byId("pattern-unit");
     const [invocation] = await suite.command(
       [{ unit: suite.units[0]!, skip: [] }],
-      { root, outputDir: await outputDir() },
+      { root, outputDir: await outputDir(), spoolDir: "/spool" },
     );
     expect(invocation!.env?.CF_PATTERN_COVERAGE_DIR).toBeUndefined();
     expect(invocation!.env?.DENO_COVERAGE_DIR).toBeUndefined();
@@ -133,7 +134,7 @@ describe("the pattern and package suites", () => {
       const suite = byId(id);
       const [invocation] = await suite.command(
         [{ unit: suite.units[0]!, skip: [] }],
-        { root, outputDir: await outputDir() },
+        { root, outputDir: await outputDir(), spoolDir: "/spool" },
       );
       expect(invocation!.env?.LOG_LEVEL).toBe("warn");
     }

--- a/tasks/test-topology/suite.test.ts
+++ b/tasks/test-topology/suite.test.ts
@@ -1,6 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { SKIP_LIST_VARIABLE } from "@commonfabric/test-support/records";
+import {
+  preloadArgument,
+  SKIP_LIST_VARIABLE,
+} from "@commonfabric/test-support/records";
 import {
   fileSuite,
   unavailableFrom,
@@ -77,7 +80,7 @@ describe("reading a configuration's skip registry", () => {
 });
 
 describe("a suite of deno test files over several packages", () => {
-  const context = { root: "/repo", outputDir: "/out" };
+  const context = { root: "/repo", outputDir: "/out", spoolDir: "/spool" };
 
   it("runs one invocation per package, each with its own report", async () => {
     // A real directory, because the leaf this configuration skips means
@@ -144,6 +147,59 @@ describe("a suite of deno test files over several packages", () => {
     ).toBeUndefined();
   });
 
+  it("grants the batch's spool to a part that cannot already write it", async () => {
+    // The preload leaves its name map there, and that map is what gives
+    // each identity its file once the preload has taken the class names.
+    const narrow = fileSuite({
+      id: "narrow",
+      needs: ["deno"],
+      parts: [{
+        packageDir: "packages/oven",
+        flags: ["--allow-read", "--allow-write=/tmp"],
+        junit: { kind: "unit", scope: "oven" },
+        files: ["packages/oven/a.test.ts"],
+      }],
+    });
+    const [invocation] = await narrow.command(
+      [{ unit: "packages/oven/a.test.ts", skip: [] }],
+      context,
+    );
+    expect(invocation!.command).toContain("--allow-write=/spool");
+  });
+
+  it("grants nothing to a part that already writes anywhere", async () => {
+    // This one runs under `-A`, which Deno refuses to take beside an
+    // `--allow-write` path list at all, ending the run before it starts.
+    const [blanket] = await twoParts().command(
+      [{ unit: "packages/mill/integration/grind.test.ts", skip: [] }],
+      context,
+    );
+    expect(blanket!.command).not.toContain("--allow-write=/spool");
+    expect(blanket!.command).toContain(preloadArgument());
+  });
+
+  it("grants nothing to a part that cannot read the tree", async () => {
+    // Writing the spool is what makes the preload take the class names,
+    // and reading is what finds the files that replace them, so a part
+    // holding one permission without the other records no file at all.
+    const unreadable = fileSuite({
+      id: "unreadable",
+      needs: ["deno"],
+      parts: [{
+        packageDir: "packages/oven",
+        flags: ["--no-check", "--allow-env", "--allow-run", "--allow-net"],
+        junit: { kind: "integration", scope: "oven" },
+        files: ["packages/oven/a.test.ts"],
+      }],
+    });
+    const [invocation] = await unreadable.command(
+      [{ unit: "packages/oven/a.test.ts", skip: [] }],
+      context,
+    );
+    expect(invocation!.command).not.toContain("--allow-write=/spool");
+    expect(invocation!.command).toContain(preloadArgument());
+  });
+
   it("builds nothing for a unit it does not hold", async () => {
     expect(await twoParts().command([{ unit: "elsewhere", skip: [] }], context))
       .toEqual([]);
@@ -200,7 +256,7 @@ describe("grouping a batch across the packages it spans", () => {
     const made = await suite.command([
       { unit: "packages/oven/a.test.ts", skip: [] },
       { unit: "packages/oven/b.test.ts", skip: [] },
-    ], { root: "/repo", outputDir: "/out" });
+    ], { root: "/repo", outputDir: "/out", spoolDir: "/spool" });
     expect(made.length).toBe(1);
     expect(made[0]!.command.filter((arg) => arg.endsWith(".test.ts")))
       .toEqual(["a.test.ts", "b.test.ts"]);

--- a/tasks/test-topology/suite.ts
+++ b/tasks/test-topology/suite.ts
@@ -14,6 +14,7 @@ import {
   serializeSkipList,
   SKIP_LIST_VARIABLE,
   type SkipList,
+  spoolWriteArgument,
   type TestIdentity,
 } from "@commonfabric/test-support/records";
 import type { CapabilityId } from "../ci-capabilities.ts";
@@ -124,6 +125,14 @@ export interface CommandContext {
    * that hold a file to being appended to compare against it.
    */
   baseRef?: string;
+
+  /**
+   * The spool this batch's records go in, absolute. An invocation that
+   * loads the registration preload is permitted to write here, which is
+   * where the preload leaves the name map that gives each identity its
+   * file.
+   */
+  spoolDir: string;
 }
 
 /** One test surface. */
@@ -331,6 +340,21 @@ export function unavailableFrom(
   return { whole, unavailable };
 }
 
+/**
+ * What an invocation takes to record: the preload, and the write
+ * permission it needs to leave its name map in the batch's spool. The
+ * permission is left out where the flags already grant one, since
+ * appending a path list to a blanket grant either ends the run or cuts
+ * the grant down to that list; `spoolWriteArgument` says which.
+ */
+export function recordingArguments(
+  flags: readonly string[],
+  context: CommandContext,
+): string[] {
+  const write = spoolWriteArgument(flags, context.spoolDir);
+  return write === undefined ? [preloadArgument()] : [preloadArgument(), write];
+}
+
 /** Writes a batch's skip list where its invocations will read it. */
 export async function writeSkipList(
   skipListPath: string,
@@ -490,7 +514,7 @@ export function fileSuite(options: FileSuiteOptions): Suite {
             Deno.execPath(),
             "test",
             ...part.flags,
-            preloadArgument(),
+            ...recordingArguments(part.flags, context),
             `--junit-path=${junitPath}`,
             ...group.map((request) =>
               path.relative(cwd, path.resolve(context.root, request.unit))

--- a/tasks/test-topology/unit.test.ts
+++ b/tasks/test-topology/unit.test.ts
@@ -173,7 +173,7 @@ describe("the workspace unit suites", () => {
     const outputDir = await Deno.makeTempDir({ prefix: "unit-out-" });
     const [invocation] = await suite.command(
       [{ unit: "packages/bakery/test/glaze.test.ts", skip: [] }],
-      { root, outputDir },
+      { root, outputDir, spoolDir: "/spool" },
     );
     expect(invocation!.command).toContain("--no-check");
     expect(invocation!.command).toContain("test/glaze.test.ts");
@@ -193,7 +193,7 @@ describe("the workspace unit suites", () => {
     const outputDir = await Deno.makeTempDir({ prefix: "unit-out-" });
     const [whole] = await suite.command(
       [{ unit: "packages/bakery/test/glaze.test.ts", skip: [] }],
-      { root, outputDir },
+      { root, outputDir, spoolDir: "/spool" },
     );
     expect(whole!.env?.[SKIP_LIST_VARIABLE]).toBeUndefined();
 
@@ -202,7 +202,7 @@ describe("the workspace unit suites", () => {
         unit: "packages/bakery/test/glaze.test.ts",
         skip: ["glaze > sets overnight"],
       }],
-      { root, outputDir },
+      { root, outputDir, spoolDir: "/spool" },
     );
     const listPath = partial!.env?.[SKIP_LIST_VARIABLE];
     expect(listPath).toBeDefined();
@@ -224,7 +224,7 @@ describe("running a member that cannot be handed a subset", () => {
     const outputDir = await Deno.makeTempDir({ prefix: "unit-out-" });
     const [invocation] = await suite.command(
       [{ unit: "packages/bakery", skip: ["glaze > sets overnight"] }],
-      { root, outputDir },
+      { root, outputDir, spoolDir: "/spool" },
     );
     expect(invocation!.command).toEqual([Deno.execPath(), "task", "test"]);
     // The environment a task inherits is how the list reaches a member
@@ -303,7 +303,7 @@ describe("running a member that cannot be handed a subset", () => {
         { unit: "packages/bakery#browser-test", skip: [] },
         { unit: "packages/bakery/test/glaze.test.ts", skip: [] },
       ],
-      { root, outputDir, coverageDir: "/cov" },
+      { root, outputDir, coverageDir: "/cov", spoolDir: "/spool" },
     );
     expect(made.length).toBe(2);
     expect(made.some((i) => i.command.includes("browser-test"))).toBe(true);
@@ -355,6 +355,7 @@ describe("running a member that cannot be handed a subset", () => {
       await suite.command([{ unit: "packages/elsewhere", skip: [] }], {
         root,
         outputDir: "/out",
+        spoolDir: "/spool",
       }),
     ).toEqual([]);
   });

--- a/tasks/test-topology/unit.ts
+++ b/tasks/test-topology/unit.ts
@@ -18,10 +18,7 @@
 
 import * as path from "@std/path";
 import { parse as parseJsonc } from "@std/jsonc";
-import {
-  preloadArgument,
-  SKIP_LIST_VARIABLE,
-} from "@commonfabric/test-support/records";
+import { SKIP_LIST_VARIABLE } from "@commonfabric/test-support/records";
 import { memberTasks, memberTestFiles } from "./deno-task.ts";
 import {
   claimsIdentity,
@@ -29,6 +26,7 @@ import {
   type Invocation,
   type LocatableRecord,
   type Location,
+  recordingArguments,
   type RecordSurface,
   skipListOf,
   type Suite,
@@ -259,7 +257,7 @@ function unitSuite(
               Deno.execPath(),
               "test",
               ...member.run.flags,
-              preloadArgument(),
+              ...recordingArguments(member.run.flags, context),
               `--junit-path=${junitPath}`,
               ...files.map((request) =>
                 path.relative(

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -9,7 +9,6 @@ import {
   acceptsPreload,
   assertMemberTestTasksDefined,
   assertTaskTestsIncluded,
-  grantableSpool,
   initializeDb,
   junitCapableMembers,
   leafFlags,
@@ -17,6 +16,7 @@ import {
   memberTestTask,
   parseDisabledPackageList,
   readWorkspaceMembers,
+  recordingSpool,
   runTests,
   selectShardMembers,
   testConcurrency,
@@ -769,12 +769,28 @@ Deno.test("the workspace's capable members are read from their manifests", async
   }
 });
 
+Deno.test("the spool a run records into is resolved once", () => {
+  // Each leaf runs with its own package as the working directory, so a
+  // relative spool would name a different place in each of them.
+  assertEquals(
+    recordingSpool("spool/records", "/work"),
+    "/work/spool/records",
+  );
+  assertEquals(recordingSpool("/var/records", "/work"), "/var/records");
+  assertEquals(recordingSpool(undefined, "/work"), undefined);
+});
+
 Deno.test("a spool Deno cannot be told about is not recorded into", () => {
   // A comma separates one path from the next inside `--allow-write=`, so
   // such a spool is granted as two paths that are not it. The run turns
   // recording off rather than failing the members that would take it.
-  assertEquals(grantableSpool("/var/spool/records"), true);
-  assertEquals(grantableSpool("/var/a,b/records"), false);
+  const said: string[] = [];
+  assertEquals(
+    recordingSpool("/var/a,b/records", "/work", (m) => said.push(m)),
+    undefined,
+  );
+  assertEquals(said.length, 1);
+  assertStringIncludes(said[0]!, "/var/a,b/records");
 });
 
 Deno.test("a forwarding runner is read by the flags it hands its leaf", () => {

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -9,6 +9,7 @@ import {
   acceptsPreload,
   assertMemberTestTasksDefined,
   assertTaskTestsIncluded,
+  grantableSpool,
   initializeDb,
   junitCapableMembers,
   leafFlags,
@@ -766,6 +767,14 @@ Deno.test("the workspace's capable members are read from their manifests", async
   ) {
     assertEquals(capable.has(member), false, `${member} should not`);
   }
+});
+
+Deno.test("a spool Deno cannot be told about is not recorded into", () => {
+  // A comma separates one path from the next inside `--allow-write=`, so
+  // such a spool is granted as two paths that are not it. The run turns
+  // recording off rather than failing the members that would take it.
+  assertEquals(grantableSpool("/var/spool/records"), true);
+  assertEquals(grantableSpool("/var/a,b/records"), false);
 });
 
 Deno.test("a forwarding runner is read by the flags it hands its leaf", () => {

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -11,6 +11,8 @@ import {
   assertTaskTestsIncluded,
   initializeDb,
   junitCapableMembers,
+  leafFlags,
+  memberRecordingArguments,
   memberTestTask,
   parseDisabledPackageList,
   readWorkspaceMembers,
@@ -19,6 +21,7 @@ import {
   testConcurrency,
   testPackage,
 } from "./workspace-tests.ts";
+import { preloadArgument } from "@commonfabric/test-support/records";
 import { WORKSPACE_TEST_WEIGHTS } from "./test-timing-weights.ts";
 import {
   readUnlaunchedMembers,
@@ -763,6 +766,50 @@ Deno.test("the workspace's capable members are read from their manifests", async
   ) {
     assertEquals(capable.has(member), false, `${member} should not`);
   }
+});
+
+Deno.test("a forwarding runner is read by the flags it hands its leaf", () => {
+  // The runner process and the leaf `deno test` carry separate flag
+  // lists, and the leaf's is the one that loads the preload. Reading the
+  // whole line would answer from the runner's.
+  assertEquals(
+    leafFlags(
+      "./tasks",
+      "deno run --allow-read runner.ts x . -- --no-check -A",
+    ),
+    ["--no-check", "-A"],
+  );
+  // A member running its leaf directly has one list, and it is the whole
+  // of the line.
+  assertEquals(
+    leafFlags("./packages/html", "deno test --allow-read a.test.ts"),
+    ["deno", "test", "--allow-read", "a.test.ts"],
+  );
+});
+
+Deno.test("a recording leaf is given the preload and a write it needs", async () => {
+  const rootUrl = new URL("../", import.meta.url);
+  const members = await readWorkspaceMembers(new URL("deno.jsonc", rootUrl));
+  const recording = await memberRecordingArguments(members, "/spool", rootUrl);
+
+  const preload = preloadArgument();
+  // A member whose task names a write list of its own, and one naming no
+  // write at all, are each granted the spool on top of what they have,
+  // so the preload has somewhere to leave the name map its class names
+  // were traded for.
+  for (const member of ["./packages/runner", "./packages/html"]) {
+    assertEquals(recording.get(member), [preload, "--allow-write=/spool"]);
+  }
+  // A member already permitted to write anywhere is granted nothing.
+  // This one runs under `-A`, which Deno refuses to take beside an
+  // `--allow-write` path list at all, ending the run before it starts.
+  assertEquals(recording.get("./packages/toolshed"), [preload]);
+  // A member that cannot read the tree is granted nothing either: the
+  // write is what makes the preload take the class names, and the read
+  // is what finds the files that replace them.
+  assertEquals(recording.get("./packages/utils"), [preload]);
+  // A member whose task cannot take the preload takes nothing at all.
+  assertEquals(recording.get("./packages/cli"), []);
 });
 
 //

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -380,13 +380,27 @@ export function acceptsPreload(
 }
 
 /**
- * Whether a spool can be named to a leaf. A comma separates one path from
- * the next inside `--allow-write=`, and Deno offers no way to write one
- * that belongs to a path, so a spool holding a comma is granted as two
- * paths that are not it.
+ * The spool this run records into, absolute, or undefined where there is
+ * none or Deno cannot be told about the one there is.
+ *
+ * Resolving here is what makes one directory of three: the runner reads
+ * the spool with the workspace as its working directory, each leaf runs
+ * with its own package as one, and the write granted to a leaf names a
+ * path. A comma separates one path from the next inside `--allow-write=`,
+ * and Deno offers no way to write one that belongs to a path, so a spool
+ * holding a comma is granted as two paths that are not it; such a run
+ * records nothing and says so, as every other recording problem does.
  */
-export function grantableSpool(spool: string): boolean {
-  return !spool.includes(",");
+export function recordingSpool(
+  raw: string | undefined,
+  workspaceCwd: string,
+  warn: (message: string) => void = console.warn,
+): string | undefined {
+  if (raw === undefined) return undefined;
+  const spool = path.resolve(workspaceCwd, raw);
+  if (!spool.includes(",")) return spool;
+  warn(`test records: no recording, the spool holds a comma: ${spool}`);
+  return undefined;
 }
 
 /**
@@ -567,22 +581,7 @@ export async function runTests(
   // plumbing: it forwards the flag and moves the results; the reported
   // names come from the leaves. A temporary directory that cannot be
   // created turns recording off with a warning; it never fails the suite.
-  // Resolved once here and used everywhere after: the parent reads this
-  // spool with the workspace as its working directory, each leaf runs with
-  // its own package as one, and the write granted to a leaf names a path.
-  // A relative `CF_TEST_RECORDS_DIR` would be three directories.
-  // A spool Deno cannot be told about turns recording off the same way,
-  // rather than failing a member that would have been granted it.
-  const rawSpoolDir = recordsDir();
-  let spoolDir = rawSpoolDir === undefined
-    ? undefined
-    : path.resolve(workspaceCwd, rawSpoolDir);
-  if (spoolDir !== undefined && !grantableSpool(spoolDir)) {
-    console.warn(
-      `test records: no recording, the spool holds a comma: ${spoolDir}`,
-    );
-    spoolDir = undefined;
-  }
+  const spoolDir = recordingSpool(recordsDir(), workspaceCwd);
   let junitRoot: string | undefined;
   if (spoolDir !== undefined) {
     try {

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -14,6 +14,7 @@ import {
   preloadArgument,
   readNameMaps,
   recordsDir,
+  spoolWriteArgument,
 } from "@commonfabric/test-support/records";
 import { parseShard, type Shard } from "./shard-utils.ts";
 import { WORKSPACE_TEST_WEIGHTS } from "./test-timing-weights.ts";
@@ -56,7 +57,7 @@ export async function testPackage(
   coverageRoot: string | undefined,
   extraEnv?: Record<string, string>,
   junitPath?: string,
-  preload = true,
+  recording: readonly string[] = [],
 ): Promise<{
   memberPath: string;
   packageName: string;
@@ -77,13 +78,13 @@ export async function testPackage(
 
     // Trailing arguments to `deno task` append to the task's command line,
     // which is what threads the flags down to the leaf `deno test`. The
-    // preload travels with the JUnit path because both reach the leaf the
-    // same way and the report is what the preload's map is joined onto; a
-    // member whose task cannot take one cannot take the other.
+    // recording arguments travel with the JUnit path because they reach
+    // the leaf the same way and the report is what the preload's map is
+    // joined onto; a member whose task cannot take one cannot take the
+    // other.
     const args = ["task", "test"];
     if (junitPath !== undefined) {
-      args.push(`--junit-path=${junitPath}`);
-      if (preload) args.push(preloadArgument());
+      args.push(`--junit-path=${junitPath}`, ...recording);
     }
     result = await new Deno.Command(Deno.execPath(), {
       args,
@@ -377,18 +378,46 @@ export function acceptsPreload(
   return task === undefined || !/--import-map[= ]/.test(task);
 }
 
-/** The members whose leaves also take the preload. */
-export async function preloadCapableMembers(
+/**
+ * The flags the leaf `deno test` of a member's task runs under. A
+ * forwarding runner's task line holds two lists: the runner process's
+ * own flags, and after `--` the ones it hands its leaf. The leaf is what
+ * loads the preload, so the leaf's list is the one that decides what
+ * permission the preload has. Every other member runs its leaf directly,
+ * and the whole line is that leaf's.
+ */
+export function leafFlags(member: string, task: string): string[] {
+  const tokens = task.split(/\s+/);
+  if (!FLAG_FORWARDING_RUNNERS.has(member)) return tokens;
+  const forwarded = tokens.indexOf("--");
+  return forwarded === -1 ? tokens : tokens.slice(forwarded + 1);
+}
+
+/**
+ * What each member's leaf takes to record, beyond the JUnit path: the
+ * preload, and the write permission it needs to leave its name map in
+ * the spool. A member whose task cannot take the preload takes neither,
+ * and appears with no arguments at all.
+ */
+export async function memberRecordingArguments(
   members: readonly string[],
+  spool: string,
   root: string | URL = Deno.cwd(),
-): Promise<Set<string>> {
-  const capable = new Set<string>();
+): Promise<Map<string, string[]>> {
+  const recording = new Map<string, string[]>();
   for (const member of members) {
-    if (acceptsPreload(member, await memberTestTask(member, root))) {
-      capable.add(member);
+    const task = await memberTestTask(member, root);
+    if (!acceptsPreload(member, task)) {
+      recording.set(member, []);
+      continue;
     }
+    const write = spoolWriteArgument(leafFlags(member, task ?? ""), spool);
+    recording.set(
+      member,
+      write === undefined ? [preloadArgument()] : [preloadArgument(), write],
+    );
   }
-  return capable;
+  return recording;
 }
 
 /** The members whose leaves take the flag, read from their manifests. */
@@ -546,9 +575,15 @@ export async function runTests(
   const capable = junitRoot !== undefined
     ? await junitCapableMembers(memberPaths, workspaceUrl)
     : new Set<string>();
-  const preloadable = junitRoot !== undefined
-    ? await preloadCapableMembers(memberPaths, workspaceUrl)
-    : new Set<string>();
+  // Resolved, because each leaf runs with its own package as the working
+  // directory and a relative spool would name a different place there.
+  const recording = junitRoot !== undefined && spoolDir !== undefined
+    ? await memberRecordingArguments(
+      memberPaths,
+      path.resolve(workspaceCwd, spoolDir),
+      workspaceUrl,
+    )
+    : new Map<string, string[]>();
 
   const results: PackageResult[] = [];
   let nextUnit = 0;
@@ -569,7 +604,7 @@ export async function runTests(
         coverageRoot,
         unit.env,
         junitPath,
-        preloadable.has(unit.memberPath),
+        recording.get(unit.memberPath),
       );
       results.push(result);
       if (

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -13,6 +13,7 @@ import {
   ingestJUnit,
   preloadArgument,
   readNameMaps,
+  RECORDS_DIR_VARIABLE,
   recordsDir,
   spoolWriteArgument,
 } from "@commonfabric/test-support/records";
@@ -556,7 +557,14 @@ export async function runTests(
   // plumbing: it forwards the flag and moves the results; the reported
   // names come from the leaves. A temporary directory that cannot be
   // created turns recording off with a warning; it never fails the suite.
-  const spoolDir = recordsDir();
+  // Resolved once here and used everywhere after: the parent reads this
+  // spool with the workspace as its working directory, each leaf runs with
+  // its own package as one, and the write granted to a leaf names a path.
+  // A relative `CF_TEST_RECORDS_DIR` would be three directories.
+  const rawSpoolDir = recordsDir();
+  const spoolDir = rawSpoolDir === undefined
+    ? undefined
+    : path.resolve(workspaceCwd, rawSpoolDir);
   let junitRoot: string | undefined;
   if (spoolDir !== undefined) {
     try {
@@ -575,14 +583,8 @@ export async function runTests(
   const capable = junitRoot !== undefined
     ? await junitCapableMembers(memberPaths, workspaceUrl)
     : new Set<string>();
-  // Resolved, because each leaf runs with its own package as the working
-  // directory and a relative spool would name a different place there.
   const recording = junitRoot !== undefined && spoolDir !== undefined
-    ? await memberRecordingArguments(
-      memberPaths,
-      path.resolve(workspaceCwd, spoolDir),
-      workspaceUrl,
-    )
+    ? await memberRecordingArguments(memberPaths, spoolDir, workspaceUrl)
     : new Map<string, string[]>();
 
   const results: PackageResult[] = [];
@@ -602,7 +604,9 @@ export async function runTests(
         unit.packageName,
         packagePath,
         coverageRoot,
-        unit.env,
+        spoolDir === undefined
+          ? unit.env
+          : { ...unit.env, [RECORDS_DIR_VARIABLE]: spoolDir },
         junitPath,
         recording.get(unit.memberPath),
       );

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -380,6 +380,16 @@ export function acceptsPreload(
 }
 
 /**
+ * Whether a spool can be named to a leaf. A comma separates one path from
+ * the next inside `--allow-write=`, and Deno offers no way to write one
+ * that belongs to a path, so a spool holding a comma is granted as two
+ * paths that are not it.
+ */
+export function grantableSpool(spool: string): boolean {
+  return !spool.includes(",");
+}
+
+/**
  * The flags the leaf `deno test` of a member's task runs under. A
  * forwarding runner's task line holds two lists: the runner process's
  * own flags, and after `--` the ones it hands its leaf. The leaf is what
@@ -561,10 +571,18 @@ export async function runTests(
   // spool with the workspace as its working directory, each leaf runs with
   // its own package as one, and the write granted to a leaf names a path.
   // A relative `CF_TEST_RECORDS_DIR` would be three directories.
+  // A spool Deno cannot be told about turns recording off the same way,
+  // rather than failing a member that would have been granted it.
   const rawSpoolDir = recordsDir();
-  const spoolDir = rawSpoolDir === undefined
+  let spoolDir = rawSpoolDir === undefined
     ? undefined
     : path.resolve(workspaceCwd, rawSpoolDir);
+  if (spoolDir !== undefined && !grantableSpool(spoolDir)) {
+    console.warn(
+      `test records: no recording, the spool holds a comma: ${spoolDir}`,
+    );
+    spoolDir = undefined;
+  }
   let junitRoot: string | undefined;
   if (spoolDir !== undefined) {
     try {


### PR DESCRIPTION
PROBLEM

A test record carries the repository-relative source file its test came from, and a record without one cannot be placed into a lane: the topology has no unit for it, so the publisher leaves it out of the selection manifest and every lane runs it. `packages/html` and `packages/runner` record no file for any test the workspace runner runs, 8327 of them between the two.

Both install a fake-clock harness through `--preload`. That harness replaces `Deno.test`, so Deno names every case's class after the harness rather than the test file, and ingestion declines such a name. The registration preload's name map is what replaces a displaced class name, and it is written only where the test process may write the spool. Neither task grants that, and neither can: the spool sits under the workspace checkout in CI and under the user's cache directory locally, and a task string cannot name it, since `deno task` expands `$VAR` but not `${VAR:-default}` and `--allow-write=` with an unset variable ends the run.

SOLUTION

Put the grant where the preload is appended. `spoolWriteArgument` builds the `--allow-write` an invocation needs to reach the spool. Deno merges two `--allow-write` path lists, so an invocation carrying a list of its own takes this one on top of it, and one carrying no write flag takes it alone. It builds nothing for an invocation already permitted to write everywhere, and nothing for one not permitted to read, since a writable spool is what makes the preload take the class names while the read is what finds the files replacing them.

The workspace runner appends it beside the preload and the JUnit path, and so do the two topology suites, which take the batch's spool through `spoolDir` on `CommandContext`. No package manifest changes.

DESIGN DISCUSSION

Four members are granted the spool — `html`, `llm`, `runner` and `runtime-client` — which are exactly those whose test task grants both environment and read. The last two gain a capture they did not have; both record a file for every test afterwards.

Measured per package, run the way the workspace runner runs it, once with the grant and once without, over one tree. `packages/html`: 64 records carrying no file without it, none with it, over 262. `packages/runner`: 8327 without, none with, over 8331. The store sees 62 of runner's, because eight of that package's test files are enumerated by no CI job and so reach the store only from local runs.

Widening `--allow-write` in the two manifests also works, and is what the documentation asked for, but it is wider than necessary and in the wrong place. It gives `packages/html` a capability its tests do not use, trades `packages/runner`'s two-directory list for the whole filesystem, and leaves the spool's location and a permission list to drift apart with nothing holding them together. The runner shard job in `.github/workflows/deno.yml` writes its own command line and already names the spool in its write list, so the mechanism was in the tree; that job is why `packages/runner` records a file in one CI lane and nowhere else. This puts the mechanism where every invocation built from a task gets it.

Withholding the grant from an invocation that cannot read is what keeps this from costing more than it gives. The preload wraps `Deno.test` as soon as it finds a writable spool, and the files replacing the names that wrapping displaces come from climbing to the directory holding `.git`. Run three ways over one tree, `packages/utils` reports 3 class names with environment and a writable spool and no read, every one of them machinery, against 23 with environment and no write, one per test file; with all three permissions it writes 21 name maps. One real invocation is in that shape, the `deployed-topology` suite's background-piece-service part.

The flags are read as tokens rather than matched as a string, which settles a clustered short flag: `-RW` grants a blanket write, and a path list beside it cuts that grant down to the list. For the three members whose task runs a script, the tokens after `--` are read, since those are the ones the script hands the leaf `deno test` that loads the preload.

Verified on deno 2.9.4. Two `--allow-write=<path>` lists merge. A list beside a bare `--allow-write` or `-W` narrows the grant to it, in either order. A list beside `-A` or `--allow-all` ends the run before it starts, in either order, with `the argument '--allow-all...' cannot be used with '--allow-write[=<PATH>...]'`; five of the twenty members already writing anywhere use `-A`, so that is the case that comes up.

The guard could instead sit in `installRegistrationCapture`, which would hold for a caller writing its own command line. It is not taken here because that wrapper also applies the skip list, and an invocation that cannot apply one must not run what it was told to leave alone, so the condition there is not this condition. It has a topic of its own.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

