### PR TITLE
test: three cf-harness cases read a CFC dial they never state

### DIFF
--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -95,16 +95,25 @@ Deno.test("resolveCfcEnforcementMode can inherit from a run manifest", () => {
 });
 
 Deno.test("resolveCfcEnforcementMode ignores malformed in-memory run manifest modes", () => {
+  const manifest = {
+    type: "cf-harness.loom-run-manifest",
+    version: 1,
+    source: "loom",
+  } as const;
+  const malformed = {
+    ...manifest,
+    cfc: { enforcementMode: "bogus" as CfcEnforcementMode },
+  };
+  // A mode nothing parses contributes nothing: the resolution is the one the
+  // same manifest gets naming no mode at all, and the source is `default`.
   assertEquals(
-    resolveCfcEnforcementMode({
-      runManifest: {
-        type: "cf-harness.loom-run-manifest",
-        version: 1,
-        source: "loom",
-        cfc: { enforcementMode: "bogus" as CfcEnforcementMode },
-      },
-    }),
-    DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE,
+    resolveCfcEnforcementMode({ runManifest: malformed }),
+    resolveCfcEnforcementMode({ runManifest: manifest }),
+  );
+  // And the source says so: the manifest decided nothing.
+  assertEquals(
+    resolveCfcEnforcementModeSource({ runManifest: malformed }),
+    "default",
   );
 });
 

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -220,10 +220,10 @@ Deno.test("CfHarnessEngine records the fabric session's resolved CFC posture in 
     }),
   });
 
-  // A session stating no dial of its own runs at the rungs the session preset
-  // pins. The itemized rungs are read off the record beside them: each pair is
-  // one answer, and a run state naming a rung its own record contradicts is
-  // what this reads for.
+  // A session stating no dial of its own runs at the rung the session preset
+  // pins. The itemized rung is read off the record beside it: the two are one
+  // answer, and a run state naming a rung its own record contradicts is what
+  // this reads for.
   const unstatedSession = {
     apiUrl: "https://toolshed.example/",
     identityKeyPath: "/keys/agent.pkcs8",
@@ -236,7 +236,6 @@ Deno.test("CfHarnessEngine records the fabric session's resolved CFC posture in 
   }).getRunState().fabricSessionCfc;
   assertEquals(pinnedCfc?.enforcementMode, unstatedRecord.enforcementMode.rung);
   assertEquals(pinnedCfc?.enforcementModeSource, "preset-pin");
-  assertEquals(pinnedCfc?.flowLabels, unstatedRecord.flowLabels.rung);
   assertEquals(pinnedCfc?.flowLabelsSource, "default");
   assertEquals(pinnedCfc?.record, unstatedRecord);
 
@@ -2001,10 +2000,9 @@ Deno.test("CfHarnessEngine records the fabric session's read ceiling in run stat
   }).getRunState();
   const recorded = runState.fabricSessionCfc;
   assertExists(recorded);
-  // Every field of the published posture but the flow-labels rung, which
-  // `CfHarnessEngine records the fabric session's resolved CFC posture in run
-  // state` reads. No session here states that dial, so the source is
-  // `default`.
+  // Every field of the published posture but the flow-labels rung, which the
+  // `fabricSessionCfcFlowLabels()` cases in `test/cfc-posture.test.ts` read.
+  // No session here states that dial, so the source is `default`.
   const { flowLabels: _rung, ...ceiling } = recorded;
   assertEquals(ceiling, {
     enforcementMode: "enforce-strict",

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -1,6 +1,11 @@
 import { checkoutDocsCorpusRoots } from "../src/docs-corpus/corpus.ts";
 import { resolveHarnessSkillsRoot } from "../src/skills/root.ts";
-import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertThrows,
+} from "@std/assert";
 import { normalize } from "@std/path/posix";
 import type { HarnessArtifactStore } from "../src/artifacts.ts";
 import { harnessFabricSessionPosture } from "../src/cfc-posture.ts";
@@ -215,10 +220,10 @@ Deno.test("CfHarnessEngine records the fabric session's resolved CFC posture in 
     }),
   });
 
-  // A session stating no dial of its own runs at the rung the session preset
-  // pins. The itemized rung is read off the record beside it: the two are one
-  // answer, and a run state naming a rung its own record contradicts is what
-  // this reads for.
+  // A session stating no dial of its own runs at the rungs the session preset
+  // pins. The itemized rungs are read off the record beside them: each pair is
+  // one answer, and a run state naming a rung its own record contradicts is
+  // what this reads for.
   const unstatedSession = {
     apiUrl: "https://toolshed.example/",
     identityKeyPath: "/keys/agent.pkcs8",
@@ -231,7 +236,7 @@ Deno.test("CfHarnessEngine records the fabric session's resolved CFC posture in 
   }).getRunState().fabricSessionCfc;
   assertEquals(pinnedCfc?.enforcementMode, unstatedRecord.enforcementMode.rung);
   assertEquals(pinnedCfc?.enforcementModeSource, "preset-pin");
-  assertEquals(pinnedCfc?.flowLabels, "off");
+  assertEquals(pinnedCfc?.flowLabels, unstatedRecord.flowLabels.rung);
   assertEquals(pinnedCfc?.flowLabelsSource, "default");
   assertEquals(pinnedCfc?.record, unstatedRecord);
 
@@ -1994,10 +1999,16 @@ Deno.test("CfHarnessEngine records the fabric session's read ceiling in run stat
     workspaceHostPath: "/host/project",
     fabricSession: boundedSession,
   }).getRunState();
-  assertEquals(runState.fabricSessionCfc, {
+  const recorded = runState.fabricSessionCfc;
+  assertExists(recorded);
+  // Every field of the published posture but the flow-labels rung, which
+  // `CfHarnessEngine records the fabric session's resolved CFC posture in run
+  // state` reads. No session here states that dial, so the source is
+  // `default`.
+  const { flowLabels: _rung, ...ceiling } = recorded;
+  assertEquals(ceiling, {
     enforcementMode: "enforce-strict",
     enforcementModeSource: "configured",
-    flowLabels: "off",
     flowLabelsSource: "default",
     readMaxConfidentiality: ["did:key:zOwner", "did:key:zFacet"],
     readOnExceed: "skip",


### PR DESCRIPTION
PROBLEM

Three cases in `packages/cf-harness` assert a CFC dial's value that none of them states, taking it from the fleet default instead, so a branch raising the dials fails cases whose subject is something else.

`resolveCfcEnforcementMode ignores malformed in-memory run manifest modes` asserts that a Loom manifest naming `bogus` resolves to `DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE`. That names the wrong constant rather than a stale one: a Loom manifest naming no usable mode is a Loom run, and a resolver that gave Loom runs their own fallback would be described wrongly by this case, not merely outrun by it.

`CfHarnessEngine records the fabric session's resolved CFC posture in run state` asserts an unstated session's flow labels are `off`, which is the fleet's answer, not the case's. `CfHarnessEngine records the fabric session's read ceiling in run state and refuses to resume under another` is about the read ceiling and the resume refusal, and carries the same flow-labels rung along in a whole-record comparison.

SOLUTION

The malformed-mode case compares the resolution of a manifest naming `bogus` against the resolution of the same manifest naming no mode at all, and reads that the mode source is `default`. That is what "ignored" means, and it holds whatever rung a manifest with no usable mode falls back to. The harness default for a resolve carrying no manifest stays pinned by `resolveCfcEnforcementMode falls back through config and inherited values` above.

The posture case reads the unstated session's flow-labels rung off the record beside it, as the enforcement rung beside it already is. The run state's itemized field and its own record were two statements of one answer with nothing comparing them; now one assertion does.

The read-ceiling case drops the flow-labels rung from its comparison and keeps the source, which is `default` at any rung.

DESIGN DISCUSSION

Checked by running the suite twice: once as shipped, and once with `RUNTIME_CFC_DIAL_DEFAULTS` and `presetCfcOptions` at their strict row, `DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE` at `enforce-strict` beside a Loom fallback of `observe`, and the engine's unstated flow labels at `persist`. All 1023 pass at both rows. Without this change, those three cases and no others fail at the raised row: the malformed-mode case resolves `observe` against the `enforce-strict` it names, and the two engine cases read `persist` against the `off` they name.

`source: "loom"` is the only source a `HarnessRunManifest` parses, so a non-Loom manifest is not constructible and no case is added for one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

