### PR TITLE
docs(runner): qualify naming gate cache guarantees

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -233,13 +233,14 @@ const RESULT_SHORTCUT_LIMIT = 4096;
  * spent budget reads as absent, and the run pays one name-sync it may not
  * have needed. A wide argument — one whose links, and the values behind
  * them, fan out past the budget within the walk's depth — is therefore held
- * even when its whole family is local. The hold is paid once per piece and
- * pattern identity while the runner's shortcut remains cached; eviction
- * can cause another probe and hold. The walk follows links in a linked
- * document's value because the name-sync's argument-link-target wave warms
- * them; a missed absence costs a conflicting first commit, a spurious hold
- * costs a re-sync the client answers from coverage it already has. The gate
- * logs a spent budget so a wide piece held for it is diagnosable.
+ * even when its whole family is local. A cached shortcut for that piece skips
+ * the probes only while its pattern identity matches the run. Eviction or
+ * replacement by another pattern can cause another probe and hold. The walk
+ * follows links in a linked document's value because the name-sync's
+ * argument-link-target wave warms them; a missed absence costs a conflicting
+ * first commit, and a spurious hold costs a re-sync the client answers from
+ * coverage it already has. The gate logs a spent budget so a wide piece
+ * held for it is diagnosable.
  */
 const NAMING_PROBE_BUDGET = 256;
 
@@ -2089,10 +2090,11 @@ export class Runner {
    *
    * A name-sync that rejects lands all the same. The run proceeds over what
    * is local, with its own subscriptions fetching the rest and the rejection
-   * logged as the signal. A later run of the same piece under the same pattern
-   * is not held again while the runner's shortcut remains cached, a transient
-   * rejection included; eviction can cause another probe and hold. Recording
-   * the landing lets the deferred run's re-check pass the gate.
+   * logged as the signal. The cached landing skips the probes for this piece
+   * only while its pattern identity matches the run, a transient rejection
+   * included. Eviction or replacement by another pattern's landing can cause
+   * another probe and hold. Recording the landing lets the deferred run's
+   * re-check pass the gate.
    */
   readonly #namedFamilies = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -233,13 +233,13 @@ const RESULT_SHORTCUT_LIMIT = 4096;
  * spent budget reads as absent, and the run pays one name-sync it may not
  * have needed. A wide argument — one whose links, and the values behind
  * them, fan out past the budget within the walk's depth — is therefore held
- * once per runtime per pattern identity even when its whole family is
- * local. That is the cheaper error. Narrowing the walk to the argument's own
- * links would skip the links a linked document's value holds, which the
- * name-sync's argument-link-target wave exists to warm; a missed absence
- * costs a conflicting first commit, a spurious hold costs a re-sync the
- * client answers from coverage it already has. The gate logs a spent budget
- * so a wide piece held for it is diagnosable.
+ * even when its whole family is local. The hold is paid once per piece and
+ * pattern identity while the runner's shortcut remains cached; eviction
+ * can cause another probe and hold. The walk follows links in a linked
+ * document's value because the name-sync's argument-link-target wave warms
+ * them; a missed absence costs a conflicting first commit, a spurious hold
+ * costs a re-sync the client answers from coverage it already has. The gate
+ * logs a spent budget so a wide piece held for it is diagnosable.
  */
 const NAMING_PROBE_BUDGET = 256;
 
@@ -2087,13 +2087,12 @@ export class Runner {
    * an internal cell the crossing never delivered. Bounded like the other
    * result shortcuts; an evicted entry costs a probe, never a wrong verdict.
    *
-   * A name-sync that rejects lands all the same. The run then degrades to
-   * what it was before the gate existed — over what is local, its own
-   * subscriptions fetching the rest, the rejection logged as the signal —
-   * and a later run under the same pattern is not held again for this
-   * runner's lifetime, a transient rejection included. Withholding the
-   * landing would name the piece again on every run, and the deferred run's
-   * own re-check of the gate would loop on the same rejection.
+   * A name-sync that rejects lands all the same. The run proceeds over what
+   * is local, with its own subscriptions fetching the rest and the rejection
+   * logged as the signal. A later run of the same piece under the same pattern
+   * is not held again while the runner's shortcut remains cached, a transient
+   * rejection included; eviction can cause another probe and hold. Recording
+   * the landing lets the deferred run's re-check pass the gate.
    */
   readonly #namedFamilies = new BoundedKeyMap<
     `${MemorySpace}/${ScopeKey}/${URI}`,


### PR DESCRIPTION
The naming gate's comments overstate how long a cached result suppresses another hold. Qualify both the probe-budget and rejected-name-sync comments: a shortcut skips probes while its cached pattern identity matches the run; eviction or replacement by another pattern can cause another probe and hold. Comments only; runtime behavior is unchanged.

Follow-up to #7168.

Validation (Deno 2.9.4):
- Repository-wide `deno fmt --check` and `deno lint` passed.
- Workspace `deno task check` and runner `deno task test` passed for the identical non-comment source: 1,393 tests passed, 8,444 steps, 0 failures.
- TypeScript's printer with comments removed confirms the final revision is identical to the tested source.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

