### PR TITLE
test(cli): observe the collection documents a cold discovery leaves unloaded

### DIFF
--- a/packages/cli/test/piece-discovery-reads.test.ts
+++ b/packages/cli/test/piece-discovery-reads.test.ts
@@ -14,37 +14,58 @@ import { PiecesController } from "@commonfabric/piece/ops";
 import { describePiece, listPieceCallables } from "../lib/piece.ts";
 
 /**
- * A pattern whose result type reaches a collection: one verb, and a list whose
- * element type is a named interface. On a real piece that list is where the
- * documents are — a board's topics, a note's blocks — so the declared result
- * type is the widest read anything could take, and `Item` is what a watch
- * under that type would descend into.
+ * A pattern shaped like the piece this file is about: one verb, a collection
+ * whose members are documents of their own, a name, and two inline scalars.
+ *
+ * The collection is where a real piece's documents are — a board's topics, a
+ * note's blocks — so its element type is the widest read anything could take,
+ * and `Item` is what a watch under the declared result type would descend
+ * into. The scalars and the name are the other half of the surface: they are
+ * data, they sit beside the verb in the same result, and a discovery that
+ * classifies from anything but the pattern's own declaration has a way to
+ * mistake one of them for a callable.
  */
 const PROGRAM = {
   main: "/main.tsx",
   files: [{
     name: "/main.tsx",
     contents: [
-      'import { action, cell, pattern, Stream } from "commonfabric";',
+      'import { action, Default, NAME, pattern, Stream } from "commonfabric";',
       "",
       "interface AddEvent { title: string; }",
       "interface Item { title: string; body: string; }",
       "",
+      "interface In { items: Default<Item[], []>; }",
+      "",
       "interface Out {",
+      "  [NAME]: string;",
+      "  title: string;",
+      "  count: number;",
       "  items: Item[];",
       "  add: Stream<AddEvent>;",
       "}",
       "",
-      "export default pattern<Record<string, never>, Out>(() => {",
-      "  const items = cell<Item[]>([]);",
+      "export default pattern<In, Out>(({ items }) => {",
       "  const add = action((event: AddEvent) => {",
       "    items.push({ title: event.title, body: 'body' });",
       "  });",
-      "  return { items, add };",
+      "  return {",
+      "    [NAME]: 'Test board',",
+      "    title: 'Board',",
+      "    count: 0,",
+      "    items,",
+      "    add,",
+      "  };",
       "});",
     ].join("\n"),
   }],
 };
+
+/** The one verb the pattern declares. Asserted as the WHOLE list rather than
+ * as membership: every other name in the result is data, and a listing that
+ * offers data as callable is the failure that matters here — a caller shown
+ * `count` as a verb cannot tell it from `add` until the call is refused. */
+const DECLARED_VERBS = ["add"];
 
 /** Whether `schema` is the pattern's declared result type — the read this file
  * exists to prove discovery never takes. Recognized by the element type only
@@ -61,13 +82,34 @@ interface RecordedSync {
   schema: unknown;
 }
 
+/** How many documents the collection holds. Three rather than one, so a read
+ * that reached the collection at all is distinguishable from one that reached
+ * a single document by another route. */
+const ITEM_COUNT = 3;
+
+/** What a cold discovery did: the answer it produced, every sync it issued,
+ * and which of the collection's documents its replica holds afterwards. */
+interface ColdDiscovery<T> {
+  result: T;
+  syncs: RecordedSync[];
+
+  /** The collection documents the reader's replica held once every load it
+   * registered had been answered. Empty is the property under test. */
+  itemsHeld: string[];
+}
+
 /**
  * Run `read` against a piece the reader replica has never seen, and return
- * what it read alongside every sync it issued.
+ * what it read alongside what the read cost.
  *
  * Two replicas over one server, because the point is which documents travel: a
  * replica that wrote the piece already holds them, and a cold one asks for
  * exactly what it needs.
+ *
+ * The collection's members are separate documents, reached from the piece's
+ * result through links, which is what makes `itemsHeld` an observation rather
+ * than a restatement of the piece document. Inline members would travel inside
+ * the piece's own document and could never be absent from it.
  */
 async function readsOfColdDiscovery<T>(
   read: (
@@ -75,7 +117,7 @@ async function readsOfColdDiscovery<T>(
     pieceId: string,
     space: string,
   ) => Promise<T>,
-): Promise<{ result: T; syncs: RecordedSync[] }> {
+): Promise<ColdDiscovery<T>> {
   // Every resource is registered for release the moment it exists, so a
   // failure while the next one is being built still closes what came before:
   // a loopback server or a runtime left open outlives the test that made it.
@@ -123,9 +165,36 @@ async function readsOfColdDiscovery<T>(
       PROGRAM as never,
       { space },
     );
-    const piece = await writerPieces.runPersistent(compiled, {}, undefined, {
-      start: true,
+
+    // One document per member, each holding a value of its own, handed to the
+    // pattern as cells so the piece's result reaches them through links.
+    const items = Array.from(
+      { length: ITEM_COUNT },
+      (_unused, index) =>
+        writerRuntime.getCell(
+          space,
+          `discovery-reads-item-${index}-` + crypto.randomUUID(),
+          {
+            type: "object",
+            properties: { title: { type: "string" }, body: { type: "string" } },
+          },
+        ),
+    );
+    await writerRuntime.editWithRetry((tx) => {
+      for (const [index, item] of items.entries()) {
+        item.withTx(tx).set({ title: `Item ${index}`, body: `body ${index}` });
+      }
     });
+    const itemUris = items.map((item) =>
+      item.getAsNormalizedFullLink().id as string
+    );
+
+    const piece = await writerPieces.runPersistent(
+      compiled,
+      { items },
+      undefined,
+      { start: true },
+    );
     await writerPieces.synced();
 
     await readerPieces.synced();
@@ -145,7 +214,23 @@ async function readsOfColdDiscovery<T>(
       entityRefToString(piece.entityId),
       space,
     );
-    return { result, syncs };
+    // Every load the read registered has been issued and answered, so a
+    // document still absent below was never asked for, rather than still on
+    // its way.
+    await readerPieces.synced();
+
+    // The replica's own record of what it holds. This is the observation the
+    // sync log cannot make: a sync records what the reader NAMED, while a
+    // watch delivers every document its schema reaches, named or not — which
+    // is the whole shape of the cost this file is about.
+    const provider = readerStorage.open(space) as {
+      get?: (uri: string) => unknown;
+    };
+    const itemsHeld = itemUris.filter((uri) =>
+      provider.get?.(uri) !== undefined
+    );
+
+    return { result, syncs, itemsHeld };
   } finally {
     await release();
   }
@@ -153,7 +238,7 @@ async function readsOfColdDiscovery<T>(
 
 describe("piece discovery reads", () => {
   it("lists the verb without syncing under the declared result type", async () => {
-    const { result, syncs } = await readsOfColdDiscovery((
+    const { result, syncs, itemsHeld } = await readsOfColdDiscovery((
       pieces,
       piece,
       space,
@@ -168,22 +253,24 @@ describe("piece discovery reads", () => {
 
     // The listing is the whole point of paying anything at all, so it is
     // asserted beside the reads: a discovery that syncs nothing and lists
-    // nothing has not been made cheaper, it has been broken.
-    expect(result.verbs.map((verb) => verb.name)).toEqual(["add"]);
+    // nothing has not been made cheaper, it has been broken. The name, the
+    // two scalars and the collection are all in the declared result beside
+    // the verb, and none of them is callable.
+    expect(result.verbs.map((verb) => verb.name)).toEqual(DECLARED_VERBS);
     expect(result.verbs[0].kind).toBe("handler");
-    // The event schema still rides the verb's own callable cell, which is what
-    // `cf piece call add --help` renders its flags from. A root narrowed past
-    // the declared type must not take this with it.
+    // The event type the pattern declares, which is what
+    // `cf piece call add --help` renders its flags from.
     expect(result.verbs[0].inputSchema).toMatchObject({
       properties: { title: { type: "string" } },
     });
 
+    expect(itemsHeld).toEqual([]);
     expect(syncs.filter((sync) => isDeclaredResultType(sync.schema)))
       .toEqual([]);
   });
 
   it("describes the piece without syncing under the declared result type", async () => {
-    const { result, syncs } = await readsOfColdDiscovery((
+    const { result, syncs, itemsHeld } = await readsOfColdDiscovery((
       pieces,
       piece,
       space,
@@ -197,10 +284,19 @@ describe("piece discovery reads", () => {
     );
 
     // `describe`'s STATE section comes from the compiled pattern, not from a
-    // projection of the piece, so narrowing the root costs it nothing.
-    expect(result.verbs.map((verb) => verb.name)).toEqual(["add"]);
-    expect(result.state?.map((field) => field.name)).toEqual(["items"]);
+    // projection of the piece, so it names every non-callable property of the
+    // declared result without reading any of their values. The piece's name
+    // is the one field `describe` does read, and it rides the piece's own
+    // document.
+    expect(result.name).toBe("Test board");
+    expect(result.verbs.map((verb) => verb.name)).toEqual(DECLARED_VERBS);
+    expect(result.state?.map((field) => field.name)).toEqual([
+      "title",
+      "count",
+      "items",
+    ]);
 
+    expect(itemsHeld).toEqual([]);
     expect(syncs.filter((sync) => isDeclaredResultType(sync.schema)))
       .toEqual([]);
   });


### PR DESCRIPTION
## Why

#7186 landed the fix this PR was opened for, at a better site: `PieceController`
reads its three meta fields through a schema-less view, so every caller of
`getPatternRef()` pays the piece document alone, and the listing reads verbs off
the compiled pattern rather than classifying stored values. The
open-under-a-bounded-schema approach here is withdrawn — it was wrong, and
@mathpirate's review says why: opening the root under the enumeration schema
made ordinary inline data fields classify as callable tools, which
`core-piece-call` caught on `$NAME`.

What remains is the second half of that review, which still applies to the test
as it now lives on `main`. `piece-discovery-reads.test.ts` recognized a wide read
by fingerprinting the declared result type in the schemas handed to `syncCell`.
That guards the mechanism it was written against, not the property behind it: a
sync records what the reader *named*, while a watch delivers every document its
schema reaches, named or not. The fixture also had no linked documents to
observe — the collection was empty in both cases — so nothing in the file
established that discovery's cost does not grow with the collection.

## What Changed

Test only. No source change.

- The collection holds three documents of its own, handed to the pattern as
  cells so the piece's result reaches them through links. Both tests assert the
  reader's replica holds none of them once every load it registered has been
  answered — the replica's own record, not a restatement of the piece document.
- The fixture gains the rest of a real piece's surface: a name and two inline
  scalars beside the verb. Both tests assert the whole verb list rather than
  membership, so data offered as callable fails the test. That is the class of
  defect this PR's earlier revision had.
- Two comments that described the withdrawn mechanism are corrected.

## Test plan

- The new assertion fails on its own. Against a `PieceController` whose
  `#metaView()` returns the schema-bearing cell, all three collection documents
  arrive on the reader; the schema fingerprint is not what catches it.
- `deno task test` green in `packages/cli` (218 files) and for
  `packages/piece/test/pull-materialization.test.ts`; `deno task check`,
  `deno fmt --check`, `deno lint`, `check-docs-history-index`,
  `check-command-docs` and `check-skill-facts` green.

The `pieceResultSourceSchema` split is dropped rather than rebased: the caller it
was extracted for is gone with the stored-signal walk, and `main` has no second
reader of a result schema resolved to a path, so landing it would add an export
with one call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hofceao5mVxs1bnkTDbxUm
