### PR TITLE
fix(test-records): a name map says which run wrote it

### DIFF
--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -120,6 +120,18 @@ and is dropped from the merged map; a leaf's whole chain is what usually
 survives that, and `global` is a title every file declaring such a hook
 shares.
 
+Every package of a workspace run writes into one spool, so each map also
+names the repository-relative directory its process ran in. A caller
+ingesting one package's report asks for that directory. A map naming it
+belongs to that package and is read whole, whatever files it names: a
+test task may name a file anywhere in the tree, and
+`packages/test-support` runs `tools/write-iframe-wrapper.test.ts`, two
+directories above itself. A map naming no directory at all is judged by
+its files instead, and contributes only those under the directory asked
+for. Either way the scope is applied before ambiguity is judged, or a
+name two packages happen to share would cost each of them a file it held
+unambiguously.
+
 The context line carries `schema` (this document describes version 1, the
 `v1` in object paths), a per-object ULID `reportId`, the canonical `repo`
 name (a constant owned by the repository's tooling, never derived from git

--- a/packages/test-support/src/records/registration.test.ts
+++ b/packages/test-support/src/records/registration.test.ts
@@ -16,6 +16,7 @@ import {
   registeringModule,
   relativeToRoot,
   repositoryRootOf,
+  runDirectory,
   serializeSkipList,
 } from "./registration.ts";
 // Imported for what loading it declares: the shared fixture runner calls
@@ -32,11 +33,12 @@ const FIXTURE_RUNNER = new URL("../fixture-runner.ts", import.meta.url).href;
 async function writeNameMap(
   dir: string,
   label: string,
-  map: Record<string, unknown>,
+  names: Record<string, unknown>,
+  ranIn?: string,
 ): Promise<void> {
   await Deno.writeTextFile(
     join(dir, `${NAME_MAP_PREFIX}${label}${NAME_MAP_SUFFIX}`),
-    JSON.stringify(map),
+    JSON.stringify({ ...(ranIn === undefined ? {} : { dir: ranIn }), names }),
   );
 }
 
@@ -253,11 +255,101 @@ describe("registration", () => {
         });
         expect((await readNameMaps(dir)).get("shared")).toBeUndefined();
         expect(
-          (await readNameMaps(dir, { within: "packages/a" })).get("shared"),
+          (await readNameMaps(dir, { ranIn: "packages/a" })).get("shared"),
         ).toBe("packages/a/one.test.ts");
         expect(
-          (await readNameMaps(dir, { within: "packages/b/" })).get("shared"),
+          (await readNameMaps(dir, { ranIn: "packages/b/" })).get("shared"),
         ).toBe("packages/b/two.test.ts");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("keeps a file outside the scope from a map written there", async () => {
+      // A test task may name a file anywhere in the tree — the one that
+      // holds the repository tools' own regression tests does — so a map
+      // the scope's own process wrote is read whole.
+
+      const dir = await Deno.makeTempDir();
+      try {
+        await writeNameMap(
+          dir,
+          "01",
+          { "tools > wraps": "tools/wrap.test.ts" },
+          "packages/a",
+        );
+        expect(
+          (await readNameMaps(dir, { ranIn: "packages/a" })).get(
+            "tools > wraps",
+          ),
+        ).toBe("tools/wrap.test.ts");
+        // Another package's read is not offered it.
+        expect(
+          (await readNameMaps(dir, { ranIn: "packages/b" })).get(
+            "tools > wraps",
+          ),
+        ).toBeUndefined();
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("takes nothing from a map another directory wrote", async () => {
+      // Its files say nothing about whose names they are: what the
+      // scope's own process registered is what the scope's read wants,
+      // and a name the two disagree on would otherwise be dropped from
+      // both.
+
+      const dir = await Deno.makeTempDir();
+      try {
+        await writeNameMap(
+          dir,
+          "01",
+          { shared: "packages/a/one.test.ts" },
+          "packages/a",
+        );
+        await writeNameMap(
+          dir,
+          "02",
+          { shared: "packages/a/two.test.ts" },
+          "packages/b",
+        );
+        expect(
+          (await readNameMaps(dir, { ranIn: "packages/a" })).get("shared"),
+        ).toBe("packages/a/one.test.ts");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("takes every file of a map naming no directory at the root", async () => {
+      // The empty string is the repository root, which every
+      // repository-relative file sits under.
+
+      const dir = await Deno.makeTempDir();
+      try {
+        await writeNameMap(dir, "01", {
+          inside: "packages/a/one.test.ts",
+          outside: "tools/wrap.test.ts",
+        });
+        const names = await readNameMaps(dir, { ranIn: "" });
+        expect(names.get("inside")).toBe("packages/a/one.test.ts");
+        expect(names.get("outside")).toBe("tools/wrap.test.ts");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("judges a map naming no directory by its files alone", async () => {
+      const dir = await Deno.makeTempDir();
+      try {
+        await writeNameMap(dir, "01", {
+          inside: "packages/a/one.test.ts",
+          outside: "tools/wrap.test.ts",
+        });
+        const names = await readNameMaps(dir, { ranIn: "packages/a" });
+        expect(names.get("inside")).toBe("packages/a/one.test.ts");
+        expect(names.get("outside")).toBeUndefined();
       } finally {
         await Deno.remove(dir, { recursive: true });
       }
@@ -410,7 +502,11 @@ describe("what the capture does with what it cannot read", () => {
         join(dir, `${NAME_MAP_PREFIX}03${NAME_MAP_SUFFIX}`),
         "null",
       );
-      await writeNameMap(dir, "04", { one: "packages/a/one.test.ts" });
+      await Deno.writeTextFile(
+        join(dir, `${NAME_MAP_PREFIX}04${NAME_MAP_SUFFIX}`),
+        JSON.stringify({ names: ["a name"] }),
+      );
+      await writeNameMap(dir, "05", { one: "packages/a/one.test.ts" });
       const names = await readNameMaps(dir);
       expect([...names.keys()]).toEqual(["one"]);
     } finally {
@@ -423,7 +519,9 @@ describe("what the capture does with what it cannot read", () => {
     try {
       await Deno.writeTextFile(
         join(dir, `${NAME_MAP_PREFIX}01${NAME_MAP_SUFFIX}`),
-        JSON.stringify({ a: 7, b: "", c: "packages/a/one.test.ts" }),
+        JSON.stringify({
+          names: { a: 7, b: "", c: "packages/a/one.test.ts" },
+        }),
       );
       const names = await readNameMaps(dir);
       expect([...names.keys()]).toEqual(["c"]);
@@ -456,6 +554,20 @@ describe("repositoryRootOf()", () => {
     } finally {
       await Deno.remove(outside, { recursive: true });
     }
+  });
+});
+
+describe("runDirectory()", () => {
+  it("names the working directory as the repository sees it", () => {
+    const dir = runDirectory();
+    expect(dir).toBeDefined();
+    // Repository-relative, so that a caller can compare it against a
+    // workspace member's path: it neither starts at the filesystem root
+    // nor climbs out of the repository.
+    expect(dir!.startsWith("/")).toBe(false);
+    expect(dir!.split("/")).not.toContain("..");
+    const root = repositoryRootOf(join(Deno.cwd(), "a.ts"));
+    expect(join(root!, dir!)).toBe(Deno.cwd());
   });
 });
 
@@ -518,6 +630,47 @@ describe("what the capture does when it cannot write", () => {
       capture.flush();
       const names = await readNameMaps(spool);
       expect(names.get("a test")).toBe("packages/a/one.test.ts");
+    } finally {
+      await Deno.remove(spool, { recursive: true });
+    }
+  });
+
+  it("writes the directory it was told it was running in", async () => {
+    const spool = await Deno.makeTempDir();
+    try {
+      const { capture } = buildCapture({
+        registrar,
+        spool,
+        dir: "packages/b",
+      });
+      capture.names.set("a test", "tools/one.test.ts");
+      capture.flush();
+      // A read scoped to that directory takes the map whole, file and
+      // all, where a read scoped elsewhere is offered nothing: the file
+      // sits under neither directory.
+      expect(
+        (await readNameMaps(spool, { ranIn: "packages/b" })).get("a test"),
+      ).toBe("tools/one.test.ts");
+      expect(
+        (await readNameMaps(spool, { ranIn: "packages/a" })).get("a test"),
+      ).toBeUndefined();
+    } finally {
+      await Deno.remove(spool, { recursive: true });
+    }
+  });
+
+  it("writes the empty directory of a run at the repository root", async () => {
+    const spool = await Deno.makeTempDir();
+    try {
+      const { capture } = buildCapture({ registrar, spool, dir: "" });
+      capture.names.set("a test", "packages/a/one.test.ts");
+      capture.flush();
+      expect(
+        (await readNameMaps(spool, { ranIn: "" })).get("a test"),
+      ).toBe("packages/a/one.test.ts");
+      expect(
+        (await readNameMaps(spool, { ranIn: "packages/a" })).get("a test"),
+      ).toBeUndefined();
     } finally {
       await Deno.remove(spool, { recursive: true });
     }

--- a/packages/test-support/src/records/registration.ts
+++ b/packages/test-support/src/records/registration.ts
@@ -13,8 +13,13 @@
  * appears in the report as skipped instead of vanishing.
  */
 
-import { dirname, join, resolve } from "@std/path";
-import { type Environment, readEnv, recordsDir } from "./paths.ts";
+import { dirname, join, relative, resolve } from "@std/path";
+import {
+  type Environment,
+  readEnv,
+  recordsDir,
+  repositoryRoot,
+} from "./paths.ts";
 
 /** What a name-map file's name starts with, inside the spool. */
 export const NAME_MAP_PREFIX = "names-";
@@ -60,13 +65,62 @@ export const MACHINERY_MODULE_SUFFIXES: readonly string[] = [
 export const NAME_SEPARATOR = " > ";
 
 /**
- * A name map as it travels: a registered name against the
- * repository-relative file it came from. The names are what `Deno.test`
- * was called with, and, for a file written with `describe` and `it`, the
- * whole chain of each leaf as well — a title two files share says
- * nothing about either, where a leaf's whole chain usually does.
+ * A name map as it travels: where the test process ran, and a registered
+ * name against the repository-relative file it came from. The names are
+ * what `Deno.test` was called with, and, for a file written with
+ * `describe` and `it`, the whole chain of each leaf as well — a title two
+ * files share says nothing about either, where a leaf's whole chain
+ * usually does.
  */
-export type NameMap = Record<string, string>;
+export interface NameMap {
+  /**
+   * The repository-relative directory the process ran in, which for a
+   * workspace member's test task is the member's own directory and for a
+   * process running at the repository root is the empty string. Absent
+   * where no repository encloses it, and the reader then has only the
+   * files to go on.
+   */
+  dir?: string;
+
+  /** Each registered name against the file it came from. */
+  names: Record<string, string>;
+}
+
+/** A name map as it comes back off disk, its values still unread. */
+interface ParsedNameMap {
+  dir?: string;
+  names: Record<string, unknown>;
+}
+
+/** One map off disk, or undefined for anything that is not one. */
+function asNameMap(parsed: unknown): ParsedNameMap | undefined {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const { dir, names } = parsed as { dir?: unknown; names?: unknown };
+  // An array is an object, and its entries are index keys against the
+  // values, so names written as one would register a test named "0".
+  if (typeof names !== "object" || names === null || Array.isArray(names)) {
+    return undefined;
+  }
+  return {
+    ...(typeof dir === "string" ? { dir } : {}),
+    names: names as Record<string, unknown>,
+  };
+}
+
+/**
+ * The repository-relative directory this process is running in, which is
+ * the empty string at the repository root. Undefined outside any
+ * repository, and undefined when the climb is not permitted to read the
+ * filesystem.
+ */
+export function runDirectory(): string | undefined {
+  const cwd = Deno.cwd();
+  const root = repositoryRoot(cwd);
+  return root === undefined ? undefined : relative(root, cwd)
+    .replaceAll("\\", "/");
+}
 
 /**
  * A skip list: the names this invocation is not to run, under the
@@ -140,18 +194,7 @@ export function relativeToRoot(url: string, root: string): string {
  * undefined when the climb is not permitted to read the filesystem.
  */
 export function repositoryRootOf(path: string): string | undefined {
-  let dir = dirname(resolve(path));
-  for (;;) {
-    try {
-      Deno.statSync(join(dir, ".git"));
-      return dir;
-    } catch (error) {
-      if (error instanceof Deno.errors.NotCapable) return undefined;
-      const parent = dirname(dir);
-      if (parent === dir) return undefined;
-      dir = parent;
-    }
-  }
+  return repositoryRoot(dirname(resolve(path)));
 }
 
 /** The repository root of this process's tree, resolved once. */
@@ -200,6 +243,17 @@ export function fileForName(
   return best;
 }
 
+/** Whether an entry of a map is one a read scoped to `ranIn` takes. */
+function inScope(
+  dir: string | undefined,
+  file: string,
+  ranIn: string | undefined,
+): boolean {
+  if (ranIn === undefined) return true;
+  if (dir !== undefined) return dir === ranIn;
+  return ranIn.length === 0 || file.startsWith(`${ranIn}/`);
+}
+
 /**
  * Merges the name maps a spool holds into one lookup. A name two files
  * both registered is dropped rather than attributed to either: the two
@@ -208,23 +262,24 @@ export function fileForName(
  * and its absence costs only the file field.
  *
  * Every package of a workspace run writes into one spool, so a caller
- * ingesting one package's report passes `within` — the path its files sit
- * under. Names outside it are dropped before the ambiguity is judged
- * rather than after, or a name two packages happen to share would cost
- * both of them a file each had unambiguously.
+ * ingesting one package's report passes `ranIn`: the directory that
+ * package's test process ran in. A map naming the directory it was
+ * written in belongs to that directory and to no other, whatever files
+ * it names. A map naming none is judged by its files, and contributes
+ * only those under `ranIn`. Either way the scope is applied before the
+ * ambiguity is judged rather than after, or a name two packages happen
+ * to share would cost both of them a file each had unambiguously.
  */
 export async function readNameMaps(
-  dir: string,
-  options: { within?: string } = {},
+  spool: string,
+  options: { ranIn?: string } = {},
 ): Promise<Map<string, string>> {
-  const within = options.within === undefined
-    ? undefined
-    : `${options.within.replace(/\/$/, "")}/`;
+  const ranIn = options.ranIn?.replace(/\/$/, "");
   const names = new Map<string, string>();
   const ambiguous = new Set<string>();
   let entries: string[] = [];
   try {
-    for await (const entry of Deno.readDir(dir)) {
+    for await (const entry of Deno.readDir(spool)) {
       if (
         entry.isFile && entry.name.startsWith(NAME_MAP_PREFIX) &&
         entry.name.endsWith(NAME_MAP_SUFFIX)
@@ -239,20 +294,15 @@ export async function readNameMaps(
   for (const entry of entries) {
     let parsed: unknown;
     try {
-      parsed = JSON.parse(await Deno.readTextFile(join(dir, entry)));
+      parsed = JSON.parse(await Deno.readTextFile(join(spool, entry)));
     } catch {
       continue;
     }
-    // An array is an object, and its entries are index keys against the
-    // values, so a map written as one would register a test named "0".
-    if (
-      typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
-    ) {
-      continue;
-    }
-    for (const [name, file] of Object.entries(parsed)) {
+    const map = asNameMap(parsed);
+    if (map === undefined) continue;
+    for (const [name, file] of Object.entries(map.names)) {
       if (typeof file !== "string" || file.length === 0) continue;
-      if (within !== undefined && !file.startsWith(within)) continue;
+      if (!inScope(map.dir, file, ranIn)) continue;
       const known = names.get(name);
       if (known === undefined) {
         names.set(name, file);
@@ -358,8 +408,10 @@ export function installRegistrationCapture(
     console.warn(`test records: ${detail}`);
   }
 
+  const dir = runDirectory();
   const built = buildCapture({
     registrar: Deno.test,
+    ...(dir === undefined ? {} : { dir }),
     ...(skips === undefined ? {} : { skips }),
     ...(spool === undefined ? {} : { spool }),
   });
@@ -379,6 +431,13 @@ export interface CaptureOptions {
 
   /** Where `flush` writes the name map. Nothing is written without one. */
   spool?: string;
+
+  /**
+   * The repository-relative directory the map says it was written in, as
+   * it stood when the capture was built. `flush` runs at process unload,
+   * by which time a test may have changed the working directory.
+   */
+  dir?: string;
 }
 
 /**
@@ -390,7 +449,7 @@ export interface CaptureOptions {
 export function buildCapture(
   options: CaptureOptions,
 ): { capture: RegistrationCapture; registrar: (...args: unknown[]) => void } {
-  const { skips, spool } = options;
+  const { dir, skips, spool } = options;
   const names = new Map<string, string>();
 
   const capture: RegistrationCapture = {
@@ -401,8 +460,10 @@ export function buildCapture(
     },
     flush: () => {
       if (spool === undefined || names.size === 0) return;
-      const map: NameMap = {};
-      for (const [name, file] of names) map[name] = file;
+      const map: NameMap = {
+        ...(dir === undefined ? {} : { dir }),
+        names: Object.fromEntries(names),
+      };
       try {
         Deno.mkdirSync(spool, { recursive: true });
         // A random name rather than a sortable one: nothing orders these,

--- a/packages/test-support/test/records/preload.test.ts
+++ b/packages/test-support/test/records/preload.test.ts
@@ -8,7 +8,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { assert } from "@std/assert";
-import { join } from "@std/path";
+import { dirname, join } from "@std/path";
 import {
   dropContainerCases,
   ingestJUnit,
@@ -42,6 +42,14 @@ const FIXTURE_CONFIG = {
 
 interface Fixture {
   dir: string;
+
+  /**
+   * The directory the run happens in, which is the fixture root unless
+   * one was named. A workspace member's test task runs in the member's
+   * own directory, and the file names a run reports are relative to it.
+   */
+  runIn: string;
+
   spool: string;
   junit: string;
 }
@@ -50,7 +58,10 @@ interface Fixture {
  * A tree that looks like a repository to the preload: the `.git` marker is
  * what it climbs to, so a fixture needs one and needs nothing else.
  */
-async function makeFixture(files: Record<string, string>): Promise<Fixture> {
+async function makeFixture(
+  files: Record<string, string>,
+  runIn = ".",
+): Promise<Fixture> {
   const dir = await Deno.makeTempDir({ prefix: "preload-fixture-" });
   await Deno.mkdir(join(dir, ".git"));
   await Deno.writeTextFile(
@@ -58,11 +69,15 @@ async function makeFixture(files: Record<string, string>): Promise<Fixture> {
     JSON.stringify(FIXTURE_CONFIG),
   );
   for (const [name, source] of Object.entries(files)) {
-    await Deno.writeTextFile(join(dir, name), source);
+    const path = join(dir, name);
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, source);
   }
   const spool = join(dir, "spool");
   await Deno.mkdir(spool);
-  return { dir, spool, junit: join(dir, "report.xml") };
+  const runDir = join(dir, runIn);
+  await Deno.mkdir(runDir, { recursive: true });
+  return { dir, runIn: runDir, spool, junit: join(dir, "report.xml") };
 }
 
 async function runFixture(
@@ -89,7 +104,7 @@ async function runFixture(
       `--junit-path=${fixture.junit}`,
       ...files,
     ],
-    cwd: fixture.dir,
+    cwd: fixture.runIn,
     env,
     stdout: "piped",
     stderr: "piped",
@@ -293,6 +308,48 @@ describe("preload", () => {
       const byName = new Map(records.map((r) => [r.test.n, r.file]));
       expect(byName.get("outer > kept")).toEqual("bdd.test.ts");
       expect(byName.get("bare kept")).toEqual("bare.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("places a file above the directory the run happened in", async () => {
+    // A workspace member's test task runs in the member's directory and
+    // may name a file anywhere in the tree: `packages/test-support` runs
+    // the repository tools' own regression tests, two directories above
+    // itself. The map says which directory the run happened in, and a
+    // read scoped to that directory takes it whole.
+
+    const fixture = await makeFixture({
+      "member/own.test.ts": BDD_FILE,
+      "tools/away.test.ts": OTHER_BDD_FILE,
+    }, "member");
+    try {
+      const run = await runFixture(fixture, [
+        "own.test.ts",
+        "../tools/away.test.ts",
+      ]);
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const names = await readNameMaps(fixture.spool, { ranIn: "member" });
+      expect(names.get("outer > kept")).toEqual("member/own.test.ts");
+      expect(names.get("elsewhere > dropped")).toEqual("tools/away.test.ts");
+      // The directory the file sits in is not the directory the run
+      // happened in, and a read scoped to it is offered nothing.
+      expect((await readNameMaps(fixture.spool, { ranIn: "tools" })).size)
+        .toEqual(0);
+
+      // The join ingestion performs, with the prefix the workspace runner
+      // passes. Every class name in the report names the wrapper, so the
+      // map is the only thing that can place either file.
+      const records = ingestJUnit(await Deno.readTextFile(fixture.junit), {
+        kind: "unit",
+        scope: "fixture",
+        filePrefix: "member",
+        fileByName: names,
+      });
+      const byName = new Map(records.map((r) => [r.test.n, r.file]));
+      expect(byName.get("outer > kept")).toEqual("member/own.test.ts");
+      expect(byName.get("elsewhere > dropped")).toEqual("tools/away.test.ts");
     } finally {
       await Deno.remove(fixture.dir, { recursive: true });
     }

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -151,7 +151,7 @@ async function ingestLeafJUnit(
         kind: "unit",
         scope,
         filePrefix: prefix,
-        fileByName: await readNameMaps(spoolDir, { within: prefix }),
+        fileByName: await readNameMaps(spoolDir, { ranIn: prefix }),
       })
     ) {
       fragment.append(record);


### PR DESCRIPTION
PROBLEM

A test record with no source file has no unit in the topology, so the publisher leaves it out of the selection manifest and every lane runs it. `readNameMaps` is asked for one package's names and takes a spool's maps by the paths of the files they name, dropping a name whose file does not sit under the package's own directory. That is a proxy for the question being asked, and it is wrong wherever a test task names a file elsewhere in the tree. `packages/test-support` runs the repository tools' own regression tests, two directories above it, so the names its process captured for `tools/write-iframe-wrapper.test.ts` are dropped before ambiguity is judged, and the report's class names cannot stand in: a path climbing out of the working directory is not one ingestion joins onto. That is 9 identities carrying no file.

SOLUTION

Have each map record the repository-relative directory its process ran in, and select by that. A map naming the directory a caller asked for belongs to it and is read whole, whatever files it names. A map naming none is judged by its files instead, and contributes only those under that directory. Either way the scope is applied before the ambiguity is judged, so a name two packages happen to share still costs neither of them a file it held unambiguously.

The directory is read where the capture is built. `flush` runs at process unload, by which time a test that called `Deno.chdir` could have moved the working directory. It arrives through `CaptureOptions` beside the registrar, the skip list and the spool, so a test names it rather than inheriting it.

Measured over packages/test-support, run the way the workspace runner runs it: 9 records carrying no file before and none after. The package produces 331 records before and 339 after, the eight extra being the cases this commit adds.

DESIGN DISCUSSION

The empty string is a directory here, not the absence of one: a process running at the repository root writes it, and a reader that discarded it would judge that run's map by its files, which is the rule this replaces. Absent means no repository encloses the process, or the climb to find one was not permitted.

What a map holds off disk is typed as unread, so the one check that reads a value stands alone rather than contradicting a declared type. The climb to the repository root is `repositoryRoot` in `paths.ts`, which both callers in this file now use.

The preload fixture gains a directory to run in, so one case covers the whole join: a run in a subdirectory, over a file inside it and a file two levels away, read back scoped to that subdirectory. Deleting the directory the capture is built with fails that case on the file outside, where the three narrower cases stay green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

