### PR TITLE
fix(test-support): name a bdd leaf by the suite its call names

### DIFF
--- a/packages/test-support/src/records/bdd.ts
+++ b/packages/test-support/src/records/bdd.ts
@@ -50,13 +50,22 @@ registerFrameworkModule(import.meta.url);
 
 /**
  * The describe chain enclosing whatever is being registered right now.
- * `describe` runs its body while it registers, so pushing the title
- * around that call is what makes the chain available to the `it`s inside.
- * A hook declared outside every `describe` opens the chain with the root
- * suite the runner invents for it, and nothing pops that one: the suite
- * holds the rest of the file.
+ * `describe` runs its body while it registers, so setting the chain
+ * around that call is what makes it available to the `it`s inside. A
+ * hook declared outside every `describe` opens the chain with the root
+ * suite the runner invents for it, and nothing takes that one off again:
+ * the suite holds the rest of the file.
  */
-const chain: string[] = [];
+let chain: string[] = [];
+
+/**
+ * For each suite `describe` has handed back, the chain that suite stands
+ * for. A call can name the suite it belongs to outright instead of
+ * sitting inside it, and the runner reports such a leaf under the named
+ * suite's chain rather than under whatever encloses the call. A value is
+ * a handle this module handed out exactly when it is a key here.
+ */
+const chains = new WeakMap<object, readonly string[]>();
 
 /**
  * The name the bdd runner gives the root suite it invents. A hook
@@ -105,12 +114,80 @@ export function bodyOf(
 type Hook = <T>(fn: (this: T) => void | Promise<void>) => void;
 
 /**
- * Wraps one `describe` entry point so the chain is pushed around the body
- * it registers. A call with no body registers nothing inside it and
- * reaches the real function untouched, so an unfamiliar overload still
- * runs and still reports its own error. A call carrying no title of its
- * own is named after its body, so the wrapper answers to the body's own
- * name and the suite is reported under it.
+ * The chain the suite a bdd call names stands for, and undefined where
+ * the call names none. A call names a suite by passing its handle ahead
+ * of everything else, or by carrying that handle in the `suite` field of
+ * a definition, and those two places are where the real functions look
+ * for it.
+ */
+function namedChain(args: readonly unknown[]): readonly string[] | undefined {
+  for (const arg of args) {
+    if (typeof arg !== "object" || arg === null) continue;
+    const own = chains.get(arg);
+    if (own !== undefined) return own;
+    const suite = (arg as { suite?: unknown }).suite;
+    if (typeof suite !== "object" || suite === null) continue;
+    const named = chains.get(suite);
+    if (named !== undefined) return named;
+  }
+  return undefined;
+}
+
+/**
+ * The chain a call's own name hangs off: the chain of the suite it
+ * names, and otherwise the chain lexically open around it.
+ */
+function enclosing(args: readonly unknown[]): readonly string[] {
+  return namedChain(args) ?? chain;
+}
+
+/**
+ * A body wrapped so that it runs with `own` as the open chain. Where a
+ * call gives no name of its own, `describe` names the suite after its
+ * body, so the replacement carries the body's own name.
+ */
+function inChain(own: string[], body: AnyFunction): AnyFunction {
+  const wrapped = function (this: unknown, ...rest: unknown[]): unknown {
+    const outer = chain;
+    chain = own;
+    try {
+      return body.apply(this, rest);
+    } finally {
+      chain = outer;
+    }
+  };
+  Object.defineProperty(wrapped, "name", { value: body.name });
+  return wrapped;
+}
+
+/** One call's arguments with its body replaced, wherever the body sits. */
+function withBody(
+  args: readonly unknown[],
+  index: number,
+  body: AnyFunction,
+): unknown[] {
+  if (index >= 0) {
+    const next = [...args];
+    next[index] = body;
+    return next;
+  }
+  return args.map((arg) =>
+    typeof arg === "object" && arg !== null &&
+      typeof (arg as { fn?: unknown }).fn === "function"
+      ? { ...arg, fn: body }
+      : arg
+  );
+}
+
+/**
+ * Wraps one `describe` entry point so the chain is set around the body it
+ * registers, and so the suite it hands back is remembered under the chain
+ * that suite stands for. A leaf naming that handle is then named the way
+ * the runner names it, wherever the call sits. A call carrying no title
+ * of its own is named after its body, so the wrapper answers to the
+ * body's own name and the suite is reported under it. A shape this does
+ * not model reaches the real function untouched, so an unfamiliar
+ * overload still runs and still reports its own error.
  *
  * Takes no capture: a wrapper is built only where one is installed, and
  * tracking the chain is the whole of what this does with it.
@@ -118,38 +195,24 @@ type Hook = <T>(fn: (this: T) => void | Promise<void>) => void;
 export function wrapDescribe(through: AnyFunction): AnyFunction {
   return (...args: unknown[]): unknown => {
     const found = bodyOf(args);
-    if (found === undefined) return through(...args);
-    const name = nameOf(args) ?? found.body.name;
-    const wrapped = function (this: unknown, ...rest: unknown[]): unknown {
-      chain.push(name);
-      try {
-        return found.body.apply(this, rest);
-      } finally {
-        chain.pop();
-      }
-    };
-    Object.defineProperty(wrapped, "name", { value: found.body.name });
-    if (found.index >= 0) {
-      const next = [...args];
-      next[found.index] = wrapped;
-      return through(...next);
+    const name = nameOf(args) ?? found?.body.name;
+    if (name === undefined) return through(...args);
+    const own = [...enclosing(args), name];
+    const result = found === undefined
+      ? through(...args)
+      : through(...withBody(args, found.index, inChain(own, found.body)));
+    if (typeof result === "object" && result !== null) {
+      chains.set(result, own);
     }
-    return through(
-      ...args.map((arg) =>
-        typeof arg === "object" && arg !== null &&
-          typeof (arg as { fn?: unknown }).fn === "function"
-          ? { ...arg, fn: wrapped }
-          : arg
-      ),
-    );
+    return result;
   };
 }
 
 /**
  * Wraps one `it` entry point so that a listed leaf is registered as
  * ignored, and so that the leaf's own file reaches the name map. The
- * leaf's identity is the enclosing chain and its own name joined, which
- * is what the store speaks in, and the file is read from the
+ * leaf's identity is the chain enclosing it and its own name joined,
+ * which is what the store speaks in, and the file is read from the
  * registration stack the same way the preload reads it — the two
  * together, because the same test name occurs in more than one file.
  *
@@ -170,7 +233,7 @@ export function wrapIt(
     const capture = active();
     const name = nameOf(args);
     if (name === undefined) return through(...args);
-    const identity = [...chain, name].join(NAME_SEPARATOR);
+    const identity = [...enclosing(args), name].join(NAME_SEPARATOR);
     const file = registeringFile(new Error().stack ?? "");
     if (file !== undefined) capture.names.set(identity, file);
     return capture.skipped(file, identity) ? ignore(...args) : through(...args);

--- a/packages/test-support/test/records/bdd.test.ts
+++ b/packages/test-support/test/records/bdd.test.ts
@@ -133,12 +133,15 @@ describe("what the wrappers do once a capture is installed", () => {
   it("passes a call it cannot read straight through", () => {
     // An unfamiliar overload still runs and still reports its own
     // error, rather than being dropped by a wrapper that did not
-    // recognize it.
+    // recognize it. A `describe` carrying neither a name nor a body is
+    // one: it opens no chain and hands back no suite this module can
+    // put a chain against. A `describe` carrying a name but no body is
+    // not, since that call is where a suite handle comes from.
     const seen: unknown[][] = [];
     const through = (...args: unknown[]) => seen.push(args);
-    wrapDescribe(through)("a name with no body");
+    wrapDescribe(through)();
     wrapIt(through, () => {}, capturing())({ no: "name" });
-    expect(seen).toEqual([["a name with no body"], [{ no: "name" }]]);
+    expect(seen).toEqual([[], [{ no: "name" }]]);
   });
 
   it("encloses a leaf in the chain of a suite declared as one definition", () => {

--- a/packages/test-support/test/records/bdd.test.ts
+++ b/packages/test-support/test/records/bdd.test.ts
@@ -4,9 +4,12 @@
  * What matters is that the wrapper is transparent: every way the real
  * ones can be called still registers, and a call the wrapper does not
  * model reaches the real function untouched rather than being dropped.
- * The shapes below are registered for real, which is the assertion — a
- * shape the wrapper mishandled would fail to register, or would register
- * a test with no body, and Deno would refuse the module.
+ * The shapes below are registered for real, and a run with a capture
+ * installed puts each of them through the wrapper. A run without one
+ * gets the real functions back, so what the shapes prove there is that
+ * the file states them as the real functions accept them; the wrapper's
+ * own behavior is asserted against it directly further down, and
+ * through a recording run in preload.test.ts.
  */
 
 import { describe, it } from "@std/testing/bdd";
@@ -43,6 +46,29 @@ describe("bdd", () => {
         expect(true).toBe(true);
       });
     },
+  });
+
+  // A suite named by the handle `describe` hands back, rather than by
+  // nesting inside its body. Each leaf below reaches the runner through
+  // the entry points a test file uses.
+  const handle = describe("a suite named by its handle");
+
+  it(handle, "registers a leaf given the suite it belongs to", () => {
+    expect(true).toBe(true);
+  });
+
+  it({
+    suite: handle,
+    name: "registers a leaf whose definition names its suite",
+    fn: () => {
+      expect(true).toBe(true);
+    },
+  });
+
+  describe(handle, "a suite given the suite it sits under", () => {
+    it("registers a leaf beneath both of them", () => {
+      expect(true).toBe(true);
+    });
   });
 
   describe("the entry points hanging off each of them", () => {
@@ -85,18 +111,23 @@ describe("reading the shape of a bdd call", () => {
 });
 
 describe("what the wrappers do once a capture is installed", () => {
-  /** A capture that skips what a case names, and says what it was asked. */
+  /**
+   * A capture that skips what a case names, and says what it was asked.
+   * One capture stands behind every call, as the installed one does, so
+   * the names it was given accumulate in a map a case can read.
+   */
   function capturing(skips: readonly string[] = []) {
     const asked: string[] = [];
-    const capture = () => ({
-      names: new Map<string, string>(),
+    const names = new Map<string, string>();
+    const capture = {
+      names,
       skipped: (_file: string | undefined, name: string) => {
         asked.push(name);
         return skips.includes(name);
       },
       flush: () => {},
-    });
-    return Object.assign(capture, { asked });
+    };
+    return Object.assign(() => capture, { asked, names });
   }
 
   it("passes a call it cannot read straight through", () => {
@@ -126,6 +157,62 @@ describe("what the wrappers do once a capture is installed", () => {
       fn: () => it_("leaf", () => {}),
     });
     expect(inner.asked).toEqual(["outer > leaf"]);
+  });
+
+  /** A `describe` that runs the body it is given and hands back a handle. */
+  function handing(...args: unknown[]): { symbol: symbol } {
+    for (const arg of args) {
+      if (typeof arg === "function") (arg as () => void)();
+    }
+    return { symbol: Symbol("suite") };
+  }
+
+  it("puts a leaf under the suite its call names", () => {
+    // A leaf can name the suite it belongs to instead of sitting inside
+    // it, and the runner reports it under that suite's chain. Nothing
+    // encloses the calls below, so the chain the capture is asked about
+    // is the handle's or nothing at all.
+    const named = capturing();
+    const describe_ = wrapDescribe(handing);
+    const it_ = wrapIt(() => {}, () => {}, named);
+    const outer = describe_("outer");
+    const inner = describe_(outer, "inner");
+    it_(outer, "direct", () => {});
+    it_({ suite: inner, name: "by definition", fn: () => {} });
+    expect(named.asked).toEqual([
+      "outer > direct",
+      "outer > inner > by definition",
+    ]);
+    // The name map is keyed by the same identity, since that is what
+    // ingestion joins a report's names onto.
+    expect([...named.names.keys()]).toEqual([
+      "outer > direct",
+      "outer > inner > by definition",
+    ]);
+  });
+
+  it("ignores the chain enclosing a call that names its own suite", () => {
+    // The chain a call sits in and the chain it names can differ, and
+    // the runner reports the named one. A leaf that names no suite in
+    // the same body still takes the chain it sits in.
+    const named = capturing();
+    const describe_ = wrapDescribe(handing);
+    const it_ = wrapIt(() => {}, () => {}, named);
+    const elsewhere = describe_("elsewhere");
+    describe_("lexical", () => {
+      it_(elsewhere, "named", () => {});
+      it_("enclosed", () => {});
+    });
+    expect(named.asked).toEqual(["elsewhere > named", "lexical > enclosed"]);
+  });
+
+  it("encloses a body in the chain of the suite its call names", () => {
+    const named = capturing();
+    const describe_ = wrapDescribe(handing);
+    const it_ = wrapIt(() => {}, () => {}, named);
+    const outer = describe_("outer");
+    describe_(outer, "inner", () => it_("leaf", () => {}));
+    expect(named.asked).toEqual(["outer > inner > leaf"]);
   });
 
   it("names a leaf by itself where no suite encloses it", () => {

--- a/packages/test-support/test/records/preload.test.ts
+++ b/packages/test-support/test/records/preload.test.ts
@@ -135,6 +135,36 @@ describe("elsewhere", () => {
 });
 `;
 
+// A file naming each suite by the handle `describe` hands back rather
+// than by nesting inside it. The runner reports a leaf under the suite
+// its call names, so that is the identity the name map has to hold and
+// the identity a skip list has to be keyed by.
+const HANDLE_BDD_FILE = `import { describe, it } from "@std/testing/bdd";
+const outer = describe("outer");
+it(outer, "kept", () => {});
+const inner = describe(outer, "inner");
+it(inner, "dropped", () => {});
+describe(inner, "bodied", () => {
+  it("nested", () => {});
+});
+`;
+
+// A file that both declares a hook outside every `describe` and names
+// its suites by handle. The root suite the runner invents holds the
+// handle-named ones, so the chain each leaf is named by opens with the
+// root suite's name and goes on through the suite the call named.
+const HOOKED_HANDLE_FILE =
+  `import { beforeEach, describe, it } from "@std/testing/bdd";
+let ran = 0;
+beforeEach(() => {
+  ran++;
+});
+const outer = describe("outer");
+it(outer, "kept", () => {
+  if (ran === 0) throw new Error("the hook did not run");
+});
+it(outer, "dropped", () => {});
+`;
 // A second file opening with the same suite title as BDD_FILE. Nothing
 // stops two files sharing one, and several packages have a title every
 // one of their files opens with.
@@ -668,6 +698,57 @@ describe("preload", () => {
     }
   });
 
+  it("names a leaf by the suite its call names rather than encloses it", async () => {
+    const fixture = await makeFixture({ "handle.test.ts": HANDLE_BDD_FILE });
+    try {
+      const run = await runFixture(fixture, ["handle.test.ts"], {
+        "handle.test.ts": ["outer > inner > dropped"],
+      });
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      // A skip list keyed by the name the report gives leaves the leaf
+      // out, which it can only do if the two are the same identity.
+      const reported = await outcomes(fixture);
+      expect(reported.get("outer > kept")).toEqual("pass");
+      expect(reported.get("outer > inner > dropped")).toEqual("skip");
+      expect(reported.get("outer > inner > bodied > nested")).toEqual("pass");
+      const names = await readNameMaps(fixture.spool);
+      expect(names.get("outer > kept")).toEqual("handle.test.ts");
+      expect(names.get("outer > inner > dropped")).toEqual("handle.test.ts");
+      expect(names.get("outer > inner > bodied > nested"))
+        .toEqual("handle.test.ts");
+
+      // The map's name and the report's name meeting is what carries the
+      // file through: a leaf recorded under a name no runner reports
+      // reaches ingestion with none.
+      const records = ingestJUnit(await Deno.readTextFile(fixture.junit), {
+        kind: "unit",
+        scope: "fixture",
+        fileByName: names,
+      });
+      const byName = new Map(records.map((r) => [r.test.n, r.file]));
+      expect(byName.get("outer > kept")).toEqual("handle.test.ts");
+      expect(byName.get("outer > inner > dropped")).toEqual("handle.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("names a handle's leaf inside the root suite a hook brings about", async () => {
+    const fixture = await makeFixture({ "both.test.ts": HOOKED_HANDLE_FILE });
+    try {
+      const run = await runFixture(fixture, ["both.test.ts"], {
+        "both.test.ts": ["global > outer > dropped"],
+      });
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const reported = await outcomes(fixture);
+      expect(reported.get("global > outer > kept")).toEqual("pass");
+      expect(reported.get("global > outer > dropped")).toEqual("skip");
+      const names = await readNameMaps(fixture.spool);
+      expect(names.get("global > outer > kept")).toEqual("both.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
   it("skips independently in two files holding the same leaf name", async () => {
     const fixture = await makeFixture({
       "bdd.test.ts": BDD_FILE,


### PR DESCRIPTION
PROBLEM

A test written with `@std/testing/bdd` can name the suite it belongs to instead of sitting inside that suite's body:

    const outer = describe("outer");
    it(outer, "leaf", () => {});

The runner reports that leaf as "outer > leaf". The `describe` and `it` this repository's import map resolves to tracked only the chain lexically open around a call, which for a call at file scope is nothing, so the leaf was recorded as "leaf". The name map then held an entry under a name no runner reports, so the leaf reached ingestion with no file, and a skip list keyed by "outer > leaf" never matched, so such a test could not be left out of an invocation.

SOLUTION

The `describe` wrapper remembers the chain each suite stands for, against the handle it hands that suite back under. Both wrappers take a call's chain from the suite it names, falling back to the chain enclosing the call where it names none. A call names its suite by passing the handle ahead of everything else, or by carrying it in the `suite` field of a definition, which is where the real functions look for it. A `describe` with no body is no longer passed straight through: it registers no leaves, and it is where a handle comes from.

DESIGN DISCUSSION

Nothing in the tree writes the explicit-suite forms today, so this was latent. Two reviewers of an unrelated change to the same file raised it independently.

The chain was a stack of names pushed and popped around each body. It is now a whole chain, replaced around a body and restored afterwards, because the chain a body runs under is no longer the enclosing one plus a name. It stays a mutable array, since the hook wrapper puts the name of the invented root suite on it.

A suite's chain is held against its handle object rather than against the symbol that handle carries. Membership is then the definition of a handle this module handed out, nothing reads how the real module represents one, and an entry can be collected. A handle rebuilt around a symbol rather than passed along no longer resolves; no caller has reason to build one.

The wrappers are covered directly in the package's own bdd tests, and the shape is covered end to end in the preload tests, which spawn a real `deno test` over fixture files and compare the resulting report against the name maps left in the spool. Two things put a name at the head of a leaf's chain — a hook declared outside every `describe`, and a call naming its suite by handle — and one fixture now does both.

The capture the wrapper tests stand behind was rebuilt on every call, so each name written into it went into a map that was then thrown away. It is one capture now, as the installed one is, and a case reads the names it was given.

That file opened by saying that registering each shape for real was the assertion. The wrapper is built only where a capture is installed and a plain run installs none, so the opening now says which run puts the shapes through the wrapper and where the wrapper's own behavior is asserted.

`docs/specs/test-records.md` says a bdd identity is the describe chain the runner reports, and describes the name map as holding the whole chain of each leaf. Both were already what this change makes true, so neither needed rewording.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

