### PR TITLE
test(runner,piece): say what a link proof's writer identity decides

### DIFF
--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -611,17 +611,18 @@ export function assertPatternSchemasBackwardCompatible(
  * `target`. This is used for durable links: validating only their current
  * materialization is insufficient because the linked cell can change later.
  *
- * The `ifc` reduction {@link comparableIfc} performs applies here as well, and
- * this entry point puts it to a different question. A pattern update compares
- * two versions of one contract, where a changed writer identity is the same
- * module recompiled. A link joins two separate pieces, where a differing
- * `moduleIdentity` names a different authoring module. What holds either way is
- * the reason the reduction exists: the runtime authorizes a write against the
- * claim on the location being written, re-verifying the live writer's
- * `moduleIdentity` there (`writeAuthorizedByReason`,
- * `packages/runner/src/cfc/prepare.ts`). Proving a link neither performs that
- * check nor stands in for it, and the binding `path` and the whole `uiContract`
- * are compared here as they are for an update.
+ * The `ifc` reduction {@link comparableIfc} performs reaches this proof as
+ * well, where the two claims come from two separate pieces and a differing
+ * `moduleIdentity` names a different authoring module rather than one module
+ * recompiled. The reduction stays because this proof is not what decides who
+ * may write. That is decided at write time, against the claim in the schema
+ * write-policy input recorded at the document a write reaches
+ * (`writeAuthorizedByReason`, `packages/runner/src/cfc/prepare.ts`), and a
+ * durable link reaches storage by routes this proof does not sit on — a
+ * handler writing a handle into a slot among them. A proof that refused a
+ * writer identity would therefore withhold no authority, and the binding
+ * `path` and the whole `uiContract` are compared here as they are for a
+ * pattern update.
  */
 export function assertSchemaSubset(
   source: JSONSchema,

--- a/packages/runner/test/cfc-link-crossing-write-authority.test.ts
+++ b/packages/runner/test/cfc-link-crossing-write-authority.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { Runtime } from "../src/runtime.ts";
+import type { ImplementationIdentity } from "../src/cfc/types.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const PRODUCER_MODULE = "producer-module-identity";
+const PRODUCER_FILE = "/patterns/producer.tsx";
+const CONSUMER_MODULE = "consumer-module-identity";
+const CONSUMER_FILE = "/patterns/consumer.tsx";
+
+const signer = await Identity.fromPassphrase(
+  "cfc-link-crossing-write-authority",
+);
+
+/** The module the producer document's claim names. */
+const asProducer: ImplementationIdentity = {
+  kind: "verified",
+  moduleIdentity: PRODUCER_MODULE,
+  sourceFile: PRODUCER_FILE,
+  bindingPath: ["setBio"],
+};
+
+/** A second verified module, which no claim in this space names. */
+const asConsumer: ImplementationIdentity = {
+  kind: "verified",
+  moduleIdentity: CONSUMER_MODULE,
+  sourceFile: CONSUMER_FILE,
+  bindingPath: ["setBio"],
+};
+
+/** The linked-to document: its `bio` authorizes writes by the producer. */
+const producerSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    bio: {
+      type: "string",
+      ifc: {
+        writeAuthorizedBy: {
+          __ctWriterIdentityOf: {
+            moduleIdentity: PRODUCER_MODULE,
+            file: PRODUCER_FILE,
+            path: ["setBio"],
+          },
+        },
+      },
+    },
+  },
+};
+
+/** The document holding the link, which declares no claim of its own. */
+const consumerSchema: JSONSchema = {
+  type: "object",
+  properties: { slot: { type: "object" } },
+};
+
+describe("cfc-link-crossing-write-authority", () => {
+  // A write below a link records its schema write-policy input at the document
+  // the link resolves to, carrying the schema the crossed link holds, so the
+  // claim that gates the write is the one that schema declares. Both cases
+  // below cross a link the consumer wrote from a schema-bearing producer cell,
+  // which carries the producer's own schema; a link carrying a schema the
+  // consumer authored is a different case, and neither measures it.
+
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    storageManager = undefined;
+    runtime = undefined;
+  });
+
+  /**
+   * Builds a space holding a producer document whose `bio` authorizes the
+   * producer module, and a consumer document whose `slot` holds a handle to
+   * the producer.
+   */
+  const linkedSpace = async (): Promise<Runtime> => {
+    storageManager = StorageManager.emulate({ as: signer });
+    const rt = runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      trustSnapshotProvider: () => ({
+        id: "cfc-link-crossing-write-authority",
+        actingPrincipal: signer.did(),
+      }),
+    });
+
+    const seedTx = rt.edit();
+    const producer = rt.getCell(
+      signer.did(),
+      "link-crossing-producer",
+      producerSchema,
+      seedTx,
+    );
+    seedTx.setCfcImplementationIdentity(asProducer);
+    producer.set({ bio: "seed" });
+    seedTx.prepareCfc();
+    expect((await seedTx.commit()).error).toBeUndefined();
+    await rt.idle();
+
+    const linkTx = rt.edit();
+    const consumer = rt.getCell(
+      signer.did(),
+      "link-crossing-consumer",
+      consumerSchema,
+      linkTx,
+    );
+    linkTx.setCfcImplementationIdentity(asConsumer);
+    consumer.key("slot").set(producer.withTx(linkTx));
+    linkTx.prepareCfc();
+    expect((await linkTx.commit()).error).toBeUndefined();
+    await rt.idle();
+
+    return rt;
+  };
+
+  /**
+   * Writes `value` at the consumer document's `slot/bio`, which the link sends
+   * to the producer document's `bio`, and returns the commit's error message.
+   */
+  const writeThroughLink = async (
+    rt: Runtime,
+    identity: ImplementationIdentity,
+    value: string,
+  ): Promise<string | undefined> => {
+    const tx = rt.edit();
+    const consumer = rt.getCell(
+      signer.did(),
+      "link-crossing-consumer",
+      consumerSchema,
+      tx,
+    );
+    await consumer.sync();
+    tx.setCfcImplementationIdentity(identity);
+    consumer.key("slot").key("bio").set(value);
+    tx.prepareCfc();
+    const error = (await tx.commit()).error?.message;
+    await rt.idle();
+    return error;
+  };
+
+  /** The producer document's `bio` as it now stands. */
+  const producerBio = async (rt: Runtime): Promise<unknown> => {
+    const producer = rt.getCell(
+      signer.did(),
+      "link-crossing-producer",
+      producerSchema,
+      rt.edit(),
+    );
+    await producer.sync();
+    return producer.key("bio").get();
+  };
+
+  it("commits a write below a link made by the module the crossed link's claim names", async () => {
+    const rt = await linkedSpace();
+    expect(await writeThroughLink(rt, asProducer, "written")).toBeUndefined();
+    expect(await producerBio(rt)).toBe("written");
+  });
+
+  it("refuses a write below a link made by a module that claim does not name, naming the linked-to coordinate", async () => {
+    // `/bio` is the producer document's own coordinate, not the `slot/bio` the
+    // write was addressed to, so the entry the check ran over is the one the
+    // crossed link's schema declares.
+    const rt = await linkedSpace();
+    expect(await writeThroughLink(rt, asConsumer, "written")).toMatch(
+      /writeAuthorizedBy failed at \/bio/,
+    );
+    expect(await producerBio(rt)).toBe("seed");
+  });
+});


### PR DESCRIPTION
The piece compatibility gate normalizes the volatile identity of an `ifc.writeAuthorizedBy` claim out of every `ifc` comparison: the content-addressed `moduleIdentity`, the legacy `bundleId`, and the resolver-dependent `file` spelling. Two entry points reach that normalization, and only one of them is described by the reason written beside it. `assertPatternSchemasBackwardCompatible` compares two versions of one pattern, where a changed `moduleIdentity` is that pattern recompiled and holding a piece to it would freeze every pattern that authorizes a write. `assertSchemaSubset` proves a durable link between two separate pieces, where a differing `moduleIdentity` names a different authoring module rather than a recompile, so the recompile argument does not reach it.

The reduction belongs at both, for a reason that has nothing to do with recompiles: this proof is not what decides who may write. That is decided at write time, against the claim in the schema write-policy input recorded at the document a write reaches, and a durable link reaches storage by routes the proof does not sit on — a handler writing a handle into a slot among them. A proof that refused a writer identity would refuse links while withholding no authority. `assertSchemaSubset`'s doc comment now says that instead of leaving the question open.

Which claim gates a write that a link sends to another document had no test, so a new one measures it. A producer document authorizes writes at `bio` by one module; a consumer document holds a handle to it at `slot`. A write at `slot/bio` records its schema write-policy input at the producer document, carrying the schema the crossed link holds — for a handle written from a schema-bearing cell, that cell's own — so the producer's claim is what gates the write. Writing under the producer's module commits and the value lands in the producer document; writing under a second verified module is refused with `writeAuthorizedBy failed at /bio`, the producer's own coordinate rather than the `slot/bio` the write was addressed to, and the producer document is unchanged.

That test says nothing about a link the consumer authored the schema of. Which claim gates a write in that case turns on a runtime seam that is being tracked separately, and the answer there is not the one this test measures.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

