### PR TITLE
fix(cf-harness): run_pattern waits for the run to be durable, not the capped whole-runtime barrier

### DIFF
--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -1433,7 +1433,18 @@ export const runPatternTool: HarnessToolDefinition<
       }
     };
     const barrier = (async () => {
-      await pieces.runtime.settled();
+      // Wait for THIS run to quiesce and its writes to land durably — NOT the
+      // capped whole-runtime `settled()`. `settled(maxRounds=50)` returns while
+      // a run is still working (its own doc: a cap "returns while the run is
+      // still working ... wrongly and silently"; runtime.ts notes "generation
+      // 50 while the chain kept running and writing"). run_pattern then reports
+      // the in-memory result as `ok` while the piece's content write is still
+      // in flight past the cap, and teardown loses it: the named piece resolves
+      // to an empty cell. `settledFor` is uncapped and scoped to this run, the
+      // same barrier the async builtins (llm, llm-dialog, navigate-to) use to
+      // wait for a result to land; the signal lets its loop stop on abort while
+      // `raceWithAbort` below still returns promptly.
+      await pieces.runtime.settledFor(piece.getCell(), signal);
       await pieces.synced();
     })();
     if (await raceWithAbort(barrier, signal) === "aborted") {


### PR DESCRIPTION
## Why

A `/cf-harness` turn that deploys a piece and names it can leave the piece with an **empty content cell** — the pane opened at its slug renders "Nothing deployed here" — while its slug/id commit fine. Seen intermittently on live pieces (`tic-tac-toe-arcade`, `dice-roller` lost content; plain `tic-tac-toe`, `tic-tac-toe-game` landed it), and confirmed from the run transcripts: `run_pattern` returned status `ok` with a `resultRef` whose entity the store holds **no data** for, hours later. Silent success, content lost.

Cause: `run_pattern` waits for the started run with `pieces.runtime.settled()`, the whole-runtime barrier that hard-caps at 50 rounds. For a run whose tracked async work chains past that cap, `settled()` returns while the run is still writing; `run_pattern` reads the in-memory result and reports `ok`, and the still-in-flight content write is then lost at session teardown (which disposes with `closeStorage: true`, skipping the uncapped drain that would otherwise catch it).

The runtime already diagnoses this against itself. The dispose drain uses the uncapped barrier and its comment records the exact measurement — *"60 generations of chained tracked work, and a capped drain returned at generation 50 while the chain kept running and writing."* `settledFor`'s JSDoc: a cap *"returns while the run is still working ... wrongly and silently."* The async builtins (`llm`, `llm-dialog`, `navigate-to`) all wait for a result with `settledFor`. `run_pattern`'s live barrier was the one durability-critical caller using the capped form.

## What Changed

`packages/cf-harness/src/tools/run-pattern.ts`, the live run barrier:

- `pieces.runtime.settled()` → `pieces.runtime.settledFor(piece.getCell(), signal)` — uncapped and scoped to this run, so the content is durable before `run_pattern` returns `ok`. Bounded in production by the existing `raceWithAbort(barrier, signal)` against the prompt loop's run-level abort.

## What deliberately did NOT change

The publish-gate probe barrier a few hundred lines down calls the same capped `settled()`, and it **stays capped**. Its own comment requires that *"a probe that never settles cannot hold the run open"*, and `context.signal` is optional (`signal?: AbortSignal`, undefined outside the prompt loop) — so `settledFor(_, undefined)` there would loop unbounded and break that guarantee, trading a rare misclassification of a slow pattern for a hang. The asymmetry is real and worth stating: the live barrier can be uncapped because durability is required and an abort bounds it; the probe keeps its cap because a bounded-but-imperfect classification beats a possible hang. (Caught in adversarial review.)

## Test plan

- `deno check` clean.
- Existing suites pass unchanged: `assign-slug` (the `run_pattern`→`assign_slug` flow), `run-pattern-publish-gate` (the probe path, incl. the abort-during-gate case), `prompt-loop-run-pattern`, `run-pattern-pattern-index`.
- **Live acceptance (in progress):** the same `arcade`/`dice` sources deployed under fresh slugs on the patched build, in a scratch space — slug-probe + headless no-facets render — going from empty content to present-and-rendering, by two independent methods. Will attach the before/after.

## Note (separate, not fixed here)

The runtime's uncapped teardown drain is gated `if (!closeStorage)`, so a storage-closing dispose (what the harness session does) skips it entirely — which is why `run_pattern`'s own live barrier was load-bearing. This fix makes that barrier correct, which is sufficient. Whether `dispose` should drain even when closing storage is a separate runtime question worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeoKMjz4dBrSSWaJnLdVgV
