### PR TITLE
fix(runner): a stream's event log is outside the writer-fit check

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -293,31 +293,89 @@ The strict-only delta is:
   piece is then un-updatable under strict because the pattern updater,
   `setsrc`, and setup over an existing piece all stamp meta.
 
-  Computed cells are outside the check at every rung too, and it is the same
-  rule over a document rather than over a path. A computed cell is the
+  Two id classes are outside the check at every rung too, and that is the
+  same rule over a document rather than over a path. A computed cell is the
   derived internal cell the runtime materializes to hold a derivation's
   result, under its own URI scheme (`computed:fid1:<hash>`; see
-  [`computed-cell-identity.md`](./computed-cell-identity.md)). A pattern
-  names the data it declares policy on, and it does not name the
-  intermediates the reactive graph materializes for it, so their ceiling is
-  the empty one and measuring them refuses every derivation that reads
-  labeled data and writes its result — ordinary reactive computation, not an
-  edge case. One predicate covers both surfaces (`isDeclarablePolicyPath` in
-  `prepare.ts`), because they answer one question: could a schema have
-  declared a policy here.
+  [`computed-cell-identity.md`](./computed-cell-identity.md)). A stream's
+  entries document holds that stream's durable event entries and the marks
+  recording which of them have been handled, at an id derived from the
+  stream's link so that the firing client, the serving space's drain and
+  another space's outbox delivery all address the same document with no
+  coordination (`STREAM_ENTRIES_DOC_PREFIX` and `streamEntriesDocId` in
+  [`packages/memory/v2.ts`](../../packages/memory/v2.ts); the code and
+  [`events.md`](./server-side-execution/events.md) also call it the stream's
+  sidecar, which in this section is otherwise a background piece). A pattern
+  names the data it declares policy on, and it names neither of these, so
+  their ceiling is the empty one. Measuring a computed cell refuses every
+  derivation that reads labeled data and writes its result; measuring an
+  entries document refuses every mark a served run writes to record that it
+  handled an event, and every entry a same-space served emission carries into
+  the document on its own transaction. Both are ordinary operation rather
+  than edge cases. One predicate covers those two classes and the meta seam
+  above (`isDeclarablePolicyPath` in `prepare.ts`), because all three answer
+  one question: could a schema have declared a policy here.
+
+  Two id classes is what this is, rather than a rule about documents the
+  runtime mints. The runtime mints many more and route 2 below is what most
+  of them take — the document anchoring splits out of a value has an id
+  derived from its parent's, which no author named either, and it is
+  measured. Adding a class here means arguing that case on its own.
+
+  What an entries document does NOT reach is the client fire. A flag-ON fire
+  from a client hands its event to the append queue, which builds its own
+  commit outside any storage transaction and carries no `cfc` envelope, so
+  that append is outside CFC at every rung and always was. The served arm is
+  the one this section is about.
+
+  The two classes differ in what an id says on its own, and an entries
+  document is the weaker of them. A computed cell carries a scheme of its
+  own, which `entityKindOfIdString` parses and nothing else mints. An entries
+  document carries a prefix inside the `of:` scheme, so its id shape does not
+  by itself say who wrote it. Two gates compose over one instead: this one
+  skips the ceiling, and the memory server owns the shape — an authored write
+  reaches a document under that prefix only as a declared tail append, and
+  only under `EXPERIMENTAL_SERVER_EXECUTION`
+  ([`events.md`](./server-side-execution/events.md) §1, §4). The admission
+  path that processed a commit settles its class and a `ClientCommit` cannot
+  express one, so pattern-authored traffic arrives `authored` whatever id it
+  names.
+
+  An entries document takes this route rather than §8.12.5's route 2 below,
+  and the ownership route 2 asks for is the reason. Route 2 declares a policy
+  out of one piece's flow join, so it reaches stores keyed on that piece's
+  own nodes, and its enrollment lasts as long as those nodes do. An entries
+  document is keyed on the stream, and every party that can reach the stream
+  writes to the same document: a piece the stream was handed to, the serving
+  space's drain, another space's outbox delivery. It also outlives all of
+  them, because it is the durable log a later wave drains. `wish`'s interval
+  clock below is off route 2 on that same keying ground, which is a separate
+  question from the measurement one this section settles above.
+
+  Where the route would lead is measured rather than argued. Route 2 declares
+  at the path the misfit was measured at, and a mark on an entries document
+  that already holds entries is measured at `/entries/<n>/consequenced`. So
+  the declaration lands at that entry's own path, and a second mark on the
+  next entry lands beside it rather than folding into it: two marks carrying
+  different atoms leave two `declared` entries, at `/entries/0/consequenced`
+  and `/entries/1/consequenced`. A declared entry is permanent, so the stored
+  label map would grow by one entry per event the stream ever carried, on a
+  durable log that outlives the pieces that wrote to it.
 
   The skip is scoped to a join the target's own space produced. Every clause
   the join carries comes from a document some read resolved, and the join
   records which space each of those lived in; where any of them lived
-  elsewhere, a computed target is measured like any other document. So the
-  residency half of the ceiling still holds for the direction it was written
-  for — a derivation cannot carry another space's labeled value into a local
-  document by materializing it — while a derivation over its own space's data
-  proceeds. Within one space the source and the computed cell share a replica
-  set, so the value reaches no reader it had not reached already, and what
-  follows it is the stamp.
+  elsewhere, the target is measured like any other document. So the residency
+  half of the ceiling still holds for the direction it was written for — a
+  derivation cannot carry another space's labeled value into a local document
+  by materializing it, and an emission cannot carry one into a local stream's
+  entries document — while work over the space's own data proceeds. A
+  computed cell shares a replica set with the source it derives from, and an
+  entries document shares one with the document holding the stream it belongs
+  to, so in both cases the value reaches no reader it had not reached
+  already, and what follows it is the stamp.
 
-  A declared entry can still reach a computed document, from a
+  A declared entry can still reach one of these documents, from a
   schema-carrying write to it, and the skip is unconditional over that route
   as it is over the meta seam's document-root route. Honoring it would make a
   derivation admit its own inputs' taint or refuse it according to whether
@@ -582,8 +640,9 @@ The strict-only delta is:
   ordinary document measures against its own ceiling whichever transaction
   makes it: a bystander written by a later transaction of the same piece is
   refused exactly as one written by the setup transaction is. A `computed:`
-  document is outside the route for a different reason — the measurement
-  skips it altogether, per the computed-cell exemption above.
+  document and a stream's entries document are outside the route for a
+  different reason — the measurement skips them altogether, per the
+  exemption above.
 
   It DOES reach further than the setup-time route in two ways worth stating,
   because neither follows from "the same rule, later". The piece's result

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -304,6 +304,18 @@ clause-subsumption predicate; tests `cfc-writer-fit.test.ts`. Two items stay
 open on the confidentiality side: (a) the standard-profile default, and (d)
 the residency half of the write ceiling, recorded next.
 
+The spec has since taken (b) and (c). §18.6.3 lists the writer-fit misfit
+among `enforce-strict`'s strict-only rejects, and §18.6.3.1 carries the
+bullet, the rule that an absent declaration is the empty ceiling and fails
+closed, and the stable-reason requirement. What this entry still owes the
+spec is the narrowings below. §18.6.3.1 states the measurement over its
+targets with no exempt class named, and the addresses §18.6.2 excludes —
+`/cfc/...` label metadata, `cid:`-addressed schema documents, program text —
+do not reach them; that section is also where the shape belongs, since it
+already calls its own exclusion "a profile decision, not a core-semantics
+fact" and mirrors it to "the write-side rule that the same addresses are not
+value-write targets".
+
 One narrowing landed alongside: the measurement quantifies over paths a
 schema could have declared a policy at, and the raw meta seam is not one.
 `setMetaRaw` lands on a document-root sibling of `value` (`schema`,
@@ -342,16 +354,33 @@ pattern names the data it declares policy on, and does not name the
 intermediates the reactive graph materializes for it — so its ceiling is the
 empty one, and measuring it refuses every derivation that reads labeled data
 and writes its result. That is ordinary reactive computation, so the refusal
-reaches product flows and not only tests. The id class is outside the check
-at every rung, through the same predicate the meta seam uses, and the skip is
-scoped to a join the target's own space produced: the join records the space
-each contributing document lived in, and a computed target whose join drew a
-clause from elsewhere is measured like any other document. The residency half
-of the ceiling therefore still holds for the direction it was written for,
-while a derivation over its own space's data proceeds — within one space the
-source and the computed cell share a replica set.
+reaches product flows and not only tests.
 
-Nothing is laundered here either. The join still lands on the computed
+A stream's entries document is the second id class the narrowing covers. It
+holds a stream's durable event entries and the marks recording which have
+been handled, at an id derived from the stream's link
+(`STREAM_ENTRIES_DOC_PREFIX`) so that every party addresses the same document
+with no coordination. No pattern names it and no value schema describes it,
+so its ceiling is the empty one, and measuring it refuses every mark a served
+run writes to record that it handled an event. Route 2 below is not open to
+it: that route declares out of one piece's flow join and is keyed on that
+piece's own nodes, while an entries document is keyed on the stream, is
+written by every party that can reach the stream, and outlives all of them.
+
+Both id classes are outside the check at every rung, through the same
+predicate the meta seam uses, and the skip is scoped to a join the target's
+own space produced: the join records the space each contributing document
+lived in, and a target whose join drew a clause from elsewhere is measured
+like any other document. The residency half of the ceiling therefore still
+holds for the direction it was written for, while work over its own space's
+data proceeds — within one space a computed cell shares a replica set with
+its source, and an entries document with the document holding its stream.
+
+Two id classes is what this is, rather than a rule about documents the
+runtime mints: the document anchoring splits out of a value has an id derived
+from its parent's, which no author named either, and it is measured.
+
+Nothing is laundered here either. The join still lands on the exempt
 document as its `derived` component, so a later read of it is tainted and a
 later write of what it read misfits on the original clause. What the
 exemption gives up is a refusal that was doing an egress gate's work by

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -25,6 +25,7 @@ import {
   valueEqual,
 } from "@commonfabric/data-model";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
+import { STREAM_ENTRIES_DOC_PREFIX } from "@commonfabric/memory/v2";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
@@ -1951,16 +1952,43 @@ const isMetaSeamPath = (
 ): boolean => metaOnlyByPath?.get(pathKey(path)) === true;
 
 /**
+ * Whether `id` names a document of one of the two id classes no schema can
+ * declare a store policy on.
+ *
+ * A computed cell holds a derivation's result, under its own URI scheme
+ * (`computed:fid1:<hash>`; see `entity-kind.ts` and
+ * `docs/specs/computed-cell-identity.md`). A stream's entries document holds
+ * that stream's durable event entries and the marks recording which have been
+ * handled, at an id derived from the stream's link so that every party — the
+ * firing client, the serving space's drain, another space's outbox delivery —
+ * addresses the same document with no coordination (`STREAM_ENTRIES_DOC_PREFIX`
+ * in `@commonfabric/memory/v2`).
+ *
+ * This is an enumeration of two id classes rather than a rule about documents
+ * the runtime mints. The runtime mints many more, and route 2 (§8.12.5) is
+ * what most of them take: the document anchoring splits out of a value has an
+ * id derived from its parent's, which no author named either, and it is
+ * measured. Adding a class here means arguing that case on its own.
+ *
+ * The entries document's half is a prefix inside the `of:` scheme rather than
+ * a scheme of its own, so the id shape alone does not say who wrote it. Two
+ * gates compose over one instead: this one skips the ceiling, and the memory
+ * server owns the shape — an authored write reaches a document under that
+ * prefix only as a declared tail append, and only under
+ * `EXPERIMENTAL_SERVER_EXECUTION` (events.md §1, §4).
+ */
+const isUndeclarableIdClass = (id: string): boolean =>
+  entityKindOfIdString(id) === "computed" ||
+  id.startsWith(STREAM_ENTRIES_DOC_PREFIX);
+
+/**
  * Whether a schema could have declared a store policy for a write at `path`
  * on `id` — the surfaces the §8.12.4 writer-fit measurement quantifies over.
  *
- * Two are outside it. The raw meta seam is one, per {@link isMetaSeamPath}:
- * no value schema describes the document-root siblings of `value`. A computed
- * cell is the other: the derived internal cell the runtime materializes to
- * hold a derivation's result, addressed under its own URI scheme
- * (`computed:fid1:<hash>`; see `entity-kind.ts` and
- * `docs/specs/computed-cell-identity.md`). A pattern declares policy on the
- * data it names, and it names neither.
+ * Two things are outside it. The raw meta seam is one, per {@link
+ * isMetaSeamPath}: no value schema describes the document-root siblings of
+ * `value`. The two id classes of {@link isUndeclarableIdClass} are the other.
+ * A pattern declares policy on the data it names, and it names none of them.
  *
  * Both stay flow stamp targets: the join lands on them as the `derived`
  * component, so a later read of one is tainted and a later egress of one is
@@ -1976,7 +2004,7 @@ const isDeclarablePolicyPath = (
   metaOnlyByPath: ReadonlyMap<string, boolean> | undefined,
   path: readonly string[],
 ): boolean =>
-  (entityKindOfIdString(id) !== "computed" || !joinIsLocal) &&
+  (!isUndeclarableIdClass(id) || !joinIsLocal) &&
   !isMetaSeamPath(metaOnlyByPath, path);
 
 // S16 flow labels (default transition): one conservative confidentiality join
@@ -7245,7 +7273,7 @@ export const prepareBoundaryCommit = (
         }
       }
       // Writer-fit measures the surfaces a schema could have declared a
-      // policy at, which leaves out the raw meta seam and computed cells
+      // policy at, which leaves out the raw meta seam and two id classes
       // alike (`isDeclarablePolicyPath`). The measurement is skipped on both
       // at every rung, so neither raises a strict reject nor a
       // persist-and-flag diagnostic.

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import { cfcAtom } from "@commonfabric/api/cfc";
+import { streamEntriesDocId } from "@commonfabric/memory/v2";
 import {
   SEED_ENVELOPE_SCHEMA_HASH,
   writeSeedEnvelopeDoc,
@@ -1081,6 +1082,248 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           "writer-fit confidentiality misfit",
         );
         expect(result.error?.message).toContain('"secret"');
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
+  describe("stream entries-document exemption", () => {
+    // The measurement quantifies over surfaces a schema could have declared a
+    // policy at, and a stream's entries document is not one. The runtime
+    // materializes it to hold that stream's durable event entries and the
+    // marks recording which of them have been handled, at an id derived from
+    // the stream's link (`STREAM_ENTRIES_DOC_PREFIX` in
+    // `@commonfabric/memory/v2`) so that every party addresses the same
+    // document with no coordination. No pattern names it and no value schema
+    // describes it, so measuring it refuses every event a handler over
+    // labeled data emits, and every mark a served run writes to record that
+    // it handled one.
+    //
+    // The exemption decides which store the entries may land in, not whether
+    // they stay labeled: the join still lands on the document as its
+    // `derived` component, which the first two cases pin alongside the
+    // verdict.
+    //
+    // The first two cases read the verdict off the prepare pass rather than
+    // off a completed commit. A write to one of these documents meets
+    // the memory server's own sidecar admission after CFC is done with it
+    // (events.md §1: authored traffic reaches one only as a declared tail
+    // append, and only under `EXPERIMENTAL_SERVER_EXECUTION`), which
+    // `packages/memory/test/v2-event-append.test.ts` covers. A recorded
+    // writer-fit reason leaves the prepare state `invalidated` and rejects
+    // ahead of all of that, so `prepared` is the whole of what this gate
+    // decides.
+
+    /**
+     * The entries document of the `events` stream inside the document the
+     * cause `stream` mints — the id every party derives rather than one an
+     * author named.
+     */
+    const entriesDocFor = (
+      runtime: Runtime,
+      stream: string,
+    ): `${string}:${string}` =>
+      streamEntriesDocId({
+        id: runtime.getCell(signer.did(), stream).getAsNormalizedFullLink().id,
+        path: ["events"],
+        scope: "space",
+      }) as `${string}:${string}`;
+
+    /**
+     * The `derived` confidentiality the prepare pass staged on `id`, read back
+     * out of the transaction. That is where the envelope sits until a commit
+     * carries it to the replica, and these cases do not reach a commit.
+     */
+    const stagedDerivedConfidentiality = (
+      tx: ReturnType<Runtime["edit"]>,
+      id: `${string}:${string}`,
+    ): string[] =>
+      (((tx.readOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id,
+        path: [],
+      }) ?? {}) as { cfc?: { labelMap?: { entries: StoredEntry[] } } })
+        .cfc?.labelMap?.entries ?? [])
+        .filter((entry) => entry.origin === "derived")
+        .flatMap((entry) => entry.label.confidentiality ?? []);
+
+    it("records no writer-fit reason for an entry's `consequenced` mark", async () => {
+      // The defect this exemption closes: a handler that read labeled data
+      // runs on the serving runtime, which records that the entry was handled
+      // by writing the mark. Measuring that write refuses the commit, and the
+      // action a user clicks then does nothing they can see.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-entries-source");
+        const entriesId = entriesDocFor(runtime, "wf-entries-stream");
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-entries-source",
+          undefined,
+          tx,
+        );
+        expect((source.getRaw() as { secret?: string }).secret).toBe("s3cr3t");
+        tx.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: entriesId,
+          path: ["value", "entries", "0", "consequenced"],
+        }, true);
+        tx.prepareCfc();
+
+        expect(tx.getCfcState().prepare.status).toBe("prepared");
+        expect(writerFitDiagnostics(tx)).toEqual([]);
+        // The mark stayed labeled: the exemption decides which store the
+        // value may land in, not whether the join follows it.
+        expect(stagedDerivedConfidentiality(tx, entriesId))
+          .toContain("secret");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("records no writer-fit reason for an appended entry", async () => {
+      // The other write a served run makes to the document: a same-space
+      // emission carries its durable entry inside the emitting transaction,
+      // so the payload takes the same join the mark does.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-entries-append-source");
+        const entriesId = entriesDocFor(runtime, "wf-entries-append-stream");
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-entries-append-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        tx.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: entriesId,
+          path: ["value", "entries"],
+        }, [{ eventId: "evt:emitted", payload: { note: `${raw.secret}!` } }]);
+        tx.prepareCfc();
+
+        expect(tx.getCfcState().prepare.status).toBe("prepared");
+        expect(writerFitDiagnostics(tx)).toEqual([]);
+        expect(stagedDerivedConfidentiality(tx, entriesId))
+          .toContain("secret");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("still rejects the same write into an ordinary document", async () => {
+      // The control: the exemption is about the document class, not about the
+      // path a mark is written at or the join this transaction carries.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-entries-plain-source");
+        const plainId = runtime
+          .getCell(signer.did(), "wf-entries-plain-target")
+          .getAsNormalizedFullLink().id;
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-entries-plain-source",
+          undefined,
+          tx,
+        );
+        expect((source.getRaw() as { secret?: string }).secret).toBe("s3cr3t");
+        tx.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: plainId,
+          path: ["value", "entries", "0", "consequenced"],
+        }, true);
+        tx.prepareCfc();
+
+        const result = await tx.commit();
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(`for ${plainId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("keeps measuring an entries document whose join came from another space", async () => {
+      // The exemption is scoped to a join this document's own space produced,
+      // the same as the computed-cell one above: an emission cannot carry a
+      // foreign space's labeled value into a local stream's entries document.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      const foreign = (await Identity.fromPassphrase("wf-entries-foreign"))
+        .did();
+      try {
+        const seed = runtime.edit();
+        const foreignCell = runtime.getCell(
+          foreign,
+          "wf-entries-foreign-source",
+          { type: "object", properties: { secret: { type: "string" } } },
+          seed,
+        );
+        const foreignId = foreignCell.getAsNormalizedFullLink().id;
+        writeSeedEnvelopeDoc(seed, foreign);
+        seed.writeOrThrow({
+          space: foreign,
+          scope: "space",
+          id: foreignId,
+          path: [],
+        }, {
+          value: { secret: "s3cr3t" },
+          cfc: {
+            version: 1,
+            schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: ["secret"],
+                label: { confidentiality: ["secret"] },
+              }],
+            },
+          },
+        });
+        expect((await seed.commit()).ok).toBeDefined();
+
+        const entriesId = entriesDocFor(runtime, "wf-entries-foreign-stream");
+        const tx = runtime.edit();
+        const source = runtime.getCellFromLink(
+          { id: foreignId, path: [], space: foreign, scope: "space" },
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        expect(raw.secret).toBe("s3cr3t");
+        tx.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: entriesId,
+          path: ["value", "entries"],
+        }, [{ eventId: "evt:foreign", payload: { note: `${raw.secret}!` } }]);
+        tx.prepareCfc();
+
+        const result = await tx.commit();
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(`for ${entriesId} at /`);
       } finally {
         await runtime.dispose();
         await storageManager.close();


### PR DESCRIPTION
PROBLEM

Under server-side execution a handler's event runs on the serving runtime, which records that the entry was handled by writing `/entries/<n>/consequenced` on the stream's entries document. That write carries the transaction's flow-label join. The document declares no store policy, so at `enforce-strict` the §8.12.4 writer-fit check measures the join against the empty ceiling and refuses the commit:

    CfcCommitRefusalError: CFC enforcement rejected commit: relevant
    transaction was not prepared: writer-fit confidentiality misfit for
    of:stream-events:DlT7O-JXhSENBfLbzAGmJVaVDNj06vKpuOqkVgoDmmA at
    /entries/0/consequenced (canWrite, §8.12.4):
    {"class":"SensitiveHealthRecord","subject":"did:example:patient",
    "type":"https://commonfabric.org/cfc/atom/Resource"}

The action a user clicks then does nothing they can see.

SOLUTION

`isDeclarablePolicyPath` already exempts computed cells, on the grounds that a pattern declares policy on the data it names and does not name the intermediates the runtime materializes for it. A stream's entries document is the same case: its id derives from the stream's link so that every party addresses the same document with no coordination, no pattern names it, and no value schema describes it. The predicate now covers both id classes under the same condition — the skip applies only to a join the target's own space produced, so a clause that reached the join from another space is measured wherever it lands. The write stays a flow stamp target, so the join persists as the `derived` component and the read-side gates are unchanged.

This is an enumeration of two id classes rather than a rule about documents the runtime mints. The runtime mints many more and §8.12.5's route 2 is what most of them take: the document anchoring splits out of a value has an id derived from its parent's, which no author named either, and it stays measured.

DESIGN DISCUSSION

Route 2 was the other option. It answers a misfit on a store the runtime owns by declaring a covering policy in the same transaction, which keeps the clause attached to the document. It asks for an owner: it declares out of one piece's flow join, so it reaches stores keyed on that piece's own nodes, and its enrollment is released when those nodes are. An entries document is keyed on the stream, is written by every party that can reach the stream, and outlives all of them, because it is the durable log a later wave drains.

Where that route leads was measured rather than argued. Route 2 declares at the path the misfit was measured at, and a mark on an entries document that already holds entries is measured at `/entries/<n>/consequenced`. So the declaration lands at that entry's own path, and a mark on the next entry lands beside it rather than folding into it: two marks carrying different atoms leave two `declared` entries. A declared entry is permanent, so the stored label map would grow by one entry per event the stream ever carried, on a durable log that outlives the pieces that wrote to it.

Two limits are worth stating. The tests read the verdict off the prepare pass rather than off a completed commit: a write to an entries document meets the memory server's own admission afterwards, which takes an authored write only as a declared tail append and only under `EXPERIMENTAL_SERVER_EXECUTION`. A recorded writer-fit reason leaves the prepare state `invalidated` and rejects ahead of that, so `prepared` is the whole of what this gate decides, and the cases pin the `derived` stamp beside it by reading the staged envelope back out of the transaction. What they do not cover is the anti-laundering property its computed-cell sibling covers — that a later transaction reading the document back carries the clause — because that needs a committed derived-class write, which this harness cannot make.

The second limit is a document this change does not reach. `of:server-execution-attention` is a fixed well-known id no schema describes, so it answers the declarability question the same way an entries document does, and it is not exempt: a transaction carrying a join that writes it is refused, with no declaration available to fix it. Whether any transaction writes it while carrying a join is not established — the notice transaction that writes it opens fresh and reads nothing, and writing a labeled document does not taint the writer. It is a different document class, and the two other well-known server-execution ids beside it want the same decision, so it is left to a change that argues them together.

Reproducing the refusal needs `cfcEnforcementMode: "enforce-strict"` with `cfcFlowLabels: "persist"`; the case that hit it in CI is `packages/patterns/integration/cfc-render-policy-demo.test.ts` under server execution, which times out clicking a trusted action.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

