### PR TITLE
docs(runner): clarify pre-commit retries and simplify disposal test

### DIFF
--- a/docs/specs/space-model/5-transactions.md
+++ b/docs/specs/space-model/5-transactions.md
@@ -150,23 +150,37 @@ This system does not implement SQL-style transaction isolation. Key differences:
 
 ### Retry Semantics
 
-The `editWithRetry()` helper provides automatic retry on a **retryable** commit
-failure:
+The `editWithRetry()` helper runs a callback in a transaction and can re-run it
+both before commit and after a **retryable** commit rejection:
 
 ```typescript
 // Shown for illustration only.
-const result = await runtime.editWithRetry(async (tx) => {
+const result = await runtime.editWithRetry((tx) => {
   const current = cell.withTx(tx).get();
   cell.withTx(tx).set(current + 1);
   return current + 1;
 });
 ```
 
-- On a retryable commit rejection, re-runs the entire function with a fresh
-  transaction
-- On any other commit rejection, returns the error immediately — the first
-  attempt is the only attempt
-- Returns success or error after exhausting retries
+- Before commit, while retry budget remains, may load documents the callback
+  read as absent that the replica has not examined. If any exist, aborts the
+  staged attempt and re-runs the entire callback with a fresh transaction,
+  without sending that attempt to the server.
+- On a retryable commit rejection, re-runs the entire callback with a fresh
+  transaction while budget remains.
+- Shares one `maxRetries` budget between those two paths, in addition to the
+  initial callback invocation. With no budget left, skips reconciliation and
+  submits the current transaction to ordinary commit validation; any rejection
+  is returned without another retry.
+- On any other commit rejection, returns the error without another retry,
+  even if earlier reconciliation already re-ran the callback.
+- Returns `{ ok }` when a transaction commits, carrying that invocation's
+  callback result, or `{ error }` when it cannot commit.
+
+Either retry path can repeat effects the callback performs outside its own
+transaction. Aborting an attempt discards only its staged operations, so effects
+committed through another channel need a stable identity or another way to make
+them idempotent.
 
 Retryability is an **allow-list**: `isRetryableCommitRejection`, defined in the
 shared rejection vocabulary (`packages/runner/src/storage/rejection.ts`) and
@@ -188,7 +202,7 @@ outcome:
 | `StorageTransactionAborted` | The attempt was discarded before storage, and a re-run is a genuinely new attempt that costs no round-trip. Producers: the callback called `tx.abort()`; a prepared CFC transaction's inputs drifted before the verdict (`cfc-prepared-digest-mismatch`, and the `invalidateCfc` drift reasons such as `read-after-prepare`); or a CFC refusal that is not wholly a verdict (`cfc-refusal-not-a-verdict`) — prepare could not evaluate an input it needed, or a resolution failed. Those clear on a fresh attempt once the input is there. |
 | `AuthorizationError` with `retriable: true` | The server itself marked this denial as one a fresh handshake heals (a session-open anti-replay race). |
 
-Everything else is **terminal on the first attempt**: a `ProtocolError` (the
+Every other rejection is **terminal when encountered**: a `ProtocolError` (the
 server refused the commit's shape), an unmarked `AuthorizationError` (the server
 evaluated the request and denied it), a `PreconditionFailedError` (permanent by
 definition — the client must not retry), a `RowLabelCommitError` (a commit-time

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2609,13 +2609,20 @@ export class Runtime {
   }
 
   /**
-   * Creates a storage transaction that can be used to read / write data into
-   * locally replicated memory spaces. Transaction allows reading from many
-   * multiple spaces but writing only to one space.
+   * Runs `fn` in a storage transaction over locally replicated memory spaces.
+   * The transaction can read from multiple spaces but write to only one.
    *
-   * If the transaction fails with a RETRYABLE commit rejection, it will be
-   * retried up to maxRetries times. Retryability is decided by the shared
-   * rejection vocabulary (`isRetryableCommitRejection`, storage/rejection.ts),
+   * After `fn` returns, while retry budget remains, the runtime may load
+   * documents read as absent that the replica has not examined. If any exist,
+   * it aborts the staged attempt and invokes `fn` with a fresh transaction
+   * before sending a commit. These reconciliation re-runs and retries after
+   * commit rejection share one `maxRetries` budget, in addition to the initial
+   * invocation. With no budget left, reconciliation is skipped and the current
+   * transaction proceeds to ordinary commit validation.
+   *
+   * A retryable commit rejection also re-runs `fn` while budget remains.
+   * Retryability is decided by the shared rejection vocabulary
+   * (`isRetryableCommitRejection`, `storage/rejection.ts`),
    * which is an allow-list: a stale basis (server conflict or the local
    * inconsistency guard), a liveness failure the memory client heals on its own
    * (a transport failure, an undecodable frame), a discarded attempt
@@ -2625,10 +2632,10 @@ export class Runtime {
    * authorization denial, a precondition failure, a commit-rule violation, a
    * CFC boundary refusal (`CfcCommitRefusalError`, a deterministic verdict on
    * the transaction's own reads and writes), a `SessionError` (nothing on this
-   * path remounts the session, so
-   * every attempt reuses the handle the server just refused) — is returned on
-   * the FIRST attempt, because re-running cannot change the outcome and each
-   * doomed attempt costs a round-trip plus a subscriber revert notification.
+   * path remounts the session, so every attempt reuses the handle the server
+   * just refused) — is returned without another retry, because re-running
+   * cannot change the outcome and each doomed attempt costs a round-trip plus
+   * a subscriber revert notification.
    *
    * Every retry invokes `fn` again with a fresh transaction. Aborting an
    * attempt discards only the operations staged in that transaction; an effect
@@ -2645,7 +2652,8 @@ export class Runtime {
    * stages nothing before it declines.
    *
    * @param fn - Function to execute with the transaction.
-   * @param maxRetries - Maximum number of retries.
+   * @param maxRetries - Maximum combined number of reconciliation re-runs and
+   *   commit-rejection retries after the initial invocation.
    * @returns `{ ok }` once the transaction commits, carrying whatever `fn`
    *   returned, or `{ error }` when it does not commit: a rejection that is not
    *   retryable, a retryable one whose retries are spent, or `fn` itself

--- a/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
+++ b/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
@@ -412,20 +412,9 @@ describe("editWithRetry absence reconciliation", () => {
       await runtime.dispose({ closeStorage: false });
       disposed = true;
 
-      const timeout = Symbol("retry readiness timeout");
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      const outcome = await Promise.race([
-        editing,
-        new Promise<typeof timeout>((resolve) => {
-          timer = setTimeout(() => resolve(timeout), 250);
-        }),
-      ]);
-      if (timer !== undefined) clearTimeout(timer);
-      expect(outcome).not.toBe(timeout);
-      if (outcome !== timeout) {
-        expect(outcome.error?.name).toBe("StorageTransactionAborted");
-        expect(outcome.error?.message).toContain("runtime is disposing");
-      }
+      const outcome = await editing;
+      expect(outcome.error?.name).toBe("StorageTransactionAborted");
+      expect(outcome.error?.message).toContain("runtime is disposing");
     } finally {
       readiness.resolve();
       await editing?.catch(() => undefined);


### PR DESCRIPTION
`editWithRetry()` can rerun its callback before submitting a commit, but its API documentation and transaction spec described only retries after commit rejection. Document the pre-commit absence reconciliation path, the shared `maxRetries` budget, ordinary commit validation once that budget is spent, and the implications for effects outside the transaction. Terminal rejections stop retries when encountered, including after an earlier reconciliation rerun.

The disposal regression test now awaits the interrupted edit directly and checks its transaction error. This removes a 250 ms timeout race whose test-owned timer is frozen by the runner harness. The test continues to require disposal to cancel a stuck retry-readiness wait.

This is the documentation-and-test follow-up to #6576, following the watch-cleanup fix in #7169. Production behavior is unchanged.

Validation:
- Full runner package suite: 1,404 tests / 8,618 steps passed on the rebased branch.
- Mutation check in an isolated checkout of the same commit: removing the teardown signal from retry readiness makes the edited test fail at the cancellation step with Deno's pending-promise error (about 185 ms). The ordinary test passes; the temporary mutation checkout was removed.
- Repository type check, formatting, and lint passed.
- All 596 checked documentation blocks passed, along with the wait, conflict-marker, control-character, and documentation-history-index gates.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

