### PR TITLE
fix(test-records): name a bdd test the way its runner names it

### DIFF
--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -29,7 +29,11 @@ A test's identity has three required parts, scoped within a repository:
   invented for it, named `global`, and every chain that file goes on to
   run opens with that name. A suite it registers as ignored is reported
   under its bare name. The runner keeps such a suite out of the root
-  suite and never runs its body.
+  suite and never runs its body. A `describe` or `it` call carrying no
+  name of its own is named after the body it was given, and a name the
+  call carries stands even where it is empty, so a chain can hold an
+  empty element. The runner refuses an empty name for the outermost
+  registration of a file, so an empty element is never the first.
 - **variant**, when present — a stable name for a non-default configuration
   that runs the same test. The default configuration has no variant. The
   server-execution deployed-topology lanes have stable `default` and

--- a/packages/test-support/src/records/bdd.ts
+++ b/packages/test-support/src/records/bdd.ts
@@ -75,15 +75,24 @@ const chains = new WeakMap<object, readonly string[]>();
  */
 const ROOT_SUITE_NAME = "global";
 
-/** The name a bdd call was given, whichever way it was called. */
+/**
+ * The name a bdd call was given, whichever way it was called: a name
+ * argument, a definition's own `name`, or the name of the body, which is
+ * what the runner falls back to. A name the call carries stands even
+ * where it is empty, so such a call names an empty element of the chain
+ * rather than nothing. A call carrying neither a name nor a body is what
+ * this has no name for.
+ */
 export function nameOf(args: readonly unknown[]): string | undefined {
   for (const arg of args) {
     if (typeof arg === "string") return arg;
     if (typeof arg === "object" && arg !== null) {
       const named = (arg as { name?: unknown }).name;
-      if (typeof named === "string" && named.length > 0) return named;
+      if (typeof named === "string") return named;
+      const fn = (arg as { fn?: unknown }).fn;
+      if (typeof fn === "function") return fn.name;
     }
-    if (typeof arg === "function" && arg.name.length > 0) return arg.name;
+    if (typeof arg === "function") return arg.name;
   }
   return undefined;
 }
@@ -195,7 +204,7 @@ function withBody(
 export function wrapDescribe(through: AnyFunction): AnyFunction {
   return (...args: unknown[]): unknown => {
     const found = bodyOf(args);
-    const name = nameOf(args) ?? found?.body.name;
+    const name = nameOf(args);
     if (name === undefined) return through(...args);
     const own = [...enclosing(args), name];
     const result = found === undefined
@@ -215,6 +224,9 @@ export function wrapDescribe(through: AnyFunction): AnyFunction {
  * which is what the store speaks in, and the file is read from the
  * registration stack the same way the preload reads it — the two
  * together, because the same test name occurs in more than one file.
+ *
+ * The body reaches the real function unchanged, so the runner names the
+ * leaf from the same function `nameOf` read it from.
  *
  * The preload's wrapper around `Deno.test` sees only the container the
  * describe chain registers, so without this the map holds one entry per

--- a/packages/test-support/test/records/bdd.test.ts
+++ b/packages/test-support/test/records/bdd.test.ts
@@ -94,9 +94,15 @@ describe("reading the shape of a bdd call", () => {
     expect(nameOf(["a name", body])).toBe("a name");
     expect(nameOf([{ name: "from options" }, body])).toBe("from options");
     expect(nameOf([function named() {}])).toBe("named");
-    // An anonymous body names nothing, and a call this cannot name goes
+    expect(nameOf([{ fn: body }])).toBe("body");
+    // A name the call carries stands in place of the body's, whatever
+    // its length, and a body with no name of its own gives the empty
+    // string. The runner reads both the same way.
+    expect(nameOf([{ name: "", fn: body }])).toBe("");
+    expect(nameOf([{}, () => {}])).toBe("");
+    // A call carrying neither a name nor a body names nothing, and goes
     // to the real function untouched rather than being dropped.
-    expect(nameOf([{}, () => {}])).toBeUndefined();
+    expect(nameOf([{ no: "name" }])).toBeUndefined();
     expect(nameOf([])).toBeUndefined();
   });
 
@@ -222,6 +228,36 @@ describe("what the wrappers do once a capture is installed", () => {
     const alone = capturing();
     wrapIt(() => {}, () => {}, alone)("bare leaf", () => {});
     expect(alone.asked).toEqual(["bare leaf"]);
+  });
+
+  it("names a leaf whose call carries no name after its body", () => {
+    const capture = capturing();
+    const passed: unknown[] = [];
+    const it_ = wrapIt(
+      (body: unknown) => passed.push(body),
+      () => {},
+      capture,
+    );
+    it_(() => {});
+    it_(function kept() {});
+    // A body with no name of its own names the leaf with the empty
+    // string, which is the last element of the chain the runner reports
+    // it under.
+    expect(capture.asked).toEqual(["", "kept"]);
+    // Each body reaches the real function as it was given rather than
+    // through a wrapper of another name, so the name the runner takes
+    // from it is the one recorded here.
+    expect(passed.map((arg) => bodyOf([arg])?.body.name))
+      .toEqual(capture.asked);
+  });
+
+  it("names a leaf given an empty name by that name and not its body", () => {
+    const capture = capturing();
+    wrapIt(() => {}, () => {}, capture)({
+      name: "",
+      fn: function unused() {},
+    });
+    expect(capture.asked).toEqual([""]);
   });
 
   it("registers a listed leaf as ignored rather than running it", () => {

--- a/packages/test-support/test/records/preload.test.ts
+++ b/packages/test-support/test/records/preload.test.ts
@@ -277,6 +277,25 @@ describe(() => {
 });
 `;
 
+// A file whose leaves carry no name of their own, so each is named
+// after its body. One body has a name and the other has none, and the
+// runner reports the second under a chain whose last element is empty.
+const BODY_NAMED_LEAF_FILE = `import { describe, it } from "@std/testing/bdd";
+describe("outer", () => {
+  it(function kept() {});
+  it(() => {});
+});
+`;
+
+// A file whose leaf is given an empty name of its own. That name stands
+// in place of the body's, so the runner reports the leaf with an empty
+// last element and the body's name reaches nothing.
+const EMPTY_NAME_LEAF_FILE = `import { describe, it } from "@std/testing/bdd";
+describe("emptied", () => {
+  it({ name: "", fn: function unused() {} });
+});
+`;
+
 // Two modules that register a suite for whoever calls them, one
 // declaring itself machinery and one not. What each leaf's file comes
 // out as is the whole of what the declaration does.
@@ -529,6 +548,36 @@ describe("preload", () => {
     }
   });
 
+  it("names a leaf whose call carries no name after its body", async () => {
+    const fixture = await makeFixture({
+      "leaf.test.ts": BODY_NAMED_LEAF_FILE,
+      "empty.test.ts": EMPTY_NAME_LEAF_FILE,
+    });
+    try {
+      const run = await runFixture(fixture, ["leaf.test.ts", "empty.test.ts"]);
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const names = await readNameMaps(fixture.spool);
+      expect(names.get("outer > kept")).toEqual("leaf.test.ts");
+      // A body with no name of its own leaves the last element of the
+      // chain empty, and so does an empty name the call carries.
+      expect(names.get("outer > ")).toEqual("leaf.test.ts");
+      expect(names.get("emptied > ")).toEqual("empty.test.ts");
+      expect(names.get("emptied > unused")).toBeUndefined();
+
+      // The names the runner reports, which the map has to agree with
+      // for a skip list to reach any of these leaves.
+      const reported = await outcomes(fixture);
+      expect([...reported.keys()].sort()).toEqual([
+        "emptied > ",
+        "outer > ",
+        "outer > kept",
+      ]);
+      for (const outcome of reported.values()) expect(outcome).toEqual("pass");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
   it("says so when the bdd re-export loaded before it", async () => {
     // Loading the re-export first is what makes it hand back the real
     // `describe` and `it`, and every leaf then reaches the report
@@ -720,6 +769,21 @@ describe("preload", () => {
       const reported = await outcomes(fixture);
       expect(reported.get("outer > kept")).toEqual("pass");
       expect(reported.get("outer > dropped")).toEqual("skip");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("skips a leaf whose name is the empty one its body gave it", async () => {
+    const fixture = await makeFixture({ "leaf.test.ts": BODY_NAMED_LEAF_FILE });
+    try {
+      const run = await runFixture(fixture, ["leaf.test.ts"], {
+        "leaf.test.ts": ["outer > "],
+      });
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const reported = await outcomes(fixture);
+      expect(reported.get("outer > ")).toEqual("skip");
+      expect(reported.get("outer > kept")).toEqual("pass");
     } finally {
       await Deno.remove(fixture.dir, { recursive: true });
     }


### PR DESCRIPTION
PROBLEM

`nameOf` reads the name a bdd call was given, and read two shapes wrongly:

    it(() => {});
    it({ name: "", fn: function unused() {} });

The runner names the first after its body and takes the second's name as given. Both are empty, so it reports each leaf with an empty last element in its chain. `nameOf` required a name of non-zero length, so it answered nothing for the first and `unused` for the second. Neither is an identity the report names, so both leaves reached ingestion with no file, and a skip list naming either left nothing out of an invocation.

SOLUTION

Give `nameOf` the whole of the runner's rule: a name argument, else a definition's own `name` whatever its length, else the name of the body. Both wrappers then read a call's name from one place, and `wrapDescribe` sheds the fallback it spelled out for itself.

DESIGN DISCUSSION

The rule is `name = options.name ?? fn.name` in `@std/testing/bdd`, and `??` is what makes an empty name stand: the definition supplied one, so the body's is not consulted.

What the runner reports was read off real `deno test` runs rather than off that source. A leaf given an anonymous body comes back as `outer > `, the same leaf registered through `it.ignore` comes back as `outer > ` carrying `<skipped/>`, and a leaf given an empty name comes back the same way while its body is called `unused`. The end-to-end tests spawn such a run and compare the report against the name maps left in the spool.

`nameOf` reads the arguments by their shape rather than by their position, which the runner does not. The two agree on every shape the runner accepts, because a name argument is the only string, a definition is the only object carrying `name` or `fn`, a suite handle carries neither, and a body is the only bare function.

No test file in the tree is written either way today, so no existing identity changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

