### PR TITLE
docs(shuttle): a position on high-latency calls and detached outcomes

### DIFF
--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -51,8 +51,11 @@ non-TTY behavior (no views, no strip) arrive with it, not before.
 The identity half is already shuttle's: one invocation session is minted at
 startup and passed explicitly into every `call`, which mints an id under it
 (decision 6, [`runtime-integration.md`](runtime-integration.md)). Replaying that
-pair commits once and hands back the original outcome — though the body runs
-again and repeats whatever effects it has outside its transaction. What v1 has
+pair deduplicates against the receipt the handling wrote: the commit lands once
+and the original outcome settles the retry, though the body runs again and
+repeats whatever effects it has outside its transaction. Where no receipt was
+written — a handling that failed, or a deployment not writing them — there is
+nothing to collide with, and the replay executes and commits again. What v1 has
 no spelling for is the wait half: `cf`'s `--wait <seconds>` patience bound, and
 its `--no-wait`, which exits at the commit acknowledgment carrying the receipt's
 address (`resolveWaitControl`, `packages/cli/commands/piece.ts`). Both belong at
@@ -70,14 +73,15 @@ allows — and never a call that outlives the process.
 Where outcomes collect while nobody is watching is a fabric question rather than
 a shuttle one, on the same stance the session scope takes above: shuttle adds
 spelling, never a private store. A receipt is addressed from the event id and
-the handler's bound closure, so a caller holding the pair reaches one and nobody
-enumerates them; listing what settled since a person left needs the retention
-collection [`../pattern-verb-contract.md`](../pattern-verb-contract.md) designs
-and has not built. Shuttle's own collector is `watch`: a verb whose result lands
-in a watched cell announces itself through the event lines B3 builds, and
-candidate 6's `--bell` and `--notify` carry that to someone who stepped away.
-The open detail is whether an armed watch on a detached call's receipt earns a
-spelling of its own, or whether `watch <receipt>` is already it.
+the handler's bound closure, so the caller collects it from the address the call
+published and nobody enumerates them; listing what settled since a person left
+needs the retention collection
+[`../pattern-verb-contract.md`](../pattern-verb-contract.md) designs and has not
+built. Shuttle's own collector is `watch`: a verb whose result lands in a
+watched cell announces itself through the event lines B3 builds, and candidate
+6's `--bell` and `--notify` carry that to someone who stepped away. The open
+detail is whether an armed watch on a detached call's receipt earns a spelling
+of its own, or whether `watch <receipt>` is already it.
 
 **A place's space is safe by its alphabet rather than by a guard.**
 `renderPosition` (`place.ts`) writes the space into what `pwd` and `where`

--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -47,6 +47,38 @@ The scripting bundle is also the agent door the non-goals hold open:
 stable machine-readable output, exit-code discipline, and deterministic
 non-TTY behavior (no views, no strip) arrive with it, not before.
 
+**A slow call's outcome collects in the fabric, not in a shuttle job table.**
+The identity half is already shuttle's: one invocation session is minted at
+startup and passed explicitly into every `call`, which mints an id under it
+(decision 6, [`runtime-integration.md`](runtime-integration.md)). Replaying that
+pair commits once and hands back the original outcome — though the body runs
+again and repeats whatever effects it has outside its transaction. What v1 has
+no spelling for is the wait half: `cf`'s `--wait <seconds>` patience bound, and
+its `--no-wait`, which exits at the commit acknowledgment carrying the receipt's
+address (`resolveWaitControl`, `packages/cli/commands/piece.ts`). Both belong at
+shuttle's `call` when a slow verb makes them worth typing, and collecting a
+detached outcome is then an ordinary `get` of that address: no second read path,
+and the handler does not run again.
+
+One fact bounds how far that goes. The handler runs in the calling process,
+which is why even a detached call awaits its own commit. A shuttle that exits
+mid-call abandons work, and the invocation id makes the retry safe rather than
+the abandonment lossless. So a backgrounded call here is a line shuttle keeps
+running while the prompt goes on reading keys — which B1f's event loop already
+allows — and never a call that outlives the process.
+
+Where outcomes collect while nobody is watching is a fabric question rather than
+a shuttle one, on the same stance the session scope takes above: shuttle adds
+spelling, never a private store. A receipt is addressed from the event id and
+the handler's bound closure, so a caller holding the pair reaches one and nobody
+enumerates them; listing what settled since a person left needs the retention
+collection [`../pattern-verb-contract.md`](../pattern-verb-contract.md) designs
+and has not built. Shuttle's own collector is `watch`: a verb whose result lands
+in a watched cell announces itself through the event lines B3 builds, and
+candidate 6's `--bell` and `--notify` carry that to someone who stepped away.
+The open detail is whether an armed watch on a detached call's receipt earns a
+spelling of its own, or whether `watch <receipt>` is already it.
+
 **A place's space is safe by its alphabet rather than by a guard.**
 `renderPosition` (`place.ts`) writes the space into what `pwd` and `where`
 show without holding it to the class a terminal acts on, and `isDID`


### PR DESCRIPTION
## Why

Shuttle's design settles how a verb call is spelled and how its invocation
is identified, but says nothing about what happens when that call is slow.
The question came up directly: is there anything here for high-latency
calls, for async responses, for outcomes collecting somewhere until a
person comes back?

The answer today is scattered across three places and adds up to a
half-built story. The id-and-session pair is real and shuttle already
mints it. The wait controls are real in `cf` and shuttle has no spelling
for them. The collect-while-away half is designed in the verb contract and
not built. Anyone reaching for this next would rediscover all three, and
would also have to rediscover the constraint that decides how far the idea
can go: the handler runs in the calling process, so there is no
fire-and-forget to build on.

Recording it as a Position is what `futures.md` is for. The positions
there are taken so later features land coherently with the settled
decisions, and this one takes the stance the section already takes
elsewhere: shuttle adds spelling, never a private store.

## What Changed

One entry in the Positions section of `docs/plans/shuttle/futures.md`,
placed after the scripting layers. It records what shuttle already has,
what v1 has no spelling for, the process-locality constraint, and where
the collecting half belongs. It ends with one open detail, matching the
section's convention.

No behavior changes and no code moves.

## Test plan

`deno task check-docs-history-index` and `deno task check-conflict-markers`
pass. `deno task check-docs` was not run: the entry adds no TypeScript
blocks for it to compile. The formatter does not reach `docs/`, so the
prose is wrapped to eighty columns by hand and checked with an awk pass
over line lengths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kBbYAqn3jm5xMPAA1QG1S


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

