### PR TITLE
Preserve empty-object alias defaults and warn on unresolved values

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -501,7 +501,8 @@ not take the alias path. (Contrast §11: CFC detection has no source check.)
    literal default. Tested: brand-payload-defaults.test.ts and
    schema/default-diagnostics.test.ts.
 
-After the applicable extraction routes return no value, the generator reports
+After the applicable extraction routes for `Default<>` or `DeepDefault<>`
+return no value, the generator reports
 **Warning** `schema-default:unresolved` and attaches no default for that
 annotation. `SchemaGenerationOptions.onDiagnostic` receives the message and the
 authored node when available; without a callback the generator logs the warning.
@@ -522,8 +523,10 @@ throw.
   `Default`'s T as a branch (`isDefaultCoveredByUnion`).
 - An object default that would *widen* an existing object member **throws**,
   pointing at `DeepDefault`.
-- `DeepDefault<V>` requires an object target and object default (else
-  **throws**), then applies nested per-property defaults, resolving
+- `DeepDefault<V>` requires an object target and an object default type (else
+  **throws**). An unrecoverable object value emits `schema-default:unresolved`
+  with `DeepDefault<>` in the message and attaches no defaults. A recovered value
+  applies nested per-property defaults, resolving
   through local `$refs` and single-object-candidate `anyOf`s; unknown keys
   **throw**.
 - Expanded empty-array arms (`[]`/`never[]`) riding along expanded

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -54,13 +54,13 @@ instance (`anonymousNames` WeakMap + counter, `src/schema-generator.ts`)
 
 ## 2. Generation Entry Points And Analysis-Path Selection
 
-Two public methods (`src/interface.ts`, implemented in
-`src/schema-generator.ts`): `generateSchema(type, checker, typeNode?,
-{widenLiterals?}?, schemaHints?, sourceFile?)` — the normal,
+Two public methods on `SchemaGenerator` (`src/schema-generator.ts`):
+`generateSchema(type, checker, typeNode?,
+options?: SchemaGenerationOptions, schemaHints?, sourceFile?)` — the normal,
 type-driven path — and `generateSchemaFromSyntheticTypeNode(typeNode, checker,
-typeRegistry?, schemaHints?, sourceFile?)`, a thin wrapper that
-passes `checker.getAnyType()` as the type, forcing the auto-detection
-below onto the node-based path.
+typeRegistry?, schemaHints?, sourceFile?, options?: SchemaGenerationOptions)`,
+a thin wrapper that passes `checker.getAnyType()` as the type, forcing the
+auto-detection below onto the node-based path.
 
 **Path selection** (`shouldUseNodeBasedAnalysis`,
 `src/schema-generator.ts`): node-based analysis is used iff a
@@ -468,7 +468,11 @@ not take the alias path. (Contrast §11: CFC detection has no source check.)
    type nodes, and `typeof CONST` queries resolved
    through import aliases to the variable initializer (unwrapping
    `as`/`satisfies`/parens/type assertions; shorthand properties via
-   `getShorthandAssignmentValueSymbol`).
+   `getShorthandAssignmentValueSymbol`). Inline object and tuple types are
+   extracted as a whole: an unresolved member at any depth makes the entire
+   value unresolved. Non-property type members require the complete type to
+   qualify as an empty record; they cannot be silently skipped. The applicable
+   type/brand fallbacks still run before an unresolved-default warning is emitted.
 2. **Type-based extraction** (both formatters): literal values, symbol value
    declarations, empty object-literal types, and empty records. An alias of `{}`
    yields `{}`, including through alias chains and imports, without requiring a

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -29,8 +29,8 @@ Package exports (`deno.jsonc`): `.` → `src/index.ts` (no `mod.ts`), plus
 five subpaths — `./cell-brand`, `./wrapper-names`, `./property-optionality`,
 `./property-name`, `./numeric-expression`.
 `src/index.ts` exports the `SchemaGenerator` class, the
-`SchemaGenerationOptions` and `WriterSourceIdentity` types, and re-exports
-`MutableJSONSchemaObj`.
+`SchemaGenerationOptions`, `SchemaGenerationDiagnostic`, and
+`WriterSourceIdentity` types, and re-exports `MutableJSONSchemaObj`.
 
 Consumers, as of this writing (verified by import grep): the only external
 consumer package is `@commonfabric/ts-transformers`, along two axes:
@@ -470,8 +470,12 @@ not take the alias path. (Contrast §11: CFC detection has no source check.)
    `as`/`satisfies`/parens/type assertions; shorthand properties via
    `getShorthandAssignmentValueSymbol`).
 2. **Type-based extraction** (both formatters): literal values, symbol value
-   declarations, and empty records. A record with no named properties or call
-   or construct signatures, and at least one index signature, yields `{}` when
+   declarations, empty object-literal types, and empty records. An alias of `{}`
+   yields `{}`, including through alias chains and imports, without requiring a
+   symbol value declaration. Empty interfaces, classes, and the broad `object`
+   type do not qualify as empty object-literal types. A record with no named
+   properties or call or construct signatures, and at least one index signature,
+   yields `{}` when
    every index value type is `never`. This includes `Record<string, never>`,
    `Record<PropertyKey, never>`, their intersections, and aliases of these types,
    in both `T | Default<V>` and `Default<T, V>`. The record check does not require
@@ -487,8 +491,21 @@ not take the alias path. (Contrast §11: CFC detection has no source check.)
    `DEFAULT_MARKER`-branded payload; when the alias is resolved away
    (`T | (T & DefaultMarker<V>)`), the payload is read back type-structurally
    (`type-utils.ts`). Union-distributed brands must **agree**;
-   disagreement bails to no-default. Tested:
-   brand-payload-defaults.test.ts (12 tests).
+   disagreement bails to no-default with a warning. Only an actual
+   `DEFAULT_MARKER` property triggers this recovery; ordinary empty objects and
+   unrelated symbol brands do not. Non-`never` index signatures cannot provide a
+   literal default. Tested: brand-payload-defaults.test.ts and
+   schema/default-diagnostics.test.ts.
+
+After the applicable extraction routes return no value, the generator reports
+**Warning** `schema-default:unresolved` and attaches no default for that
+annotation. `SchemaGenerationOptions.onDiagnostic` receives the message and the
+authored node when available; without a callback the generator logs the warning.
+The transformer forwards it to its diagnostic collector, deduplicated by source
+location. An imported declaration is reported at the local schema use.
+Successful fallback extraction and valid falsy defaults (`null`, `false`, `0`,
+`""`) do not warn. Existing invalid-arity and `Default<undefined>` errors still
+throw.
 
 `default` may sit as a sibling of `$ref` (Draft 2020-12 rationale in comment,
 `common-fabric-formatter.ts`); boolean schemas become `{ default }` /
@@ -793,8 +810,10 @@ way into the emitted schema. Lookups always try the node and
 
 ## 14. Options
 
-Exactly one generation option exists as of this writing: `widenLiterals`
-(`interface.ts`, plumbed at `schema-generator.ts`). Effects:
+`SchemaGenerationOptions` (`interface.ts`, plumbed at `schema-generator.ts`)
+supports `onDiagnostic` for recoverable generation problems (§7),
+`writerIdentityForSourceFile` for writer claims (§11), and `widenLiterals`.
+The effects of `widenLiterals` are:
 (1) single literal types emit bare base types instead of one-value enums
 (`primitive-formatter.ts`; bigint literals → `{ type: "integer" }`);
 (2) structurally-identical-modulo-enum union members merge recursively
@@ -856,9 +875,8 @@ synthetic node resolution failure → `any` → `true`
    pinned by `test/widen-literals.test.ts`): all-literal unions stay enums
    under the flag while the same literals DO widen inside mixed unions, and a
    single-literal property widens next to an unwidened literal-union sibling.
-   Compounding: `generateSchemaFromSyntheticTypeNode` takes no options, so
-   the flag is silently dropped whenever the consumer routes node-based; and
-   the transformer-side `widenLiteralType` (same name, schema-injection
+   Both generation entry points receive the same options. The transformer-side
+   `widenLiteralType` (same name, schema-injection
    pre-widening) DOES widen literal unions — the two mechanisms disagree.
    Decide the policy (including nested enum-typed properties) before changing
    the in-package behavior.
@@ -940,7 +958,7 @@ canonical; update prose from it, not the other way around. Paths relative to
 | CFC payload map (§11) | `buildIfcMetadataForAlias` switch (`src/formatters/common-fabric-formatter.ts`) | cfc-authoring tests |
 | `ifc` key vocabulary (§11) | `JSONSchemaObj.ifc` (`packages/api/index.ts`) | — |
 | Hint shape (§13) | `SchemaHint` / `UiContractHint` (`src/interface.ts`) | — |
-| Generation options (§14) | `GenerationContext["widenLiterals"]` (`src/interface.ts`) | sole option as of this writing |
+| Generation options (§14) | `SchemaGenerationOptions` (`src/interface.ts`) | widening, writer identity, and diagnostics |
 | Throw inventory (§15) | grep `throw new Error` under `src/` | messages quoted above verified this snapshot |
 | Fixture env knobs (§17) | `test/fixtures-runner.test.ts`; `packages/test-support/src/fixture-runner.ts` | — |
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -897,10 +897,11 @@ report these through the same collector (deduplicated via §2.2's
 `markDiagnosticReported` channel):
 
 - **Warning** `schema-default:unresolved` (`schema-generator.ts`) — the
-  schema generator cannot recover a `Default<>` value after trying the node,
-  type, and applicable brand-payload routes. That annotation supplies no schema
-  default; compilation continues. The warning points to the default value
-  type when it belongs to the current file, otherwise to the local schema use.
+  schema generator cannot recover a `Default<>` or `DeepDefault<>` value after
+  trying the node, type, and applicable brand-payload routes. That annotation
+  supplies no schema default; compilation continues. The warning points to the
+  default value type when it belongs to the current file, otherwise to the local
+  schema use.
   Repeated reports for that source range collapse to one. See §7 of the
   schema-generator mapping spec and `test/default-empty-record-schema.test.ts`.
 - **Error** `pattern-context:receiver-method-call`

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -896,6 +896,13 @@ Not every diagnostic comes from a validation transformer. The lowering stages
 report these through the same collector (deduplicated via §2.2's
 `markDiagnosticReported` channel):
 
+- **Warning** `schema-default:unresolved` (`schema-generator.ts`) — the
+  schema generator cannot recover a `Default<>` value after trying the node,
+  type, and applicable brand-payload routes. That annotation supplies no schema
+  default; compilation continues. The warning points to the default value
+  type when it belongs to the current file, otherwise to the local schema use.
+  Repeated reports for that source range collapse to one. See §7 of the
+  schema-generator mapping spec and `test/default-empty-record-schema.test.ts`.
 - **Error** `pattern-context:receiver-method-call`
   (`pattern-body-reactive-root-lowering.ts:162`) — the pattern-body
   reactive-root seam could not admit a receiver-method call on a tracked
@@ -1933,8 +1940,10 @@ Special path:
 - empty-record defaults emit `default: {}` in pattern argument schemas,
   including inside `Writable`. Both `Record<string, unknown> | Default<V>`
   and `Default<Record<string, unknown>, V>` support `V` written as `{}`,
-  `Record<string, never>`, `Record<PropertyKey, never>`, or an alias of either
-  record (`test/default-empty-record-schema.test.ts`). The extraction rules
+  `Record<string, never>`, `Record<PropertyKey, never>`, or an alias of any of
+  these types, including alias chains and imports
+  (`test/default-empty-record-schema.test.ts`). Unresolved default values emit
+  `schema-default:unresolved` warnings (§6.12). The extraction rules
   live in §7 of the schema-generator mapping spec.
 - the node-based generator analyzes through a `readonly` type operator to
   its wrapped array type. A pattern-scope `.get()` on a `Cell<unknown[]>`

--- a/packages/schema-generator/src/default-diagnostics.ts
+++ b/packages/schema-generator/src/default-diagnostics.ts
@@ -1,0 +1,32 @@
+/** Reports defaults whose values cannot be recovered during schema generation. */
+
+import { getLogger } from "@commonfabric/utils/logger";
+import type ts from "typescript";
+
+import type {
+  GenerationContext,
+  SchemaGenerationDiagnostic,
+} from "./interface.ts";
+
+const logger = getLogger("schema-generator.default");
+
+/** Reports only after all applicable default-value extraction routes fail. */
+export function reportUnresolvedDefault(
+  context: GenerationContext,
+  node: ts.Node | undefined = context.typeNode,
+): void {
+  const diagnostic: SchemaGenerationDiagnostic = {
+    severity: "warning",
+    type: "schema-default:unresolved",
+    message:
+      "Cannot extract a value for Default<>; this annotation supplies no schema default. " +
+      "Use a literal value type, an empty-object type, or typeof a constant " +
+      "with a literal initializer.",
+    ...(node && { node }),
+  };
+  if (context.onDiagnostic) {
+    context.onDiagnostic(diagnostic);
+  } else {
+    logger.warn("schema-gen", () => diagnostic.message);
+  }
+}

--- a/packages/schema-generator/src/default-diagnostics.ts
+++ b/packages/schema-generator/src/default-diagnostics.ts
@@ -14,12 +14,13 @@ const logger = getLogger("schema-generator.default");
 export function reportUnresolvedDefault(
   context: GenerationContext,
   node: ts.Node | undefined = context.typeNode,
+  wrapper: "Default" | "DeepDefault" = "Default",
 ): void {
   const diagnostic: SchemaGenerationDiagnostic = {
     severity: "warning",
     type: "schema-default:unresolved",
     message:
-      "Cannot extract a value for Default<>; this annotation supplies no schema default. " +
+      `Cannot extract a value for ${wrapper}<>; this annotation supplies no schema default. ` +
       "Use a literal value type, an empty-object type, or typeof a constant " +
       "with a literal initializer.",
     ...(node && { node }),

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -1856,28 +1856,35 @@ export class CommonFabricFormatter implements TypeFormatter {
 
     // Handle array literals (tuples) like [1, 2] or ["item1", "item2"]
     if (ts.isTupleTypeNode(typeNode)) {
-      return typeNode.elements.map((element) =>
-        this.#extractDefaultValueFromNode(element, context)
-      );
+      const values: unknown[] = [];
+      for (const element of typeNode.elements) {
+        const value = this.#extractDefaultValueFromNode(element, context);
+        if (value === undefined) return undefined;
+        values.push(value);
+      }
+      return values;
     }
 
-    // Handle object literals like { theme: "dark", count: 10 }
     if (ts.isTypeLiteralNode(typeNode)) {
       const obj: Record<string, unknown> = {};
       for (const member of typeNode.members) {
-        if (ts.isPropertySignature(member) && member.name && member.type) {
-          const propName = getPropertyNameText(
-            member.name,
-            context.typeChecker,
-          );
-          if (!propName) {
-            continue;
-          }
-          obj[propName] = this.#extractDefaultValueFromNode(
-            member.type,
-            context,
-          );
+        if (!ts.isPropertySignature(member) || !member.name || !member.type) {
+          const type = context.typeRegistry?.get(typeNode) ??
+            context.typeChecker.getTypeFromTypeNode(typeNode);
+          return isEmptyObjectDefaultType(type, context.typeChecker)
+            ? {}
+            : undefined;
         }
+        const propName = getPropertyNameText(member.name, context.typeChecker);
+        if (propName === undefined) return undefined;
+        const value = this.#extractDefaultValueFromNode(member.type, context);
+        if (value === undefined) return undefined;
+        Object.defineProperty(obj, propName, {
+          value,
+          enumerable: true,
+          writable: true,
+          configurable: true,
+        });
       }
       return obj;
     }

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -11,6 +11,7 @@ import {
 import { isObjectOrArray } from "@commonfabric/utils/types";
 import ts from "typescript";
 
+import { reportUnresolvedDefault } from "../default-diagnostics.ts";
 import type { GenerationContext, TypeFormatter } from "../interface.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
 import {
@@ -18,7 +19,7 @@ import {
   extractDefaultBrandPayloadValue,
   getArrayElementInfo,
   getPropertyNameText,
-  isEmptyRecordType,
+  isEmptyObjectDefaultType,
   resolveWrapperNode,
   type TypeWithInternals,
 } from "../type-utils.ts";
@@ -311,7 +312,11 @@ export class CommonFabricFormatter implements TypeFormatter {
               : { default: defaultValue }) as MutableJSONSchemaObj;
           }
           (valueSchema as Record<string, unknown>).default = defaultValue;
+        } else {
+          reportUnresolvedDefault(context);
         }
+      } else {
+        reportUnresolvedDefault(context);
       }
 
       return valueSchema;
@@ -990,6 +995,8 @@ export class CommonFabricFormatter implements TypeFormatter {
           : { default: defaultValue }) as MutableJSONSchemaObj;
       }
       (valueSchema as any).default = defaultValue;
+    } else {
+      reportUnresolvedDefault(context, defaultTypeNode);
     }
 
     return valueSchema;
@@ -1906,8 +1913,8 @@ export class CommonFabricFormatter implements TypeFormatter {
       return undefined;
     }
 
-    // Mapped records have type declarations but no `.valueDeclaration`.
-    if (isEmptyRecordType(type, context.typeChecker)) {
+    // Empty type literals and mapped records need no value declaration.
+    if (isEmptyObjectDefaultType(type, context.typeChecker)) {
       return {};
     }
 

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -858,25 +858,35 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     if (ts.isTupleTypeNode(typeNode)) {
-      return typeNode.elements.map((element) =>
-        this.#extractDefaultValueFromNode(element, context)
-      );
+      const values: unknown[] = [];
+      for (const element of typeNode.elements) {
+        const value = this.#extractDefaultValueFromNode(element, context);
+        if (value === undefined) return undefined;
+        values.push(value);
+      }
+      return values;
     }
 
     if (ts.isTypeLiteralNode(typeNode)) {
       const obj: Record<string, unknown> = {};
       for (const member of typeNode.members) {
         if (!ts.isPropertySignature(member) || !member.name || !member.type) {
-          continue;
+          const type = context.typeRegistry?.get(typeNode) ??
+            context.typeChecker.getTypeFromTypeNode(typeNode);
+          return isEmptyObjectDefaultType(type, context.typeChecker)
+            ? {}
+            : undefined;
         }
         const propName = getPropertyNameText(member.name, context.typeChecker);
-        if (!propName) {
-          continue;
-        }
-        obj[propName] = this.#extractDefaultValueFromNode(
-          member.type,
-          context,
-        );
+        if (propName === undefined) return undefined;
+        const value = this.#extractDefaultValueFromNode(member.type, context);
+        if (value === undefined) return undefined;
+        Object.defineProperty(obj, propName, {
+          value,
+          enumerable: true,
+          writable: true,
+          configurable: true,
+        });
       }
       return obj;
     }

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -370,6 +370,13 @@ export class UnionFormatter implements TypeFormatter {
         nonDefaultNodes,
         context.typeChecker,
       );
+      if (defaultEntry.entry.defaultValue === undefined) {
+        reportUnresolvedDefault(
+          context,
+          defaultEntry.entry.defaultTypeNode,
+          "DeepDefault",
+        );
+      }
       return this.#applyDeepDefaultToSchema(
         this.#combineUnionSchemas(schemas, context),
         defaultEntry.entry.defaultValue,

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -6,6 +6,7 @@ import { hashStringOf } from "@commonfabric/data-model";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import ts from "typescript";
 
+import { reportUnresolvedDefault } from "../default-diagnostics.ts";
 import type { GenerationContext, TypeFormatter } from "../interface.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
 import {
@@ -14,8 +15,9 @@ import {
   extractDefaultValueFromBrandedMembers,
   getNativeTypeSchema,
   getPropertyNameText,
+  hasDefaultMarker,
   isDefaultBrandedMember,
-  isEmptyRecordType,
+  isEmptyObjectDefaultType,
   resolveWrapperNode,
   TypeWithInternals,
 } from "../type-utils.ts";
@@ -263,9 +265,8 @@ export class UnionFormatter implements TypeFormatter {
    * Authored-node handling stays primary: tryFormatDefaultUnion runs first
    * and also covers non-literal V forms (e.g. `typeof CONST`) via
    * declaration reads. This fallback fires only when the alias node is
-   * unavailable, and bails (returning undefined) when the union carries no
-   * brand, more than one brand, or a payload that is not literal-shaped —
-   * preserving prior behavior exactly in those cases.
+   * unavailable. An actual Default brand with an unextractable or conflicting
+   * payload produces a warning before falling back to ordinary union formatting.
    */
   #tryFormatExpandedDefaultViaBrandPayload(
     members: readonly ts.Type[],
@@ -281,7 +282,12 @@ export class UnionFormatter implements TypeFormatter {
     // all carrying the same payload — extract the agreed value across all of
     // them, and exclude all of them from the formatted remainder.
     const extracted = extractDefaultValueFromBrandedMembers(branded, checker);
-    if (!extracted) return undefined;
+    if (!extracted) {
+      if (branded.some((member) => hasDefaultMarker(member, checker))) {
+        reportUnresolvedDefault(context);
+      }
+      return undefined;
+    }
 
     let rest = members.filter((m) => !isDefaultBrandedMember(m, checker));
     // Degenerate empty-array members (the empty tuple `[]` / `never[]`) ride
@@ -387,6 +393,10 @@ export class UnionFormatter implements TypeFormatter {
       schemas.push(
         this.#formatTypeNodeMember(defaultEntry.entry.valueTypeNode, context),
       );
+    }
+
+    if (defaultEntry.entry.defaultValue === undefined) {
+      reportUnresolvedDefault(context, defaultEntry.entry.defaultTypeNode);
     }
 
     return this.#applySchemaDefault(
@@ -900,7 +910,7 @@ export class UnionFormatter implements TypeFormatter {
       return undefined;
     }
 
-    if (isEmptyRecordType(type, context.typeChecker)) {
+    if (isEmptyObjectDefaultType(type, context.typeChecker)) {
       return {};
     }
 

--- a/packages/schema-generator/src/index.ts
+++ b/packages/schema-generator/src/index.ts
@@ -3,6 +3,7 @@ export { SchemaGenerator } from "./schema-generator.ts";
 
 // Public types for API consumers
 export type {
+  SchemaGenerationDiagnostic,
   SchemaGenerationOptions,
   WriterSourceIdentity,
 } from "./interface.ts";

--- a/packages/schema-generator/src/interface.ts
+++ b/packages/schema-generator/src/interface.ts
@@ -35,9 +35,20 @@ export interface SchemaHint {
 
 export type SchemaHints = WeakMap<ts.Node, SchemaHint>;
 
+/** A recoverable schema-generation problem at its authored node, if known. */
+export interface SchemaGenerationDiagnostic {
+  readonly severity: "warning";
+  readonly type: "schema-default:unresolved";
+  readonly message: string;
+  readonly node?: ts.Node;
+}
+
 /** Options that affect schema generation without changing the authored type. */
 export interface SchemaGenerationOptions {
   readonly widenLiterals?: boolean;
+
+  /** Receives warnings; without a callback the generator logs them. */
+  readonly onDiagnostic?: (diagnostic: SchemaGenerationDiagnostic) => void;
 
   /**
    * Resolves a TypeScript source-file name to the writer identity that should
@@ -97,6 +108,9 @@ export interface GenerationContext {
 
   /** Widen literal types to base types during schema generation */
   widenLiterals?: boolean;
+
+  /** Receives recoverable schema-generation problems. */
+  onDiagnostic?: (diagnostic: SchemaGenerationDiagnostic) => void;
 
   /** Resolve writer-claim file spelling and optional mint-time identity. */
   writerIdentityForSourceFile?: (

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -146,6 +146,7 @@ export class SchemaGenerator {
       ...(options?.writerIdentityForSourceFile && {
         writerIdentityForSourceFile: options.writerIdentityForSourceFile,
       }),
+      ...(options?.onDiagnostic && { onDiagnostic: options.onDiagnostic }),
       ...(schemaHints && { schemaHints }),
     };
 

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -904,10 +904,10 @@ function followAliasToWrapperNode(
 }
 
 /**
- * Returns whether a record has no named properties and only `never`-valued
- * index signatures, so its default can be represented by `{}`.
+ * Recognizes `{}` literals and propertyless records with only `never`-valued
+ * indexes as empty defaults, including when reached through type aliases.
  */
-export function isEmptyRecordType(
+export function isEmptyObjectDefaultType(
   type: ts.Type,
   typeChecker: ts.TypeChecker,
 ): boolean {
@@ -921,8 +921,14 @@ export function isEmptyRecordType(
   ) return false;
 
   const indexes = typeChecker.getIndexInfosOfType(type);
-  return indexes.length > 0 &&
-    indexes.every((index) => (index.type.flags & ts.TypeFlags.Never) !== 0);
+  if (indexes.length > 0) {
+    return indexes.every((index) =>
+      (index.type.flags & ts.TypeFlags.Never) !== 0
+    );
+  }
+  return type.getSymbol()?.declarations?.some((declaration) =>
+    ts.isTypeLiteralNode(declaration) && declaration.members.length === 0
+  ) ?? false;
 }
 
 /**
@@ -976,6 +982,11 @@ export function extractValueFromLiteralType(
     type.getCallSignatures().length === 0 &&
     type.getConstructSignatures().length === 0
   ) {
+    if (typeChecker.getIndexInfosOfType(type).length > 0) {
+      return isEmptyObjectDefaultType(type, typeChecker)
+        ? { value: {} }
+        : undefined;
+    }
     const props = typeChecker.getPropertiesOfType(type);
     const result: Record<string, unknown> = {};
     for (const prop of props) {
@@ -1012,38 +1023,54 @@ export function isBrandOnlyMarkerType(
 }
 
 /**
- * Read `Default<T, V>`'s V back out of the DEFAULT_MARKER brand payload of an
- * expanded type: `T | (T & DefaultMarker<V>)`, a bare `T & DefaultMarker<V>`
- * intersection, or a standalone `DefaultMarker<V>` (the nullish arm). Returns
- * the extracted JSON value wrapped, or undefined when the type carries no
- * brand, more than one branded member, or a payload that is not
- * literal-shaped. The payload is the only place V survives once the checker
- * resolves the alias away — see Default<> in packages/api/index.ts.
+ * Recognizes an actual DEFAULT_MARKER property on an expanded Default member.
+ * Ordinary empty objects and unrelated symbol brands do not promise a default.
+ */
+export function hasDefaultMarker(
+  member: ts.Type,
+  typeChecker: ts.TypeChecker,
+): boolean {
+  return getDefaultMarkerProperty(member, typeChecker) !== undefined;
+}
+
+/**
+ * Selects candidate brand constituents for expanded-default extraction.
+ * Empty objects and other symbol brands remain candidates; the payload reader
+ * requires an actual DEFAULT_MARKER on every candidate before accepting a value.
  */
 export function isDefaultBrandedMember(
   member: ts.Type,
   typeChecker: ts.TypeChecker,
 ): boolean {
   if (isBrandOnlyMarkerType(member, typeChecker)) return true;
-  if ((member.flags & ts.TypeFlags.Intersection) === 0) return false;
-  const parts = (member as ts.IntersectionType).types ?? [];
-  return parts.some((part) => isBrandOnlyMarkerType(part, typeChecker));
+  if (!member.isIntersection()) return false;
+  return member.types.some((part) => isBrandOnlyMarkerType(part, typeChecker));
+}
+
+/** Finds the marker on a brand-only constituent of an expanded Default. */
+function getDefaultMarkerProperty(
+  member: ts.Type,
+  typeChecker: ts.TypeChecker,
+): ts.Symbol | undefined {
+  const brandParts = (member.flags & ts.TypeFlags.Intersection) !== 0
+    ? ((member as ts.IntersectionType).types ?? []).filter((part) =>
+      isBrandOnlyMarkerType(part, typeChecker)
+    )
+    : isBrandOnlyMarkerType(member, typeChecker)
+    ? [member]
+    : [];
+  return brandParts
+    .flatMap((part) => typeChecker.getPropertiesOfType(part))
+    .find((prop) =>
+      String(prop.escapedName as string).startsWith("__@DEFAULT_MARKER")
+    );
 }
 
 function extractPayloadFromBrandedMember(
   member: ts.Type,
   typeChecker: ts.TypeChecker,
 ): { value: unknown } | undefined {
-  const brandParts = (member.flags & ts.TypeFlags.Intersection) !== 0
-    ? ((member as ts.IntersectionType).types ?? []).filter((part) =>
-      isBrandOnlyMarkerType(part, typeChecker)
-    )
-    : [member];
-  const markerProp = brandParts
-    .flatMap((part) => typeChecker.getPropertiesOfType(part))
-    .find((prop) =>
-      String(prop.escapedName as string).startsWith("__@DEFAULT_MARKER")
-    );
+  const markerProp = getDefaultMarkerProperty(member, typeChecker);
   if (!markerProp) return undefined;
   const payload = typeChecker.getTypeOfSymbol(markerProp);
   const extracted = extractValueFromLiteralType(payload, typeChecker);

--- a/packages/schema-generator/test/brand-payload-defaults.test.ts
+++ b/packages/schema-generator/test/brand-payload-defaults.test.ts
@@ -59,6 +59,7 @@ describe("brand-payload default recovery (expanded Default<T, V>)", () => {
     const code = `${DEFAULT_PRELUDE}
       interface Tagged<V extends string> {
         note: Default<string, V>;
+        config: Default<{ tag: string }, { tag: V }>;
       }
       interface Holder {
         tagged: Tagged<"from-generic">;
@@ -78,6 +79,9 @@ describe("brand-payload default recovery (expanded Default<T, V>)", () => {
     expect(tagged.properties?.note).toEqual({
       type: "string",
       default: "from-generic",
+    });
+    expect(tagged.properties?.config).toHaveProperty("default", {
+      tag: "from-generic",
     });
     expect(diagnostics).toEqual([]);
   });

--- a/packages/schema-generator/test/brand-payload-defaults.test.ts
+++ b/packages/schema-generator/test/brand-payload-defaults.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { SchemaGenerator } from "../src/schema-generator.ts";
+import type { SchemaGenerationDiagnostic } from "../src/interface.ts";
 import { asObjectSchema, getTypeFromCode } from "./utils.ts";
 
 // The DEFAULT_MARKER brand payload carries V (the default VALUE's type) — see
@@ -64,7 +65,12 @@ describe("brand-payload default recovery (expanded Default<T, V>)", () => {
       }
     `;
     const { type, checker } = await getTypeFromCode(code, "Holder");
-    const schema = asObjectSchema(transformer.generateSchema(type, checker));
+    const diagnostics: SchemaGenerationDiagnostic[] = [];
+    const schema = asObjectSchema(
+      transformer.generateSchema(type, checker, undefined, {
+        onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+      }),
+    );
 
     const tagged = asObjectSchema(
       (schema.properties?.tagged ?? {}) as Record<string, unknown>,
@@ -73,6 +79,7 @@ describe("brand-payload default recovery (expanded Default<T, V>)", () => {
       type: "string",
       default: "from-generic",
     });
+    expect(diagnostics).toEqual([]);
   });
 
   it("recovers tuple and object literal payloads", async () => {

--- a/packages/schema-generator/test/schema/default-diagnostics.test.ts
+++ b/packages/schema-generator/test/schema/default-diagnostics.test.ts
@@ -10,6 +10,43 @@ import {
 import { asObjectSchema, getTypeFromCode, getTypeFromFiles } from "../utils.ts";
 
 describe("default diagnostics", () => {
+  describe("DeepDefault", () => {
+    for (
+      const payload of [
+        '{ nested: { label: string }; known: "yes" }',
+        '{ nested: { values: [0, string] }; known: "yes" }',
+      ]
+    ) {
+      it(`warns when ${payload} cannot be fully extracted`, async () => {
+        const { type, checker, typeNode } = await getTypeFromCode(
+          `interface DeepDefault<V> {}
+           interface Config {
+             known: string;
+             nested: { label: string; values: unknown[] };
+           }
+           type Root = Config | DeepDefault<${payload}>;`,
+          "Root",
+        );
+        const diagnostics: SchemaGenerationDiagnostic[] = [];
+        const schema = asObjectSchema(
+          new SchemaGenerator().generateSchema(type, checker, typeNode, {
+            onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+          }),
+        );
+
+        expect(schema).not.toHaveProperty("default");
+        expect(schema).not.toHaveProperty("properties");
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]).toMatchObject({
+          severity: "warning",
+          type: "schema-default:unresolved",
+        });
+        expect(diagnostics[0]?.message).toContain("DeepDefault<>");
+        expect(diagnostics[0]?.node).toBeDefined();
+      });
+    }
+  });
+
   for (const form of ["union member", "two arguments"]) {
     for (
       const [valueType, payload] of [

--- a/packages/schema-generator/test/schema/default-diagnostics.test.ts
+++ b/packages/schema-generator/test/schema/default-diagnostics.test.ts
@@ -10,6 +10,67 @@ import {
 import { asObjectSchema, getTypeFromCode, getTypeFromFiles } from "../utils.ts";
 
 describe("default diagnostics", () => {
+  for (const form of ["union member", "two arguments"]) {
+    for (
+      const [valueType, payload] of [
+        ["Record<string, unknown>", '{ known: "yes"; unresolved: string }'],
+        ["unknown[]", '["yes", string]'],
+        ["Record<string, unknown>", '{ nested: { items: ["yes", number] } }'],
+        ["unknown[]", "[{ known: 1; nested: { unresolved: boolean } }]"],
+        ["Record<string, unknown>", "{ known: 1; [key: string]: unknown }"],
+      ]
+    ) {
+      it(`warns instead of emitting a partial ${form} default for ${payload}`, async () => {
+        const wrapped = form === "union member"
+          ? `${valueType} | Default<${payload}>`
+          : `Default<${valueType}, ${payload}>`;
+        const { type, checker, typeNode } = await getTypeFromCode(
+          `interface Default<T, V extends T = T> {}
+           type Root = ${wrapped};`,
+          "Root",
+        );
+        const diagnostics: SchemaGenerationDiagnostic[] = [];
+        const schema = asObjectSchema(
+          new SchemaGenerator().generateSchema(type, checker, typeNode, {
+            onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+          }),
+        );
+
+        expect(schema).not.toHaveProperty("default");
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]?.type).toBe("schema-default:unresolved");
+      });
+    }
+
+    it(`preserves a complete nested ${form} default without warning`, async () => {
+      const payload =
+        '{ nested: { values: [null, false, 0, "", {}, []]; "": 0; "__proto__": false } }';
+      const wrapped = form === "union member"
+        ? `Record<string, unknown> | Default<${payload}>`
+        : `Default<Record<string, unknown>, ${payload}>`;
+      const { type, checker, typeNode } = await getTypeFromCode(
+        `interface Default<T, V extends T = T> {}
+         type Root = ${wrapped};`,
+        "Root",
+      );
+      const diagnostics: SchemaGenerationDiagnostic[] = [];
+      const schema = asObjectSchema(
+        new SchemaGenerator().generateSchema(type, checker, typeNode, {
+          onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+        }),
+      );
+
+      expect(schema.default).toEqual({
+        nested: {
+          values: [null, false, 0, "", {}, []],
+          "": 0,
+          ["__proto__"]: false,
+        },
+      });
+      expect(diagnostics).toEqual([]);
+    });
+  }
+
   for (
     const declaration of [
       "Default<string>",

--- a/packages/schema-generator/test/schema/default-diagnostics.test.ts
+++ b/packages/schema-generator/test/schema/default-diagnostics.test.ts
@@ -1,0 +1,127 @@
+/** Checks warnings for unresolved defaults and successful fallback extraction. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  type SchemaGenerationDiagnostic,
+  SchemaGenerator,
+} from "../../src/index.ts";
+import { asObjectSchema, getTypeFromCode, getTypeFromFiles } from "../utils.ts";
+
+describe("default diagnostics", () => {
+  for (
+    const declaration of [
+      "Default<string>",
+      "Default<string, string>",
+      "string | Default<string>",
+      "Default<object, Record<string, string>>",
+    ]
+  ) {
+    it(`warns when ${declaration} cannot supply a value`, async () => {
+      const { type, checker, typeNode } = await getTypeFromCode(
+        `interface Default<T, V extends T = T> {}
+         type Root = ${declaration};`,
+        "Root",
+      );
+      const diagnostics: SchemaGenerationDiagnostic[] = [];
+      const schema = asObjectSchema(
+        new SchemaGenerator().generateSchema(type, checker, typeNode, {
+          onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+        }),
+      );
+
+      expect(schema).not.toHaveProperty("default");
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]).toMatchObject({
+        type: "schema-default:unresolved",
+        severity: "warning",
+      });
+      expect(diagnostics[0]?.message).toContain("supplies no schema default");
+      expect(diagnostics[0]?.node).toBeDefined();
+    });
+  }
+
+  for (
+    const [valueType, payload] of [
+      ["string", "string"],
+      ["string", '"first" | "second"'],
+      ["object", "Record<string, string>"],
+    ]
+  ) {
+    it(`warns for an expanded default with payload ${payload}`, async () => {
+      const { type, checker, typeNode } = await getTypeFromCode(
+        `declare const DEFAULT_MARKER: unique symbol;
+         type Marker<V> = { readonly [DEFAULT_MARKER]: V };
+         type Root = ${valueType} | (${valueType} & Marker<${payload}>);`,
+        "Root",
+      );
+      const diagnostics: SchemaGenerationDiagnostic[] = [];
+      const schema = asObjectSchema(
+        new SchemaGenerator().generateSchema(type, checker, typeNode, {
+          onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+        }),
+      );
+
+      expect(schema).not.toHaveProperty("default");
+      expect(diagnostics).toHaveLength(1);
+    });
+  }
+
+  it("preserves imported empty-object aliases without warning", async () => {
+    const { type, checker } = await getTypeFromFiles(
+      {
+        "/types.ts": "export type Empty = {}; export type Alias = Empty;",
+        "/main.ts": `
+        import type { Alias } from "./types.ts";
+        interface Default<T, V extends T = T> {}
+        interface Root {
+          direct: Default<Alias>;
+          union: Record<string, unknown> | Default<Alias>;
+          two: Default<Record<string, unknown>, Alias>;
+        }
+      `,
+      },
+      "/main.ts",
+      "Root",
+    );
+    const diagnostics: SchemaGenerationDiagnostic[] = [];
+    const schema = asObjectSchema(
+      new SchemaGenerator().generateSchema(type, checker, undefined, {
+        onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+      }),
+    );
+
+    for (const name of ["direct", "union", "two"]) {
+      expect(schema.properties?.[name]).toHaveProperty("default", {});
+    }
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("does not warn for ordinary unions or falsy defaults", async () => {
+    const { type, checker } = await getTypeFromCode(
+      `interface Default<T, V extends T = T> {}
+       interface Root {
+         object: {} | string;
+         array: string[] | [];
+         text: Default<"">;
+         number: Default<0>;
+         flag: Default<false>;
+         missing: Default<null>;
+       }`,
+      "Root",
+    );
+    const diagnostics: SchemaGenerationDiagnostic[] = [];
+    const schema = asObjectSchema(
+      new SchemaGenerator().generateSchema(type, checker, undefined, {
+        onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+      }),
+    );
+
+    expect(schema.properties?.text).toHaveProperty("default", "");
+    expect(schema.properties?.number).toHaveProperty("default", 0);
+    expect(schema.properties?.flag).toHaveProperty("default", false);
+    expect(schema.properties?.missing).toHaveProperty("default", null);
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/packages/schema-generator/test/schema/default-empty-record.test.ts
+++ b/packages/schema-generator/test/schema/default-empty-record.test.ts
@@ -12,6 +12,7 @@ describe("default-empty-record", () => {
     describe(form, () => {
       for (
         const value of [
+          "{}",
           "Record<string, never>",
           "Record<number, never>",
           "Record<symbol, never>",
@@ -28,7 +29,8 @@ describe("default-empty-record", () => {
           const { type, checker, typeNode } = await getTypeFromCode(
             `
             interface Default<T, V extends T = T> {}
-            type Value = ${value};
+            type Original = ${value};
+            type Value = Original;
             type SchemaRoot = ${wrapped};
             `,
             "SchemaRoot",
@@ -43,6 +45,10 @@ describe("default-empty-record", () => {
 
       for (
         const value of [
+          "object",
+          ...(form === "two arguments"
+            ? ["{ (): void }", "{ new (): object }"]
+            : []),
           "Record<string, string>",
           "Record<string, unknown>",
           'Record<"required", never>',

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -8,6 +8,7 @@ import ts from "typescript";
 import {
   getNodeText,
   getTypeFromTypeNodeWithFallback,
+  recoverAuthoredPosition,
   visitEachChildWithJsx,
 } from "../ast/mod.ts";
 import {
@@ -46,6 +47,7 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
       };
     };
 
+    let schemaUse: ts.Node = sourceFile;
     const visit: ts.Visitor = (node) => {
       if (isToSchemaNode(node)) {
         const typeArg = node.typeArguments[0]!;
@@ -107,6 +109,23 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
         // Build options for schema generation
         const generationOptions: SchemaGenerationOptions = {
           ...(widenLiterals !== undefined ? { widenLiterals } : {}),
+          onDiagnostic: (diagnostic) => {
+            const original = diagnostic.node &&
+              ts.getOriginalNode(diagnostic.node);
+            const useRange = recoverAuthoredPosition(node) ??
+              recoverAuthoredPosition(schemaUse);
+            context.reportDiagnosticOnce({
+              ...diagnostic,
+              node: original?.getSourceFile()?.fileName === sourceFile.fileName
+                ? original
+                : useRange
+                ? ts.setTextRange(
+                  context.factory.createIdentifier(""),
+                  useRange,
+                )
+                : schemaUse,
+            });
+          },
           // The schema-generator owns the general/nested CFC alias path. Give
           // it the same spelling and stamp source used by the direct
           // WriteAuthorizedBy special case below, including for bindings
@@ -202,7 +221,16 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
         return satisfiesExpression;
       }
 
-      return visitEachChildWithJsx(node, visit, transformation);
+      // Injected toSchema calls have no position or parent links. Their nearest
+      // enclosing authored range locates diagnostics about imported types.
+      const enclosingUse = schemaUse;
+      const range = recoverAuthoredPosition(node);
+      if (range) {
+        schemaUse = node;
+      }
+      const visited = visitEachChildWithJsx(node, visit, transformation);
+      schemaUse = enclosingUse;
+      return visited;
     };
 
     return ts.visitNode(sourceFile, visit) as ts.SourceFile;

--- a/packages/ts-transformers/test/default-empty-record-schema.test.ts
+++ b/packages/ts-transformers/test/default-empty-record-schema.test.ts
@@ -3,9 +3,13 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
+import {
+  type TransformationDiagnostic,
+  transformCfDirective,
+} from "../src/mod.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import { parseModule, patternSchemas } from "./transformed-ast.ts";
-import { transformSource } from "./utils.ts";
+import { transformFiles, transformSource } from "./utils.ts";
 
 describe("default-empty-record-schema", () => {
   for (const form of ["union member", "two arguments"]) {
@@ -15,6 +19,7 @@ describe("default-empty-record-schema", () => {
         stringKeys: "Record<string, never>",
         propertyKeys: "Record<PropertyKey, never>",
         alias: "EmptyRecord",
+        literalAlias: "EmptyObject",
       };
       const properties = Object.entries(defaults).map(([name, value]) => {
         const type = form === "union member"
@@ -22,19 +27,27 @@ describe("default-empty-record-schema", () => {
           : `Default<Record<string, unknown>, ${value}>`;
         return `${name}: Writable<${type}>;`;
       }).join("\n");
+      const diagnostics: TransformationDiagnostic[] = [];
       const output = await transformSource(
         `/// <cts-enable />
         import { Default, pattern, Writable } from "commonfabric";
         type EmptyRecord = Record<string, never>;
+        type Empty = {};
+        type EmptyObject = Empty;
         interface Input { ${properties} }
         export default pattern<Input>((state) => ({
           literal: state.literal,
           stringKeys: state.stringKeys,
           propertyKeys: state.propertyKeys,
           alias: state.alias,
+          literalAlias: state.literalAlias,
         }));
         `,
-        { types: COMMONFABRIC_TYPES, typeCheck: true },
+        {
+          types: COMMONFABRIC_TYPES,
+          typeCheck: true,
+          pipelineDiagnostics: diagnostics,
+        },
       );
       const { input } = patternSchemas(parseModule(output));
       const schemas = input.properties as Record<
@@ -53,12 +66,14 @@ describe("default-empty-record-schema", () => {
       )).toEqual(Object.fromEntries(
         Object.keys(defaults).map((name) => [name, {}]),
       ));
+      expect(diagnostics).toEqual([]);
     });
   }
 
   it("omits the default for never-valued types that are not empty records", async () => {
     // Named properties disqualify arrays and finite-key records from
     // representing empty-object defaults, even when their value type is `never`.
+    const diagnostics: TransformationDiagnostic[] = [];
     const output = await transformSource(
       `/// <cts-enable />
       import { Default, pattern, Writable } from "commonfabric";
@@ -73,7 +88,11 @@ describe("default-empty-record-schema", () => {
         unionNamedNever: state.unionNamedNever,
       }));
       `,
-      { types: COMMONFABRIC_TYPES, typeCheck: true },
+      {
+        types: COMMONFABRIC_TYPES,
+        typeCheck: true,
+        pipelineDiagnostics: diagnostics,
+      },
     );
     const { input } = patternSchemas(parseModule(output));
     const schemas = input.properties as Record<string, Record<string, unknown>>;
@@ -82,5 +101,49 @@ describe("default-empty-record-schema", () => {
       expect(schemas[name]).toMatchObject({ type: "object", asCell: ["cell"] });
       expect(schemas[name]).not.toHaveProperty("default");
     }
+    const warnings = diagnostics.filter((diagnostic) =>
+      diagnostic.type === "schema-default:unresolved"
+    );
+    expect(warnings).toHaveLength(3);
+    expect(warnings.map((warning) => warning.line)).toEqual([5, 6, 7]);
+    expect(warnings.every((warning) => warning.severity === "warning")).toBe(
+      true,
+    );
+  });
+
+  it("locates imported unresolved defaults at the schema use", async () => {
+    const diagnostics: TransformationDiagnostic[] = [];
+    const source = `/// <cts-enable />
+        import { pattern } from "commonfabric";
+        import type { Input } from "./types.ts";
+        export default pattern<Input>((state) => ({ value: state.value }));
+      `;
+    await transformFiles({
+      "/types.ts": `
+        import type { Default, Writable } from "commonfabric";
+        export interface Input { value: Writable<Default<string>>; }
+      `,
+      "/test.tsx": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+      typeCheck: true,
+      pipelineDiagnostics: diagnostics,
+    });
+
+    const warnings = diagnostics.filter((diagnostic) =>
+      diagnostic.type === "schema-default:unresolved"
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      fileName: "/test.tsx",
+      severity: "warning",
+    });
+    const warning = warnings[0]!;
+    expect(
+      transformCfDirective(source).slice(
+        warning.start,
+        warning.start + warning.length,
+      ),
+    ).toContain("pattern<Input>");
   });
 });

--- a/packages/ts-transformers/test/default-empty-record-schema.test.ts
+++ b/packages/ts-transformers/test/default-empty-record-schema.test.ts
@@ -18,6 +18,7 @@ describe("default-empty-record-schema", () => {
         literal: "{}",
         stringKeys: "Record<string, never>",
         propertyKeys: "Record<PropertyKey, never>",
+        indexSignature: "{ [key: string]: never }",
         alias: "EmptyRecord",
         literalAlias: "EmptyObject",
       };
@@ -39,6 +40,7 @@ describe("default-empty-record-schema", () => {
           literal: state.literal,
           stringKeys: state.stringKeys,
           propertyKeys: state.propertyKeys,
+          indexSignature: state.indexSignature,
           alias: state.alias,
           literalAlias: state.literalAlias,
         }));
@@ -145,5 +147,42 @@ describe("default-empty-record-schema", () => {
         warning.start + warning.length,
       ),
     ).toContain("pattern<Input>");
+  });
+
+  it("warns instead of emitting partial object and tuple defaults", async () => {
+    const diagnostics: TransformationDiagnostic[] = [];
+    const output = await transformSource(
+      `/// <cts-enable />
+      import { Default, pattern, Writable } from "commonfabric";
+      interface Input {
+        object: Writable<Default<Record<string, unknown>, { known: 1; missing: string }>>;
+        tuple: Writable<Default<unknown[], [1, string]>>;
+        unionObject: Writable<Record<string, unknown> | Default<{ nested: { missing: string } }>>;
+        unionTuple: Writable<unknown[] | Default<[{ nested: [0, string] }]>>;
+      }
+      export default pattern<Input>((state) => ({
+        object: state.object,
+        tuple: state.tuple,
+        unionObject: state.unionObject,
+        unionTuple: state.unionTuple,
+      }));
+      `,
+      {
+        types: COMMONFABRIC_TYPES,
+        typeCheck: true,
+        pipelineDiagnostics: diagnostics,
+      },
+    );
+    const { input } = patternSchemas(parseModule(output));
+    const schemas = input.properties as Record<string, Record<string, unknown>>;
+
+    for (const name of ["object", "tuple", "unionObject", "unionTuple"]) {
+      expect(schemas[name]).not.toHaveProperty("default");
+    }
+    const warnings = diagnostics.filter((diagnostic) =>
+      diagnostic.type === "schema-default:unresolved"
+    );
+    expect(warnings).toHaveLength(4);
+    expect(warnings.map((warning) => warning.line)).toEqual([5, 6, 7, 8]);
   });
 });

--- a/packages/ts-transformers/test/default-empty-record-schema.test.ts
+++ b/packages/ts-transformers/test/default-empty-record-schema.test.ts
@@ -185,4 +185,49 @@ describe("default-empty-record-schema", () => {
     expect(warnings).toHaveLength(4);
     expect(warnings.map((warning) => warning.line)).toEqual([5, 6, 7, 8]);
   });
+
+  it("warns for unresolved DeepDefault values and preserves complete ones", async () => {
+    const diagnostics: TransformationDiagnostic[] = [];
+    const output = await transformSource(
+      `/// <cts-enable />
+      import { DeepDefault, pattern, Writable } from "commonfabric";
+      interface Config { nested: { label: string; values: unknown[] }; }
+      interface Input {
+        object: Writable<Config | DeepDefault<{ nested: { label: string } }>>;
+        tuple: Writable<Config | DeepDefault<{ nested: { values: [0, string] } }>>;
+        complete: Writable<Config | DeepDefault<{ nested: { values: [null, false, 0, ""] } }>>;
+      }
+      export default pattern<Input>((state) => ({
+        object: state.object,
+        tuple: state.tuple,
+        complete: state.complete,
+      }));
+      `,
+      {
+        types: COMMONFABRIC_TYPES,
+        typeCheck: true,
+        pipelineDiagnostics: diagnostics,
+      },
+    );
+    const { input } = patternSchemas(parseModule(output));
+    const schemas = input.properties as Record<string, Record<string, unknown>>;
+
+    for (const name of ["object", "tuple"]) {
+      expect(schemas[name]).not.toHaveProperty("default");
+    }
+    expect(schemas.complete).toHaveProperty("default", {
+      nested: { values: [null, false, 0, ""] },
+    });
+    const warnings = diagnostics.filter((diagnostic) =>
+      diagnostic.type === "schema-default:unresolved"
+    );
+    expect(warnings).toHaveLength(2);
+    expect(warnings.map((warning) => warning.line)).toEqual([6, 7]);
+    expect(
+      warnings.every((warning) =>
+        warning.severity === "warning" &&
+        warning.message.includes("DeepDefault<>")
+      ),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
`type Empty = {}` now supplies `default: {}` when used in `Default<>`, including alias chains, imports, union members, and the two-argument form. This follows up on #7166.

When the applicable extraction routes for `Default<>` or `DeepDefault<>` cannot recover a value, the generator reports `schema-default:unresolved` as a warning. The compiler collects and deduplicates these warnings at the default declaration or its local schema use. Standalone callers can collect them through `SchemaGenerationOptions.onDiagnostic`; otherwise they are logged. Existing invalid-arity and `Default<undefined>` errors remain errors.

The warning requires an actual Default marker on expanded types, so ordinary unions do not warn. Payload extraction also rejects non-`never` index signatures instead of treating them as empty literal values. Inline object and tuple defaults must resolve completely; a failed member at any depth discards the partial value before trying the remaining fallback. Tests cover both annotation forms, emitted pattern schemas, imported diagnostic locations, generic fallback success, and falsy defaults.

Validation:

- Schema-generator suite: 59 tests / 401 steps passed.
- Transformer suite: 1,165 tests / 933 steps passed.
- Root format, lint, and type checks; both package type checks; all 596 documentation code blocks passed.
- Full pattern compatibility: all 327 contracts passed against their recorded baselines. No baseline changes are needed.

Unresolved default shapes in existing patterns now produce non-blocking warnings; their schemas continue to omit those defaults.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



