### PR TITLE
refactor(data-model): dispatch the codec registry on JS type tags

### DIFF
--- a/packages/data-model/src/codec-common/CodecRegistry.ts
+++ b/packages/data-model/src/codec-common/CodecRegistry.ts
@@ -23,7 +23,11 @@ import {
 } from "@/codec-interface/interface.ts";
 import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
 import { BaseTerminalCodec } from "@/codec-interface/BaseTerminalCodec.ts";
-import { jsTypeTag, type JsTypeValueTag, VALUE_TAGS } from "@/value-tags.ts";
+import {
+  jsTagFromValue,
+  type JsTypeValueTag,
+  VALUE_TAGS,
+} from "@/value-tags.ts";
 import { isCodecTypeTag } from "./isCodecTypeTag.ts";
 
 /**
@@ -283,7 +287,7 @@ export class CodecRegistry<Encoded> {
   ): CodecForFormat<Encoded> | typeof SELF_REP | undefined {
     // Primitive dispatch on the value's primitive `type` key, which is its JS
     // type tag. The type's codec is tried first, then self-representation.
-    const type = jsTypeTag(value);
+    const type = jsTagFromValue(value);
 
     if (type === VALUE_TAGS.function) {
       // Not a `FabricValue`; nothing can encode it.

--- a/packages/data-model/src/codec-common/CodecRegistry.ts
+++ b/packages/data-model/src/codec-common/CodecRegistry.ts
@@ -23,6 +23,7 @@ import {
 } from "@/codec-interface/interface.ts";
 import { BaseNonterminalCodec } from "@/codec-interface/BaseNonterminalCodec.ts";
 import { BaseTerminalCodec } from "@/codec-interface/BaseTerminalCodec.ts";
+import { jsTypeTag, type JsTypeValueTag, VALUE_TAGS } from "@/value-tags.ts";
 import { isCodecTypeTag } from "./isCodecTypeTag.ts";
 
 /**
@@ -33,19 +34,12 @@ import { isCodecTypeTag } from "./isCodecTypeTag.ts";
 export const SELF_REP = "self-rep" as const;
 
 /**
- * The primitive `type` keys the registry accepts: the `typeof` results that are
- * encodable `FabricValue` primitives, plus `"null"` for the `null` value.
- * `"object"` and `"function"` are deliberately excluded -- object values are
- * matched by class via {@link CodecRegistry#register}.
+ * The primitive `type` keys the registry accepts: the JS type tags of the
+ * encodable `FabricValue` primitives, `null` included. A function is no
+ * `FabricValue`, and an object value is matched by class via
+ * {@link CodecRegistry#register}, so neither has a key here.
  */
-export type PrimitiveTypeName =
-  | "null"
-  | "undefined"
-  | "boolean"
-  | "number"
-  | "bigint"
-  | "string"
-  | "symbol";
+export type PrimitiveTypeName = Exclude<JsTypeValueTag, "function">;
 
 /**
  * Gets the constructor function ("class") of the given value, if any, for
@@ -287,35 +281,14 @@ export class CodecRegistry<Encoded> {
   codecFromValue(
     value: FabricValue,
   ): CodecForFormat<Encoded> | typeof SELF_REP | undefined {
-    // Primitive dispatch on the value's primitive `type` key (its `typeof`, or
-    // `"null"`). The type's codec is tried first, then self-representation.
-    let type: PrimitiveTypeName | undefined;
-    const valueType = typeof value;
-    switch (valueType) {
-      case "bigint":
-      case "boolean":
-      case "number":
-      case "string":
-      case "symbol":
-      case "undefined": {
-        type = valueType;
-        break;
-      }
+    // Primitive dispatch on the value's primitive `type` key, which is its JS
+    // type tag. The type's codec is tried first, then self-representation.
+    const type = jsTypeTag(value);
 
-      case "object": {
-        if (value === null) {
-          type = "null";
-        }
-        break;
-      }
-
-      case "function": {
-        // Not a `FabricValue`; nothing can encode it.
-        return undefined;
-      }
-    }
-
-    if (type !== undefined) {
+    if (type === VALUE_TAGS.function) {
+      // Not a `FabricValue`; nothing can encode it.
+      return undefined;
+    } else if (type !== "object") {
       const matched = this.#primitiveCodecs.get(type);
       if (matched && matched.canEncode(value)) {
         return matched;

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -89,7 +89,7 @@ export {
   FABRIC_PRIMITIVE_VALUE_TAGS,
   type FabricPrimitiveValueTag,
   JS_TYPE_VALUE_TAGS,
-  jsTypeTag,
+  jsTagFromValue,
   type JsTypeValueTag,
   tagFromFabricPrimitive,
   tagFromFabricPrimitiveElseNull,

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -89,6 +89,7 @@ export {
   FABRIC_PRIMITIVE_VALUE_TAGS,
   type FabricPrimitiveValueTag,
   JS_TYPE_VALUE_TAGS,
+  jsTypeTag,
   type JsTypeValueTag,
   tagFromFabricPrimitive,
   tagFromFabricPrimitiveElseNull,

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -190,79 +190,70 @@ function feedLength(hasher: IncrementalHasher, value: number): void {
 
 /**
  * Feeds a single `FabricValue` into the hasher, using the type-tagged byte
- * format from the byte-level spec.
+ * format from the byte-level spec. Dispatches on the value's tag, with the
+ * primitives ahead of everything else, those being the leaves a walk ends at.
  */
 function feedValue(hasher: IncrementalHasher, value: unknown): void {
-  switch (typeof value) {
-    case "boolean":
+  switch (tagFromNativeValueElseNull(value)) {
+    case VALUE_TAGS.boolean: {
       hasher.update(value ? TAG_BOOLEAN_TRUE_BYTES : TAG_BOOLEAN_FALSE_BYTES);
-      break;
+      return;
+    }
 
-    case "number":
+    case VALUE_TAGS.number: {
       hasher.update(TAG_NUMBER_BYTES);
       if (Number.isNaN(value)) {
         hasher.update(CANONICAL_NAN_BYTES);
       } else {
-        f64View.setFloat64(0, value, false); // big-endian
+        f64View.setFloat64(0, value as number, false); // big-endian
         hasher.update(f64Bytes);
       }
-      break;
-
-    case "string": {
-      hasher.update(getStringRep(value));
-      break;
+      return;
     }
 
-    case "bigint": {
+    case VALUE_TAGS.string: {
+      hasher.update(getStringRep(value as string));
+      return;
+    }
+
+    case VALUE_TAGS.bigint: {
       hasher.update(TAG_BIGINT_BYTES);
-      const bytes = bigintToMinimalTwosComplement(value);
+      const bytes = bigintToMinimalTwosComplement(value as bigint);
       feedLength(hasher, bytes.length);
       hasher.update(bytes);
-      break;
+      return;
     }
 
-    case "symbol": {
-      const key = Symbol.keyFor(value);
+    case VALUE_TAGS.symbol: {
+      const key = Symbol.keyFor(value as symbol);
       if (key === undefined) {
         throw new Error("Cannot hash unique (uninterned) symbol");
       }
       hasher.update(TAG_SYMBOL_BYTES);
       hasher.update(getStringRep(key));
-      break;
+      return;
     }
 
-    case "undefined":
+    case VALUE_TAGS.undefined: {
       hasher.update(TAG_UNDEFINED_BYTES);
-      break;
+      return;
+    }
 
-    case "object":
-      if (value === null) {
-        hasher.update(TAG_NULL_BYTES);
-      } else {
-        feedObjectValue(hasher, value);
-      }
-      break;
+    case VALUE_TAGS.null: {
+      hasher.update(TAG_NULL_BYTES);
+      return;
+    }
 
-    default:
-      throw new Error(
-        `\`hashOf()\`: unsupported type \`${typeof value}\``,
-      );
-  }
-}
+    case VALUE_TAGS.Array: {
+      feedArray(hasher, value as unknown[]);
+      return;
+    }
 
-/**
- * Feed an object-typed value (`FabricPrimitive`, `FabricInstance`, `Array`,
- * or plain object) into the hasher. Dispatches via
- * `tagFromNativeValueElseNull()` / `VALUE_TAGS` for recognized types. The
- * `null` case is handled by the caller (`feedValue()`).
- */
-function feedObjectValue(
-  hasher: IncrementalHasher,
-  value: object,
-): void {
-  const nativeTag = tagFromNativeValueElseNull(value);
+    case VALUE_TAGS.Object: {
+      feedPlainObject(hasher, value as Record<string, unknown>);
+      return;
+    }
 
-  switch (nativeTag) {
     case VALUE_TAGS.FabricEpochNsec: {
       hasher.update(TAG_EPOCH_NSEC_BYTES);
       const bytes = bigintToMinimalTwosComplement(
@@ -294,14 +285,6 @@ function feedObjectValue(
       hasher.update(cidBytes);
       return;
     }
-
-    case VALUE_TAGS.Array:
-      feedArray(hasher, value as unknown[]);
-      return;
-
-    case VALUE_TAGS.Object:
-      feedPlainObject(hasher, value as Record<string, unknown>);
-      return;
 
     case VALUE_TAGS.FabricBytes: {
       hasher.update(TAG_BYTES_BYTES);
@@ -357,12 +340,16 @@ function feedObjectValue(
       return;
     }
 
+    case VALUE_TAGS.function: {
+      throw new Error("`hashOf()`: unsupported type `function`");
+    }
+
     default: {
       // Nothing else is handled. As of this writing, specifically missing are
       // `Map`, `Set`, and `Error`.
       throw new Error(
         `\`hashOf()\`: unsupported object type ${
-          backtickQuote(value?.constructor?.name ?? typeof value)
+          backtickQuote((value as object).constructor?.name ?? typeof value)
         }`,
       );
     }

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -190,70 +190,79 @@ function feedLength(hasher: IncrementalHasher, value: number): void {
 
 /**
  * Feeds a single `FabricValue` into the hasher, using the type-tagged byte
- * format from the byte-level spec. Dispatches on the value's tag, with the
- * primitives ahead of everything else, those being the leaves a walk ends at.
+ * format from the byte-level spec.
  */
 function feedValue(hasher: IncrementalHasher, value: unknown): void {
-  switch (tagFromNativeValueElseNull(value)) {
-    case VALUE_TAGS.boolean: {
+  switch (typeof value) {
+    case "boolean":
       hasher.update(value ? TAG_BOOLEAN_TRUE_BYTES : TAG_BOOLEAN_FALSE_BYTES);
-      return;
-    }
+      break;
 
-    case VALUE_TAGS.number: {
+    case "number":
       hasher.update(TAG_NUMBER_BYTES);
       if (Number.isNaN(value)) {
         hasher.update(CANONICAL_NAN_BYTES);
       } else {
-        f64View.setFloat64(0, value as number, false); // big-endian
+        f64View.setFloat64(0, value, false); // big-endian
         hasher.update(f64Bytes);
       }
-      return;
+      break;
+
+    case "string": {
+      hasher.update(getStringRep(value));
+      break;
     }
 
-    case VALUE_TAGS.string: {
-      hasher.update(getStringRep(value as string));
-      return;
-    }
-
-    case VALUE_TAGS.bigint: {
+    case "bigint": {
       hasher.update(TAG_BIGINT_BYTES);
-      const bytes = bigintToMinimalTwosComplement(value as bigint);
+      const bytes = bigintToMinimalTwosComplement(value);
       feedLength(hasher, bytes.length);
       hasher.update(bytes);
-      return;
+      break;
     }
 
-    case VALUE_TAGS.symbol: {
-      const key = Symbol.keyFor(value as symbol);
+    case "symbol": {
+      const key = Symbol.keyFor(value);
       if (key === undefined) {
         throw new Error("Cannot hash unique (uninterned) symbol");
       }
       hasher.update(TAG_SYMBOL_BYTES);
       hasher.update(getStringRep(key));
-      return;
+      break;
     }
 
-    case VALUE_TAGS.undefined: {
+    case "undefined":
       hasher.update(TAG_UNDEFINED_BYTES);
-      return;
-    }
+      break;
 
-    case VALUE_TAGS.null: {
-      hasher.update(TAG_NULL_BYTES);
-      return;
-    }
+    case "object":
+      if (value === null) {
+        hasher.update(TAG_NULL_BYTES);
+      } else {
+        feedObjectValue(hasher, value);
+      }
+      break;
 
-    case VALUE_TAGS.Array: {
-      feedArray(hasher, value as unknown[]);
-      return;
-    }
+    default:
+      throw new Error(
+        `\`hashOf()\`: unsupported type \`${typeof value}\``,
+      );
+  }
+}
 
-    case VALUE_TAGS.Object: {
-      feedPlainObject(hasher, value as Record<string, unknown>);
-      return;
-    }
+/**
+ * Feed an object-typed value (`FabricPrimitive`, `FabricInstance`, `Array`,
+ * or plain object) into the hasher. Dispatches via
+ * `tagFromNativeValueElseNull()` / `VALUE_TAGS` for recognized types. The
+ * `null` case is handled by the caller (`feedValue()`).
+ */
+function feedObjectValue(
+  hasher: IncrementalHasher,
+  value: object,
+): void {
+  const nativeTag = tagFromNativeValueElseNull(value);
 
+  switch (nativeTag) {
     case VALUE_TAGS.FabricEpochNsec: {
       hasher.update(TAG_EPOCH_NSEC_BYTES);
       const bytes = bigintToMinimalTwosComplement(
@@ -285,6 +294,14 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
       hasher.update(cidBytes);
       return;
     }
+
+    case VALUE_TAGS.Array:
+      feedArray(hasher, value as unknown[]);
+      return;
+
+    case VALUE_TAGS.Object:
+      feedPlainObject(hasher, value as Record<string, unknown>);
+      return;
 
     case VALUE_TAGS.FabricBytes: {
       hasher.update(TAG_BYTES_BYTES);
@@ -340,16 +357,12 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
       return;
     }
 
-    case VALUE_TAGS.function: {
-      throw new Error("`hashOf()`: unsupported type `function`");
-    }
-
     default: {
       // Nothing else is handled. As of this writing, specifically missing are
       // `Map`, `Set`, and `Error`.
       throw new Error(
         `\`hashOf()\`: unsupported object type ${
-          backtickQuote((value as object).constructor?.name ?? typeof value)
+          backtickQuote(value?.constructor?.name ?? typeof value)
         }`,
       );
     }

--- a/packages/data-model/src/value-tags.ts
+++ b/packages/data-model/src/value-tags.ts
@@ -147,7 +147,7 @@ export function tagFromFabricPrimitiveElseNull(
  * Returns `object` for any other object, which has no JS type tag; its tag is
  * a question for `tagFromFabricValue()` or `tagFromNativeValueElseNull()`.
  */
-export function jsTypeTag(value: unknown): JsTypeValueTag | "object" {
+export function jsTagFromValue(value: unknown): JsTypeValueTag | "object" {
   return (value === null) ? VALUE_TAGS.null : typeof value;
 }
 
@@ -175,7 +175,7 @@ export function tagFromFabricValue(value: FabricValue): ValueTag {
 export function tagFromFabricValueElseNull(
   value: FabricValue,
 ): ValueTag | null {
-  const jsType = jsTypeTag(value);
+  const jsType = jsTagFromValue(value);
 
   if (jsType === VALUE_TAGS.function) {
     // A function is no `FabricValue`, so its tag is not one this returns.
@@ -293,7 +293,7 @@ export function tagFromNativeBuiltinClassElseNull(
  * the array rule, which alone decides what an array may be.
  */
 export function tagFromNativeValueElseNull(value: unknown): ValueTag | null {
-  const jsType = jsTypeTag(value);
+  const jsType = jsTagFromValue(value);
 
   if (jsType !== "object") {
     return jsType;

--- a/packages/data-model/src/value-tags.ts
+++ b/packages/data-model/src/value-tags.ts
@@ -145,7 +145,7 @@ export function tagFromFabricPrimitiveElseNull(
  * Maps a value to its JS type tag, which is decided by `typeof` alone: the
  * `typeof` name of a non-object, and the `null` tag for the value `null`.
  * Returns `object` for any other object, which has no JS type tag; its tag is
- * a question for one of the value dispatches below.
+ * a question for `tagFromFabricValue()` or `tagFromNativeValueElseNull()`.
  */
 export function jsTypeTag(value: unknown): JsTypeValueTag | "object" {
   return (value === null) ? VALUE_TAGS.null : typeof value;

--- a/packages/data-model/src/value-tags.ts
+++ b/packages/data-model/src/value-tags.ts
@@ -142,6 +142,16 @@ export function tagFromFabricPrimitiveElseNull(
 }
 
 /**
+ * Maps a value to its JS type tag, which is decided by `typeof` alone: the
+ * `typeof` name of a non-object, and the `null` tag for the value `null`.
+ * Returns `object` for any other object, which has no JS type tag; its tag is
+ * a question for one of the value dispatches below.
+ */
+export function jsTypeTag(value: unknown): JsTypeValueTag | "object" {
+  return (value === null) ? VALUE_TAGS.null : typeof value;
+}
+
+/**
  * Maps a presumed valid `FabricValue` to its tag. This `throw`s if it
  * determines that the given value cannot possibly be valid. To be clear, this
  * function does not go out of its way to make a validity determination.
@@ -165,15 +175,13 @@ export function tagFromFabricValue(value: FabricValue): ValueTag {
 export function tagFromFabricValueElseNull(
   value: FabricValue,
 ): ValueTag | null {
-  const type = typeof value;
+  const jsType = jsTypeTag(value);
 
-  if (type === "function") {
+  if (jsType === VALUE_TAGS.function) {
+    // A function is no `FabricValue`, so its tag is not one this returns.
     return null;
-  } else if (type !== "object") {
-    // A primitive's tag is its `typeof` name.
-    return type;
-  } else if (value === null) {
-    return VALUE_TAGS.null;
+  } else if (jsType !== "object") {
+    return jsType;
   }
 
   if (isFabricArray(value)) {
@@ -285,13 +293,10 @@ export function tagFromNativeBuiltinClassElseNull(
  * the array rule, which alone decides what an array may be.
  */
 export function tagFromNativeValueElseNull(value: unknown): ValueTag | null {
-  const type = typeof value;
+  const jsType = jsTypeTag(value);
 
-  if (type !== "object") {
-    // The tag of a primitive or a function is its `typeof` name.
-    return type;
-  } else if (value === null) {
-    return VALUE_TAGS.null;
+  if (jsType !== "object") {
+    return jsType;
   }
 
   // Arrays first, and unconditionally: see above.

--- a/packages/data-model/test/value-tags.test.ts
+++ b/packages/data-model/test/value-tags.test.ts
@@ -48,7 +48,7 @@ import {
   FABRIC_PRIMITIVE_VALUE_TAGS,
   type FabricPrimitiveValueTag,
   JS_TYPE_VALUE_TAGS,
-  jsTypeTag,
+  jsTagFromValue,
   type JsTypeValueTag,
   tagFromFabricPrimitive,
   tagFromFabricPrimitiveElseNull,
@@ -205,10 +205,10 @@ describe("value-tags", () => {
     });
   });
 
-  describe("jsTypeTag()", () => {
+  describe("jsTagFromValue()", () => {
     for (const [label, value, tag] of JS_TYPE_TAGS) {
       it(`returns \`${tag}\` for ${label}`, () => {
-        expect(jsTypeTag(value)).toBe(tag);
+        expect(jsTagFromValue(value)).toBe(tag);
       });
     }
 
@@ -217,12 +217,12 @@ describe("value-tags", () => {
       // its class; a plain object, an array, and both kinds of fabric class
       // are the same to this.
 
-      expect(jsTypeTag({})).toBe("object");
-      expect(jsTypeTag([])).toBe("object");
-      expect(jsTypeTag(new Date())).toBe("object");
-      expect(jsTypeTag(new FabricHash(new Uint8Array(32), "fid1")))
+      expect(jsTagFromValue({})).toBe("object");
+      expect(jsTagFromValue([])).toBe("object");
+      expect(jsTagFromValue(new Date())).toBe("object");
+      expect(jsTagFromValue(new FabricHash(new Uint8Array(32), "fid1")))
         .toBe("object");
-      expect(jsTypeTag(FabricError.fromNativeError(new Error("x"))))
+      expect(jsTagFromValue(FabricError.fromNativeError(new Error("x"))))
         .toBe("object");
     });
   });

--- a/packages/data-model/test/value-tags.test.ts
+++ b/packages/data-model/test/value-tags.test.ts
@@ -48,6 +48,7 @@ import {
   FABRIC_PRIMITIVE_VALUE_TAGS,
   type FabricPrimitiveValueTag,
   JS_TYPE_VALUE_TAGS,
+  jsTypeTag,
   type JsTypeValueTag,
   tagFromFabricPrimitive,
   tagFromFabricPrimitiveElseNull,
@@ -201,6 +202,28 @@ describe("value-tags", () => {
       expect(new Set(JS_TYPE_TAGS.map(([, , tag]) => tag))).toEqual(
         new Set(Object.values(JS_TYPE_VALUE_TAGS)),
       );
+    });
+  });
+
+  describe("jsTypeTag()", () => {
+    for (const [label, value, tag] of JS_TYPE_TAGS) {
+      it(`returns \`${tag}\` for ${label}`, () => {
+        expect(jsTypeTag(value)).toBe(tag);
+      });
+    }
+
+    it("returns `object` for an object of any kind", () => {
+      // The value `null` has a tag and every other object has none, whatever
+      // its class; a plain object, an array, and both kinds of fabric class
+      // are the same to this.
+
+      expect(jsTypeTag({})).toBe("object");
+      expect(jsTypeTag([])).toBe("object");
+      expect(jsTypeTag(new Date())).toBe("object");
+      expect(jsTypeTag(new FabricHash(new Uint8Array(32), "fid1")))
+        .toBe("object");
+      expect(jsTypeTag(FabricError.fromNativeError(new Error("x"))))
+        .toBe("object");
     });
   });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## Summary

The per-type value tags reach the two places that had been asking the
`typeof` question by hand.

* `jsTagFromValue()` is that question with `null` corrected: it returns a
  value's JS type tag, or `object` for anything `typeof` files there other
  than `null`. Both value dispatches in `value-tags.ts` open with it, in place
  of a `typeof` ladder each.
* `CodecRegistry`'s primitive `type` keys, `PrimitiveTypeName`, are derived
  from the vocabulary as the JS type tags less `function`, rather than listed
  by hand. Its encode dispatch reads a value's key through `jsTagFromValue()`
  in place of a `switch` over the `typeof` results.

`value-hash.ts` is unchanged. Its `feedValue()` keeps a `typeof` switch over
the primitives ahead of the tag dispatch over objects: a single switch on the
tag measured two to four percent slower per leaf on uncached container walks,
which novel hashes are common enough to make not worth the simplicity.

## Benchmarks

Three runs per side, medians of `deno bench --json`. The decode cases, which
touch none of the changed code, sit within ±2% and are the control.

* `hashing.bench.ts` on the final tree: median delta +0.1%, spread -4.4% to
  +4.5% with mixed signs, which is noise. The single-switch `feedValue()` that
  was tried and dropped measured +2.4% to +4.2% on every uncached container
  case, holding its percentage as size grew.
* `codec-json.bench.ts` and `codec-realm.bench.ts` were measured with that
  dropped change in the tree as well; nothing in either bench reaches
  `value-hash.ts`, so the numbers stand for the registry change. Encode of
  primitive-heavy arrays measured +5% to +6%, encode of one primitive about
  +2 ns (39 to 41 ns), encode of objects +2% to +4.5%.

## Verification

Locally on the final tree: the `data-model` suite, `deno task check`,
`deno lint`, and `deno fmt --check`. The `runner`, `memory`, and connector
suites are left to CI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

