### PR TITLE
fix(test-selection): measure flakiness against a test's passing runs

### DIFF
--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -158,14 +158,17 @@ setting to fix.
 | `ENVIRONMENTAL_MIN_SOURCES` | 5 | sources | chosen | How many distinct sources a failure must span inside `CATCH_BREADTH_WINDOW_DAYS` before it reads as the environment. Up when a genuinely broad regression is written off; down when a broken runner's failures still count as catches. |
 | `CHURN_HALF_LIFE_DAYS` | 14 | days | chosen | Up when recent trouble should stay relevant for longer; down when a problem already fixed keeps its tests selected for weeks afterwards. |
 | `CHURN_WINDOW_DAYS` | 60 | days | chosen | How far back the decayed counts are read. Past this the weight is under one part in sixteen, so moving it is a performance decision rather than a policy one. |
-| `FLAKE_WINDOW_DAYS` | 60 | days | chosen | Up when a flake rate swings about on too little evidence; down when a test that has since been fixed stays excluded. |
+| `FLAKE_HALF_LIFE_RUNS` | 200 | runs | chosen | How many runs without disagreeing halve what a disagreement counts for. It is also how much evidence the share is measured over, so far below one over `FLAKE_EXCLUSION_RATE` the share swings about on too little: up when it does; down when a test that has plainly settled is still judged by what it did. |
+| `FLAKE_WINDOW_DAYS` | 60 | days | chosen | How far back the counts are read at all. The weight decays by runs rather than by days, so this bounds what is remembered rather than marking where the weight has faded: a test that runs rarely can still be carrying weight when its days fall off the end. |
 | `COST_WINDOW_DAYS` | 7 | days | chosen | Up when cost estimates are noisy; down when durations drift with the code or the runner image faster than the estimate follows. |
 | `FILL_VALUE_SHARE` | 0.6 | share of the run's budget | chosen | Up when expensive high-value tests are crowded out by cheap ones; down when a lane spends its budget on a few slow tests and runs little else. The three shares sum to one. |
 | `FILL_DENSITY_SHARE` | 0.25 | share of the run's budget | chosen | Up when more of the cheap tail should run; down when the tail is displacing tests with a record. |
 | `FILL_EXPLORATION_SHARE` | 0.15 | share of the run's budget | chosen | Up when the unselected corpus is going stale; down when lanes spend the share on tests that never find anything. |
-| `FLAKE_EXCLUSION_RATE` | 0.05 | share of runs | chosen | Up when fewer tests should be held back from pull requests; down when flakes are still blocking people. |
-| `FLAKE_REPEAT_RATES` | 0.01, 0.03 | share of runs | chosen | Up when repeats cost more lane time than the intermittent failures they catch are worth; down when intermittent failures are still slipping through. Every band stays under `FLAKE_EXCLUSION_RATE`, or an item is excluded before it reaches the band and the band never fires. |
-| `MAX_REPEATS` | 3 | runs of one item | chosen | Up when intermittent regressions still get through; down when repeats are crowding a lane. |
+| `FLAKE_EXCLUSION_RATE` | 0.005 | share of runs | chosen | Up when fewer tests should be held back from pull requests; down when flakes are still blocking people. |
+| `FLAKE_MIN_EXECUTIONS` | 2 | runs of one item | chosen | What an item that has ever disagreed runs. Down to one when the cheapest evidence of intermittency is not worth a second execution; nowhere useful above two, since the line through the anchor covers everything flakier. |
+| `FLAKE_ANCHOR_RATE` | 0.01 | share of runs | chosen | With `FLAKE_ANCHOR_EXECUTIONS`, the point the count's line passes through. Down to make the count climb faster with the rate; up to make it climb slower. |
+| `FLAKE_ANCHOR_EXECUTIONS` | 5 | runs of one item | chosen | What an item at `FLAKE_ANCHOR_RATE` runs. Up when intermittent regressions still get through; down when executions crowd a lane. |
+| `MAX_EXECUTIONS` | 10 | runs of one item | chosen | Where the line stops. Up when the flakiest items a change forces in still are not proven by what runs; down when they crowd a lane. |
 | `SUITE_FLAKE_PRIOR_RATE` | 0.02 | share of runs | chosen | Up when too many suites count as flake-prone and their new items are repeated needlessly; down when new tests in a noisy suite land unrepeated and then flake. |
 | `COVERAGE_COMMENT_LINES` | 25 | lines | chosen | Up when coverage comments are too noisy; down when debt is climbing unnoticed. |
 | `LOCAL_COVERAGE_MAX_SECONDS` | 30 | seconds | chosen | Up when too many packages are reported as expensive for the report to be worth reading; down when one is quietly eating a lane. Nothing is excluded either way; it only decides what the summary mentions. |
@@ -611,8 +614,9 @@ is counted per author, per team, or per anything, and no history is kept:
 each comment is a pure function of one run, and no tile, report or query
 rolls them up. A test the selector declined to run is described as
 coverage this design traded away, because the author did not miss it. A
-test the store knows disagrees with itself is labelled as one. And the
-comment is edited in place rather than repeated, which the hidden marker
+test the store has seen disagreeing with itself is labelled as one, with
+the counts behind the label rather than a figure to be taken on trust.
+And the comment is edited in place rather than repeated, which the hidden marker
 at the top makes possible; a later attempt that finds nothing withdraws
 what an earlier one said.
 

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1609,8 +1609,8 @@ too noisy to judge a change by. `main` still runs it, the dashboard still
 shows it, and it appears on a work queue. This replaces the usual
 quarantine list, and it is better than one in three ways: it is derived
 from measurement rather than from somebody's judgement at one moment, it
-needs no owner or expiry to stop it rotting, and it reverses on its own
-once the test is fixed. The exception is a change that edits the test
+needs no owner or expiry to stop it rotting, and it reverses on its own as
+the test goes back to passing. The exception is a change that edits the test
 itself, or that the test's suite maps onto its unit, which is very likely
 a fix and has to be allowed to prove itself.
 
@@ -1828,7 +1828,34 @@ expect that to bound the over-crediting, because a test flaky enough on
 `main` to matter is being run far more often on pull requests, but nothing
 here measures it.
 
-`flakeRate` is the share of a test's failures that fall under either rule.
+`flakeRate` is how often a test was seen falling under either rule, as a
+share of the runs it took part in rather than of the failures among them.
+What the rate decides is whether running the test once fails somebody's
+change for something its author cannot act on, and that is a chance per
+run: a test that failed once in ten thousand runs and passed on the rerun
+has every one of its failures a flake, and a share of failures would read
+it as wholly unreliable. Counting runs is also what lets an exclusion
+reverse, since a run that does not disagree lowers the share.
+
+Nothing is charged against the count. A disagreement is a proof rather
+than a sample, since a deterministic test cannot pass and fail at one
+commit, so shrinking the share toward zero would shrink it toward what
+the observation has already ruled out. A test seen twice that disagreed once
+reads a half; one that disagreed once in ten thousand runs reads a
+ten-thousandth. What separates them is how much each has been run.
+
+A disagreement's weight halves every `FLAKE_HALF_LIFE_RUNS` runs that
+follow it. A test that disagreed twice and then passed two hundred times
+has settled; one that passed two hundred times and then disagreed twice
+has just started. Those are the same counts and not the same test, and a
+flat sum over the window gives them the same number. Runs rather than
+days, because what shows a test has settled is running without
+disagreeing, and a test left untouched for three weeks has shown nothing.
+
+Both counts are published beside the share. A share cannot be weighed
+without them, and everything that shows a person this figure — the wall
+and the report a red `main` leaves — shows the counts with it. They are
+counted flat, so they are not what the share divides.
 
 Two things follow from knowing it.
 
@@ -3018,9 +3045,10 @@ observation about it:
   When a test was not selected, the honest statement is that this design
   traded that coverage away, and the comment says so in those words. The
   author did not miss anything; the selector did.
-- **It is accurate about flakes.** A test with a known flake rate is
-  labelled as one, so nobody is told they broke something that breaks on
-  its own.
+- **It is accurate about flakes.** A test the store has seen disagreeing
+  with itself is labelled as one, with the counts behind the label, so
+  nobody is told they broke something that breaks on its own and nobody
+  is asked to take that on trust.
 - **It is actionable and it ends.** Every comment says what to do, and it
   is edited in place rather than repeated when the same thing recurs.
 

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -241,10 +241,12 @@ cannot tell a pass from a lucky pass.
 
 A share the manifest records is rounded, and a share that is not zero is
 held above zero rather than rounded to it. Zero is what says a test has
-never been seen to disagree, and both this count and the exclusion turn
-on that rather than on the size of the share, so a rounding that reached
-zero would report a test as clean on the strength of how many times it
-had run.
+never been seen to disagree, and this count is the decision that turns on
+that rather than on the size of the share, so a rounding that reached
+zero would run a test once on the strength of how many times it had run.
+The exclusion turns on the size, and a share held just above zero is far
+under `FLAKE_EXCLUSION_RATE`, so what a test is selected for is the same
+either way.
 
 The line runs past `FLAKE_EXCLUSION_RATE`, which the exclusion rule makes
 sensible rather than contradictory. A test that flaky is not selected, so

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -126,13 +126,21 @@ and one number damages most of them.
 | `catches`, `lastCatch` | unbounded; `freshness` does the discounting |
 | `sources` | unbounded, counted only over catches |
 | `churn` | decayed with a `CHURN_HALF_LIFE_DAYS` half-life, read over `CHURN_WINDOW_DAYS` |
-| `flakeRate` | `FLAKE_WINDOW_DAYS` |
+| `flakeRate` | decayed with a `FLAKE_HALF_LIFE_RUNS` half-life in runs, read over `FLAKE_WINDOW_DAYS` |
 | `cost` | `COST_WINDOW_DAYS` |
 
-The counts behind `churn` are decayed rather than cut off. A ratio over a
-long undecayed window measures total historical brokenness rather than the
-current rate, and a week of failures eight months ago would otherwise
-outrank a test that is failing right now.
+The counts behind `churn` and `flakeRate` are decayed rather than cut off.
+A ratio over a long undecayed window measures total historical brokenness
+rather than the current rate, and a week of failures eight months ago
+would otherwise outrank a test that is failing right now. What they decay
+against differs, because they ask different questions. Churn asks how much
+trouble is here lately, which is a question about time. The flake share
+asks whether a test still disagrees with itself, and what answers that is
+runs that did not.
+
+One set of run counts serves both `churn` and `flakeRate`, so it is kept
+for the longer of the two windows and each term reads back only as far as
+its own.
 
 `cost` is the largest of the days' ninetieth percentiles inside its
 window: the ninetieth rather than the maximum, because one unlucky runner
@@ -142,21 +150,109 @@ the time budget.
 
 ## Flakes
 
-A flake is a test that disagrees with itself. Above
-`FLAKE_EXCLUSION_RATE` an identity leaves the selectable set entirely: it
-is too noisy to judge a change by. It keeps running on the default branch,
-it appears on the wall, and the exclusion reverses on its own the moment
-the test is fixed, which is what makes this better than a quarantine list
-somebody has to remember to empty.
+A flake is a test that disagrees with itself. `flakeRate` is how often it
+was seen doing so, as a share of the runs it took part in inside
+`FLAKE_WINDOW_DAYS`, weighted toward what it has done lately.
 
-Below that rate, an identity may be run more than once inside one run, at
-the bands `FLAKE_REPEAT_RATES` names, up to `MAX_REPEATS`. Every band
-stays under the exclusion rate, or an identity would be excluded before it
-reached the band and the band would never fire.
+A share of runs rather than a share of failures. What the rate decides is
+whether running the test once fails somebody's change for something its
+author cannot act on, and that is a chance per run. The two quantities
+differ by everything a test's passes say. A test that failed once in ten
+thousand runs, and passed when the commit was run again, has every one of
+its failures a flake: a share of failures reads it as wholly unreliable,
+and a share of runs reads it as one part in ten thousand. Counting runs is
+also what lets an exclusion reverse, since a run that does not disagree
+lowers a share of runs and leaves a share of failures exactly where it
+was.
 
-**A repeat is not a retry.** Every repeat must pass, and any failure among
-them fails the run. Three runs of a test is strictly stricter than one,
-never laxer. Nothing is retried and nothing is masked.
+The share is a lower bound on how often a test fails on its own. The only
+spurious failure it can count is one with a pass beside it at the same
+commit, and a test run once per commit produces none. What raises the
+bound is repeats, and a rising share is what buys those, so the measure
+sharpens itself on exactly the tests it is least sure of.
+
+Nothing is charged against the count, and no belief about how tests
+usually behave survives into it. **A disagreement is a proof rather than a
+sample**: a test that is deterministic cannot pass and fail at one commit,
+so an observation of one rules out the possibility the share would
+otherwise be shrunk toward. A test seen twice that disagreed once reads a
+half, and a test that disagreed once in ten thousand runs reads a
+ten-thousandth; what separates them is how much each has been run, not how
+much either is believed.
+
+So the exclusion is the plain comparison it looks like, and what it says
+is that a disagreement holds a test out until about one over the exclusion
+rate runs stand behind it. A test that has just been seen to disagree, and
+has nothing else on its record, is held out until it has shown otherwise.
+
+That cuts the other way for a disagreement the environment caused rather
+than the test. Nothing here separates the two, so a bad runner that makes
+several tests disagree at one commit holds out the ones with few runs
+behind them. The rule that reads a failure across many sources as the
+environment covers catches and not disagreements, and extending it is what
+would fix this.
+
+Both counts are published beside the share, because a share cannot be
+weighed without them: one disagreement in two runs and a thousand in two
+thousand are the same ratio and not the same claim. Everything that shows
+a person this figure shows the counts with it. They are counted flat, so
+they are not what the share divides: the share weights a day by the runs
+that have followed it, and a test reads flakier when its disagreements are
+the recent part of its counts.
+
+Above `FLAKE_EXCLUSION_RATE` an identity leaves the selectable set
+entirely: it is too noisy to judge a change by. It keeps running on the
+default branch, it appears on the wall, and the exclusion reverses on its
+own as those runs stop disagreeing, which is what makes this better than a
+quarantine list somebody has to remember to empty.
+
+A disagreement's weight halves every `FLAKE_HALF_LIFE_RUNS` runs that
+follow it, because a sum cannot tell two histories apart that nobody would
+confuse. A test that disagreed twice and then passed two hundred times has
+settled; a test that passed two hundred times and then disagreed twice has
+just started. Those are the same counts and not the same test, and an
+undecayed share gives them the same number.
+
+**Runs rather than days.** What shows a test has settled is running
+without disagreeing. A test that has sat untouched for three weeks has
+shown nothing, and a calendar that cleared it would be clearing it for
+having been left alone. So an exclusion reverses on evidence: what falls
+is the weight of what a test did against the weight of what it has done
+since, and a test that is not running does not work its way back.
+
+That is also how much evidence the share is measured over, which is what
+stops the half-life going much below one over `FLAKE_EXCLUSION_RATE`.
+Below that there are not enough runs in view to tell the rate the
+exclusion turns on from nothing.
+
+`FLAKE_WINDOW_DAYS` still bounds what is read at all. It is a bound on
+what is remembered rather than a point where the weight has faded, so a
+test that runs rarely can be carrying weight when its days fall off the
+end.
+
+### How many times a lane runs one test
+
+A test that has never disagreed with itself runs once. Any share at all
+puts it on the line through `FLAKE_MIN_EXECUTIONS` at a share of nothing
+and `FLAKE_ANCHOR_EXECUTIONS` at `FLAKE_ANCHOR_RATE`, which carries on
+past that anchor until `MAX_EXECUTIONS` stops it. So a test that has been
+seen to disagree at all is run at least twice, because one execution
+cannot tell a pass from a lucky pass.
+
+The line runs past `FLAKE_EXCLUSION_RATE`, which the exclusion rule makes
+sensible rather than contradictory. A test that flaky is not selected, so
+the only way it reaches a lane is a change that edits it or that its suite
+maps onto its unit — very likely a fix, and the execution count is what
+makes it prove itself.
+
+The exclusion threshold is per execution, and a test appears once per
+execution, so a test run five times fails a lane spuriously about five
+times as often as its share says. That cost is deliberate, and the
+exclusion is what bounds which tests pay it.
+
+**An execution is not a retry.** Every one must pass, and any failure
+among them fails the run. Five runs of a test is strictly stricter than
+one, never laxer. Nothing is retried and nothing is masked.
 
 ## What must run, and what must not
 
@@ -208,7 +304,8 @@ under the dataset area
 schema version, the generation time, the exploration seed, the commit
 whose tree was enumerated, how many runs the aggregate saw, every dial it
 was built with, the fitted calibration numbers, every identity with its
-score and the inputs behind it, the withheld set with its reason, the
+score and its flake share and the inputs and counts behind both, the
+withheld set with its reason, the
 tests a configuration deliberately does not run, a reference packing into
 lanes, the unschedulable list, a count and digest of known identities, and
 the per-package coverage baselines.
@@ -315,9 +412,10 @@ test's score, so the next change in that area runs it.
 A report addresses the change and never a person. No author is named, no
 figure is counted per author or per team, and no history of such reports
 is kept anywhere: a report is a pure function of one run, and nothing
-rolls a series of them up. A test the store holds a flake rate for is
-labelled as one, so nobody is told they broke something that breaks on
-its own.
+rolls a series of them up. A test the store has seen disagreeing with
+itself is labelled as one, with the counts behind the label, so nobody is
+told they broke something that breaks on its own and nobody is asked to
+take that on trust.
 
 Nothing gates on any of this. A report is best-effort, and a run on the
 default branch is never failed by it.

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -240,13 +240,12 @@ seen to disagree at all is run at least twice, because one execution
 cannot tell a pass from a lucky pass.
 
 A share the manifest records is rounded, and a share that is not zero is
-held above zero rather than rounded to it. Zero is what says a test has
-never been seen to disagree, and this count is the decision that turns on
-that rather than on the size of the share, so a rounding that reached
-zero would run a test once on the strength of how many times it had run.
-The exclusion turns on the size, and a share held just above zero is far
-under `FLAKE_EXCLUSION_RATE`, so what a test is selected for is the same
-either way.
+held above zero rather than rounded to it. Zero is the one point the
+count steps at, between running a test once and running it at least
+twice, and a rounding that reached zero would take that step on the
+strength of how many times a test had run. Above zero the count follows
+the size of the share, and so does the exclusion, which a share held just
+above zero leaves far under `FLAKE_EXCLUSION_RATE`.
 
 The line runs past `FLAKE_EXCLUSION_RATE`, which the exclusion rule makes
 sensible rather than contradictory. A test that flaky is not selected, so

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -239,6 +239,13 @@ past that anchor until `MAX_EXECUTIONS` stops it. So a test that has been
 seen to disagree at all is run at least twice, because one execution
 cannot tell a pass from a lucky pass.
 
+A share the manifest records is rounded, and a share that is not zero is
+held above zero rather than rounded to it. Zero is what says a test has
+never been seen to disagree, and both this count and the exclusion turn
+on that rather than on the size of the share, so a rounding that reached
+zero would report a test as clean on the strength of how many times it
+had run.
+
 The line runs past `FLAKE_EXCLUSION_RATE`, which the exclusion rule makes
 sensible rather than contradictory. A test that flaky is not selected, so
 the only way it reaches a lane is a change that edits it or that its suite

--- a/packages/dashboard/test-selection-page.test.ts
+++ b/packages/dashboard/test-selection-page.test.ts
@@ -27,6 +27,7 @@ const NOW = Date.parse("2026-08-20T04:00:00.000Z");
 function heldBack(fields: Partial<Manifest> = {}): Manifest {
   const entry = sampleEntry({ k: "unit", s: "memory", n: "space > writes" }, {
     flakeRate: 0.42,
+    flakeEvidence: { flakes: 84, runs: 180 },
   });
   return sampleManifest({
     entries: [entry],
@@ -50,12 +51,38 @@ describe("test-selection-page", () => {
       expect(page).toContain(`id="${FLAKY_SECTION_ID}"`);
     });
 
-    it("says the flake share counts failures rather than runs", () => {
-      // 100% is a share of one test's failures, so it says nothing about
-      // how often that test fails. A page showing the figure has to say so.
+    it("shows the counts a rate was taken from beside it", () => {
+      // A share without its denominator cannot be weighed, and the
+      // exclusion this page explains was decided on the share.
       const page = testSelectionPage(heldBack(), NOW);
-      expect(page).toContain("counts failures rather than runs");
-      expect(page).toContain("failed once and flaked once reads 100%");
+      expect(page).toContain("42.0% · 84 in 180");
+    });
+
+    it("shows the share alone where a manifest carries no counts", () => {
+      const bare = sampleEntry({ k: "unit", s: "memory", n: "bare" }, {
+        flakeRate: 0.3,
+      });
+      const page = testSelectionPage(
+        sampleManifest({
+          entries: [bare],
+          withheld: [{
+            test: bare.test,
+            suite: bare.suite,
+            reason: "flaky",
+          }],
+        }),
+        NOW,
+      );
+      expect(page).toContain(`<td class="measure">30.0%</td>`);
+    });
+
+    it("says the flake share counts runs, and what it is measured against", () => {
+      // A share without its denominator is not a figure anybody can read,
+      // and neither half of this one is guessable from the number.
+      const page = testSelectionPage(heldBack(), NOW);
+      expect(page).toContain("The share of the runs each test took part in");
+      expect(page).toContain("nothing is charged against the count");
+      expect(page).toContain("one disagreement among two runs reads as the half");
     });
 
     it("takes the flake window and threshold from the manifest's own dials", () => {

--- a/packages/dashboard/test-selection-page.ts
+++ b/packages/dashboard/test-selection-page.ts
@@ -12,6 +12,7 @@
 
 import {
   type Manifest,
+  type ManifestEntry,
   type TestIdentity,
   testIdentityKey,
 } from "@commonfabric/test-support/records";
@@ -127,10 +128,13 @@ function testSection(section: {
 }
 
 /**
- * What the flake share counts. The denominator is what a reader gets
- * wrong: the publisher divides a test's flakes by its failures, not by
- * its runs, so a test whose one failure in the window was a flake reads
- * 100% however reliably it passes the rest of the time.
+ * What the flake share counts. The share is over runs rather than over
+ * failures, so a test that passes reliably reads as small however many of
+ * its rare failures were flakes, and a disagreement weighs less the more
+ * runs have followed it, so a test that has settled since reads lower
+ * than one that has just started. The counts beside it are what let a reader weigh it,
+ * since one disagreement in two runs and a thousand in two thousand are
+ * the same ratio and not the same claim.
  */
 function flakeLead(manifest: Manifest): string {
   const days = numberDial(
@@ -143,34 +147,49 @@ function flakeLead(manifest: Manifest): string {
     "FLAKE_EXCLUSION_RATE",
     FLAKE_EXCLUSION_FALLBACK,
   );
-  return `The share of each test's failures over the last ${days} days that ` +
-    "were flakes: the same commit both passing and failing, with nothing " +
-    "between the two runs but chance. It counts failures rather than runs, " +
-    `so a test that failed once and flaked once reads 100%. Past ${
-      percent(exclusion)
-    } a test is held back from pull requests, and comes back on its own ` +
-    "once it stops disagreeing.";
+  return `The share of the runs each test took part in over the last ${days} ` +
+    "days that it was seen disagreeing with itself over: the same commit " +
+    "both passing and failing, with nothing between the two runs but " +
+    "chance. A test that is deterministic cannot do that, so nothing is " +
+    "charged against the count and one disagreement among two runs reads " +
+    "as the half it is; a disagreement counts for less as the test goes " +
+    "on running without repeating it. " +
+    `Past ${percent(exclusion)} a test is held back from pull requests, ` +
+    "and the share falls again as it goes on running without disagreeing, " +
+    "so the exclusion reverses on its own. The counts are flat, so they " +
+    "are not what the share divides.";
 }
 
 /** The tests held back as flaky, worst-measured first. */
 function flakyRows(manifest: Manifest): TestRow[] {
-  const rates = new Map(
-    manifest.entries.map((entry) => [
-      testIdentityKey(entry.test),
-      entry.flakeRate,
-    ]),
+  const scored = new Map(
+    manifest.entries.map((entry) => [testIdentityKey(entry.test), entry]),
   );
   return manifest.withheld
     .filter((entry) => entry.reason === "flaky")
     .map((entry) => ({
       test: entry.test,
-      rate: rates.get(testIdentityKey(entry.test)),
+      scored: scored.get(testIdentityKey(entry.test)),
     }))
-    .sort((a, b) => (b.rate ?? 0) - (a.rate ?? 0))
-    .map(({ test, rate }) => ({
+    .sort((a, b) => (b.scored?.flakeRate ?? 0) - (a.scored?.flakeRate ?? 0))
+    .map(({ test, scored }) => ({
       test,
-      measure: rate === undefined ? undefined : percent(rate),
+      ...(scored === undefined ? {} : { measure: flakeMeasure(scored) }),
     }));
+}
+
+/**
+ * One test's flake share with the counts it was taken from, where the
+ * manifest carries them. The share alone says how the exclusion was
+ * decided; the counts say how much is behind that decision.
+ */
+function flakeMeasure(entry: ManifestEntry): string {
+  const share = percent(entry.flakeRate);
+  const evidence = entry.flakeEvidence;
+  if (evidence === undefined) return share;
+  return `${share} · ${groupDigits(evidence.flakes)} in ${
+    groupDigits(evidence.runs)
+  }`;
 }
 
 /** The lanes a pull request would run, each against the budget it was packed to. */

--- a/packages/test-support/src/records/mod.ts
+++ b/packages/test-support/src/records/mod.ts
@@ -135,6 +135,7 @@ export {
 export type {
   Calibration,
   CoverageBaseline,
+  FlakeEvidence,
   LanePlan,
   Manifest,
   ManifestEntry,

--- a/packages/test-support/src/records/selection.test.ts
+++ b/packages/test-support/src/records/selection.test.ts
@@ -114,6 +114,36 @@ describe("selection", () => {
       }
     });
 
+    it("keeps an entry whose manifest carries no flake counts", () => {
+      // They are absent from a manifest written before they were
+      // published. Refusing it would cost every test its score, and an
+      // absent manifest makes the whole corpus mandatory, to save one
+      // column a reader can simply not show.
+      const manifest = sampleManifest();
+      delete manifest.entries[0]!.flakeEvidence;
+      const parsed = parseManifest(JSON.stringify(manifest));
+      expect(parsed?.entries[0]?.flakeEvidence).toBeUndefined();
+      expect(parsed?.entries.length).toBe(manifest.entries.length);
+    });
+
+    it("rejects flake counts that cannot both be true", () => {
+      // Counts of runs, and a test cannot disagree with itself more
+      // often than it ran. A count past its own denominator would put
+      // the share over one and read as a test that always flakes.
+      for (
+        const flakeEvidence of [
+          { flakes: 3, runs: 2 },
+          { flakes: -1, runs: 10 },
+          { flakes: 1.5, runs: 10 },
+          { flakes: 1, runs: -10 },
+        ]
+      ) {
+        const manifest = sampleManifest();
+        manifest.entries[0]!.flakeEvidence = flakeEvidence;
+        expect(parseManifest(JSON.stringify(manifest))).toBeUndefined();
+      }
+    });
+
     it("rejects a generation time that is not one", () => {
       // A reader measures a manifest's age from this, and a value that
       // does not parse compares false against every threshold, so a

--- a/packages/test-support/src/records/selection.ts
+++ b/packages/test-support/src/records/selection.ts
@@ -58,8 +58,21 @@ export interface ManifestEntry {
   /** The inputs behind that score, so a manifest explains itself. */
   inputs: ScoreInputs;
 
-  /** How often it disagrees with itself. */
+  /**
+   * The share of the runs it took part in that it was seen disagreeing
+   * with itself over, rather than the share of the failures among them.
+   */
   flakeRate: number;
+
+  /**
+   * The evidence behind that share, so a manifest explains this figure
+   * as it does the score. Counted flat, where the share weights recent
+   * days more heavily, so the share is not these divided. Absent from a
+   * manifest written before they were published: a reader shows nothing
+   * for it, since refusing the manifest would cost every test its score
+   * to save one column.
+   */
+  flakeEvidence?: FlakeEvidence;
 
   /** How many times a lane runs it. Every one of them must pass. */
   repeats: number;
@@ -77,6 +90,19 @@ export interface ManifestEntry {
    * it has, its siblings are not skipped and the unit is what runs.
    */
   independent?: boolean;
+}
+
+/**
+ * What a flake share was measured over. A share alone cannot be weighed:
+ * one disagreement in two runs and a thousand in two thousand are the
+ * same ratio and not the same claim.
+ */
+export interface FlakeEvidence {
+  /** Runs seen to disagree with another run of the same commit. */
+  flakes: number;
+
+  /** Runs they were seen among, inside the flake window. */
+  runs: number;
 }
 
 /** Why an identity is not selectable on a pull request. */
@@ -294,6 +320,10 @@ function parseEntry(value: unknown): ManifestEntry | undefined {
   if (value.lastRun !== undefined && !isNonEmptyString(value.lastRun)) {
     return undefined;
   }
+  const evidence = parseFlakeEvidence(value.flakeEvidence);
+  if (value.flakeEvidence !== undefined && evidence === undefined) {
+    return undefined;
+  }
   const entry: ManifestEntry = {
     test,
     suite: value.suite,
@@ -306,7 +336,26 @@ function parseEntry(value: unknown): ManifestEntry | undefined {
   };
   if (value.lastRun !== undefined) entry.lastRun = value.lastRun;
   if (value.independent !== undefined) entry.independent = value.independent;
+  if (evidence !== undefined) entry.flakeEvidence = evidence;
   return entry;
+}
+
+/**
+ * Validates the counts behind a flake share. Counts of runs, so neither
+ * is fractional or negative, and a test cannot disagree with itself more
+ * often than it ran.
+ */
+function parseFlakeEvidence(value: unknown): FlakeEvidence | undefined {
+  if (!isRecord(value)) return undefined;
+  const { flakes, runs } = value;
+  if (
+    !isFiniteNumber(flakes) || !Number.isInteger(flakes) || flakes < 0 ||
+    !isFiniteNumber(runs) || !Number.isInteger(runs) || runs < 0 ||
+    flakes > runs
+  ) {
+    return undefined;
+  }
+  return { flakes, runs };
 }
 
 /**

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -588,7 +588,9 @@ export function describePlan(
         : `, ${unmeasured} of ${entries} costs unmeasured`),
   );
   lines.push("");
-  lines.push("| Suite | Units | Tests | Their own time | Repeats | Chosen |");
+  lines.push(
+    "| Suite | Units | Tests | Their own time | Executions | Chosen |",
+  );
   lines.push("| --- | --- | --- | --- | --- | --- |");
   for (const batch of batches) {
     const share = chosenFor(batch.suite.id, chosen.selections);

--- a/tasks/post-main-report.test.ts
+++ b/tasks/post-main-report.test.ts
@@ -464,10 +464,17 @@ describe("post-main-report", () => {
     }];
     const manifest = sampleManifest({
       entries: [
-        sampleEntry(kneads, { unit, flakeRate: 0.5, cost: 1 }),
+        sampleEntry(kneads, {
+          unit,
+          flakeRate: 0.5,
+          flakeEvidence: { flakes: 20, runs: 20 },
+          cost: 1,
+        }),
+        // No counts, as an entry from a manifest written before they
+        // were published has none.
         sampleEntry(proves, {
           unit,
-          flakeRate: 0.02,
+          flakeRate: 0.002,
           cost: 1,
           inputs: { catches: 3, sources: 2, churn: 0 },
         }),
@@ -482,9 +489,14 @@ describe("post-main-report", () => {
       expect(view.selected.has(testIdentityKey(proves))).toBe(true);
     });
 
-    it("carries the flake rate and the catches behind every entry", () => {
+    it("carries the flake counts and the catches behind every entry", () => {
       const view = manifestView(manifest, suites, new Set());
-      expect(view.flakeRates.get(testIdentityKey(kneads))).toBe(0.5);
+      expect(view.flakes.get(testIdentityKey(kneads)))
+        .toEqual({ flakes: 20, runs: 20 });
+      // An entry with no counts is still a key, since membership is what
+      // says the store has seen the test at all.
+      expect(view.flakes.has(testIdentityKey(proves))).toBe(true);
+      expect(view.flakes.get(testIdentityKey(proves))).toBeUndefined();
       expect(view.catches.get(testIdentityKey(proves))).toBe(3);
     });
 

--- a/tasks/post-main-report.ts
+++ b/tasks/post-main-report.ts
@@ -47,6 +47,7 @@
 import { join } from "@std/path";
 import {
   datePartition,
+  type FlakeEvidence,
   listObjects,
   parseReportGroups,
   readObject,
@@ -427,16 +428,16 @@ export function manifestView(
   for (const entry of seen.manifest.withheld) {
     withheld.set(testIdentityKey(entry.test), entry.reason);
   }
-  const flakeRates = new Map<string, number>();
+  const flakes = new Map<string, FlakeEvidence | undefined>();
   const catches = new Map<string, number>();
   const units = new Map<string, string>();
   for (const entry of manifest.entries) {
     const key = testIdentityKey(entry.test);
-    flakeRates.set(key, entry.flakeRate);
+    flakes.set(key, entry.flakeEvidence);
     catches.set(key, entry.inputs.catches);
     units.set(key, `${entry.suite}\t${entry.unit}`);
   }
-  return { manifest: true, selected, withheld, flakeRates, catches, units };
+  return { manifest: true, selected, withheld, flakes, catches, units };
 }
 
 /**

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -764,6 +764,19 @@ describe("what buildManifest() does with the states it is given", () => {
     expect(manifest.entries[0]!.repeats).toBe(FLAKE_MIN_EXECUTIONS);
   });
 
+  it("holds a share that is not zero above the precision it records", () => {
+    // One disagreement among enough runs that the share rounds to
+    // nothing. Zero is what says a test has never been seen to disagree,
+    // so the execution count would read this as a test that never has.
+    const state = emptyState();
+    state.runsByDay["2026-08-20"] = 100_000;
+    state.failuresByDay["2026-08-20"] = 1;
+    state.flakesByDay["2026-08-20"] = 1;
+    const entry = built(new Map([[KEY, state]])).entries[0]!;
+    expect(entry.flakeRate).toBeGreaterThan(0);
+    expect(entry.repeats).toBe(FLAKE_MIN_EXECUTIONS);
+  });
+
   it("carries the counts the share was taken from", () => {
     const state = emptyState();
     state.runsByDay["2026-08-20"] = 80;

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -13,6 +13,7 @@ import {
   CI_SOURCE,
   dayOf,
   emptyAggregate,
+  executionsFor,
   Fold,
   foldReports,
   lastRun,
@@ -22,7 +23,6 @@ import {
   provenance,
   readReport,
   recordSurface,
-  repeatsFor,
   reportFromText,
 } from "./build.ts";
 import { parseManifest, serializeManifest } from "./manifest.ts";
@@ -35,8 +35,11 @@ import {
 } from "./score.ts";
 import {
   COST_WINDOW_DAYS,
+  FLAKE_ANCHOR_EXECUTIONS,
+  FLAKE_ANCHOR_RATE,
   FLAKE_EXCLUSION_RATE,
-  MAX_REPEATS,
+  FLAKE_MIN_EXECUTIONS,
+  MAX_EXECUTIONS,
 } from "./policy.ts";
 
 const NO_ALIASES = new AliasResolver([]);
@@ -194,18 +197,32 @@ describe("build", () => {
     });
   });
 
-  describe("repeatsFor()", () => {
-    it("runs a steady test once", () => {
-      expect(repeatsFor(0)).toBe(1);
+  describe("executionsFor()", () => {
+    it("runs a test that has never disagreed once", () => {
+      expect(executionsFor(0)).toBe(1);
     });
 
-    it("runs a slightly intermittent one more than once", () => {
-      expect(repeatsFor(0.02)).toBeGreaterThan(1);
-      expect(repeatsFor(0.04)).toBe(MAX_REPEATS);
+    it("runs a test that has disagreed at all at least twice", () => {
+      // One execution cannot tell a pass from a lucky pass.
+      expect(executionsFor(Number.MIN_VALUE)).toBe(FLAKE_MIN_EXECUTIONS);
+      expect(executionsFor(0.0001)).toBe(FLAKE_MIN_EXECUTIONS);
     });
 
-    it("runs one past the exclusion rate once, since it is not selected", () => {
-      expect(repeatsFor(FLAKE_EXCLUSION_RATE + 0.1)).toBe(1);
+    it("runs a test at the anchor rate the anchor count of times", () => {
+      expect(executionsFor(FLAKE_ANCHOR_RATE)).toBe(FLAKE_ANCHOR_EXECUTIONS);
+    });
+
+    it("climbs between the two, and goes on climbing past the anchor", () => {
+      const half = executionsFor(FLAKE_ANCHOR_RATE / 2);
+      expect(half).toBeGreaterThan(FLAKE_MIN_EXECUTIONS);
+      expect(half).toBeLessThan(FLAKE_ANCHOR_EXECUTIONS);
+      expect(executionsFor(FLAKE_ANCHOR_RATE * 2)).toBeGreaterThan(
+        FLAKE_ANCHOR_EXECUTIONS,
+      );
+    });
+
+    it("stops climbing at the cap", () => {
+      expect(executionsFor(1)).toBe(MAX_EXECUTIONS);
     });
   });
 
@@ -401,7 +418,12 @@ describe("build", () => {
       ]);
       const state = second.finish().states.get(KEY)!;
       expect(state.mainCatches).toBe(0);
-      expect(flakeRate(state, "2026-08-20")).toBe(1);
+      expect(state.flakesByDay["2026-08-20"]).toBe(1);
+      // One run of two disagreed, which is what holds it out until it
+      // has run enough to say the rate is lower than that.
+      expect(flakeRate(state, "2026-08-20")).toBeGreaterThan(
+        FLAKE_EXCLUSION_RATE,
+      );
     });
 
     it("does not fold an object it has already folded", () => {
@@ -720,11 +742,40 @@ describe("what buildManifest() does with the states it is given", () => {
 
   it("withholds a test that disagrees with itself too often", () => {
     const state = emptyState();
+    state.runsByDay["2026-08-20"] = 100;
     state.failuresByDay["2026-08-20"] = 10;
     state.flakesByDay["2026-08-20"] = 10;
     const manifest = built(new Map([[KEY, state]]));
     expect(manifest.withheld.length).toBe(1);
     expect(manifest.withheld[0]!.reason).toBe("flaky");
+  });
+
+  it("withholds nothing for a test that flaked once and passes since", () => {
+    // Every failure it has had was a flake, so a share of its failures
+    // would hold it out of every pull request for one bad run.
+    const state = emptyState();
+    state.runsByDay["2026-08-20"] = 10000;
+    state.failuresByDay["2026-08-20"] = 1;
+    state.flakesByDay["2026-08-20"] = 1;
+    const manifest = built(new Map([[KEY, state]]));
+    expect(manifest.withheld).toEqual([]);
+    // Selectable, and still run twice: it has disagreed with itself, and
+    // one execution cannot tell a pass from a lucky pass.
+    expect(manifest.entries[0]!.repeats).toBe(FLAKE_MIN_EXECUTIONS);
+  });
+
+  it("carries the counts the share was taken from", () => {
+    const state = emptyState();
+    state.runsByDay["2026-08-20"] = 80;
+    state.failuresByDay["2026-08-20"] = 12;
+    state.flakesByDay["2026-08-20"] = 12;
+    const entry = built(new Map([[KEY, state]])).entries[0]!;
+    expect(entry.flakeEvidence).toEqual({ flakes: 12, runs: 80 });
+    // The counts are what was seen, flat. The share weights recent days
+    // more heavily, so it is not those counts divided; what it is, is
+    // the figure every decision here was taken on.
+    expect(entry.flakeRate).toBe(0.15);
+    expect(entry.repeats).toBe(executionsFor(entry.flakeRate));
   });
 
   it("withholds nothing for a test that has never failed", () => {

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -528,8 +528,8 @@ export function buildManifest(input: BuildInput): Manifest {
     // carries is the figure every decision here was taken on, and a
     // consumer applying the same threshold reaches the same answer. A
     // share that is not zero is held above zero: zero is what says a
-    // test has never been seen to disagree, and both the execution count
-    // and the exclusion turn on that rather than on the size of it.
+    // test has never been seen to disagree, and the execution count
+    // turns on that rather than on the size of the share.
     const measured = flakeRate(state, input.today);
     const rate = measured === 0
       ? 0

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -527,9 +527,10 @@ export function buildManifest(input: BuildInput): Manifest {
     // Rounded before anything reads it, so the figure the manifest
     // carries is the figure every decision here was taken on, and a
     // consumer applying the same threshold reaches the same answer. A
-    // share that is not zero is held above zero: zero is what says a
-    // test has never been seen to disagree, and the execution count
-    // turns on that rather than on the size of the share.
+    // share that is not zero is held above zero, because zero is the one
+    // point the execution count steps at: once below it, at least twice
+    // above. A rounding that reached zero would take that step on how
+    // many times the test had run.
     const measured = flakeRate(state, input.today);
     const rate = measured === 0
       ? 0

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -490,6 +490,9 @@ export interface BuildInput {
   calibration?: Partial<Calibration>;
 }
 
+/** Decimal places a manifest records a flake share to. */
+const SHARE_PLACES = 4;
+
 /** A number with the digits past `places` dropped. */
 function round(value: number, places: number): number {
   const scale = 10 ** places;
@@ -523,8 +526,14 @@ export function buildManifest(input: BuildInput): Manifest {
     const evidence = flakeCounts(state, input.today);
     // Rounded before anything reads it, so the figure the manifest
     // carries is the figure every decision here was taken on, and a
-    // consumer applying the same threshold reaches the same answer.
-    const rate = round(flakeRate(state, input.today), 4);
+    // consumer applying the same threshold reaches the same answer. A
+    // share that is not zero is held above zero: zero is what says a
+    // test has never been seen to disagree, and both the execution count
+    // and the exclusion turn on that rather than on the size of it.
+    const measured = flakeRate(state, input.today);
+    const rate = measured === 0
+      ? 0
+      : Math.max(round(measured, SHARE_PLACES), 10 ** -SHARE_PLACES);
     // Rounded because the digits past these are noise, and because a
     // manifest carries one entry per identity: at twenty thousand of them
     // the difference between a rounded float and a full one is megabytes.

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -25,6 +25,7 @@ import {
   emptyContext,
   emptySamples,
   emptyState,
+  flakeCounts,
   flakeRate,
   type FoldContext,
   foldObservations,
@@ -55,10 +56,12 @@ import {
 import { ObservationSpool } from "./observation-spool.ts";
 import {
   COST_WINDOW_DAYS,
+  FLAKE_ANCHOR_EXECUTIONS,
+  FLAKE_ANCHOR_RATE,
   FLAKE_EXCLUSION_RATE,
-  FLAKE_REPEAT_RATES,
+  FLAKE_MIN_EXECUTIONS,
   LANE_PROLOGUE_SECONDS,
-  MAX_REPEATS,
+  MAX_EXECUTIONS,
 } from "./policy.ts";
 
 /** The publisher's rolling aggregate, as one stored object. */
@@ -446,14 +449,28 @@ export function locateSurfaces(
   return { placed, unplaced };
 }
 
-/** How many times a lane runs an identity, given how flaky it is. */
-export function repeatsFor(rate: number): number {
-  if (rate > FLAKE_EXCLUSION_RATE) return 1;
-  let repeats = 1;
-  for (const band of FLAKE_REPEAT_RATES) {
-    if (rate > band) repeats++;
-  }
-  return Math.min(repeats, MAX_REPEATS);
+/**
+ * How many times a lane runs an identity, given how flaky it is.
+ *
+ * A test that has never disagreed with itself runs once. Any rate at all
+ * puts it on the line through `FLAKE_MIN_EXECUTIONS` at a rate of
+ * nothing and `FLAKE_ANCHOR_EXECUTIONS` at `FLAKE_ANCHOR_RATE`, which
+ * carries on past that anchor until `MAX_EXECUTIONS` stops it.
+ *
+ * The line runs past `FLAKE_EXCLUSION_RATE` on purpose. A test that
+ * flaky is not selected, so the only way it reaches a lane is a change
+ * that edits it or that its suite maps onto its unit — which is very
+ * likely a fix, and the count is what makes it prove itself.
+ */
+export function executionsFor(rate: number): number {
+  if (rate <= 0) return 1;
+  const line = FLAKE_MIN_EXECUTIONS +
+    (FLAKE_ANCHOR_EXECUTIONS - FLAKE_MIN_EXECUTIONS) *
+      (rate / FLAKE_ANCHOR_RATE);
+  return Math.min(
+    MAX_EXECUTIONS,
+    Math.max(FLAKE_MIN_EXECUTIONS, Math.round(line)),
+  );
 }
 
 /** What a manifest is built from beyond the folded state. */
@@ -503,7 +520,11 @@ export function buildManifest(input: BuildInput): Manifest {
     if (test === undefined) continue;
     const surface = input.surfaces.get(key) ?? recordSurface(test, undefined);
     const inputs = scoreInputs(state, input.today);
-    const rate = flakeRate(state, input.today);
+    const evidence = flakeCounts(state, input.today);
+    // Rounded before anything reads it, so the figure the manifest
+    // carries is the figure every decision here was taken on, and a
+    // consumer applying the same threshold reaches the same answer.
+    const rate = round(flakeRate(state, input.today), 4);
     // Rounded because the digits past these are noise, and because a
     // manifest carries one entry per identity: at twenty thousand of them
     // the difference between a rounded float and a full one is megabytes.
@@ -517,8 +538,9 @@ export function buildManifest(input: BuildInput): Manifest {
       cost: round(costSeconds(state, input.today), 3),
       score: round(value(inputs, input.today), 4),
       inputs,
-      flakeRate: round(rate, 4),
-      repeats: repeatsFor(rate),
+      flakeRate: rate,
+      flakeEvidence: evidence,
+      repeats: executionsFor(rate),
       ...(ran === undefined ? {} : { lastRun: ran }),
     });
     if (rate > FLAKE_EXCLUSION_RATE) {

--- a/tasks/test-selection/census.ts
+++ b/tasks/test-selection/census.ts
@@ -85,6 +85,7 @@ export function standIn(
     score: VALUE_FLOOR,
     inputs: { catches: 0, sources: 0, churn: 0 },
     flakeRate: 0,
+    flakeEvidence: { flakes: 0, runs: 0 },
     repeats: 1,
   };
 }

--- a/tasks/test-selection/policy.test.ts
+++ b/tasks/test-selection/policy.test.ts
@@ -160,20 +160,29 @@ describe("policy", () => {
       expect(weights + policy.VALUE_FLOOR).toBeCloseTo(1, 10);
     });
 
-    it("puts the repeat rates below the exclusion rate, in order", () => {
-      const rates = policy.FLAKE_REPEAT_RATES;
-      expect(rates.length).toBe(policy.MAX_REPEATS - 1);
-      for (let i = 1; i < rates.length; i++) {
-        expect(rates[i]!).toBeGreaterThan(rates[i - 1]!);
-      }
-      expect(rates[rates.length - 1]!).toBeLessThan(
+    it("climbs the execution count with the rate, up to its cap", () => {
+      expect(policy.FLAKE_ANCHOR_EXECUTIONS).toBeGreaterThan(
+        policy.FLAKE_MIN_EXECUTIONS,
+      );
+      expect(policy.MAX_EXECUTIONS).toBeGreaterThanOrEqual(
+        policy.FLAKE_ANCHOR_EXECUTIONS,
+      );
+      expect(policy.FLAKE_MIN_EXECUTIONS).toBeGreaterThan(1);
+    });
+
+    it("anchors the count past the rate that stops a test being picked", () => {
+      // The line is allowed past the exclusion, and has to be: what
+      // reaches a lane above that rate is a change that edits the test,
+      // and the count is what makes it prove itself.
+      expect(policy.FLAKE_ANCHOR_RATE).toBeGreaterThan(
         policy.FLAKE_EXCLUSION_RATE,
       );
     });
 
-    it("reads churn and flakes over windows the decay has faded", () => {
+    it("reads churn over a window its decay has faded", () => {
       // Past four half-lives a day's weight is under one part in sixteen,
-      // which is what makes the read window a performance choice.
+      // which is what makes that read window a performance choice. The
+      // flake window has no such property, since its decay is by runs.
       expect(policy.CHURN_WINDOW_DAYS).toBeGreaterThanOrEqual(
         4 * policy.CHURN_HALF_LIFE_DAYS,
       );

--- a/tasks/test-selection/policy.ts
+++ b/tasks/test-selection/policy.ts
@@ -112,7 +112,14 @@ export const CHURN_HALF_LIFE_DAYS = 14;
 /** Days of decayed failure counts the churn term reads. */
 export const CHURN_WINDOW_DAYS = 60;
 
-/** Days of history the flake rate is measured over. */
+/**
+ * Runs after a disagreement over which its weight halves. Runs rather
+ * than days, because what shows a test has settled is running without
+ * disagreeing; a test that has not run has shown nothing.
+ */
+export const FLAKE_HALF_LIFE_RUNS = 200;
+
+/** Days of flake counts the flake rate reads at all. */
 export const FLAKE_WINDOW_DAYS = 60;
 
 /** Days of durations an item's cost estimate reads. */
@@ -128,18 +135,28 @@ export const FILL_DENSITY_SHARE = 0.25;
 export const FILL_EXPLORATION_SHARE = 0.15;
 
 /** The flake rate above which an item leaves the selectable set. */
-export const FLAKE_EXCLUSION_RATE = 0.05;
+export const FLAKE_EXCLUSION_RATE = 0.005;
 
 /**
- * The flake rates at which an item is run twice and three times. Below
- * the first it runs once. Every band has to stay under
- * `FLAKE_EXCLUSION_RATE`, or an item reaches the exclusion before it
- * reaches the band and the band never fires.
+ * What an item that has ever disagreed with itself runs, however rarely
+ * it does. One execution cannot tell a pass from a lucky pass, so an
+ * item with any flake rate at all is run at least twice.
  */
-export const FLAKE_REPEAT_RATES: readonly number[] = [0.01, 0.03];
+export const FLAKE_MIN_EXECUTIONS = 2;
+
+/**
+ * The flake rate the execution count is anchored at, with
+ * `FLAKE_ANCHOR_EXECUTIONS`. Between that point and
+ * `FLAKE_MIN_EXECUTIONS` at a rate of nothing, and beyond it, the count
+ * is the line through the two.
+ */
+export const FLAKE_ANCHOR_RATE = 0.01;
+
+/** What an item at `FLAKE_ANCHOR_RATE` runs. */
+export const FLAKE_ANCHOR_EXECUTIONS = 5;
 
 /** The most times one item is run inside a lane. */
-export const MAX_REPEATS = 3;
+export const MAX_EXECUTIONS = 10;
 
 /** The suite flake rate above which a suite's new items are repeated. */
 export const SUITE_FLAKE_PRIOR_RATE = 0.02;
@@ -529,13 +546,25 @@ export const DIALS: readonly Dial[] = [
       "rather than a policy one.",
   },
   {
+    name: "FLAKE_HALF_LIFE_RUNS",
+    value: FLAKE_HALF_LIFE_RUNS,
+    unit: "runs",
+    setBy: "chosen",
+    why: "How many runs without disagreeing halve what a disagreement counts " +
+      "for. It is also how much evidence the share is measured over, so far " +
+      "below one over `FLAKE_EXCLUSION_RATE` the share swings about on too " +
+      "little: up when it does; down when a test that has plainly settled " +
+      "is still judged by what it did.",
+  },
+  {
     name: "FLAKE_WINDOW_DAYS",
     value: FLAKE_WINDOW_DAYS,
     unit: "days",
     setBy: "chosen",
-    why:
-      "Up when a flake rate swings about on too little evidence; down when a " +
-      "test that has since been fixed stays excluded.",
+    why: "How far back the counts are read at all. The weight decays by " +
+      "runs rather than by days, so this bounds what is remembered rather " +
+      "than marking where the weight has faded: a test that runs rarely can " +
+      "still be carrying weight when its days fall off the end.",
   },
   {
     name: "COST_WINDOW_DAYS",
@@ -582,24 +611,40 @@ export const DIALS: readonly Dial[] = [
       "flakes are still blocking people.",
   },
   {
-    name: "FLAKE_REPEAT_RATES",
-    value: FLAKE_REPEAT_RATES,
-    unit: "share of runs",
+    name: "FLAKE_MIN_EXECUTIONS",
+    value: FLAKE_MIN_EXECUTIONS,
+    unit: "runs of one item",
     setBy: "chosen",
-    why: "Up when repeats cost more lane time than the intermittent failures " +
-      "they catch are worth; down when intermittent failures are still " +
-      "slipping through. Every band stays under `FLAKE_EXCLUSION_RATE`, or " +
-      "an item is excluded before it reaches the band and the band never " +
-      "fires.",
+    why: "What an item that has ever disagreed runs. Down to one when the " +
+      "cheapest evidence of intermittency is not worth a second execution; " +
+      "nowhere useful above two, since the line through the anchor covers " +
+      "everything flakier.",
   },
   {
-    name: "MAX_REPEATS",
-    value: MAX_REPEATS,
+    name: "FLAKE_ANCHOR_RATE",
+    value: FLAKE_ANCHOR_RATE,
+    unit: "share of runs",
+    setBy: "chosen",
+    why: "With `FLAKE_ANCHOR_EXECUTIONS`, the point the count's line passes " +
+      "through. Down to make the count climb faster with the rate; up to " +
+      "make it climb slower.",
+  },
+  {
+    name: "FLAKE_ANCHOR_EXECUTIONS",
+    value: FLAKE_ANCHOR_EXECUTIONS,
+    unit: "runs of one item",
+    setBy: "chosen",
+    why: "What an item at `FLAKE_ANCHOR_RATE` runs. Up when intermittent " +
+      "regressions still get through; down when executions crowd a lane.",
+  },
+  {
+    name: "MAX_EXECUTIONS",
+    value: MAX_EXECUTIONS,
     unit: "runs of one item",
     setBy: "chosen",
     why:
-      "Up when intermittent regressions still get through; down when repeats " +
-      "are crowding a lane.",
+      "Where the line stops. Up when the flakiest items a change forces in " +
+      "still are not proven by what runs; down when they crowd a lane.",
   },
   {
     name: "SUITE_FLAKE_PRIOR_RATE",

--- a/tasks/test-selection/report.test.ts
+++ b/tasks/test-selection/report.test.ts
@@ -96,7 +96,7 @@ function ranThere(
     ...unknownPullRequest(),
     manifest: true,
     ran: run(entries),
-    flakeRates: new Map(entries.map(([name]) => [key(name), 0])),
+    flakes: new Map(entries.map(([name]) => [key(name), undefined])),
     ...extra,
   };
 }
@@ -115,7 +115,7 @@ function knows(
     ...unknownPullRequest(),
     manifest: true,
     ran: new Map(),
-    flakeRates: new Map(names.map((name) => [key(name), 0])),
+    flakes: new Map(names.map((name) => [key(name), undefined])),
     ...extra,
   };
 }
@@ -185,9 +185,9 @@ describe("report", () => {
     it("separates each reason a run did not reach a test", () => {
       const view = knows(["bakes"], {
         withheld: new Map([[key("kneads"), "flaky" as const]]),
-        flakeRates: new Map([
-          [key("kneads"), 0],
-          [key("bakes"), 0],
+        flakes: new Map([
+          [key("kneads"), undefined],
+          [key("bakes"), undefined],
         ]),
       });
       expect(selectionOf(view, key("kneads"))).toBe("withheld-flaky");
@@ -208,7 +208,7 @@ describe("report", () => {
     // manifest explains is the test skipping itself.
     it("separates a skip the selector chose from one the test chose", () => {
       const chosen = ranThere([["kneads", "skip"]], {
-        flakeRates: new Map([[key("kneads"), 0]]),
+        flakes: new Map([[key("kneads"), undefined]]),
       });
       expect(selectionOf(chosen, key("kneads"))).toBe("not-selected");
       const itself: PullRequestView = {
@@ -216,7 +216,7 @@ describe("report", () => {
         manifest: true,
         ran: run([["kneads", "skip"]]),
         selected: new Set([key("kneads")]),
-        flakeRates: new Map([[key("kneads"), 0]]),
+        flakes: new Map([[key("kneads"), undefined]]),
       };
       expect(selectionOf(itself, key("kneads"))).toBe("skipped-there");
     });
@@ -315,11 +315,11 @@ describe("report", () => {
         previous: run([["kneads", "pass"]]),
         current: run([["kneads", "fail"]]),
         pullRequest: ranThere([["kneads", "pass"]], {
-          flakeRates: new Map([[key("kneads"), 0.04]]),
+          flakes: new Map([[key("kneads"), { flakes: 4, runs: 100 }]]),
         }),
       }));
       expect(failures[0]?.selection).toBe("passed-there");
-      expect(failures[0]?.flakeRate).toBe(0.04);
+      expect(failures[0]?.flakes).toEqual({ flakes: 4, runs: 100 });
     });
   });
 
@@ -656,7 +656,7 @@ describe("report", () => {
         current: run([["kneads the dougk", "pass"], ["proves", "pass"]]),
         pullRequest: {
           ...withCatches("kneads the dough", 4, "proves"),
-          flakeRates: new Map([[key("kneads the dougk"), 0]]),
+          flakes: new Map([[key("kneads the dougk"), undefined]]),
         },
       }))).toEqual([]);
     });
@@ -838,9 +838,9 @@ describe("report", () => {
         ]),
         pullRequest: knows(["proves", "bakes"], {
           catches: new Map([[key("kneads the dough"), 6]]),
-          flakeRates: new Map([
-            [key("proves"), 0.05],
-            [key("bakes"), 0],
+          flakes: new Map([
+            [key("proves"), { flakes: 5, runs: 80 }],
+            [key("bakes"), undefined],
           ]),
           units: inOneUnit("kneads the dough", "proves", "bakes"),
         }),
@@ -926,13 +926,45 @@ describe("report", () => {
           previous: run([["proves", "pass"]]),
           current: run([["proves", "fail"]]),
           pullRequest: ranThere([["proves", "pass"]], {
-            flakeRates: new Map([[key("proves"), 0.07]]),
+            flakes: new Map([[key("proves"), { flakes: 7, runs: 900 }]]),
           }),
         })),
         context,
       )!;
-      expect(body).toContain("7.0% of the time");
+      // The counts rather than the share, so a reader can weigh them:
+      // seven in nine hundred is not the claim seven in nine is.
+      expect(body).toContain("disagree with itself 7 times in 900 runs");
       expect(body).toContain("may be its own and not the change's");
+    });
+
+    it("counts one disagreement in words rather than as a figure", () => {
+      const body = renderReport(
+        buildReport(input({
+          previous: run([["proves", "pass"]]),
+          current: run([["proves", "fail"]]),
+          pullRequest: ranThere([["proves", "pass"]], {
+            flakes: new Map([[key("proves"), { flakes: 1, runs: 40 }]]),
+          }),
+        })),
+        context,
+      )!;
+      expect(body).toContain("disagree with itself once in 40 runs");
+    });
+
+    it("says nothing of a test the store has never seen disagree", () => {
+      // A hedge on no evidence tells somebody a real failure may be
+      // noise, which is the thing the label exists to avoid saying.
+      const body = renderReport(
+        buildReport(input({
+          previous: run([["proves", "pass"]]),
+          current: run([["proves", "fail"]]),
+          pullRequest: ranThere([["proves", "pass"]], {
+            flakes: new Map([[key("proves"), { flakes: 0, runs: 900 }]]),
+          }),
+        })),
+        context,
+      )!;
+      expect(body).not.toContain("may be its own and not the change's");
     });
 
     it("says a withheld test could not have run rather than was not run", () => {

--- a/tasks/test-selection/report.test.ts
+++ b/tasks/test-selection/report.test.ts
@@ -937,6 +937,20 @@ describe("report", () => {
       expect(body).toContain("may be its own and not the change's");
     });
 
+    it("counts one run as a run rather than as runs", () => {
+      const body = renderReport(
+        buildReport(input({
+          previous: run([["proves", "pass"]]),
+          current: run([["proves", "fail"]]),
+          pullRequest: ranThere([["proves", "pass"]], {
+            flakes: new Map([[key("proves"), { flakes: 1, runs: 1 }]]),
+          }),
+        })),
+        context,
+      )!;
+      expect(body).toContain("disagree with itself once in 1 run over");
+    });
+
     it("counts one disagreement in words rather than as a figure", () => {
       const body = renderReport(
         buildReport(input({

--- a/tasks/test-selection/report.ts
+++ b/tasks/test-selection/report.ts
@@ -19,13 +19,15 @@
  * named. Nothing is counted per author, per team, or per anything, and
  * no history is kept anywhere. A test the selector declined to run is
  * described as coverage this design traded away, because the author did
- * not miss it. A test the store knows disagrees with itself is labelled
- * as one. And every note says what to do, in a comment that is edited in
- * place rather than repeated.
+ * not miss it. A test the store has seen disagreeing with itself is
+ * labelled as one, with the evidence behind the label. And every note
+ * says what to do, in a comment that is edited in place rather than
+ * repeated.
  */
 
 import {
   ALIAS_FILE,
+  type FlakeEvidence,
   type TestIdentity,
   testIdentityKey,
   testIdentityOfKey,
@@ -39,6 +41,7 @@ import type { WithheldReason } from "./manifest.ts";
 import {
   COVERAGE_COMMENT_LINES,
   EXCLUDED_FROM_COVERAGE_GATE,
+  FLAKE_WINDOW_DAYS,
   LOCAL_COVERAGE_MAX_PACKAGES,
   RENAME_MARGIN,
   RENAME_SIMILARITY,
@@ -116,11 +119,13 @@ export interface PullRequestView {
   withheld: ReadonlyMap<string, WithheldReason>;
 
   /**
-   * How often the store says each identity disagrees with itself. Every
-   * identity the manifest holds is in here, so membership is also the
-   * answer to whether the store has ever seen a test.
+   * How often the store saw each identity disagree with itself, and over
+   * how many runs. Every identity the manifest holds is a key here, so
+   * membership is also the answer to whether the store has ever seen a
+   * test; the value is absent for a manifest written before the counts
+   * were published.
    */
-  flakeRates: ReadonlyMap<string, number>;
+  flakes: ReadonlyMap<string, FlakeEvidence | undefined>;
 
   /** The weighted catches behind each identity the store knows. */
   catches: ReadonlyMap<string, number>;
@@ -141,7 +146,7 @@ export function unknownPullRequest(): PullRequestView {
     manifest: false,
     selected: new Set(),
     withheld: new Map(),
-    flakeRates: new Map(),
+    flakes: new Map(),
     catches: new Map(),
     units: new Map(),
   };
@@ -171,8 +176,12 @@ export interface FirstFailure {
   test: TestIdentity;
   selection: ReportedSelection;
 
-  /** Present when the store knows how often the test disagrees with itself. */
-  flakeRate?: number;
+  /**
+   * Present when the store has seen the test disagree with itself, with
+   * the runs it saw that among. A reader weighs the two: one in five is
+   * not the claim one in five thousand is.
+   */
+  flakes?: FlakeEvidence;
 }
 
 /** A rise in the repository's whole uncovered-line count. */
@@ -304,7 +313,7 @@ export function selectionOf(
   // With a manifest, the packing says whether the test was to have run:
   // an identity the packing reached, and one the store has never seen,
   // are both identities that run.
-  if (view.manifest && view.flakeRates.has(key) && !view.selected.has(key)) {
+  if (view.manifest && view.flakes.has(key) && !view.selected.has(key)) {
     return "not-selected";
   }
   if (there === "skip") return "skipped-there";
@@ -337,11 +346,11 @@ export function firstFailures(input: ReportInput): FirstFailure[] {
     if (input.previous.get(key) !== "pass") continue;
     const selection = selectionOf(input.pullRequest, key);
     if (selection === "failed-there") continue;
-    const flakeRate = input.pullRequest.flakeRates.get(key);
+    const flakes = input.pullRequest.flakes.get(key);
     failures.push({
       test: identityOf(key),
       selection,
-      ...(flakeRate === undefined ? {} : { flakeRate }),
+      ...(flakes === undefined || flakes.flakes === 0 ? {} : { flakes }),
     });
   }
   return failures.sort(byIdentity);
@@ -498,7 +507,7 @@ export function flakyNewTests(input: ReportInput): FlakyNewTest[] {
   for (const [key, verdict] of input.current) {
     if (verdict !== "mixed") continue;
     if (input.previous.has(key)) continue;
-    if (input.pullRequest.flakeRates.has(key)) continue;
+    if (input.pullRequest.flakes.has(key)) continue;
     flaky.push({ test: identityOf(key) });
   }
   return flaky.sort(byIdentity);
@@ -583,7 +592,7 @@ export function renames(input: ReportInput): RenameSuggestion[] {
     ranHere.has(input.pullRequest.units.get(key) ?? "")
   );
   const arrived = [...input.current.keys()].filter((key) =>
-    !input.previous.has(key) && !input.pullRequest.flakeRates.has(key)
+    !input.previous.has(key) && !input.pullRequest.flakes.has(key)
   );
   const suggestions: RenameSuggestion[] = [];
   for (const key of gone) {
@@ -769,12 +778,13 @@ export function renderReport(
       out.push("");
       out.push(`- ${shownIdentity(failure.test)}`);
       out.push(`  ${SELECTION_PROSE[failure.selection]}`);
-      if (failure.flakeRate !== undefined && failure.flakeRate > 0) {
+      if (failure.flakes !== undefined) {
+        const { flakes, runs } = failure.flakes;
         out.push(
-          `  The store has it disagreeing with itself ${
-            (failure.flakeRate * 100).toFixed(1)
-          }% of the time, so this failure may be its own and not the ` +
-            "change's.",
+          `  The store has seen this test disagree with itself ${
+            flakes === 1 ? "once" : `${flakes} times`
+          } in ${runs} runs over the last ${FLAKE_WINDOW_DAYS} days, so ` +
+            "this failure may be its own and not the change's.",
         );
       }
     }

--- a/tasks/test-selection/report.ts
+++ b/tasks/test-selection/report.ts
@@ -783,8 +783,9 @@ export function renderReport(
         out.push(
           `  The store has seen this test disagree with itself ${
             flakes === 1 ? "once" : `${flakes} times`
-          } in ${runs} runs over the last ${FLAKE_WINDOW_DAYS} days, so ` +
-            "this failure may be its own and not the change's.",
+          } in ${runs} ${runs === 1 ? "run" : "runs"} over the last ` +
+            `${FLAKE_WINDOW_DAYS} days, so this failure may be its own ` +
+            "and not the change's.",
         );
       }
     }

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -646,6 +646,15 @@ describe("flakeCounts()", () => {
     state.flakesByDay["2026-08-20"] = 10;
     expect(flakeCounts(state, "2026-08-20")).toEqual({ flakes: 10, runs: 200 });
   });
+
+  it("counts neither half from a day the window cannot reach", () => {
+    const state = emptyState();
+    state.runsByDay["2026-08-20"] = 200;
+    state.flakesByDay["2026-08-20"] = 10;
+    state.runsByDay["2020-01-01"] = 9000;
+    state.flakesByDay["2020-01-01"] = 500;
+    expect(flakeCounts(state, "2026-08-20")).toEqual({ flakes: 10, runs: 200 });
+  });
 });
 
 describe("flakeRate()", () => {

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -9,6 +9,7 @@ import {
   daysBetween,
   emptyContext,
   emptyState,
+  flakeCounts,
   flakeRate,
   foldObservations,
   type Observation,
@@ -26,6 +27,7 @@ import {
 import {
   CATCH_BREADTH_WINDOW_DAYS,
   FLAKE_COMMIT_REACH,
+  FLAKE_EXCLUSION_RATE,
   SAME_COMMIT_REACH_DAYS,
   VALUE_FLOOR,
 } from "./policy.ts";
@@ -290,7 +292,15 @@ describe("score", () => {
         saw("fail", { commit: "c1", place: "pr", source: "branch" }),
       ]);
       expect(state.prCatches).toBe(0);
-      expect(flakeRate(state, "2026-08-20")).toBe(1);
+      expect(state.flakesByDay["2026-08-20"]).toBe(1);
+      // Two runs, one of them a disagreement. Nothing is charged
+      // against that, so it reads as the half it is and the test is too
+      // noisy to judge a change by until it has run enough to say
+      // otherwise.
+      expect(flakeRate(state, "2026-08-20")).toBe(0.5);
+      expect(flakeRate(state, "2026-08-20")).toBeGreaterThan(
+        FLAKE_EXCLUSION_RATE,
+      );
     });
 
     it("reads a failure across many branches as the environment", () => {
@@ -370,7 +380,10 @@ describe("score", () => {
         }),
       ]);
       expect(state.mainCatches).toBe(0);
-      expect(flakeRate(state, "2026-08-21")).toBe(1);
+      expect(state.flakesByDay["2026-08-20"]).toBe(1);
+      expect(flakeRate(state, "2026-08-21")).toBeGreaterThan(
+        FLAKE_EXCLUSION_RATE,
+      );
     });
   });
 
@@ -626,18 +639,126 @@ describe("sealDay()", () => {
   });
 });
 
-describe("flakeRate()", () => {
-  it("counts only failures inside the window", () => {
+describe("flakeCounts()", () => {
+  it("reports both halves of the share, so a reader can weigh it", () => {
     const state = emptyState();
-    state.failuresByDay["2026-08-20"] = 2;
-    state.flakesByDay["2026-08-20"] = 1;
-    // Far enough back that the window cannot reach it, so neither its
-    // failures nor its flakes are in the share.
-    state.failuresByDay["2020-01-01"] = 50;
-    expect(flakeRate(state, "2026-08-20")).toBe(0.5);
+    state.runsByDay["2026-08-20"] = 200;
+    state.flakesByDay["2026-08-20"] = 10;
+    expect(flakeCounts(state, "2026-08-20")).toEqual({ flakes: 10, runs: 200 });
+  });
+});
+
+describe("flakeRate()", () => {
+  it("counts flakes against the runs they happened among", () => {
+    const state = emptyState();
+    state.runsByDay["2026-08-20"] = 200;
+    state.flakesByDay["2026-08-20"] = 10;
+    expect(flakeRate(state, "2026-08-20")).toBe(10 / 200);
   });
 
-  it("is zero for a test that has never failed", () => {
+  it("keeps a flake whose pass has aged out of the window", () => {
+    // A disagreement is a pass and a failure at one commit, and the two
+    // can be days apart. Where the pass falls outside the window and the
+    // failure inside it, the window holds a disagreement with no pass
+    // beside it, and the share reads at its ceiling until the test runs
+    // again.
+    const state = stateFrom([
+      saw("pass", { day: "2026-06-20", commit: "c1", place: "pr" }),
+      saw("fail", { day: "2026-06-22", commit: "c1", place: "pr" }),
+    ]);
+    expect(flakeCounts(state, "2026-06-22")).toEqual({ flakes: 1, runs: 2 });
+    trimWindows(state, "2026-08-20");
+    expect(flakeCounts(state, "2026-08-20")).toEqual({ flakes: 1, runs: 1 });
+    expect(flakeRate(state, "2026-08-20")).toBe(1);
+  });
+
+  it("counts a disagreement for less as the test settles after it", () => {
+    // The same counts on both, and not the same test. One disagreed and
+    // has passed since; the other passed and has just disagreed. A share
+    // that summed the window flat would call them equally flaky.
+    const today = "2026-08-20";
+    const settled = emptyState();
+    settled.runsByDay["2026-07-23"] = 2;
+    settled.flakesByDay["2026-07-23"] = 2;
+    settled.runsByDay[today] = 200;
+
+    const started = emptyState();
+    started.runsByDay["2026-07-23"] = 200;
+    started.runsByDay[today] = 2;
+    started.flakesByDay[today] = 2;
+
+    expect(flakeCounts(settled, today)).toEqual(flakeCounts(started, today));
+    expect(flakeRate(settled, today)).toBeLessThan(flakeRate(started, today));
+  });
+
+  it("holds a test out until it has settled for long enough", () => {
+    // Forty disagreements among a hundred runs in one day. It goes on
+    // running on the default branch and never disagrees again, and what
+    // brings it back is those runs together with the age of what it did.
+    const state = emptyState();
+    state.runsByDay["2026-08-20"] = 100;
+    state.flakesByDay["2026-08-20"] = 40;
+    expect(flakeRate(state, "2026-08-20")).toBeGreaterThan(
+      FLAKE_EXCLUSION_RATE,
+    );
+    for (let day = 21; day <= 23; day++) {
+      state.runsByDay[`2026-08-${day}`] = 100;
+    }
+    expect(flakeRate(state, "2026-08-23")).toBeGreaterThan(
+      FLAKE_EXCLUSION_RATE,
+    );
+    for (let day = 24; day <= 30; day++) {
+      state.runsByDay[`2026-08-${day}`] = 100;
+    }
+    expect(flakeRate(state, "2026-08-30")).toBeLessThan(FLAKE_EXCLUSION_RATE);
+  });
+
+  it("tells two tests apart that fail only ever as flakes", () => {
+    // Every failure either of these has is a flake, so a share of their
+    // failures reads them both as wholly unreliable. What separates them
+    // is how much of the time they pass.
+    const noisy = emptyState();
+    noisy.runsByDay["2026-08-20"] = 20;
+    noisy.failuresByDay["2026-08-20"] = 10;
+    noisy.flakesByDay["2026-08-20"] = 10;
+    const reliable = emptyState();
+    reliable.runsByDay["2026-08-20"] = 10000;
+    reliable.failuresByDay["2026-08-20"] = 1;
+    reliable.flakesByDay["2026-08-20"] = 1;
+    expect(flakeRate(noisy, "2026-08-20")).toBeGreaterThan(
+      FLAKE_EXCLUSION_RATE,
+    );
+    expect(flakeRate(reliable, "2026-08-20")).toBeLessThan(
+      FLAKE_EXCLUSION_RATE,
+    );
+  });
+
+  it("falls as the test goes on passing", () => {
+    const state = emptyState();
+    state.runsByDay["2026-08-20"] = 4;
+    state.flakesByDay["2026-08-20"] = 2;
+    const held = flakeRate(state, "2026-08-20");
+    expect(held).toBeGreaterThan(FLAKE_EXCLUSION_RATE);
+    state.runsByDay["2026-08-21"] = 400;
+    expect(flakeRate(state, "2026-08-21")).toBeLessThan(FLAKE_EXCLUSION_RATE);
+  });
+
+  it("counts only the days inside the window", () => {
+    const state = emptyState();
+    state.runsByDay["2026-08-20"] = 20;
+    state.flakesByDay["2026-08-20"] = 1;
+    // Far enough back that the window cannot reach it, so neither its
+    // runs nor its flakes are in the share.
+    state.runsByDay["2020-01-01"] = 10000;
+    state.flakesByDay["2020-01-01"] = 500;
+    expect(flakeRate(state, "2026-08-20")).toBe(1 / 20);
+  });
+
+  it("is zero for a test that has never flaked", () => {
+    const state = emptyState();
+    state.runsByDay["2026-08-20"] = 50;
+    state.failuresByDay["2026-08-20"] = 5;
+    expect(flakeRate(state, "2026-08-20")).toBe(0);
     expect(flakeRate(emptyState(), "2026-08-20")).toBe(0);
   });
 });

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -11,6 +11,7 @@
  */
 
 import type {
+  FlakeEvidence,
   ScoreInputs,
   TestIdentity,
 } from "@commonfabric/test-support/records";
@@ -26,6 +27,7 @@ import {
   COST_WINDOW_DAYS,
   ENVIRONMENTAL_MIN_SOURCES,
   FLAKE_COMMIT_REACH,
+  FLAKE_HALF_LIFE_RUNS,
   FLAKE_WINDOW_DAYS,
   FRESHNESS_FLOOR,
   FRESHNESS_HALF_LIFE_DAYS,
@@ -89,10 +91,10 @@ export interface IdentityState {
   /** Failures per day, the numerator of the churn term. */
   failuresByDay: Record<string, number>;
 
-  /** Runs per day, its denominator. */
+  /** Runs per day, the denominator of that term and of the flake rate. */
   runsByDay: Record<string, number>;
 
-  /** Flake observations per day, against the failures of the same day. */
+  /** Flake observations per day, the numerator of the flake rate. */
   flakesByDay: Record<string, number>;
 
   /**
@@ -718,43 +720,140 @@ export function trimWindows(state: IdentityState, today: string): void {
       if (daysBetween(day, today) > windowDays) delete counts[day];
     }
   };
-  drop(state.runsByDay, CHURN_WINDOW_DAYS);
+  // The run counts answer three questions with two windows: the churn
+  // term's denominator, the flake rate's, and how recently `lastRun` saw
+  // the test. They are kept for the longer of the two windows, and each
+  // reader reads back only as far as its own.
+  drop(state.runsByDay, Math.max(CHURN_WINDOW_DAYS, FLAKE_WINDOW_DAYS));
   drop(state.failuresByDay, CHURN_WINDOW_DAYS);
   drop(state.flakesByDay, FLAKE_WINDOW_DAYS);
   drop(state.costByDay, COST_WINDOW_DAYS);
 }
 
 /**
- * The churn term: recent failures over recent runs, with each day's
- * counts halved every `CHURN_HALF_LIFE_DAYS` as they age. Decayed rather
- * than cut off at a window's edge, because a ratio over a long window
- * measures total historical brokenness rather than the current rate. A
- * week of failures eight months ago would otherwise outrank a test that
- * is failing right now.
+ * A share of a test's runs over the days inside `windowDays`, each day's
+ * counts weighed by `weigh` against how old the day is and how many runs
+ * have followed it.
+ *
+ * Decayed rather than summed flat, because a sum cannot tell two
+ * histories apart that a reader would never confuse. A test that
+ * disagreed twice and then passed two hundred times has settled; one
+ * that passed two hundred times and then disagreed twice has just
+ * started. The same counts, and not the same test.
+ *
+ * Read over a window as well, so what is measured stays bounded. Past
+ * four half-lives a day is worth under one part in sixteen, which makes
+ * the window a performance choice rather than a policy one.
  */
-export function churn(state: IdentityState, today: string): number {
-  let failures = 0;
+function decayedShare(
+  counted: Record<string, number>,
+  state: IdentityState,
+  today: string,
+  windowDays: number,
+  weigh: (ageDays: number, runsSince: number) => number,
+): number {
+  // Newest day first, so the runs a day has been followed by are known
+  // by the time that day is weighed. A day's own runs are weighed
+  // together, as though all of them happened at the end of it, which is
+  // as fine a grain as counters kept per day can answer at.
+  const days = Object.keys(state.runsByDay).sort().reverse();
+  let runsSince = 0;
+  let top = 0;
   let runs = 0;
-  for (const [day, count] of Object.entries(state.runsByDay)) {
+  for (const day of days) {
     const age = daysBetween(day, today);
-    if (age > CHURN_WINDOW_DAYS) continue;
-    const weight = 0.5 ** (age / CHURN_HALF_LIFE_DAYS);
+    if (age > windowDays) continue;
+    const count = state.runsByDay[day] ?? 0;
+    const weight = weigh(age, runsSince);
     runs += count * weight;
-    failures += (state.failuresByDay[day] ?? 0) * weight;
+    top += (counted[day] ?? 0) * weight;
+    runsSince += count;
   }
-  return runs === 0 ? 0 : failures / runs;
+  return runs === 0 ? 0 : top / runs;
 }
 
-/** The share of a test's failures that were flake observations. */
+/**
+ * The churn term: recent failures over recent runs. A ratio over a long
+ * undecayed window measures total historical brokenness rather than the
+ * current rate, and a week of failures eight months ago would otherwise
+ * outrank a test that is failing right now.
+ */
+export function churn(state: IdentityState, today: string): number {
+  return decayedShare(
+    state.failuresByDay,
+    state,
+    today,
+    CHURN_WINDOW_DAYS,
+    (age) => 0.5 ** (age / CHURN_HALF_LIFE_DAYS),
+  );
+}
+
+/**
+ * The share of a test's runs it was seen disagreeing with itself over.
+ *
+ * Runs rather than failures in the denominator, because what the rate
+ * decides is whether running this test once fails somebody's change for
+ * something its author cannot act on, and that is a chance per run. The
+ * two differ by everything a test's passes say: a test that failed once
+ * in ten thousand runs, and passed on the rerun, has every one of its
+ * failures a flake, and a share of failures would read it as wholly
+ * unreliable. Counting runs is also what lets an exclusion reverse, since
+ * a run that does not disagree lowers the share.
+ *
+ * A disagreement's weight halves every `FLAKE_HALF_LIFE_RUNS` runs that
+ * follow it, so a test that has settled since is not judged as though it
+ * had just started. Runs rather than days, because what shows a test has
+ * settled is running without disagreeing. A test that has not run has
+ * shown nothing, and time alone should not clear it.
+ *
+ * A lower bound on how often the test fails on its own, because the only
+ * spurious failure this can count is one with a pass beside it at the
+ * same commit. What raises the bound is repeats, which put several
+ * executions at one commit, and which a rising share is what buys.
+ *
+ * Nothing is charged against the count, and no belief about how tests
+ * usually behave survives into it. A disagreement is not a sample from
+ * an unknown rate the way a failure is; it is a proof, since a test that
+ * is deterministic cannot pass and fail at one commit. Shrinking the
+ * share toward zero would be shrinking it toward what the observation
+ * has already ruled out. So a test seen twice that disagreed once reads
+ * a half, and one that disagreed once in ten thousand runs reads a
+ * ten-thousandth: what separates them is how much each has been run, not
+ * how much either is believed.
+ */
 export function flakeRate(state: IdentityState, today: string): number {
-  let failures = 0;
+  return decayedShare(
+    state.flakesByDay,
+    state,
+    today,
+    FLAKE_WINDOW_DAYS,
+    (_age, runsSince) => 0.5 ** (runsSince / FLAKE_HALF_LIFE_RUNS),
+  );
+}
+
+/**
+ * What a person is shown beside the share: the disagreements inside the
+ * flake window and the runs they were seen among, counted flat. A share
+ * cannot be weighed without them, and they are not what the share
+ * divides — the share weights recent days more heavily, so a test with
+ * these counts reads higher when the disagreements are the recent part
+ * of them.
+ */
+export function flakeCounts(
+  state: IdentityState,
+  today: string,
+): FlakeEvidence {
   let flakes = 0;
-  for (const [day, count] of Object.entries(state.failuresByDay)) {
+  for (const [day, count] of Object.entries(state.flakesByDay)) {
     if (daysBetween(day, today) > FLAKE_WINDOW_DAYS) continue;
-    failures += count;
-    flakes += state.flakesByDay[day] ?? 0;
+    flakes += count;
   }
-  return failures === 0 ? 0 : flakes / failures;
+  let runs = 0;
+  for (const [day, count] of Object.entries(state.runsByDay)) {
+    if (daysBetween(day, today) > FLAKE_WINDOW_DAYS) continue;
+    runs += count;
+  }
+  return { flakes, runs };
 }
 
 /**
@@ -773,7 +872,7 @@ export function costSeconds(state: IdentityState, today: string): number {
   return worst / 1000;
 }
 
-export type { ScoreInputs };
+export type { FlakeEvidence, ScoreInputs };
 
 /** The score's inputs for one identity, as of a given day. */
 export function scoreInputs(


### PR DESCRIPTION
PROBLEM

The flake share a test-selection manifest carries was a test's flake observations divided by its failures, so nothing its passes said reached the figure. A test that failed once, passed when the commit ran again, and then passed ten thousand times read 100%: every failure it ever had was a flake. It was held out of every pull request, headed the dashboard's flake list, and had every report on its failures hedged. A test that fails every other run and flakes each time read 100% too, and nothing told the two apart.

The share also summed its window flat, so when a test disagreed did not reach the figure either:

    disagreed twice, then passed 200 times   0.009009
    passed 200 times, then disagreed twice   0.009009

SOLUTION

Divide by runs, and decay by runs. The share is flake observations over the runs they were seen among, with a disagreement's weight halving every `FLAKE_HALF_LIFE_RUNS` runs that follow it. It answers the question the exclusion asks — how likely is one execution to fail somebody's change for something its author cannot act on — and it tells a test that has settled from one that has just started.

Runs rather than days, because what shows a test has settled is running without disagreeing. A test left untouched for three weeks has shown nothing, and a calendar that cleared it would be clearing it for having been left alone.

Nothing is charged against the count. A disagreement is a proof rather than a sample, since a test that is deterministic cannot pass and fail at one commit, so shrinking the share toward zero would shrink it toward what the observation has already ruled out. A test seen twice that disagreed once reads a half; one that disagreed once in ten thousand runs reads a ten-thousandth.

The counts are published beside the share, so the wall and the report a red default branch leaves show evidence rather than a verdict — "seen disagree with itself 7 times in 900 runs".

DESIGN DISCUSSION

How often a lane runs one test is a line rather than a ladder of bands. A test that has never disagreed runs once; any share at all puts it on the line through `FLAKE_MIN_EXECUTIONS` at a share of nothing and `FLAKE_ANCHOR_EXECUTIONS` at `FLAKE_ANCHOR_RATE`, carrying on past that anchor until `MAX_EXECUTIONS` stops it. So a test seen to disagree at all runs at least twice, because one execution cannot tell a pass from a lucky pass.

That line runs past `FLAKE_EXCLUSION_RATE` on purpose. A test that flaky is not selected, so the only way it reaches a lane is a change that edits it or that its suite maps onto its unit, which is very likely a fix; the count is what makes it prove itself.

Churn and the flake share are the same shape, so one helper serves both, weighing each day by a function of its age and of the runs that have followed it. Churn weighs by age, since it asks how much trouble is here lately, which is a question about time.

The half-life is also how much evidence the share is measured over, which is what stops it going far below one over the exclusion rate: below that there are not enough runs in view to tell the rate the exclusion turns on from nothing. `FLAKE_WINDOW_DAYS` still bounds what is read, but bounds what is remembered rather than marking where the weight has faded.

The published counts are flat, so they are not what the share divides, and every comment and document that shows them says so. They are for a person weighing the share: "7 times in 900 runs" is a sentence somebody can read where a decayed sum is not.

`buildManifest` rounds the share once, before anything reads it, so the figure the manifest carries is the figure the execution count and the withheld decision were taken on.

The counts are an optional field and the schema version does not move. A manifest written before them still parses, because refusing one costs every test its score and an absent manifest makes the whole corpus mandatory, which is a high price for a column a reader can not show.

The share is a lower bound on how often a test fails on its own, since the only spurious failure it can count is one with a pass beside it at the same commit. Executions are what raise the bound, and a rising share is what buys executions.

Nothing separates a disagreement the test caused from one the environment caused, so a bad runner that makes several tests disagree at one commit holds out the ones with few runs behind them. The environmental rule, which reads a failure across many sources as infrastructure and covers catches only, is where that belongs.

A window can hold a disagreement whose pass has aged out of it, and such a test reads at its ceiling until it runs again. It is a test that ran once in sixty days, so what the exclusion costs it is nothing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

