### PR TITLE
fix(test-selection): stop scoring a lane's measurements of itself

### DIFF
--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -1627,11 +1627,20 @@ describe("what a lane does with the batches it was given", () => {
       });
   }
 
-  async function run(command: readonly string[]): Promise<boolean> {
+  /**
+   * Runs a lane over that suite, and answers with its verdict beside the
+   * measurements it wrote. The spool is the lane's own, so what it
+   * records about itself stays here rather than reaching the spool of
+   * the run testing it.
+   */
+  async function run(
+    command: readonly string[],
+  ): Promise<{ ok: boolean; measured: TestRecord[] }> {
+    const spool = await Deno.makeTempDir({ prefix: "lane-spool-" });
     const log = console.log;
     console.log = () => {};
     try {
-      return await runLane(
+      const ok = await runLane(
         {
           lane: 1,
           of: 1,
@@ -1641,15 +1650,41 @@ describe("what a lane does with the batches it was given", () => {
           root: REPOSITORY,
           at: "2026-09-01T00:00:00Z",
         },
-        { manifest: selecting(), topology: topology(command) },
+        {
+          manifest: selecting(),
+          topology: topology(command),
+          spool: () => spool,
+        },
       );
+      const written = (await Promise.all(
+        (await Array.fromAsync(Deno.readDir(spool)))
+          .filter((entry) => entry.isFile)
+          .map((entry) => Deno.readTextFile(`${spool}/${entry.name}`)),
+      )).join("");
+      const measured = written.split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as TestRecord);
+      return { ok, measured };
     } finally {
       console.log = log;
+      await Deno.remove(spool, { recursive: true });
     }
   }
 
+  /** The outcome the lane recorded for its one batch. */
+  function batchOutcome(measured: readonly TestRecord[]): string | undefined {
+    return measured.find((record) =>
+      record.test.n === "ci-lane batch workspace-unit"
+    )?.outcome;
+  }
+
   it("passes when every batch passed", async () => {
-    expect(await run([Deno.execPath(), "eval", "0"])).toBe(true);
+    const { ok, measured } = await run([Deno.execPath(), "eval", "0"]);
+    expect(ok).toBe(true);
+    // The measurement says what the lane says. A batch recorded green
+    // while the lane reports red, or the other way about, is one commit
+    // carrying both outcomes for the identity.
+    expect(batchOutcome(measured)).toBe("pass");
   });
 
   it("gives each batch the environment its own suite asked for", async () => {
@@ -1710,6 +1745,9 @@ describe("what a lane does with the batches it was given", () => {
               reporting("asked", ["deno", "cf"]),
               reporting("did-not", ["deno"]),
             ]),
+          // What this case reads is the environment each batch ran in,
+          // so the lane records nothing about itself.
+          spool: () => undefined,
         },
       );
       expect(await Deno.readTextFile(`${dir}/asked`)).toBe(REPOSITORY);
@@ -1723,7 +1761,13 @@ describe("what a lane does with the batches it was given", () => {
   it("fails when a batch failed, having run it", async () => {
     // A lane reports what it measured: the batch ran and went red, so
     // the lane is red, and nothing about that is a crash or a timeout.
-    expect(await run([Deno.execPath(), "eval", "Deno.exit(1)"])).toBe(false);
+    const { ok, measured } = await run([
+      Deno.execPath(),
+      "eval",
+      "Deno.exit(1)",
+    ]);
+    expect(ok).toBe(false);
+    expect(batchOutcome(measured)).toBe("fail");
   });
 
   it("says it could not date the tree it is testing", async () => {

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -623,6 +623,15 @@ export interface LaneDeps {
    * repository's real suites to find out.
    */
   topology?: (root: string) => Promise<Suite[]>;
+
+  /**
+   * Where the lane writes what it measured about itself. The default is
+   * the enclosing run's spool, which is the job the lane is. A caller
+   * that supplies one is saying where those measurements go, and a lane
+   * run from inside a test needs to, because the enclosing run there is
+   * the run testing it and its spool ships.
+   */
+  spool?: () => string | undefined;
 }
 
 /** What reading this tree against its manifest came to. */
@@ -809,7 +818,7 @@ export async function runLane(
   if (options.dryRun) return true;
 
   const workDir = await Deno.makeTempDir({ prefix: "ci-lane-" });
-  const spool = recordsDir();
+  const spool = (deps.spool ?? recordsDir)();
   // The directory belongs to the lane from the moment it exists, and a
   // capability that refuses to open is one of the ways the lane ends.
   let opened;

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -254,6 +254,34 @@ describe("build", () => {
           .observations,
       ).toEqual([]);
     });
+
+    it("reads nothing from a lane measuring itself", () => {
+      // The lane's own measurements travel as ordinary records, so they
+      // arrive here beside the tests they were recorded with. A lane is
+      // not a test: scoring one reads the batch it ran going red as the
+      // lane disagreeing with itself, which is the shape of a flake and
+      // is nothing of the kind.
+      const read = readReport(
+        stored(CI_NAME, context(), [
+          record(),
+          record({
+            test: { k: "gate", s: "ci", n: "ci-lane batch workspace-unit" },
+            outcome: "fail",
+          }),
+          record({
+            test: { k: "gate", s: "ci", n: "ci-lane setup deno" },
+          }),
+        ]),
+        NO_ALIASES,
+      );
+      // The test beside them is read, so this is the measurements being
+      // left out rather than the whole group.
+      expect(read.observations.map((seen) => seen.test.n)).toEqual([
+        "space > writes",
+      ]);
+      expect([...read.surfaces.keys()]).toEqual([KEY]);
+      expect([...read.durations.keys()]).toEqual([KEY]);
+    });
   });
 
   describe("the fold", () => {
@@ -402,6 +430,27 @@ describe("build", () => {
       const state = second.finish().states.get(KEY)!;
       expect(state.mainCatches).toBe(0);
       expect(flakeRate(state, "2026-08-20")).toBe(1);
+    });
+
+    it("drops a lane measurement an earlier aggregate carried", () => {
+      // Nothing adds one now, and nothing has ever removed one, so an
+      // aggregate written while they were still folded would carry them
+      // for good.
+      const aggregate = emptyAggregate("2026-08-20");
+      const measurement = testIdentityKey({
+        k: "gate",
+        s: "ci",
+        n: "ci-lane batch workspace-unit",
+      });
+      aggregate.states[measurement] = emptyState();
+      aggregate.states[KEY] = emptyState();
+
+      const states = new Fold(aggregate, NO_ALIASES, "2026-08-20")
+        .finish().states;
+      expect(states.has(measurement)).toBe(false);
+      // The test beside it survives, so this drains the measurements
+      // rather than the aggregate.
+      expect(states.has(KEY)).toBe(true);
     });
 
     it("does not fold an object it has already folded", () => {

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -286,6 +286,13 @@ export function readReport(
     const day = dayOf(group.context.startedAt);
     for (const record of group.records) {
       const test = resolver.resolve(record.test, day);
+      // A lane measuring its own setup or one of its batches is not a
+      // test, so nothing here scores it: a catch, a flake observation and
+      // a churn rate are all statements about a test, and a lane is
+      // neither passing nor failing in the sense they read. It reaches
+      // the store as an ordinary record so that it travels the path every
+      // record travels, and this is where that path parts.
+      if (isLaneMeasurement(test)) continue;
       const key = testIdentityKey(test);
       // A record with no file names its own identity as the unit, which
       // is all an unmapped record can say. Where another record of the
@@ -579,9 +586,17 @@ export class Fold {
     today: string,
   ) {
     this.#states = new Map(
-      Object.entries(aggregate.states).map((
-        [key, state],
-      ) => [key, { ...emptyState(), ...state }]),
+      Object.entries(aggregate.states)
+        // An aggregate written before lane measurements stopped being
+        // folded carries a state for each of them. Nothing new adds one,
+        // and a state nothing adds to is a state nothing removes either,
+        // so an aggregate carrying one carries it for good unless it is
+        // dropped on the way in.
+        .filter(([key]) => {
+          const test = testIdentityOfKey(key);
+          return test === undefined || !isLaneMeasurement(test);
+        })
+        .map(([key, state]) => [key, { ...emptyState(), ...state }]),
     );
     this.#context = parseContext(aggregate.context);
     this.#folded = [...aggregate.folded];


### PR DESCRIPTION
PROBLEM

`tasks/lane-measurement.ts` says a lane's measurements of itself are not test surfaces and that nothing scores them. Two things broke that.

Three cases in `tasks/ci-lane.test.ts` run a lane for real, and `runLane` writes what it measured to the enclosing run's spool, which inside a job is the job's own and ships. Two of them run one suite id, one with a command that passes and one with a command that fails, so every run shipped a pass and a failure at one commit. `readReport` then scored both identities, and a pass and a failure at one commit reads as the identity disagreeing with itself.

Measured over 2026-08-19 to 2026-09-09:

    ci-lane batch workspace-unit    2,006 runs
                                    1,003 failures
                                    1,003 flake observations

Exactly half on every individual day, which is deterministic rather than chance. Over 2026-09-06 to 2026-09-09 that one identity accounts for 403 of the 415 flake observations the whole store holds.

SOLUTION

`LaneDeps` gains a `spool`, beside the `manifest` and `topology` it already carries for the same reason. The default stays `recordsDir()`, so the job a lane is behaves as before, and the three cases supply one. Two of them now assert that the outcome the lane recorded is the outcome it reported.

`readReport` drops a record `isLaneMeasurement` recognizes, so it yields no observation, no surface and no duration. That is the one funnel turning records into observations, so nothing downstream needs to know.

Nothing has ever removed a state, so the `Fold` constructor drops both identities on the way in. An aggregate written earlier drains on the next publish rather than carrying them for good.

DESIGN DISCUSSION

The measurements go on reaching the store. They travel as ordinary records so that they need no pipeline of their own, and the calibration a manifest carries is meant to be fitted from them; every manifest so far carries `setupCost`, `suites` and `unitOverhead` empty, so nothing fits anything from them yet. A fitter reads the records. What changes here is only whether a lane is scored as a test.

Both halves were worth fixing rather than either alone. The writer is what put the records in the store, and the fold is what read them as a test; fixing the fold is what makes the next writer harmless.

The fold's skip could sit in `foldObservations` instead. That is the wrong layer: scoring knows about tests and identities, and what a lane is belongs to the side of the tree that runs one. `readReport` is also where `locateSurfaces` already asks the same question, three files away.

Redirecting `CF_TEST_RECORDS_DIR` around each case would close the leak too, and one case in the file already does it. It is weaker, because the variable is process-wide and covers every other recorder in the process while it is set; that case says so in its own comment.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

