### PR TITLE
fix(piece): judge a node's semantic extensions once, on the node

### DIFF
--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -612,7 +612,10 @@ caller compiles and verifies the candidate and runs these structural
 comparisons. Descriptions, titles, examples, and listing annotations do not
 change a contract, including inside defaulted unions. Defaults, reference
 targets, value constraints, and capability and CFC metadata remain part of the
-proof. The unconstrained schemas `true`, `{}`, and `{ type: "unknown" }`
+proof. Capability and CFC metadata are compared once, on the node that carries
+them, whatever spelling that node's alternatives take: one member type, a
+`type` list, or `anyOf` branches. The unconstrained schemas `true`, `{}`, and
+`{ type: "unknown" }`
 accept the same values; constraints beside `type: "unknown"` still apply.
 Adding an optional `unknown` read to an open producer contract is compatible,
 while adding an optional typed read requires the producer to guarantee that

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -614,10 +614,13 @@ change a contract, including inside defaulted unions. Defaults, reference
 targets, value constraints, and capability and CFC metadata remain part of the
 proof. Capability and CFC metadata are compared once, on the node that carries
 them, whatever spelling that node's alternatives take: one member type, a
-`type` list, or `anyOf` branches. The unconstrained schemas `true`, `{}`, and
-`{ type: "unknown" }`
-accept the same values; constraints beside `type: "unknown"` still apply.
-Adding an optional `unknown` read to an open producer contract is compatible,
+`type` list, or `anyOf` branches. Adding or removing a semantic extension on
+one of two `anyOf` nodes is incompatible in either the argument or result
+contract, subject to the same CFC metadata normalization as other nodes.
+
+The unconstrained schemas `true`, `{}`, and `{ type: "unknown" }` accept the
+same values; constraints beside `type: "unknown"` still apply. Adding an
+optional `unknown` read to an open producer contract is compatible,
 while adding an optional typed read requires the producer to guarantee that
 type whenever the property is present.
 

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -784,13 +784,11 @@ function schemaSubsetIssue(
   if (pairIsActive(source, target, context)) return undefined;
   markPairActive(source, target, context);
   try {
-    // A semantic extension is a fact about the node as a whole, compared for
-    // exact equality, so it is judged here, once, whatever spelling the
-    // node's alternatives take. The fragments an expansion produces below
-    // carry none of these keys ({@link schemaAlternatives}): a fragment that
-    // did carry one would meet a fragment that does not — an `anyOf` node's
-    // base holds the extension while its branches hold the types — and the
-    // one-sided key would read as a change the node never made.
+    // Semantic extensions describe the whole node and are compared here
+    // before its alternatives expand. `schemaAlternatives` omits the parent
+    // node's extensions from the fragments so a branch carrying only a type
+    // is not mistaken for a node that removed an extension. Extensions
+    // declared on branch and descendant nodes remain part of their proofs.
     //
     // The `ifc` extension is compared for exact equality except for a
     // `writeAuthorizedBy` writer claim's volatile identity — its content hash
@@ -908,7 +906,7 @@ const DEFAULT_STABLE_SCHEMA_KEYS = new Set([
   // Four of the five `SEMANTIC_EXTENSION_KEYS` say how a value is delivered,
   // stored, or written, not what shape it has, so a default inserted beneath
   // one cannot falsify it. A change to the marker itself is still refused by
-  // the exact comparison in `objectSubsetIssue`. `ifc` is left out on
+  // the exact comparison in `schemaSubsetIssue`. `ifc` is left out on
   // purpose: a label is policy the write-authority comparison reasons about
   // (`comparableIfc`), and whether a materialized default satisfies a
   // labeled node's floor is that comparison's question, not this one's, so
@@ -1505,11 +1503,10 @@ function schemaMayProduceType(
 }
 
 /**
- * The alternatives a node states, each a conjunction of fragments, after the
- * caller has judged the node's own keywords ({@link NODE_LEVEL_KEYWORDS}). No
- * fragment carries those keywords — the single fragment of a node that states
- * one thing included — so the branch proofs concern value constraints alone.
- * Descendant schemas keep their defaults and extensions.
+ * Returns a conjunction of fragments for each alternative after the caller
+ * checks the node's own keywords ({@link NODE_LEVEL_KEYWORDS}). Fragments omit
+ * the parent node's default and extensions, including for a single-type node.
+ * Branch and descendant schemas retain their own defaults and extensions.
  */
 function schemaAlternatives(schema: SchemaObject): JSONSchema[][] {
   const fragment = withoutNodeLevelKeywords(schema);
@@ -1528,7 +1525,7 @@ function schemaAlternatives(schema: SchemaObject): JSONSchema[][] {
  * {@link schemaSubsetIssue} judges once at the node before it expands the
  * node's alternatives: the `default`, checked for validity or for change
  * there, and the semantic extensions, compared for exact equality there. A
- * fragment entering a branch proof carries none of them.
+ * fragment entering a branch proof omits the parent node's occurrences.
  */
 const NODE_LEVEL_KEYWORDS: ReadonlySet<string> = new Set([
   "default",
@@ -1536,9 +1533,9 @@ const NODE_LEVEL_KEYWORDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * The schema without its node-level keywords; the same object when it has
- * none. Copies with {@link keep}, so a `__proto__` key read off the wire lands
- * as an own property the way it does everywhere else in this comparison.
+ * Returns the schema without its node-level keywords, or the same object when
+ * it has none. Copies with {@link keep}, so a `__proto__` key read off the wire
+ * remains an own property.
  */
 function withoutNodeLevelKeywords(schema: SchemaObject): SchemaObject {
   const keys = Object.keys(schema);

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -784,6 +784,27 @@ function schemaSubsetIssue(
   if (pairIsActive(source, target, context)) return undefined;
   markPairActive(source, target, context);
   try {
+    // A semantic extension is a fact about the node as a whole, compared for
+    // exact equality, so it is judged here, once, whatever spelling the
+    // node's alternatives take. The fragments an expansion produces below
+    // carry none of these keys ({@link schemaAlternatives}): a fragment that
+    // did carry one would meet a fragment that does not — an `anyOf` node's
+    // base holds the extension while its branches hold the types — and the
+    // one-sided key would read as a change the node never made.
+    //
+    // The `ifc` extension is compared for exact equality except for a
+    // `writeAuthorizedBy` writer claim's volatile identity — its content hash
+    // and its resolver-dependent file spelling, which the runtime does not
+    // hold fixed either — and the derived per-value label annotations, which
+    // describe the label a write produces rather than the policy the store
+    // declares. `keywordValuesEqual` applies that reduction, the same one it
+    // applies to an `ifc` nested below a composite keyword.
+    for (const key of SEMANTIC_EXTENSION_KEYS) {
+      if (!keywordValuesEqual(key, source[key], target[key])) {
+        return `${path}: ${key} changed`;
+      }
+    }
+
     if (
       source.anyOf || target.anyOf ||
       Array.isArray(source.type) || Array.isArray(target.type)
@@ -830,19 +851,6 @@ function schemaSubsetIssue(
 
     const constraintIssue = scalarConstraintSubsetIssue(source, target, path);
     if (constraintIssue) return constraintIssue;
-
-    for (const key of SEMANTIC_EXTENSION_KEYS) {
-      // The `ifc` extension is compared for exact equality except for a
-      // `writeAuthorizedBy` writer claim's volatile identity — its content hash
-      // and its resolver-dependent file spelling, which the runtime does not
-      // hold fixed either — and the derived per-value label annotations, which
-      // describe the label a write produces rather than the policy the store
-      // declares. `keywordValuesEqual` applies that reduction, the same one it
-      // applies to an `ifc` nested below a composite keyword.
-      if (!keywordValuesEqual(key, source[key], target[key])) {
-        return `${path}: ${key} changed`;
-      }
-    }
 
     for (const key of COMPLEX_CONSTRAINT_KEYS) {
       const applicableTypes = COMPLEX_CONSTRAINT_TYPES[key];
@@ -1497,21 +1505,51 @@ function schemaMayProduceType(
 }
 
 /**
- * Conjunctions for each alternative after the caller checks whole-schema
- * defaults. The root default is omitted from both sides, including a schema
- * with a single type, so branch comparisons concern their value constraints.
- * Descendant schemas and their defaults remain intact.
+ * The alternatives a node states, each a conjunction of fragments, after the
+ * caller has judged the node's own keywords ({@link NODE_LEVEL_KEYWORDS}). No
+ * fragment carries those keywords — the single fragment of a node that states
+ * one thing included — so the branch proofs concern value constraints alone.
+ * Descendant schemas keep their defaults and extensions.
  */
 function schemaAlternatives(schema: SchemaObject): JSONSchema[][] {
-  const { default: _default, ...withoutDefault } = schema;
-  if (withoutDefault.anyOf) {
-    const { anyOf, ...base } = withoutDefault;
+  const fragment = withoutNodeLevelKeywords(schema);
+  if (fragment.anyOf) {
+    const { anyOf, ...base } = fragment;
     return anyOf.map((alternative) => [base, alternative]);
   }
-  if (Array.isArray(withoutDefault.type)) {
-    return withoutDefault.type.map((type) => [{ ...withoutDefault, type }]);
+  if (Array.isArray(fragment.type)) {
+    return fragment.type.map((type) => [{ ...fragment, type }]);
   }
-  return [[withoutDefault]];
+  return [[fragment]];
+}
+
+/**
+ * The keywords a node states about itself as a whole, which
+ * {@link schemaSubsetIssue} judges once at the node before it expands the
+ * node's alternatives: the `default`, checked for validity or for change
+ * there, and the semantic extensions, compared for exact equality there. A
+ * fragment entering a branch proof carries none of them.
+ */
+const NODE_LEVEL_KEYWORDS: ReadonlySet<string> = new Set([
+  "default",
+  ...SEMANTIC_EXTENSION_KEYS,
+]);
+
+/**
+ * The schema without its node-level keywords; the same object when it has
+ * none. Copies with {@link keep}, so a `__proto__` key read off the wire lands
+ * as an own property the way it does everywhere else in this comparison.
+ */
+function withoutNodeLevelKeywords(schema: SchemaObject): SchemaObject {
+  const keys = Object.keys(schema);
+  if (!keys.some((key) => NODE_LEVEL_KEYWORDS.has(key))) return schema;
+  const fragment: Record<string, unknown> = {};
+  for (const key of keys) {
+    if (!NODE_LEVEL_KEYWORDS.has(key)) {
+      keep(fragment, key, (schema as Record<string, unknown>)[key]);
+    }
+  }
+  return fragment as SchemaObject;
 }
 
 /**

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -2410,7 +2410,7 @@ describe("piece schema compatibility", () => {
     });
   }
 
-  it("judges a node's semantic extensions once, on the node", () => {
+  describe("semantic extensions on union nodes", () => {
     const a: JSONSchema = {
       type: "object",
       properties: { a: { type: "string" } },
@@ -2423,103 +2423,187 @@ describe("piece schema compatibility", () => {
       { asCell: ["cell"] },
       { ifc: { confidentiality: ["secret"] } },
       { readOnly: true },
+      { scope: "session" },
+      { writeOnly: true },
     ] satisfies Exclude<JSONSchema, boolean>[];
+
     for (const extension of extensions) {
+      const key = Object.keys(extension)[0];
       const single: JSONSchema = { ...a, ...extension };
       const union: JSONSchema = { anyOf: [a, b], ...extension };
-      // An argument widens and a result narrows across the two spellings.
+
+      describe(key, () => {
+        it("accepts argument widening from a single type to `anyOf`", () => {
+          expect(() =>
+            assertPatternSchemasBackwardCompatible(
+              pattern(single, true),
+              pattern(union, true),
+            )
+          ).not.toThrow();
+        });
+
+        it("accepts result narrowing from `anyOf` to a single type", () => {
+          expect(() =>
+            assertPatternSchemasBackwardCompatible(
+              pattern(true, union),
+              pattern(true, single),
+            )
+          ).not.toThrow();
+        });
+
+        it("accepts a single-type producer for a union demand", () => {
+          expect(() => assertSchemaSubset(single, union)).not.toThrow();
+        });
+
+        it("refuses a union producer for a single-type demand", () => {
+          expect(() => assertSchemaSubset(union, single)).toThrow(
+            /schema alternative accepted previously/,
+          );
+        });
+
+        it("refuses argument narrowing from `anyOf` to a single type", () => {
+          expect(() =>
+            assertPatternSchemasBackwardCompatible(
+              pattern(union, true),
+              pattern(single, true),
+            )
+          ).toThrow(/schema alternative accepted previously/);
+        });
+
+        it("refuses result widening from a single type to `anyOf`", () => {
+          expect(() =>
+            assertPatternSchemasBackwardCompatible(
+              pattern(true, single),
+              pattern(true, union),
+            )
+          ).toThrow(/schema alternative accepted previously/);
+        });
+
+        for (const role of ["argument", "result"] as const) {
+          for (const change of ["adding", "removing"] as const) {
+            it(`refuses ${change} the extension between two \`anyOf\` ${role} nodes`, () => {
+              const bare: JSONSchema = { anyOf: [a, b] };
+              const previous = change === "adding" ? bare : union;
+              const candidate = change === "adding" ? union : bare;
+              expect(() =>
+                assertPatternSchemasBackwardCompatible(
+                  role === "argument"
+                    ? pattern(previous, true)
+                    : pattern(true, previous),
+                  role === "argument"
+                    ? pattern(candidate, true)
+                    : pattern(true, candidate),
+                )
+              ).toThrow(`${role}: ${key} changed`);
+            });
+          }
+        }
+      });
+    }
+
+    it("refuses changes to extensions on descendant properties", () => {
+      const withHandle: JSONSchema = {
+        anyOf: [
+          {
+            type: "object",
+            properties: { value: { type: "string", asCell: ["cell"] } },
+            required: ["value"],
+          },
+          { type: "null" },
+        ],
+        asCell: ["opaque"],
+      };
+      const withoutHandle: JSONSchema = {
+        anyOf: [
+          {
+            type: "object",
+            properties: { value: { type: "string" } },
+            required: ["value"],
+          },
+          { type: "null" },
+        ],
+        asCell: ["opaque"],
+      };
+      expect(() => assertSchemaSubset(withHandle, withoutHandle)).toThrow();
+      expect(() => assertSchemaSubset(withoutHandle, withHandle)).toThrow();
+    });
+
+    it("accepts a `type` list and `anyOf` as equivalent union contracts", () => {
+      const list: JSONSchema = {
+        type: ["string", "undefined"],
+        asCell: ["cell"],
+      };
+      const branches: JSONSchema = {
+        anyOf: [{ type: "string" }, { type: "undefined" }],
+        asCell: ["cell"],
+      };
       expect(() =>
         assertPatternSchemasBackwardCompatible(
-          pattern(single, union),
-          pattern(union, single),
+          pattern(list, branches),
+          pattern(branches, list),
         )
       ).not.toThrow();
-      // A producer stating one shape links into a demand stating either.
-      expect(() => assertSchemaSubset(single, union)).not.toThrow();
-      // The other way round is a narrowing, as it stands.
-      expect(() => assertSchemaSubset(union, single)).toThrow(
-        /schema alternative accepted previously/,
-      );
-      expect(() =>
-        assertPatternSchemasBackwardCompatible(
-          pattern(union, single),
-          pattern(single, union),
-        )
-      ).toThrow(/schema alternative accepted previously/);
-    }
+    });
 
-    // The `type` list and `anyOf` spellings of one union, in either order.
-    const list: JSONSchema = {
-      type: ["string", "undefined"],
-      asCell: ["cell"],
-    };
-    const branches: JSONSchema = {
-      anyOf: [{ type: "string" }, { type: "undefined" }],
-      asCell: ["cell"],
-    };
-    expect(() =>
-      assertPatternSchemasBackwardCompatible(
-        pattern(list, branches),
-        pattern(branches, list),
-      )
-    ).not.toThrow();
+    it("accepts optional opaque cells with a referenced payload", () => {
+      // The generator represents `Cell<Doc | undefined>` as an `anyOf` of
+      // `undefined` and a reference, beside `asCell: ["opaque"]`.
 
-    // The generator's own spelling of `Cell<Doc | undefined>` held opaquely:
-    // an `anyOf` of `undefined` and a reference, beside `asCell: ["opaque"]`.
-    const defs = {
-      $defs: {
-        Doc: {
-          type: "object",
-          properties: { id: { type: "string" } },
-          required: ["id"],
+      const defs = {
+        $defs: {
+          Doc: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+          },
         },
-      },
-    } satisfies Exclude<JSONSchema, boolean>;
-    const doc: JSONSchema = {
-      $ref: "#/$defs/Doc",
-      asCell: ["opaque"],
-      ...defs,
-    };
-    const optionalDoc: JSONSchema = {
-      anyOf: [{ type: "undefined" }, { $ref: "#/$defs/Doc" }],
-      asCell: ["opaque"],
-      ...defs,
-    };
-    expect(() =>
-      assertPatternSchemasBackwardCompatible(
-        pattern(doc, optionalDoc),
-        pattern(optionalDoc, doc),
-      )
-    ).not.toThrow();
-    expect(() =>
-      assertSchemaSubset(doc, optionalDoc, "value", {
-        sourceRoot: doc,
-        targetRoot: optionalDoc,
-      })
-    ).not.toThrow();
+      } satisfies Exclude<JSONSchema, boolean>;
+      const doc: JSONSchema = {
+        $ref: "#/$defs/Doc",
+        asCell: ["opaque"],
+        ...defs,
+      };
+      const optionalDoc: JSONSchema = {
+        anyOf: [{ type: "undefined" }, { $ref: "#/$defs/Doc" }],
+        asCell: ["opaque"],
+        ...defs,
+      };
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(doc, optionalDoc),
+          pattern(optionalDoc, doc),
+        )
+      ).not.toThrow();
+      expect(() =>
+        assertSchemaSubset(doc, optionalDoc, "value", {
+          sourceRoot: doc,
+          targetRoot: optionalDoc,
+        })
+      ).not.toThrow();
+    });
 
-    // The extension is still held to exact equality on the node, and a
-    // difference is reported as the extension's own, not the alternatives'.
-    const cell: JSONSchema = { ...a, asCell: ["cell"] };
-    for (
-      const changed of [
-        { anyOf: [a, b] },
-        { anyOf: [a, b], asCell: ["readonly"] },
-      ] satisfies JSONSchema[]
-    ) {
-      expect(() =>
-        assertPatternSchemasBackwardCompatible(
-          pattern(cell, true),
-          pattern(changed, true),
-        )
-      ).toThrow(/asCell changed/);
-      expect(() =>
-        assertPatternSchemasBackwardCompatible(
-          pattern(changed, true),
-          pattern(cell, true),
-        )
-      ).toThrow(/asCell changed/);
-    }
+    it("refuses a changed or missing capability across single and union nodes", () => {
+      const cell: JSONSchema = { ...a, asCell: ["cell"] };
+      for (
+        const changed of [
+          { anyOf: [a, b] },
+          { anyOf: [a, b], asCell: ["readonly"] },
+        ] satisfies JSONSchema[]
+      ) {
+        expect(() =>
+          assertPatternSchemasBackwardCompatible(
+            pattern(cell, true),
+            pattern(changed, true),
+          )
+        ).toThrow(/asCell changed/);
+        expect(() =>
+          assertPatternSchemasBackwardCompatible(
+            pattern(changed, true),
+            pattern(cell, true),
+          )
+        ).toThrow(/asCell changed/);
+      }
+    });
   });
 
   it("rejects unresolved references and terminates on recursive references", () => {

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -2410,6 +2410,118 @@ describe("piece schema compatibility", () => {
     });
   }
 
+  it("judges a node's semantic extensions once, on the node", () => {
+    const a: JSONSchema = {
+      type: "object",
+      properties: { a: { type: "string" } },
+    };
+    const b: JSONSchema = {
+      type: "object",
+      properties: { b: { type: "number" } },
+    };
+    const extensions = [
+      { asCell: ["cell"] },
+      { ifc: { confidentiality: ["secret"] } },
+      { readOnly: true },
+    ] satisfies Exclude<JSONSchema, boolean>[];
+    for (const extension of extensions) {
+      const single: JSONSchema = { ...a, ...extension };
+      const union: JSONSchema = { anyOf: [a, b], ...extension };
+      // An argument widens and a result narrows across the two spellings.
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(single, union),
+          pattern(union, single),
+        )
+      ).not.toThrow();
+      // A producer stating one shape links into a demand stating either.
+      expect(() => assertSchemaSubset(single, union)).not.toThrow();
+      // The other way round is a narrowing, as it stands.
+      expect(() => assertSchemaSubset(union, single)).toThrow(
+        /schema alternative accepted previously/,
+      );
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(union, single),
+          pattern(single, union),
+        )
+      ).toThrow(/schema alternative accepted previously/);
+    }
+
+    // The `type` list and `anyOf` spellings of one union, in either order.
+    const list: JSONSchema = {
+      type: ["string", "undefined"],
+      asCell: ["cell"],
+    };
+    const branches: JSONSchema = {
+      anyOf: [{ type: "string" }, { type: "undefined" }],
+      asCell: ["cell"],
+    };
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(list, branches),
+        pattern(branches, list),
+      )
+    ).not.toThrow();
+
+    // The generator's own spelling of `Cell<Doc | undefined>` held opaquely:
+    // an `anyOf` of `undefined` and a reference, beside `asCell: ["opaque"]`.
+    const defs = {
+      $defs: {
+        Doc: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+        },
+      },
+    } satisfies Exclude<JSONSchema, boolean>;
+    const doc: JSONSchema = {
+      $ref: "#/$defs/Doc",
+      asCell: ["opaque"],
+      ...defs,
+    };
+    const optionalDoc: JSONSchema = {
+      anyOf: [{ type: "undefined" }, { $ref: "#/$defs/Doc" }],
+      asCell: ["opaque"],
+      ...defs,
+    };
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(doc, optionalDoc),
+        pattern(optionalDoc, doc),
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertSchemaSubset(doc, optionalDoc, "value", {
+        sourceRoot: doc,
+        targetRoot: optionalDoc,
+      })
+    ).not.toThrow();
+
+    // The extension is still held to exact equality on the node, and a
+    // difference is reported as the extension's own, not the alternatives'.
+    const cell: JSONSchema = { ...a, asCell: ["cell"] };
+    for (
+      const changed of [
+        { anyOf: [a, b] },
+        { anyOf: [a, b], asCell: ["readonly"] },
+      ] satisfies JSONSchema[]
+    ) {
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(cell, true),
+          pattern(changed, true),
+        )
+      ).toThrow(/asCell changed/);
+      expect(() =>
+        assertPatternSchemasBackwardCompatible(
+          pattern(changed, true),
+          pattern(cell, true),
+        )
+      ).toThrow(/asCell changed/);
+    }
+  });
+
   it("rejects unresolved references and terminates on recursive references", () => {
     const unresolved = pattern(
       {


### PR DESCRIPTION
`setsrc --check` refuses an update that widens a `Cell<A>` argument to `Cell<A | B>`, or narrows a `Cell<A | B>` result to `Cell<A>`, whenever the union is spelled with `anyOf`. That is the spelling the generator uses for unions of object types and for `T | undefined` held under `asCell: ["opaque"]`. The same update with no extension on the node is accepted, and so is the same union spelled as a `type` list.

The comparison expands an `anyOf` node into a base fragment, which carries the node's semantic extensions (`asCell`, `ifc`, `readOnly`, `scope`, `writeOnly`), and one fragment per branch, which carries the type. Each fragment is then held to exact equality of those extensions against a whole node that carries them, so a branch fragment reads as `asCell` removed, and the conjunction proof reports `a schema alternative accepted previously is not accepted by the candidate`.

This judges a node's semantic extensions once, at the node, before its alternatives expand, and omits the parent node's extensions from the fragments, the way #7178 already treats the node's `default`. Nothing else in the conjunction proof changes. A node whose extension differs from its counterpart's, or that carries one its counterpart lacks, is refused with a diagnostic naming the extension, such as `asCell changed`. This also tightens the gate: between two `anyOf` nodes, the old conjunction proof could accept removal of an argument's `asCell` or addition of a result's `asCell`. Those updates are now refused, consistently with single-type nodes. The piece-source-lifecycle spec explicitly states that adding or removing an extension between union nodes is incompatible in either contract, under the existing IFC normalization.

Reach: 46 nodes across the shipped pattern baselines put `asCell` beside `anyOf` (agent-sessions-debug, cfc-group-chat-demo, notes, system, primitives, reading-list, test, gideon-tests), against 2 that put it beside a `type` list.

Not changed: an `anyOf` node whose base carries a complex constraint (`not`, `allOf`, `patternProperties`, and the rest) or a keyword this checker does not know is still compared conservatively. Those keywords take part in the object proof, so they cannot leave the fragments the way an extension can, and the generator emits none of them on a union node.

### Validation

- The behavior-specific tests fail against the base checker and pass here. They cover all five extensions (`asCell`, `ifc`, `readOnly`, `scope`, and `writeOnly`); argument widening and result narrowing across the single and `anyOf` spellings; the `type` list against the `anyOf` spelling; the generator's `Cell<Doc | undefined>` shape with a `$ref` branch under `asCell: ["opaque"]`; a link proof from the single producer into the union demand; argument narrowing and result widening across the spellings; addition and removal of each extension between two `anyOf` nodes in both contract slots; and extensions retained on descendant properties.
- A 21-case probe run against `main` and against this branch: the ten refusals that were false are accepted, the six controls stay refused, and the two complex-keyword cases stay conservative.
- Full piece package suite and `deno task pattern-compat`.
- Repository-wide `deno fmt --check`, `deno lint`, and `deno task check`.

Follow-up to #7178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

