### PR TITLE
test(runner): pin the replica cold before counting absences

### DIFF
--- a/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
+++ b/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
@@ -669,8 +669,19 @@ describe("editWithRetry absence reconciliation", () => {
         storageManager: smB,
       });
       const txB = runtimeB.edit();
-      runtimeB.getCell(space, "provider-level-doc", valueSchema, txB).get();
-      runtimeB.getCell(space, "provider-level-absent", valueSchema, txB).get();
+      const presentAddress = toMemorySpaceAddress(
+        runtimeB.getCell(space, "provider-level-doc", valueSchema, txB)
+          .getAsNormalizedFullLink(),
+      );
+      const absentAddress = toMemorySpaceAddress(
+        runtimeB.getCell(space, "provider-level-absent", valueSchema, txB)
+          .getAsNormalizedFullLink(),
+      );
+
+      // Recording the reads loads neither document, so reconciliation is
+      // what fetches them.
+      txB.read(presentAddress, { trackReadWithoutLoad: true });
+      txB.read(absentAddress, { trackReadWithoutLoad: true });
 
       const provider = smB.open(space);
       expect(provider.loadUnexaminedAbsences).toBeDefined();
@@ -688,6 +699,14 @@ describe("editWithRetry absence reconciliation", () => {
       )).did();
       runtimeB.getCell(otherSpace, "unrelated-write", valueSchema, txB)
         .set({ value: 1 });
+      // The provider counts the documents this replica lacks at the moment
+      // it is asked. The count below rests on `provider-level-doc` being
+      // one of them, which holds once everything the replica owes has
+      // synchronized.
+      await smB.synced();
+      expect(
+        provider.replica.getDocument(presentAddress.id, presentAddress.scope),
+      ).toBeUndefined();
       // Of the two cold reads, exactly one document turns out to exist; the
       // other's absence is examined and stays a sound claim.
       expect(await provider.loadUnexaminedAbsences!(txB.tx)).toBe(1);


### PR DESCRIPTION
PROBLEM

The step "reports through the provider how many unexamined absences exist" fails under load, reporting 0 unexamined absences where it expects 1. It records its two cold reads through `Cell.get()`, which registers the read and starts a background synchronization of the document it finds absent. Several awaits follow before the step asks the provider for its count, one of them a passphrase key derivation that runs off-thread and leaves the event loop free. Where the background synchronization lands in that window, the replica holds the document, so nothing is left unexamined and the count is 0.

SOLUTION

Record the two reads with `trackReadWithoutLoad`, which the rest of the file already uses for its cold reads, so the step starts no synchronization of its own. Drain what the replica owes with `synced()` and assert `provider-level-doc` is still absent from it immediately before asking for the count, so the state the count rests on is checked rather than assumed.

DESIGN DISCUSSION

Inserting `await smB.synced()` between the reads and the count reproduces the failure every time, with the same "Actual 0 / Expected 1" the failing run reported. That drain is now part of the step, so a loading read reintroduced here fails the run rather than making it flaky: ten runs out of ten stop at the absence assertion, which names the document the replica turned out to hold.

Only `provider-level-doc` carries that assertion. `getDocument` answers `undefined` both for a document the replica has never heard of and for one whose absence it has examined, which keeps a record at `confirmed.seq` zero with no value, so the same assertion over `provider-level-absent` — a document nobody writes — reports the same result either way.

`editWithRetry` calls `loadUnexaminedAbsences` on the statement after the one that runs its action, so no turn of the event loop separates the two and no synchronization can land between them. The window this step opened is one only a test can open.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

