### PR TITLE
docs(runner): record which URI scheme names are registered

### DIFF
--- a/packages/runner/src/entity-kind.ts
+++ b/packages/runner/src/entity-kind.ts
@@ -35,8 +35,32 @@
  *   a property of the binding, not of the entity, and unrelated to
  *   identity despite sharing the word (and the value `"stream"`).
  *
+ * ## Which scheme names are registered
+ *
+ * The IANA URI scheme registry lists every registered scheme name:
+ * <https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml>.
+ * Consult it before minting another prefix. A name used here falls into
+ * one of three cases.
+ *
+ * - **Registered, and used for what it was registered for.** `did:`,
+ *   defined by the W3C Decentralized Identifiers specification, and
+ *   `data:`, defined by RFC 2397.
+ * - **Absent from the registry.** `of:` and `computed:` are private to
+ *   this codebase.
+ * - **Registered for an unrelated subject.** `cid:` prefixes a
+ *   content-addressed schema document reference (`schema-decompose.ts`).
+ *   RFC 2392 registers the same name for a body part of a MIME message,
+ *   addressed by its `Content-ID` header.
+ *
+ * RFC 3986 section 3.1 bounds what a scheme name may contain: a letter,
+ * then any number of letters, digits, `+`, `-`, and `.`. A prefix holding
+ * a character outside that set, such as `@`, is not a scheme name at all,
+ * and so cannot collide with one.
+ *
  * See `docs/specs/computed-cell-identity.md`.
  */
+
+/** The kinds an entity id can carry, beyond the unkinded `of:` default. */
 export type EntityKind = "computed";
 
 /** The URI scheme of computed-kind entity ids (`computed:fid1:<hash>`). */

--- a/packages/runner/src/schema-decompose.ts
+++ b/packages/runner/src/schema-decompose.ts
@@ -64,7 +64,13 @@ const RESOURCE_SCOPE_KEYWORDS = [
   "$recursiveRef",
 ] as const;
 
-/** The URI scheme prefix of a content-addressed schema document reference. */
+/**
+ * The URI scheme prefix of a content-addressed schema document reference,
+ * `cid` being short for content identifier. RFC 2392 registers the same
+ * name for a body part of a MIME message, addressed by its `Content-ID`
+ * header. The two uses share the name and nothing else. `entity-kind.ts`
+ * records the other scheme names this tree uses.
+ */
 export const SCHEMA_DOCUMENT_REF_PREFIX = "cid:";
 
 /** A parsed external schema reference. */

--- a/packages/runner/test/entity-kind.test.ts
+++ b/packages/runner/test/entity-kind.test.ts
@@ -77,6 +77,18 @@ describe("entity-kind", () => {
     }
   });
 
+  it("keeps every entity URI scheme within RFC 3986 scheme syntax", () => {
+    // RFC 3986 section 3.1 admits a letter followed by any number of
+    // letters, digits, `+`, `-`, and `.`, and makes lowercase the canonical
+    // form. Iterating `ENTITY_URI_SCHEMES` settles the claim rather than
+    // sampling it, because that constant is the set `entityUriSchemePrefix`
+    // matches an id against.
+    expect(ENTITY_URI_SCHEMES.length).toBeGreaterThan(0);
+    for (const scheme of ENTITY_URI_SCHEMES) {
+      expect(scheme).toMatch(/^[a-z][a-z0-9+.-]*$/);
+    }
+  });
+
   it("detects canonical entity URI schemes", () => {
     expect(hasEntityUriScheme("of:fid1:abc")).toBe(true);
     expect(hasEntityUriScheme("computed:fid1:abc")).toBe(true);


### PR DESCRIPTION
The entity and document identifiers in this tree carry a mix of URI scheme names. Some are registered with IANA and mean here what they mean there; some were invented for this codebase; and one is a registered name reused for an unrelated subject. Nothing recorded which was which, so someone choosing the next scheme name had no way to tell what was already taken, and no pointer to the registry that would answer the question.

The note goes in `entity-kind.ts`, which already explains that an entity's kind is carried by its URI scheme and holds the single definition of `ENTITY_URI_SCHEMES`, so it is where someone adding a scheme is already reading. It gives three cases rather than a list of names:

- Registered, and used for what it was registered for. `did:`, defined by the W3C Decentralized Identifiers specification, and `data:`, defined by RFC 2397.
- Absent from the registry. `of:` and `computed:` are private to this codebase.
- Registered for an unrelated subject. `cid:` prefixes a content-addressed schema document reference. RFC 2392 registers the same name for a body part of a MIME message, addressed by its `Content-ID` header.

A list of names would have been false. `grants.ts` mints document ids under a reserved `grant:` scheme, `pattern-metadata.ts` under `keyless:`, and the sandbox resolves module specifiers under `cf:`; none of those is registered either, and a reader consulting a five-name list to find out whether a name was free would have concluded that taken names were available. A roster in one file also cannot stay true, because minting a prefix elsewhere brings nobody back to edit it. Every scheme name falls into one of the three cases, however many there turn out to be.

What a reader needs in order to act is stated directly: the registry itself, and the syntax RFC 3986 section 3.1 bounds a name to. A prefix carrying a character outside that syntax, `@` among them, is not a scheme name at all, and so cannot collide with one.

`SCHEMA_DOCUMENT_REF_PREFIX` carries the `cid:` fact where the prefix is defined, since that is the site where the shared name would otherwise surprise someone. It states the disposition rather than leaving a reader to supply it: the two uses share the name and nothing else.

Making room for the note exposed a placement defect. Nothing separated the module comment from `export type EntityKind`, so the whole of it was that type's doc comment rather than a header for the file, and anything added to it would have rendered as documentation for a one-word string literal type. A blank line makes it a file header, which is what its content describes, and `EntityKind` gets a doc comment of its own.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

