### PR TITLE
fix(cli): retain definitions in inline verb event schemas

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -41,7 +41,6 @@ import {
 import {
   Cell,
   type ConsoleHandler,
-  decodeJsonPointer,
   decomposeSchema,
   deepEqual,
   encodeJsonPointer,
@@ -78,6 +77,7 @@ import {
   getCarriedCfcLabelView,
   type IFCLabel,
   mergeCfcLabelViews,
+  pruneCfcSchemaDefinitions,
   redactCaveatSourcesForDisplay,
   resolveCfcSchemaRefRoot,
   resolveCfcSchemaRefs,
@@ -2430,72 +2430,12 @@ const VERB_PROPERTY_KEYS: readonly string[] = [
 ];
 
 /**
- * The `$defs` key a reference into the document's own definitions names, or
- * `undefined` for anything else — a reference elsewhere, or deeper than one
- * definition. A reference is a JSON Pointer, so the key is its second
- * segment decoded: `Topic~1Author` names the definition `Topic/Author`.
- */
-function localDefinitionName(ref: unknown): string | undefined {
-  if (typeof ref !== "string" || !ref.startsWith("#/")) return undefined;
-  const [, root, name, ...rest] = decodeJsonPointer(ref.slice(1));
-  return root === "$defs" && name !== undefined && rest.length === 0
-    ? name
-    : undefined;
-}
-
-/**
- * The names of the local definitions `schema` references at any depth,
- * `$defs` bodies excepted: what a document's own `$defs` must carry for the
- * document to stand alone.
- */
-function localDefinitionRefs(
-  schema: JSONSchema,
-  into: Set<string> = new Set(),
-): Set<string> {
-  if (!isObjectOrArray(schema)) return into;
-  const name = localDefinitionName(schema.$ref);
-  if (name !== undefined) into.add(name);
-  mapSubschemas(
-    schema as Parameters<typeof mapSubschemas>[0],
-    (child) => {
-      localDefinitionRefs(child, into);
-      return child;
-    },
-    { includeUnused: true },
-  );
-  return into;
-}
-
-/**
- * `schema` carrying only the `$defs` entries its body reaches, transitively,
- * and no `$defs` key at all when it reaches none. A resolved reference
- * arrives with its whole document's definitions attached, most of which
- * describe other positions; a served schema carries what makes it stand
- * alone and nothing more.
- */
-function withReachableDefinitions(schema: JSONSchema & object): JSONSchema {
-  const { $defs, ...body } = schema as Record<string, unknown>;
-  if (!isObjectOrArray($defs)) return body as JSONSchema;
-  const kept: Record<string, unknown> = {};
-  const pending = [...localDefinitionRefs(body as JSONSchema)];
-  while (pending.length > 0) {
-    const name = pending.pop()!;
-    if (Object.hasOwn(kept, name) || !Object.hasOwn($defs, name)) continue;
-    const definition = ($defs as Record<string, unknown>)[name];
-    kept[name] = definition;
-    pending.push(...localDefinitionRefs(definition as JSONSchema));
-  }
-  return Object.keys(kept).length > 0
-    ? { ...body, $defs: kept } as JSONSchema
-    : body as JSONSchema;
-}
-
-/**
  * The input schema a declared verb serves: the property's event type, made
  * self-contained. A property written as a reference resolves to its
  * definition, with the property's own keys merged over it; the keys that
- * describe the verb rather than its event are then dropped, and the
- * definitions carried along are cut to the ones the event reaches. So a
+ * describe the verb rather than its event are then dropped. The event's active
+ * definition scope is attached and cut to the definitions the event reaches,
+ * including references nested inside an inline event. So a
  * `Stream<void>` verb serves an empty object schema rather than a stream
  * marker with the verb's prose hung on it, and a referenced event serves its
  * definition alone. A reference that does not resolve serves `true`: the
@@ -2514,7 +2454,13 @@ function declaredVerbInput(
       !VERB_PROPERTY_KEYS.includes(key)
     ),
   ) as JSONSchema & object;
-  return withReachableDefinitions(event);
+  const eventRoot = cfcSchemaChildRoot(event, root);
+  return pruneCfcSchemaDefinitions({
+    ...event,
+    ...(isObjectOrArray(eventRoot) && isObjectOrArray(eventRoot.$defs)
+      ? { $defs: eventRoot.$defs }
+      : {}),
+  });
 }
 
 /** The listing marks and prose a declared property carries. */

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2434,12 +2434,12 @@ const VERB_PROPERTY_KEYS: readonly string[] = [
  * self-contained. A property written as a reference resolves to its
  * definition, with the property's own keys merged over it; the keys that
  * describe the verb rather than its event are then dropped. The event's active
- * definition scope is attached and cut to the definitions the event reaches,
- * including references nested inside an inline event. So a
- * `Stream<void>` verb serves an empty object schema rather than a stream
- * marker with the verb's prose hung on it, and a referenced event serves its
- * definition alone. A reference that does not resolve serves `true`: the
- * surface cannot invent structure.
+ * definition scope is attached and cut to the definitions the event reaches
+ * within it. Nested scopes retain `$defs: {}` when pruning removes all their
+ * definitions, preserving the scope boundary. A `Stream<void>` verb serves an
+ * empty object schema rather than a stream marker with the verb's prose hung
+ * on it, and a referenced event serves its definition alone. A reference that
+ * does not resolve serves `true`: the surface cannot invent structure.
  */
 function declaredVerbInput(
   property: Record<string, unknown>,
@@ -2454,6 +2454,8 @@ function declaredVerbInput(
       !VERB_PROPERTY_KEYS.includes(key)
     ),
   ) as JSONSchema & object;
+  // `resolveCfcSchemaRefs` already carries the target's effective `$defs` onto
+  // the resolved view; `root` supplies the inherited scope for inline events.
   const eventRoot = cfcSchemaChildRoot(event, root);
   return pruneCfcSchemaDefinitions({
     ...event,

--- a/packages/cli/test/piece-verbs-live.test.ts
+++ b/packages/cli/test/piece-verbs-live.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { Runtime } from "@commonfabric/runner";
+import { resolveCfcSchemaRefs } from "@commonfabric/runner/cfc";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { getResultCellWithSourceSchema } from "../../runner/src/piece-helpers.ts";
 import { listPieceCallables } from "../lib/piece.ts";
@@ -193,6 +194,56 @@ describe("listPieceCallables against a live piece", () => {
     expect(listing.verbs[0].inputSchema).toMatchObject({
       properties: { title: { type: "string" } },
     });
+  });
+
+  it("returns a resolvable author schema for a compiled anonymous event", async () => {
+    // The compiler puts `Author` in the result root's `$defs`, while the
+    // anonymous event carries a reference to it in a nested property.
+
+    const listing = await listLivePiece(
+      {
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: `
+            import { action, cell, pattern, Stream } from "commonfabric";
+
+            interface Author { name: string }
+            interface Out { add: Stream<{ author: Author }> }
+
+            export default pattern<Record<string, never>, Out>(() => {
+              const names = cell<string[]>([]);
+              const add = action((event: { author: Author }) => {
+                names.push(event.author.name);
+              });
+              return { add };
+            });
+          `,
+        }],
+      },
+      "piece-verbs-live-inline-event",
+      "listing-live-inline-event",
+    );
+
+    expect(listing.verbs.map((verb) => verb.name)).toEqual(["add"]);
+    const event = listing.verbs[0].inputSchema;
+    expect(event).toMatchObject({
+      type: "object",
+      properties: { author: { $ref: expect.any(String) } },
+      required: ["author"],
+    });
+    if (typeof event !== "object") throw new Error("Expected an event schema");
+    const author = event.properties?.author;
+    if (typeof author !== "object") {
+      throw new Error("Expected an author schema");
+    }
+    expect(resolveCfcSchemaRefs(author, event)).toMatchObject(
+      {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      },
+    );
   });
 
   it("lists a verb the pattern's declared result type omits", async () => {

--- a/packages/cli/test/piece-verbs-live.test.ts
+++ b/packages/cli/test/piece-verbs-live.test.ts
@@ -205,20 +205,20 @@ describe("listPieceCallables against a live piece", () => {
         main: "/main.tsx",
         files: [{
           name: "/main.tsx",
-          contents: `
-            import { action, cell, pattern, Stream } from "commonfabric";
-
-            interface Author { name: string }
-            interface Out { add: Stream<{ author: Author }> }
-
-            export default pattern<Record<string, never>, Out>(() => {
-              const names = cell<string[]>([]);
-              const add = action((event: { author: Author }) => {
-                names.push(event.author.name);
-              });
-              return { add };
-            });
-          `,
+          contents: [
+            'import { action, cell, pattern, Stream } from "commonfabric";',
+            "",
+            "interface Author { name: string }",
+            "interface Out { add: Stream<{ author: Author }> }",
+            "",
+            "export default pattern<Record<string, never>, Out>(() => {",
+            "  const names = cell<string[]>([]);",
+            "  const add = action((event: { author: Author }) => {",
+            "    names.push(event.author.name);",
+            "  });",
+            "  return { add };",
+            "});",
+          ].join("\n"),
         }],
       },
       "piece-verbs-live-inline-event",

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -374,6 +374,78 @@ describe("listPieceCallables", () => {
     }]);
   });
 
+  for (const on of ["result", "input"] as const) {
+    const schemaKey = on === "result" ? "resultSchema" : "argumentSchema";
+
+    it(`carries transitive definitions in an inline ${on} verb's event schema`, async () => {
+      const event: JSONSchema = {
+        type: "object",
+        properties: { author: { $ref: "#/$defs/Author" } },
+        required: ["author"],
+      };
+      const author: JSONSchema = {
+        type: "object",
+        properties: { address: { $ref: "#/$defs/Address" } },
+      };
+      const address: JSONSchema = {
+        type: "object",
+        properties: { city: { type: "string" } },
+      };
+      const listing = await listPattern(compiledPattern({
+        [schemaKey]: {
+          type: "object",
+          properties: { add: { ...event, asCell: ["stream"] } },
+          $defs: {
+            Author: author,
+            Address: address,
+            Unused: { type: "number" },
+          },
+        },
+      }));
+
+      expect(listing.verbs).toEqual([{
+        name: "add",
+        kind: "handler",
+        on,
+        inputSchema: { ...event, $defs: { Author: author, Address: address } },
+      }]);
+    });
+
+    it(`preserves local definition scopes in an inline ${on} verb's event schema`, async () => {
+      const localAuthor: JSONSchema = { type: "string" };
+      const nested: JSONSchema = {
+        type: "object",
+        properties: { author: { $ref: "#/$defs/Author" } },
+        $defs: { Author: { type: "number" } },
+      };
+      const event: JSONSchema = {
+        type: "object",
+        properties: { author: { $ref: "#/$defs/Author" }, nested },
+        $defs: { Author: localAuthor },
+      };
+      const listing = await listPattern(compiledPattern({
+        [schemaKey]: {
+          type: "object",
+          properties: {
+            add: {
+              ...event,
+              asCell: ["stream"],
+              $defs: { ...event.$defs, Unused: { type: "null" } },
+            },
+          },
+          $defs: { Author: { type: "boolean" } },
+        },
+      }));
+
+      expect(listing.verbs).toEqual([{
+        name: "add",
+        kind: "handler",
+        on,
+        inputSchema: event,
+      }]);
+    });
+  }
+
   it("reports a handler's declared result as its outputSchema", async () => {
     // A handler's declared result is not on its property — it rides the
     // module of the node the handler compiled to. The listing finds that node


### PR DESCRIPTION
Verb discovery can publish a dangling reference for an inline event such as `Stream<{ author: Author }>`: the compiler places `Author` in the enclosing schema's `$defs`, but the listing drops it. This fixes the regression reported on #7186 ([review finding](https://github.com/commontoolsinc/labs/pull/7186#discussion_r3974110666)).

The event now carries its effective definition scope before unused definitions are pruned with the runner's `pruneCfcSchemaDefinitions` helper. This preserves transitive references and event-local scopes, and removes the CLI's duplicate definition walker.

Validation:
- A real compiled anonymous-event regression fails before the fix and passes afterward.
- Tests cover both input and result verbs, transitive definitions, unused definitions, and local scopes.
- Repository-wide `deno fmt --check`, `deno lint`, and `deno task check` pass.
- Full CLI package suite passes with `env -u NO_COLOR deno task test` (the inherited `NO_COLOR=1` otherwise breaks two existing color-output tests).

— Codex (GPT-6 Astra), on behalf of @mathpirate

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

