### PR TITLE
fix(runner): eight absence assertions that could not fail

### DIFF
--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -426,6 +426,38 @@ cover. A stand-in the test hands the class declares itself as one where it is
 passed in, with an `as` on the argument or a small typed helper, never with a
 cast on the receiver.
 
+**`SpaceReplica.getDocument()` reads `undefined` for three different states.**
+The replica has never examined the document, the replica examined it and found
+it absent, and the replica holds a record whose value materializes as
+`undefined` all read the same. So
+`expect(replica.getDocument(id, scope)).toBeUndefined()` states only that the
+replica has no value for the document, whichever of the three put it in that
+position. Where the document is one no passing run holds a value for, the case
+cannot fail: a change that makes the replica examine that document leaves it
+green. Say which state is meant. Either name a document a run genuinely could
+hold a value for, so a value arriving where none belongs turns the case red, or
+read the record alongside the value:
+
+```ts
+// Shown at module scope.
+import { expect } from "@std/expect";
+import type { URI } from "@commonfabric/memory/interface";
+import type { SpaceReplica } from "@commonfabric/runner/storage/v2";
+
+declare const replica: SpaceReplica;
+declare const id: URI;
+
+expect(replica.accessForTestingOnly.hasDocumentRecord(id, "space")).toBe(true);
+expect(replica.getDocument(id, "space")).toBeUndefined();
+```
+
+`hasDocumentRecord()` reports whether the replica holds a record for the
+document, which is the predicate the absence-reconciliation path in
+`packages/runner/src/storage/v2.ts` decides by. A record appears once the
+replica has examined the document and also once a local write for it is
+pending, so a case turning on the first of those says in a comment that
+nothing has written the document yet.
+
 ## What a claim ranges over
 
 A test exhibits instances. To exhibit an absence it has to exhaust the set the

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -3471,7 +3471,8 @@ export class SpaceReplica
   /**
    * The caught-up and stale-floor bookkeeping, the read builder, the
    * session-sync consumer, the watch-set refresh, the session-sync apply
-   * step, and the conflict read repair, which a test drives directly.
+   * step, and the conflict read repair, which a test drives directly. It
+   * also reports whether the replica holds a record for a document.
    */
   get accessForTestingOnly(): {
     noteCaughtUpLocalSeq(localSeq: number | undefined): void;
@@ -3493,6 +3494,11 @@ export class SpaceReplica
     waitForConflictReadRepair(
       rejection: StorageTransactionRejected,
     ): Promise<void>;
+    hasDocumentRecord(
+      id: URI,
+      scope?: CellScope,
+      identity?: ScopeKeyIdentity,
+    ): boolean;
   } {
     return {
       noteCaughtUpLocalSeq: (localSeq) => this.#noteCaughtUpLocalSeq(localSeq),
@@ -3509,6 +3515,8 @@ export class SpaceReplica
       applySessionSync: (sync, type) => this.#applySessionSync(sync, type),
       waitForConflictReadRepair: (rejection) =>
         this.#waitForConflictReadRepair(rejection),
+      hasDocumentRecord: (id, scope, identity) =>
+        this.#hasDocumentRecord(id, scope, identity),
     };
   }
 
@@ -3583,6 +3591,27 @@ export class SpaceReplica
       address.id,
       this.instanceKey(address.scope, identity, address.scopeKey),
     );
+  }
+
+  /**
+   * Whether this replica holds a record for the document. A record appears
+   * once the replica has examined the document — an examination that found
+   * a value and one that found the document absent both leave one — and
+   * also once a local write for it is pending. This is the predicate
+   * {@link loadUnexaminedAbsences} decides by. It takes `scope` and
+   * `identity` as {@link getDocument} takes them, so a caller reading the
+   * two together names one document across both.
+   *
+   * `getDocument()` reads `undefined` for a record whose value materializes
+   * as `undefined` and for a document with no record at all, so a caller
+   * separating those two reads both.
+   */
+  #hasDocumentRecord(
+    id: URI,
+    scope?: CellScope,
+    identity?: ScopeKeyIdentity,
+  ): boolean {
+    return this.#docs.has(this.#docKeyOf({ id, scope }, identity));
   }
 
   /**

--- a/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
+++ b/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@commonfabric/memory/v2/execution-lease";
 import { resolveScopeKey } from "@commonfabric/memory/v2";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { SpaceReplica } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type {
   IExtendedStorageTransaction,
@@ -633,9 +634,16 @@ describe("editWithRetry absence reconciliation", () => {
           actorIdentity,
         )?.value as { value?: number } | undefined)?.value,
       ).toBe(22);
-      expect(provider.replica.getDocument(userId, "user")).toBeUndefined();
-      expect(provider.replica.getDocument(sessionId, "session"))
-        .toBeUndefined();
+      // Both loads are keyed under the ACTOR's instance. The serving
+      // replica holds no record at all for its OWN instance of either
+      // document.
+      const replica = provider.replica as SpaceReplica;
+      expect(
+        replica.accessForTestingOnly.hasDocumentRecord(userId, "user"),
+      ).toBe(false);
+      expect(
+        replica.accessForTestingOnly.hasDocumentRecord(sessionId, "session"),
+      ).toBe(false);
       tx.abort("inspection only");
     } finally {
       lease?.release();

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -666,14 +666,26 @@ describe("schema-doc-sync", () => {
   it("the background consumer survives a frame that fails to apply and keeps consuming", async () => {
     const provider = readerStorage.open(space);
     const replica = provider.replica as SpaceReplica;
-    // The first frame has no `upserts`, which the apply reads at once and
-    // throws on: the belt in consumeUpdates must swallow that, keep the loop
-    // alive, and apply the NEXT frame.
+    // The first frame's `operationFields` is not a list, which the apply
+    // walks before it touches any record and throws on: the belt in
+    // consumeUpdates must swallow that, keep the loop alive, and apply the
+    // NEXT frame. The frame carries a document of its own, so the replica's
+    // state says whether the frame was dropped whole. That the delivery
+    // walk precedes the upserts is `applySessionSync`'s stated contract, so
+    // a failure here says the contract moved.
     const frames: SessionSync[] = [
       {
         type: "sync",
         fromSeq: 600_000,
         toSeq: 600_001,
+        operationFields: 1,
+        upserts: [{
+          branch: "",
+          id: "of:survivor-1",
+          scope: "space",
+          seq: 1,
+          doc: { value: { n: 1 } },
+        }],
         removes: [],
       } as unknown as SessionSync,
       {

--- a/packages/runner/test/space-host-late-hint.test.ts
+++ b/packages/runner/test/space-host-late-hint.test.ts
@@ -8,8 +8,10 @@ import { internSchema } from "@commonfabric/data-model-schema";
 import {
   type Options,
   type SessionFactory,
+  type SpaceReplica,
   StorageManager,
 } from "../src/storage/v2.ts";
+import type { ISpaceReplica } from "../src/storage/interface.ts";
 import { Runtime } from "../src/runtime.ts";
 import { loadSchemaDocument } from "../src/cfc/prepare.ts";
 import {
@@ -81,6 +83,20 @@ const makeServer = (name: string): MemoryV2Server.Server =>
     },
     sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
+
+/**
+ * Pins that `replica` holds a record for `id` and no value under it: the
+ * read reached this replica and found nothing. `getDocument()` reads
+ * `undefined` for a document this replica never looked at as well. Each
+ * caller below asserts before any transaction writes `id`, which is the
+ * other way a record appears.
+ */
+function expectExaminedAbsent(replica: ISpaceReplica, id: URI): void {
+  expect(
+    (replica as SpaceReplica).accessForTestingOnly.hasDocumentRecord(id),
+  ).toBe(true);
+  expect(replica.getDocument(id)).toBeUndefined();
+}
 
 describe("late space host hints", () => {
   it("confirms the default host without rebuilding its provider", async () => {
@@ -317,7 +333,7 @@ describe("late space host hints", () => {
         schema: true,
       });
       expect(firstRead.error).toBeUndefined();
-      expect(provider.replica.getDocument(targetId)).toBeUndefined();
+      expectExaminedAbsent(provider.replica, targetId);
 
       expect(
         reader.registerSpaceHost(
@@ -416,8 +432,8 @@ describe("late space host hints", () => {
         ).toBeUndefined();
       }
       expect((await provider.sync(secondId)).error).toBeUndefined();
-      expect(provider.replica.getDocument(firstId)).toBeUndefined();
-      expect(provider.replica.getDocument(secondId)).toBeUndefined();
+      expectExaminedAbsent(provider.replica, firstId);
+      expectExaminedAbsent(provider.replica, secondId);
 
       expect(
         reader.registerSpaceHost(
@@ -477,7 +493,7 @@ describe("late space host hints", () => {
 
       const provider = reader.open(targetSpace);
       expect((await provider.sync(targetId)).error).toBeUndefined();
-      expect(provider.replica.getDocument(targetId)).toBeUndefined();
+      expectExaminedAbsent(provider.replica, targetId);
 
       const stale = reader.edit();
       const address = {
@@ -818,7 +834,7 @@ describe("late space host hints", () => {
 
       const targetProvider = reader.open(targetSpace);
       expect((await targetProvider.sync(targetId)).error).toBeUndefined();
-      expect(targetProvider.replica.getDocument(targetId)).toBeUndefined();
+      expectExaminedAbsent(targetProvider.replica, targetId);
 
       const stale = reader.edit();
       const target = stale.read({


### PR DESCRIPTION
PROBLEM

`SpaceReplica.getDocument(id, scope)` returns `undefined` for three different states: the replica has never examined the document, it examined the document and found it absent, and it holds a record whose value materializes as `undefined`. A test writing

    expect(replica.getDocument(id, scope)).toBeUndefined();

to mean the first of those asserts far less than it reads as. Where no passing run holds a value for that document, the assertion cannot fail at all. Eight assertions across three `packages/runner/test` files stood in that position, one of them left behind by a refactor that dropped the document its frame carried.

SOLUTION

`SpaceReplica` gains `#hasDocumentRecord`, reachable from a test through `accessForTestingOnly`. It reports whether the replica holds a record for the document — the predicate `loadUnexaminedAbsences` decides by — and takes `scope` and `identity` as `getDocument` takes them. A record appears once the replica has examined the document and also once a local write for it is pending, which the doc comment says.

The five `space-host-late-hint` assertions say the replica holds a record and no value under it, through a helper naming its precondition: every caller asserts before any transaction writes the document. The two `edit-with-retry-absence-reconciliation` ones say the serving replica holds no record at all for its own instance.

The `schema-doc-sync` frame that fails to apply carries a document again. Its malformation moves from a missing `upserts` to an `operationFields` that is not a list, which the apply walks first.

`unit-test-coding-style.md` records the hazard with a type-checked example.

DESIGN DISCUSSION

Each of the eight was checked by making the state it describes true and confirming the case stayed green, and each replacement by inverting the new predicate and confirming the case turned red. The `schema-doc-sync` one was checked by making its first frame well formed: the case then fails with `of:survivor-1` holding `{ value: { n: 1 } }`. That the delivery walk precedes the upserts is `applySessionSync`'s stated contract, and the test comment names it, so a failure there reads as the contract having moved.

Sixteen further absence assertions over `getDocument` were read and left alone. Each names a document that a passing run could hold a value for, so a value arriving where none belongs turns the case red. The `cfc-writer-fit` group is the clearest of these: a rejected commit's write is exactly a value that would appear.

The predicate is named for what it reports rather than for the question a caller asks of it. `#docs` holds a record for a document the replica has examined, and `#applyPending` installs one for a purely local write as well, so a name saying "examined" would claim more than the predicate delivers — the defect this change exists to remove.

It stays behind `accessForTestingOnly` rather than becoming public replica API. The Topic "Loud sync-state for one-shot reads: distinguish 'absent' from 'not synced here'" designates a typed `DataUnavailable` marker with a `syncing` variant as the fix for the underlying gap, and its program retires the replica-presence heuristic that a public predicate would be a new spelling of. A test-only accessor carries no production callers, and the `cf-source/no-access-for-testing-only` lint rule keeps it that way.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

