### PR TITLE
fix(cf-harness): the console never blocks — bounded reads, then turns off the request path

### DIFF
--- a/packages/cf-harness/audit/checks/structural.ts
+++ b/packages/cf-harness/audit/checks/structural.ts
@@ -1888,16 +1888,23 @@ const cellLabelsSnapshot: AuditCheck = {
       return notReadable("run-state.json", run.runState);
     }
     const state = runStateOf(run)!;
-    if (run.cellLabels.status === "present" || state.cellLabels !== undefined) {
+    if (run.cellLabels.status === "present") {
       return {
         verdict: "pass",
         message:
           "this run kept a snapshot of the labels its space carried; what it holds is not read here",
       };
     }
-    const attempted = state.failureRecords?.find((record) =>
-      record.source === "cell_labels"
-    );
+    // A run records what its snapshot found on its state and the records
+    // themselves in the artifact, so a state naming a snapshot with no
+    // artifact beside it is a read that happened and whose evidence is gone —
+    // the same finding a recorded failure reports, reached the other way.
+    const attempted = state.cellLabels !== undefined
+      ? {
+        detail:
+          `the run's state records a \`${state.cellLabels.status}\` snapshot over ${state.cellLabels.cellCount} cells, and the snapshot artifact is not here`,
+      }
+      : state.failureRecords?.find((record) => record.source === "cell_labels");
     const evidence: readonly CheckEvidence[] = [{
       artifact: "cell-labels.json",
       detail: cellLabelsRetentionDetail(run),
@@ -1925,17 +1932,16 @@ const cellLabelsSnapshot: AuditCheck = {
 //
 
 /**
- * The snapshot a run holds, from whichever of the two places carries it.
+ * The snapshot a run holds.
  *
- * A run writes the snapshot beside itself and records it on its state, so a
- * tree missing one of the two can still be read. {@link cellLabelsSnapshot}
- * accepts either as evidence that a snapshot was kept; this reads what the
- * snapshot SAYS, so it needs the value rather than the artifact's presence.
+ * The per-cell records live in the snapshot artifact and nowhere else: a run's
+ * state carries what the snapshot found about itself — its status, its space,
+ * how many cells it covers — and the records are the part whose size tracks
+ * the space. So a check reading what the snapshot SAYS ABOUT A CELL has the
+ * artifact or it has nothing, and the state's summary is not a substitute.
  */
 const cellLabelsOf = (run: RunEvidence): HarnessCellLabels | undefined =>
-  run.cellLabels.status === "present"
-    ? run.cellLabels.value
-    : runStateOf(run)?.cellLabels;
+  run.cellLabels.status === "present" ? run.cellLabels.value : undefined;
 
 /** One place a snapshot held a link, and the cell record it sat in. */
 interface FollowedLink {
@@ -2064,7 +2070,7 @@ const derivedCellLabels: AuditCheck = {
         }],
       };
     }
-    if (run.cellLabels.status !== "present" && state.cellLabels === undefined) {
+    if (run.cellLabels.status !== "present") {
       return notReadable("cell-labels.json", run.cellLabels);
     }
     const labels = cellLabelsOf(run)!;

--- a/packages/cf-harness/audit/test/regenerate-fixtures.ts
+++ b/packages/cf-harness/audit/test/regenerate-fixtures.ts
@@ -30,7 +30,10 @@ import {
   createFileSystemHarnessArtifactStore,
   readHarnessRunState,
 } from "../../src/artifacts.ts";
-import type { HarnessCellLabels } from "../../src/contracts/cell-labels.ts";
+import {
+  type HarnessCellLabels,
+  harnessCellLabelsSummary,
+} from "../../src/contracts/cell-labels.ts";
 import { CfHarnessEngine } from "../../src/engine.ts";
 import {
   createHarnessHandleTable,
@@ -309,7 +312,7 @@ export const regenerateFixtures = async (
     await store.persistRunState(
       patchHarnessRunState(
         state,
-        { cellLabels, cellLabelsPath },
+        { cellLabels: harnessCellLabelsSummary(cellLabels, cellLabelsPath) },
         state.updatedAt,
       ),
     );

--- a/packages/cf-harness/audit/test/seeded-violations.test.ts
+++ b/packages/cf-harness/audit/test/seeded-violations.test.ts
@@ -22,6 +22,7 @@ import {
   HARNESS_CELL_LABELS_TYPE,
   type HarnessCellLabelRecord,
   type HarnessCellLabels,
+  harnessCellLabelsSummary,
 } from "../../src/contracts/cell-labels.ts";
 import type { HarnessCfcInvocationContext } from "../../src/contracts/cfc-invocation-context.ts";
 import type { HarnessHandleEntry } from "../../src/contracts/handle-table.ts";
@@ -1050,7 +1051,8 @@ describe("seeded violations", () => {
         root.cellLabels = held === "both"
           ? { status: "present", path: root.cellLabels.path, value: labels }
           : { status: "absent", path: root.cellLabels.path };
-        (stateOf(root) as Mutable<HarnessRunState>).cellLabels = labels;
+        (stateOf(root) as Mutable<HarnessRunState>).cellLabels =
+          harnessCellLabelsSummary(labels, root.cellLabels.path);
       });
 
     /** A cell record carrying one labeled row behind the link at `result/0`. */
@@ -1168,11 +1170,13 @@ describe("seeded violations", () => {
       ).toEqual({ ...SESSION_CLEAN, [at("AUD-25")]: "not-applicable" });
     });
 
-    it("reads the snapshot off the run state when the artifact is gone", () => {
-      // A run records the snapshot in both places, so a tree that lost the
-      // file still answers. AUD-24 moves too and is right to: what became of
-      // the artifact is its subject, and this check's is what the snapshot
-      // says.
+    it("concludes nothing from a run state that names a snapshot whose artifact is gone", () => {
+      // The per-cell records live in the artifact and nowhere else: what a run
+      // keeps on its state is what the snapshot found about itself, and no
+      // count of cells says what any one of them was labelled. So this check
+      // has the artifact or it has nothing. AUD-24 reads the same tree as a
+      // read that happened and whose evidence is not here, which is its
+      // subject rather than this one's.
       expect(
         verdicts(
           withCellLabels([{
@@ -1180,7 +1184,11 @@ describe("seeded violations", () => {
             entries: [linkEntry(), labeledRowEntry()],
           }], "state-only"),
         ),
-      ).toEqual({ ...SESSION_CLEAN, [at("AUD-25")]: "pass" });
+      ).toEqual({
+        ...SESSION_CLEAN,
+        [at("AUD-24")]: "fail",
+        [at("AUD-25")]: "inconclusive",
+      });
     });
 
     it("cannot conclude anything when neither place holds a snapshot", () => {
@@ -1226,7 +1234,9 @@ describe("seeded violations", () => {
             CONFORMING_SESSION_POSTURE,
           ) as DeepMutable<HarnessFabricSessionCfcPosture>;
           const bare = {
-            ...(stateOf(root).cellLabels as HarnessCellLabels),
+            ...(root.cellLabels.status === "present"
+              ? root.cellLabels.value
+              : undefined as unknown as HarnessCellLabels),
           } as Mutable<HarnessCellLabels>;
           delete bare.unavailableDetail;
           delete bare.unavailableReason;
@@ -1236,7 +1246,10 @@ describe("seeded violations", () => {
             value: bare as HarnessCellLabels,
           };
           (stateOf(root) as Mutable<HarnessRunState>).cellLabels =
-            bare as HarnessCellLabels;
+            harnessCellLabelsSummary(
+              bare as HarnessCellLabels,
+              root.cellLabels.path,
+            );
         }),
         RUN_CHECKS,
       );

--- a/packages/cf-harness/src/contracts/cell-labels.ts
+++ b/packages/cf-harness/src/contracts/cell-labels.ts
@@ -277,3 +277,49 @@ export interface HarnessCellLabels {
 
   cells: readonly HarnessCellLabelRecord[];
 }
+
+/**
+ * A cell-label snapshot's findings about itself, without the per-cell records
+ * that carry the labels.
+ *
+ * This is what a run's own state holds. The records are the large part of a
+ * snapshot — one entry per cell the run touched, against a space whose piece
+ * graph decides how many that is — and a run's state is rewritten whole every
+ * time anything about the run advances, so carrying them there costs the
+ * snapshot's size once per write rather than once. The records live in the
+ * snapshot file that {@link HarnessCellLabelsSummary.cellsPath} names, and
+ * every reader of the labels themselves reads that file.
+ *
+ * What stays is what a reader needs in order to know whether to open it: the
+ * `status` distinction between "the space holds no label" and "nobody asked",
+ * the space that was read, and how many cells the snapshot covers.
+ */
+export interface HarnessCellLabelsSummary
+  extends Omit<HarnessCellLabels, "cells"> {
+  /** How many cells the snapshot holds a record for. */
+  cellCount: number;
+
+  /** How many of those records carry at least one label entry. */
+  labelledCellCount: number;
+
+  /**
+   * The snapshot file holding the records, when one was written. Absent where
+   * the run's artifact store does not persist one, in which case the findings
+   * here are the whole of what the run records about its labels.
+   */
+  cellsPath?: string;
+}
+
+/** The findings of `labels`, with its per-cell records left behind. */
+export const harnessCellLabelsSummary = (
+  labels: HarnessCellLabels,
+  cellsPath?: string,
+): HarnessCellLabelsSummary => {
+  const { cells, ...findings } = labels;
+  return {
+    ...findings,
+    cellCount: cells.length,
+    labelledCellCount: cells.filter((cell) => cell.entries.length > 0).length,
+    ...(cellsPath !== undefined ? { cellsPath } : {}),
+  };
+};

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -38,6 +38,7 @@ import {
 } from "./docs-corpus/corpus.ts";
 import type { HarnessExploreQueryRunner } from "./docs-corpus/explore.ts";
 import type { HarnessToolContext } from "./tools/types.ts";
+import { harnessCellLabelsSummary } from "./contracts/cell-labels.ts";
 import type { HarnessDocsCorpusRecord } from "./contracts/docs-corpus.ts";
 import {
   createHarnessCfcInvocationContext,
@@ -1759,7 +1760,13 @@ export class CfHarnessEngine {
       const cellLabelsPath = await this.artifactStore?.persistCellLabels?.(
         cellLabels,
       );
-      return patchHarnessRunState(state, { cellLabels, cellLabelsPath }, now);
+      // The records go to the file and the findings to the state. A run's
+      // state is rewritten whole whenever anything about the run advances, so
+      // the records there would cost the snapshot's size at every one of those
+      // writes; the summary is the same size whatever the space holds.
+      return patchHarnessRunState(state, {
+        cellLabels: harnessCellLabelsSummary(cellLabels, cellLabelsPath),
+      }, now);
     } catch (error) {
       return appendHarnessFailureRecord(
         state,

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -11,7 +11,7 @@ import {
   type HarnessCfcModelContext,
   type HarnessCfcModelContextObservationInput,
 } from "./contracts/cfc-model-context.ts";
-import type { HarnessCellLabels } from "./contracts/cell-labels.ts";
+import type { HarnessCellLabelsSummary } from "./contracts/cell-labels.ts";
 import type { HarnessDocsCorpusRecord } from "./contracts/docs-corpus.ts";
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
 import type { HarnessHandleTable } from "./contracts/handle-table.ts";
@@ -187,14 +187,13 @@ export interface HarnessRunState {
   cfcInvocationContexts?: HarnessCfcInvocationContext[];
 
   /**
-   * The per-cell CFC labels the run's space holds for the cells it touched.
-   * Every other artifact a run writes is the run's own record of itself; this
-   * one is read out of the space, and it is the only place a reader working
-   * from the tree can learn what a cell is labelled.
+   * What the run's space holds for the cells it touched, as findings rather
+   * than as the labels themselves. Every other artifact a run writes is the
+   * run's own record of itself; this one is read out of the space, and the
+   * snapshot file it names is the only place a reader working from the tree
+   * can learn what a cell is labelled.
    */
-  cellLabels?: HarnessCellLabels;
-
-  cellLabelsPath?: string;
+  cellLabels?: HarnessCellLabelsSummary;
   handleTable?: HarnessHandleTable;
   docsCorpus?: HarnessDocsCorpusRecord;
   skillsRoot?: HarnessSkillsRootRecord;
@@ -256,8 +255,7 @@ export interface CreateHarnessRunStateOptions {
   policyTracePath?: string;
   cfcModelContext?: HarnessCfcModelContext;
   cfcInvocationContexts?: HarnessCfcInvocationContext[];
-  cellLabels?: HarnessCellLabels;
-  cellLabelsPath?: string;
+  cellLabels?: HarnessCellLabelsSummary;
   handleTable?: HarnessHandleTable;
   docsCorpus?: HarnessDocsCorpusRecord;
   skillsRoot?: HarnessSkillsRootRecord;
@@ -373,9 +371,6 @@ export const createHarnessRunState = (
       : {}),
     ...(options.cellLabels !== undefined
       ? { cellLabels: structuredClone(options.cellLabels) }
-      : {}),
-    ...(options.cellLabelsPath !== undefined
-      ? { cellLabelsPath: options.cellLabelsPath }
       : {}),
     ...(options.handleTable !== undefined
       ? { handleTable: structuredClone(options.handleTable) }

--- a/packages/cf-harness/src/schema-read-bound.ts
+++ b/packages/cf-harness/src/schema-read-bound.ts
@@ -120,12 +120,6 @@ const admitsObject = (schema: JSONSchemaObj): boolean => {
  */
 const isOpenObjectPosition = (node: SchemaNode): boolean => {
   const schema = node.schema;
-  if (schema === false) {
-    return false;
-  }
-  if (schema === true) {
-    return true;
-  }
   if (!isObjectNotArray(schema) || typeof schema.$ref === "string") {
     return false;
   }
@@ -239,6 +233,18 @@ const recursiveDefinitionName = (schema: JSONSchema): string | undefined => {
   return undefined;
 };
 
+/** How much of a schema {@link unboundedSchemaPosition} is asked about. */
+export interface UnboundedSchemaPositionOptions {
+  /**
+   * Leave the schema's own root position unreported, and report only a
+   * position within it. For a schema that describes what its author declared,
+   * the two are different claims: a root that names nothing declares nothing,
+   * while a position inside a declared shape is a field its author named and
+   * left unbounded. Positions under the root are reported either way.
+   */
+  readonly allowOpenRoot?: boolean;
+}
+
 /**
  * The first position of `schema` that does not bound the read it drives, or
  * `undefined` when every position does.
@@ -250,6 +256,7 @@ const recursiveDefinitionName = (schema: JSONSchema): string | undefined => {
  */
 export const unboundedSchemaPosition = (
   schema: JSONSchema | undefined,
+  options: UnboundedSchemaPositionOptions = {},
 ): UnboundedSchemaPosition | undefined => {
   if (schema === undefined) {
     return undefined;
@@ -274,10 +281,22 @@ export const unboundedSchemaPosition = (
   // `$defs` bodies are walked too: a definition no reference reaches drives no
   // read, but one that is reached is read at whatever shape it declares, and
   // the walk has no way to tell a reached body from an orphan.
-  const open = findSchema(schema, isOpenObjectPosition, {
-    includeDefs: true,
-    visitBooleans: true,
-  });
+  if (schema === true) {
+    return options.allowOpenRoot === true
+      ? undefined
+      : { pointer: "", reason: "open-object" };
+  }
+  // Booleans are left unvisited: `additionalProperties: true` is the openness
+  // of the object holding it rather than a position of its own, and reporting
+  // it as one would name the same fact at two pointers — and put the second
+  // outside whatever the caller allowed at the first.
+  const open = findSchema(
+    schema,
+    (node) =>
+      !(options.allowOpenRoot === true && node.path.length === 0) &&
+      isOpenObjectPosition(node),
+    { includeDefs: true },
+  );
   return open === undefined ? undefined : {
     pointer: pointerForPath(open.path),
     reason: "open-object",
@@ -301,4 +320,31 @@ export const unboundedSchemaPositionMessage = (
   return position.reason === "recursive-ref"
     ? `${label} is recursive ${at}: \`${position.ref}\` is reachable from itself, so reading at this schema follows a value's links for as deep as they go. Declare the depth you need as nested properties instead of referring back to the enclosing shape.`
     : `${label} leaves an object open ${at}: it admits keys it does not name, so reading at this schema descends every key the value carries and follows every link it reaches. Declare the properties you need — an \`object\` with no \`properties\` asks for the whole graph.`;
+};
+
+/**
+ * Whether `schema` declares a position holding a database handle.
+ *
+ * A `SqliteDb` position declares `additionalProperties: true` over the handle's
+ * own record, so it reads as an open object to
+ * {@link unboundedSchemaPosition} while the read it drives returns that record
+ * and nothing more — the rows stay in the database file. The `sqlite` cell kind
+ * is what tells this position from a `Cell<T>`, whose read is of `T`'s value
+ * and is as open as `T` is.
+ */
+export const isDatabaseArgumentPosition = (
+  schema: JSONSchema | undefined,
+): boolean => {
+  if (!isObjectNotArray(schema)) {
+    return false;
+  }
+  const asCell = (schema as { asCell?: unknown }).asCell;
+  if (!Array.isArray(asCell)) {
+    return false;
+  }
+  return asCell.some((entry) =>
+    entry === "sqlite" ||
+    (isObjectNotArray(entry) &&
+      (entry as { kind?: unknown }).kind === "sqlite")
+  );
 };

--- a/packages/cf-harness/src/schema-read-bound.ts
+++ b/packages/cf-harness/src/schema-read-bound.ts
@@ -1,0 +1,304 @@
+/**
+ * Whether a JSON Schema bounds the read it drives.
+ *
+ * A schema handed to the runner is not only a description of a value; it is the
+ * instruction set for materializing one. The traverser descends the properties
+ * the schema names and follows every link it reaches, so the schema decides how
+ * much of a space one `get()` touches. Two positions leave that unbounded:
+ *
+ * - An object position the schema does not close. With no `properties` and no
+ *   `additionalProperties`, JSON Schema makes the position equivalent to
+ *   `additionalProperties: true`, and the traverser descends every key the
+ *   value happens to carry.
+ * - A `$ref` on a cycle. The schema is finite and the data it drives need not
+ *   be: a value whose links lead back to its own shape is followed for as deep
+ *   as the links go.
+ *
+ * Either one against a space holding a large piece graph is work with no
+ * ceiling, on whatever thread asked for it. So a caller that is about to read
+ * at a schema checks it first and refuses a position it cannot bound, naming
+ * the position so whoever wrote the schema can close it.
+ *
+ * The bound on this check: it decides the question from the schema's structure
+ * alone, which is what lets it answer before any read. A closed schema can
+ * still drive a large read — a hundred thousand declared rows are declared —
+ * and nothing here says otherwise. It rules out the positions that have no
+ * ceiling at all, not the reads that are merely big.
+ */
+
+import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
+import {
+  findSchema,
+  forEachSubschema,
+  type SchemaNode,
+} from "@commonfabric/runner/schema-walk";
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
+/** Why a schema position does not bound the read it drives. */
+export type UnboundedSchemaReason =
+  /** An object position admitting keys the schema does not name. */
+  | "open-object"
+  /** A `$ref` reachable from itself. */
+  | "recursive-ref";
+
+/** A schema position that does not bound the read it drives. */
+export interface UnboundedSchemaPosition {
+  /**
+   * JSON Pointer to the position, within the schema that was checked —
+   * `/properties/entries/items/properties/value`. The root is the empty
+   * string.
+   */
+  readonly pointer: string;
+
+  readonly reason: UnboundedSchemaReason;
+
+  /** The `$ref` on the cycle, for a `recursive-ref` position. */
+  readonly ref?: string;
+}
+
+/**
+ * The keyword a local `$ref` goes through and the definition it names, or
+ * `undefined` when `ref` is not a fragment-only reference into the root's
+ * definition map. Capture 1 is the keyword, capture 2 the definition name.
+ */
+const LOCAL_REF_PATTERN = /^#\/(\$defs|definitions)\/([^/]+)$/;
+
+/**
+ * The definition name `ref` denotes, or `undefined` for a reference this check
+ * does not resolve: an external one, a pointer into a nested definition scope,
+ * or one at the root itself.
+ *
+ * Reference tokens are decoded per RFC 6901 — `~1` before `~0`, so the token
+ * `a~01b` decodes to the name `a~1b` rather than to `a/b` — after the fragment
+ * is percent-decoded, because a `$ref` is a URI and `%2F` is a separator
+ * rather than part of a name.
+ */
+const localRefName = (ref: string): string | undefined => {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(ref);
+  } catch {
+    return undefined;
+  }
+  const token = LOCAL_REF_PATTERN.exec(decoded)?.[2];
+  return token === undefined || /~(?![01])/.test(token)
+    ? undefined
+    : token.replaceAll("~1", "/").replaceAll("~0", "~");
+};
+
+/** The JSON Pointer for a walk path, with each segment escaped per RFC 6901. */
+const pointerForPath = (path: ReadonlyArray<string | number>): string =>
+  path
+    .map((segment) =>
+      `/${String(segment).replaceAll("~", "~0").replaceAll("/", "~1")}`
+    )
+    .join("");
+
+/**
+ * Whether `schema` admits an object value. A schema naming no `type` admits
+ * every type, an object among them, which is why the open empty schema is
+ * caught here rather than slipping through as untyped.
+ */
+const admitsObject = (schema: JSONSchemaObj): boolean => {
+  const type = schema.type;
+  if (type === undefined) {
+    return true;
+  }
+  return Array.isArray(type) ? type.includes("object") : type === "object";
+};
+
+/**
+ * Whether `node` is an object position the schema leaves open. A position
+ * carrying `properties` and no `additionalProperties` is closed: the traverser
+ * descends the named properties and leaves the rest alone. A position carrying
+ * neither is the JSON Schema default of `additionalProperties: true`, and so is
+ * an explicit `true`.
+ *
+ * A `$ref` defers the whole question to its target, and a combinator defers it
+ * to its arms; both are positions the walk reaches on their own, so neither
+ * answers here.
+ */
+const isOpenObjectPosition = (node: SchemaNode): boolean => {
+  const schema = node.schema;
+  if (schema === false) {
+    return false;
+  }
+  if (schema === true) {
+    return true;
+  }
+  if (!isObjectNotArray(schema) || typeof schema.$ref === "string") {
+    return false;
+  }
+  if (!admitsObject(schema)) {
+    return false;
+  }
+  const additional = (schema as { additionalProperties?: unknown })
+    .additionalProperties;
+  if (additional === true) {
+    return true;
+  }
+  if (additional !== undefined) {
+    return false;
+  }
+  // A combinator arm may be the thing that closes the position, so a schema
+  // whose own keywords name nothing is left to the arms rather than refused
+  // here.
+  if (
+    schema.allOf !== undefined || schema.anyOf !== undefined ||
+    schema.oneOf !== undefined
+  ) {
+    return false;
+  }
+  return !isObjectNotArray(schema.properties);
+};
+
+/**
+ * The local definition names `schema`'s own body refers to, not descending
+ * into a nested definition scope — a subschema carrying its own `$defs`
+ * resolves its references against that map rather than against the root's.
+ */
+const localRefNamesWithin = (schema: JSONSchema): ReadonlySet<string> => {
+  const names = new Set<string>();
+  const collect = (node: JSONSchema): void => {
+    if (!isObjectNotArray(node)) {
+      return;
+    }
+    if (typeof node.$ref === "string") {
+      const name = localRefName(node.$ref);
+      if (name !== undefined) {
+        names.add(name);
+      }
+    }
+    forEachSubschema(node, (child, keyword) => {
+      if (
+        keyword !== "$defs" &&
+        !(isObjectNotArray(child) && child.$defs !== undefined)
+      ) {
+        collect(child);
+      }
+    }, { includeUnused: true });
+  };
+  collect(schema);
+  return names;
+};
+
+/** The root's definition map, under either keyword, or an empty one. */
+const rootDefinitions = (
+  schema: JSONSchema,
+): Readonly<Record<string, JSONSchema>> => {
+  if (!isObjectNotArray(schema)) {
+    return {};
+  }
+  const source = schema as {
+    $defs?: unknown;
+    definitions?: unknown;
+  };
+  const map = isObjectNotArray(source.$defs)
+    ? source.$defs
+    : isObjectNotArray(source.definitions)
+    ? source.definitions
+    : undefined;
+  return map === undefined ? {} : map as Readonly<Record<string, JSONSchema>>;
+};
+
+/**
+ * The name of a definition that is reachable from `schema` and reachable from
+ * itself, or `undefined` when no definition is. Depth-first over the graph
+ * whose nodes are the root's definitions and whose edges are the local `$ref`s
+ * in each body, with the current path held so that a node found on it is a
+ * cycle rather than a definition two siblings share.
+ */
+const recursiveDefinitionName = (schema: JSONSchema): string | undefined => {
+  const definitions = rootDefinitions(schema);
+  const settled = new Set<string>();
+  const onPath = new Set<string>();
+  const descend = (name: string): string | undefined => {
+    if (onPath.has(name)) {
+      return name;
+    }
+    if (settled.has(name) || !Object.hasOwn(definitions, name)) {
+      return undefined;
+    }
+    onPath.add(name);
+    for (const next of localRefNamesWithin(definitions[name])) {
+      const found = descend(next);
+      if (found !== undefined) {
+        return found;
+      }
+    }
+    onPath.delete(name);
+    settled.add(name);
+    return undefined;
+  };
+  for (const name of localRefNamesWithin(schema)) {
+    const found = descend(name);
+    if (found !== undefined) {
+      return found;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * The first position of `schema` that does not bound the read it drives, or
+ * `undefined` when every position does.
+ *
+ * An open object position is reported at its own pointer. A recursive `$ref`
+ * is reported at the first reference to the definition on the cycle, which is
+ * the position a caller can close; the cycle may run through several
+ * definitions, and only the one entered twice is named.
+ */
+export const unboundedSchemaPosition = (
+  schema: JSONSchema | undefined,
+): UnboundedSchemaPosition | undefined => {
+  if (schema === undefined) {
+    return undefined;
+  }
+  const recursive = recursiveDefinitionName(schema);
+  if (recursive !== undefined) {
+    const ref = `#/$defs/${recursive}`;
+    const site = findSchema(
+      schema,
+      (node) =>
+        isObjectNotArray(node.schema) &&
+        typeof node.schema.$ref === "string" &&
+        localRefName(node.schema.$ref) === recursive,
+      { includeDefs: true },
+    );
+    return {
+      pointer: site === undefined ? "" : pointerForPath(site.path),
+      reason: "recursive-ref",
+      ref,
+    };
+  }
+  // `$defs` bodies are walked too: a definition no reference reaches drives no
+  // read, but one that is reached is read at whatever shape it declares, and
+  // the walk has no way to tell a reached body from an orphan.
+  const open = findSchema(schema, isOpenObjectPosition, {
+    includeDefs: true,
+    visitBooleans: true,
+  });
+  return open === undefined ? undefined : {
+    pointer: pointerForPath(open.path),
+    reason: "open-object",
+  };
+};
+
+/**
+ * What to tell whoever wrote a schema carrying `position`: where the position
+ * is, why it has no ceiling, and what closing it takes.
+ *
+ * `label` names the schema in the caller's own vocabulary, so the sentence
+ * reads as being about the thing they passed.
+ */
+export const unboundedSchemaPositionMessage = (
+  label: string,
+  position: UnboundedSchemaPosition,
+): string => {
+  const at = position.pointer === ""
+    ? "at its root"
+    : `at \`${position.pointer}\``;
+  return position.reason === "recursive-ref"
+    ? `${label} is recursive ${at}: \`${position.ref}\` is reachable from itself, so reading at this schema follows a value's links for as deep as they go. Declare the depth you need as nested properties instead of referring back to the enclosing shape.`
+    : `${label} leaves an object open ${at}: it admits keys it does not name, so reading at this schema descends every key the value carries and follows every link it reaches. Declare the properties you need — an \`object\` with no \`properties\` asks for the whole graph.`;
+};

--- a/packages/cf-harness/src/tools/describe-handle.ts
+++ b/packages/cf-harness/src/tools/describe-handle.ts
@@ -408,15 +408,46 @@ const declaredSchema = async (
 };
 
 /**
+ * The shape this tool reads an arbitrary referent at to decide whether it is a
+ * database. `id` is the whole of the test `isSqliteDbRef` applies, and naming
+ * it as the only property is what bounds the read: a schema carrying
+ * `properties` and no `additionalProperties` descends the properties it names
+ * and leaves the rest of the value alone, so the read reaches one string
+ * however large a graph the referent opens onto.
+ *
+ * Exported because that bound is the contract, not an implementation detail —
+ * this tool is asked about every reference a model holds, so widening this
+ * schema makes an unbounded read of an arbitrary referent reachable from a
+ * tool whose answer is a shape.
+ */
+export const DESCRIBE_HANDLE_DATABASE_MARKER_SCHEMA: JSONSchema = {
+  type: "object",
+  properties: { id: { type: "string" } },
+};
+
+/**
  * The referent's table contract as a fragment to spread, empty where it has
- * none. The read is permissive-schema and resolving because a handle written
- * before the sqlite builtin stored it inline can hold links where its table
- * schemas belong, and the SqliteDb shape declares no properties, so a shaped
- * read would reduce the handle to `{}`.
+ * none.
+ *
+ * This tool is asked about any reference a model holds, and most of them are
+ * not databases, so the marker is read first and the tables only after it has
+ * answered. The table read is permissive-schema and resolving because a handle
+ * written before the sqlite builtin stored it inline can hold links where its
+ * table schemas belong, and the SqliteDb shape declares no properties, so a
+ * shaped read would reduce the handle to `{}`. That read is open, and what
+ * bounds it is what it runs on: a value already carrying the marker, whose
+ * tables are the column declarations the sqlite builtin wrote.
  */
 const databaseOf = (
   referent: Cell<unknown>,
 ): Pick<DescribedReferent, "database"> => {
+  if (
+    !isSqliteDbRef(
+      referent.asSchema(DESCRIBE_HANDLE_DATABASE_MARKER_SCHEMA).get(),
+    )
+  ) {
+    return {};
+  }
   const database = describedDatabase(
     referent.asSchema({ type: "object", additionalProperties: true }).get(),
   );

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -45,6 +45,7 @@ import {
 } from "../fabric-observations.ts";
 import { defineOwnEntry } from "../handle-table.ts";
 import {
+  isDatabaseArgumentPosition,
   unboundedSchemaPosition,
   unboundedSchemaPositionMessage,
 } from "../schema-read-bound.ts";
@@ -1246,7 +1247,17 @@ export const runPatternTool: HarnessToolDefinition<
     // run and whether or not the caller asked for values, so a position that
     // schema leaves unbounded is unbounded work on this thread. Refused here:
     // after the compile that produced the schema, and before the read at it.
-    const resultPosition = unboundedSchemaPosition(pattern.resultSchema);
+    //
+    // The root position is the exception. A pattern declaring `object` for its
+    // whole result declares nothing about it, and what the read then returns
+    // is what the pattern itself computed — the rendering, and whatever it
+    // put beside it. A position INSIDE a declared shape is the other case: its
+    // author named a field and left its contents unbounded, and a field is
+    // where a reference into a graph the pattern does not own arrives. That is
+    // the shape that stalled this console, and it is the one refused.
+    const resultPosition = unboundedSchemaPosition(pattern.resultSchema, {
+      allowOpenRoot: true,
+    });
     if (resultPosition !== undefined) {
       return errorOutput(
         "error",
@@ -1372,9 +1383,21 @@ export const runPatternTool: HarnessToolDefinition<
       // What this input is read at decides how much of the space the read
       // touches, and an input naming a reference reaches whatever that
       // reference reaches. An unbounded position here is refused rather than
-      // read: a handle on a large piece graph read at an open object is work
-      // with no ceiling, and the pattern has not run yet.
-      const inputPosition = unboundedSchemaPosition(readSchema);
+      // read: a reference onto a large piece graph, read at an open object, is
+      // work with no ceiling, and the pattern has not run yet.
+      //
+      // A database position is the exception, and it is about what the read
+      // returns rather than about what the schema says. `SqliteDb` declares
+      // `additionalProperties: true` over the handle's own record — an id, a
+      // revision, and the table declarations — and that record is the whole of
+      // what reading the position yields; the rows stay in the database file,
+      // which nothing here opens. So the position is open and the read is
+      // bounded by the handle, and refusing it would refuse every pattern
+      // written against an injected store.
+      const inputPosition =
+        isDatabaseArgumentPosition(argumentSchemaForKey(key))
+          ? undefined
+          : unboundedSchemaPosition(readSchema);
       if (inputPosition !== undefined) {
         return errorOutput(
           "error",

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -45,6 +45,10 @@ import {
 } from "../fabric-observations.ts";
 import { defineOwnEntry } from "../handle-table.ts";
 import {
+  unboundedSchemaPosition,
+  unboundedSchemaPositionMessage,
+} from "../schema-read-bound.ts";
+import {
   addressSealedPositions,
   isSealedOpaqueLinkObject,
   parseStructuredResultSchema,
@@ -341,7 +345,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
   toolId: "run_pattern",
   title: "Run Pattern",
   description:
-    `Compile and run a Common Fabric pattern in the configured space, returning a reference to its live result cell. Give it either your own sourceText or the patternId of a pattern search_patterns found. Source you write imports the runtime from "${RUNTIME_MODULE_SPECIFIER}" and from no other module — every pattern opens with a line of the form ${RUNTIME_MODULE_IMPORT_LINE} — and no package named after the product resolves. When the run's session reads under a confidentiality ceiling, every db.query result must be declared per session (PerSession<> on the result type, or the query's { scope: "session" } option); a query left space-scoped is refused under a ceiling rather than read. Bound every query's rows with a LIMIT — a few hundred is a sensible ceiling for a view — because an ordinary result row is materialized as its own document in the space, so an unbounded query over a large store writes a document per row it returns; an aggregate returning one row per group — count(*), sum(), a GROUP BY — is bounded by its own shape and needs no LIMIT. The piece stays out of the space's piece list; assign_slug names and lists it when it deserves a public address.`,
+    `Compile and run a Common Fabric pattern in the configured space, returning a reference to its live result cell. Give it either your own sourceText or the patternId of a pattern search_patterns found. Source you write imports the runtime from "${RUNTIME_MODULE_SPECIFIER}" and from no other module — every pattern opens with a line of the form ${RUNTIME_MODULE_IMPORT_LINE} — and no package named after the product resolves. When the run's session reads under a confidentiality ceiling, every db.query result must be declared per session (PerSession<> on the result type, or the query's { scope: "session" } option); a query left space-scoped is refused under a ceiling rather than read. Bound every query's rows with a LIMIT — a few hundred is a sensible ceiling for a view — because an ordinary result row is materialized as its own document in the space, so an unbounded query over a large store writes a document per row it returns; an aggregate returning one row per group — count(*), sum(), a GROUP BY — is bounded by its own shape and needs no LIMIT. Declare every position your pattern reads at: an object type with no named fields — TypeScript \`object\` or \`any\` — asks the runtime to descend every key the value carries and follow every link it reaches, so a pattern declaring one in its result type, or in the type of an input you wire by reference, is refused before it runs, naming the position. Name the fields you need, and declare a nested shape rather than referring back to the enclosing one. The piece stays out of the space's piece list; assign_slug names and lists it when it deserves a public address.`,
   effectClass: "side-effect",
   inputSchema: {
     type: "object",
@@ -379,7 +383,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
           { type: "object", additionalProperties: true },
         ],
         description:
-          'JSON Schema for the result value. Without it you get resultRef only and no value at all, so pass it whenever you need to read what the pattern computed. A value is returned only for the fields the schema models: an inert one (a number, a boolean, an enum or const string) comes back as itself; anything else is withheld as text and comes back as a reference token addressing that position, which describe_handle can inspect and a later run_pattern can wire by reference. Example: {"type":"object","properties":{"total":{"type":"number"}},"required":["total"]}. The framework\'s own result keys ($NAME, $UI and the other rendering variants) need not be declared. When the space\'s policy does not admit releasing the values to you, value is withheld, valueError says why and which input carried the refused label, and resultRef still names the result: pass it on by reference.',
+          'JSON Schema for the result value. Without it you get resultRef only and no value at all, so pass it whenever you need to read what the pattern computed. A value is returned only for the fields the schema models: an inert one (a number, a boolean, an enum or const string) comes back as itself; anything else is withheld as text and comes back as a reference token addressing that position, which describe_handle can inspect and a later run_pattern can wire by reference. Example: {"type":"object","properties":{"total":{"type":"number"}},"required":["total"]}. The framework\'s own result keys ($NAME, $UI and the other rendering variants) need not be declared. When the space\'s policy does not admit releasing the values to you, value is withheld, valueError says why and which input carried the refused label, and resultRef still names the result: pass it on by reference. Every object position here names its properties or the call is refused: {"type":"object"} with no properties, or additionalProperties: true, asks for the whole graph the result reaches.',
       },
     },
     // Exactly one of `sourceText` and `patternId` is required, which is a
@@ -1041,6 +1045,16 @@ export const runPatternTool: HarnessToolDefinition<
         );
       }
     }
+    const callerResultPosition = unboundedSchemaPosition(input.resultSchema);
+    if (callerResultPosition !== undefined) {
+      return errorOutput(
+        "error",
+        unboundedSchemaPositionMessage(
+          "run_pattern resultSchema",
+          callerResultPosition,
+        ),
+      );
+    }
     let parsedResultSchema;
     try {
       parsedResultSchema = parseStructuredResultSchema(input.resultSchema, {
@@ -1228,6 +1242,20 @@ export const runPatternTool: HarnessToolDefinition<
           rawCauseMessage: errorMessage(error),
         };
     }
+    // The result is read at the compiled pattern's own result schema, on every
+    // run and whether or not the caller asked for values, so a position that
+    // schema leaves unbounded is unbounded work on this thread. Refused here:
+    // after the compile that produced the schema, and before the read at it.
+    const resultPosition = unboundedSchemaPosition(pattern.resultSchema);
+    if (resultPosition !== undefined) {
+      return errorOutput(
+        "error",
+        unboundedSchemaPositionMessage(
+          "the pattern's result schema",
+          resultPosition,
+        ),
+      );
+    }
     // An input's value must match the compiled pattern's argument schema for
     // its key before any piece exists, so a mismatch is a model-correctable
     // error rather than a persisted broken piece. What supplies the value
@@ -1340,6 +1368,21 @@ export const runPatternTool: HarnessToolDefinition<
       const readSchema = readSchemaForKey(key);
       if (readSchema === undefined) {
         continue;
+      }
+      // What this input is read at decides how much of the space the read
+      // touches, and an input naming a reference reaches whatever that
+      // reference reaches. An unbounded position here is refused rather than
+      // read: a handle on a large piece graph read at an open object is work
+      // with no ceiling, and the pattern has not run yet.
+      const inputPosition = unboundedSchemaPosition(readSchema);
+      if (inputPosition !== undefined) {
+        return errorOutput(
+          "error",
+          unboundedSchemaPositionMessage(
+            `the pattern's argument schema for input "${key}"`,
+            inputPosition,
+          ),
+        );
       }
       // The read goes through the argument schema: a schema-less sync can
       // complete without data for a referent that needs schema-driven

--- a/packages/cf-harness/test/describe-handle.test.ts
+++ b/packages/cf-harness/test/describe-handle.test.ts
@@ -33,7 +33,11 @@ import type {
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
 import { responsesBodyFromChatFixture } from "./support/responses-fixture.ts";
-import { describeHandleTool } from "../src/tools/describe-handle.ts";
+import {
+  DESCRIBE_HANDLE_DATABASE_MARKER_SCHEMA,
+  describeHandleTool,
+} from "../src/tools/describe-handle.ts";
+import { unboundedSchemaPosition } from "../src/schema-read-bound.ts";
 import { runPatternTool } from "../src/tools/run-pattern.ts";
 import type { RunPatternToolSuccessOutput } from "../src/tools/run-pattern.ts";
 import type { HarnessFabricSession } from "../src/fabric-session.ts";
@@ -1087,6 +1091,38 @@ describe("describe_handle", () => {
 
         expect(output.hasSchema).toBe(true);
         expect(output.database).toBeUndefined();
+      });
+
+      describe("the shape an arbitrary referent is read at", () => {
+        // This tool is asked about every reference a model holds, and deciding
+        // whether one is a database is the one place it reads a value. So what
+        // that read is bounded by is the contract, and these pin it: the
+        // marker schema itself, and the referent that is not a database.
+
+        it("returns no unbounded position for the database marker schema", () => {
+          expect(
+            unboundedSchemaPosition(DESCRIBE_HANDLE_DATABASE_MARKER_SCHEMA),
+          ).toBeUndefined();
+        });
+
+        it("reports no database for a referent whose value carries no `id`", async () => {
+          const ref = await seedUndeclaredCell({
+            pieceRegistry: { entries: [{ name: "a" }, { name: "b" }] },
+            mentionable: true,
+          });
+          const minted = await mintAddressHandle(
+            createHarnessHandleTable("run-describe"),
+            ref,
+          );
+
+          const output = await describeHandleTool.invoke(
+            contextWith(minted.table, session),
+            { token: minted.token },
+          );
+
+          expect(output.known).toBe(true);
+          expect(output.database).toBeUndefined();
+        });
       });
     });
   });

--- a/packages/cf-harness/test/interactive-chat-cell-labels.test.ts
+++ b/packages/cf-harness/test/interactive-chat-cell-labels.test.ts
@@ -231,8 +231,11 @@ describe("interactive chat cell labels", () => {
           join(runRoot, "run-state.json"),
         );
         expect(state.status).toBe("completed");
-        expect(state.cellLabelsPath).toBe(join(runRoot, "cell-labels.json"));
+        expect(state.cellLabels?.cellsPath).toBe(
+          join(runRoot, "cell-labels.json"),
+        );
         const labels = await readCellLabels(runRoot);
+        expect(state.cellLabels?.cellCount).toBe(labels.cells.length);
         expect(labels.status).toBe("read");
         expect(labels.space?.dbPath).toBe(spaceDbPath);
         expect(labels.cells.map((cell) => cell.entityId)).toEqual([

--- a/packages/cf-harness/test/run-end-cell-labels.test.ts
+++ b/packages/cf-harness/test/run-end-cell-labels.test.ts
@@ -14,7 +14,12 @@ import {
   FileSystemHarnessArtifactStore,
   readHarnessRunState,
 } from "../src/artifacts.ts";
-import type { HarnessCellLabels } from "../src/contracts/cell-labels.ts";
+import {
+  HARNESS_CELL_LABELS_TYPE,
+  type HarnessCellLabelEntry,
+  type HarnessCellLabels,
+  harnessCellLabelsSummary,
+} from "../src/contracts/cell-labels.ts";
 import {
   CfHarnessEngine,
   type CreateHarnessEngineOptions,
@@ -32,6 +37,16 @@ import {
 
 /** A reference into the labelled cell, of the shape an input cell carries. */
 const LABELED_REF = `/${LABELED_CELL_ID}/value/secret`;
+
+/** One label entry, for the cases that only need a cell to carry any. */
+const LABELLED_ENTRY: HarnessCellLabelEntry = {
+  path: ["value", "secret"],
+  origin: "declared",
+  confidentiality: [
+    { type: "https://cfc.test/atom/email", name: "email" },
+  ],
+  integrity: [],
+};
 
 const withDirectory = async (
   body: (directory: string) => Promise<void>,
@@ -101,6 +116,52 @@ const exists = async (path: string): Promise<boolean> => {
 
 describe("run-end cell labels", () => {
   describe("completeRun()", () => {
+    it("keeps the per-cell records out of the run's own state", () => {
+      // A run's state is rewritten whole whenever anything about the run
+      // advances, so a record per cell the run touched would cost the
+      // snapshot's size at every one of those writes. The state carries the
+      // findings, whose size is fixed, and names the file holding the rest.
+      const labels: HarnessCellLabels = {
+        type: HARNESS_CELL_LABELS_TYPE,
+        version: 1,
+        generatedAt: "2026-09-10T00:00:00.000Z",
+        status: "read",
+        space: { configured: "a-space" },
+        cells: [
+          { entityId: "of:fid1:labelled", entries: [LABELLED_ENTRY] },
+          { entityId: "of:fid1:bare", entries: [] },
+        ],
+      };
+
+      const summary = harnessCellLabelsSummary(labels, "/runs/r/cells.json");
+
+      expect(Object.hasOwn(summary, "cells")).toBe(false);
+      expect(summary.cellCount).toBe(2);
+      expect(summary.labelledCellCount).toBe(1);
+      expect(summary.cellsPath).toBe("/runs/r/cells.json");
+      expect(summary.status).toBe("read");
+      expect(summary.space).toEqual({ configured: "a-space" });
+    });
+
+    it("omits `cellsPath` for a snapshot no store wrote", () => {
+      // With no file beside it, the findings are the whole of what the run
+      // records — which is what keeps the `read` against `unavailable`
+      // distinction alive on a store that persists no snapshot.
+      const summary = harnessCellLabelsSummary({
+        type: HARNESS_CELL_LABELS_TYPE,
+        version: 1,
+        generatedAt: "2026-09-10T00:00:00.000Z",
+        status: "unavailable",
+        unavailableReason: "space-not-found",
+        cells: [],
+      });
+
+      expect(summary.cellsPath).toBeUndefined();
+      expect(summary.status).toBe("unavailable");
+      expect(summary.unavailableReason).toBe("space-not-found");
+      expect(summary.cellCount).toBe(0);
+    });
+
     it("writes `cell-labels.json` beside the run, read from the space, and records it on the run's outcome", async () => {
       await withDirectory(async (directory) => {
         const runId = "run-completed";
@@ -113,11 +174,16 @@ describe("run-end cell labels", () => {
           join(runRoot, "run-state.json"),
         );
         expect(state.status).toBe("completed");
-        expect(state.cellLabelsPath).toBe(join(runRoot, "cell-labels.json"));
+        expect(state.cellLabels?.cellsPath).toBe(
+          join(runRoot, "cell-labels.json"),
+        );
         expect(state.cellLabels?.status).toBe("read");
         expect(state.failureRecords ?? []).toEqual([]);
         const labels = await readCellLabels(runRoot);
-        expect(labels).toEqual(state.cellLabels);
+        expect(state.cellLabels).toEqual(
+          harnessCellLabelsSummary(labels, join(runRoot, "cell-labels.json")),
+        );
+        expect(state.cellLabels?.cellCount).toBe(labels.cells.length);
         expect(labels.status).toBe("read");
         expect(labels.space).toEqual({
           configured: SPACE_DB_DID,
@@ -184,7 +250,6 @@ describe("run-end cell labels", () => {
         );
         expect(state.status).toBe("completed");
         expect(state.cellLabels).toBeUndefined();
-        expect(state.cellLabelsPath).toBeUndefined();
         expect(state.failureRecords ?? []).toEqual([]);
         expect(await exists(join(runRoot, "cell-labels.json"))).toBe(false);
       });
@@ -240,7 +305,6 @@ describe("run-end cell labels", () => {
         expect(state.status).toBe("completed");
         expect(state.terminalReason).toBe("assistant_completed");
         expect(state.cellLabels).toBeUndefined();
-        expect(state.cellLabelsPath).toBeUndefined();
         expect(state.failureRecords).toHaveLength(1);
         expect(state.failureRecords?.[0]).toMatchObject({
           kind: "harness_error",
@@ -267,7 +331,9 @@ describe("run-end cell labels", () => {
         expect(state.status).toBe("failed");
         expect(state.terminalReason).toBe("max_model_turns");
         expect(state.primaryFailure?.detail).toContain("out of turns");
-        expect(state.cellLabelsPath).toBe(join(runRoot, "cell-labels.json"));
+        expect(state.cellLabels?.cellsPath).toBe(
+          join(runRoot, "cell-labels.json"),
+        );
         expect(state.cellLabels?.status).toBe("read");
         const labels = await readCellLabels(runRoot);
         expect(labels.status).toBe("read");

--- a/packages/cf-harness/test/run-pattern-description.test.ts
+++ b/packages/cf-harness/test/run-pattern-description.test.ts
@@ -44,4 +44,32 @@ describe("run-pattern description", () => {
       "bounded by its own shape and needs no LIMIT",
     );
   });
+
+  it("tells the model that an unnamed object position is refused before the run", () => {
+    expect(runPatternToolDescriptor.description).toContain(
+      "Declare every position your pattern reads at",
+    );
+    expect(runPatternToolDescriptor.description).toContain(
+      "refused before it runs, naming the position",
+    );
+  });
+
+  it("states the same bound on a caller's `resultSchema`", () => {
+    const schema = runPatternToolDescriptor.inputSchema;
+    if (
+      typeof schema !== "object" || schema === null ||
+      schema.type !== "object" || schema.properties === undefined
+    ) {
+      throw new Error("expected `run_pattern` object input schema");
+    }
+    const resultSchema = schema.properties.resultSchema as JSONSchema;
+    const description = typeof resultSchema === "object" &&
+        resultSchema !== null
+      ? resultSchema.description
+      : undefined;
+
+    expect(description).toContain(
+      "Every object position here names its properties",
+    );
+  });
 });

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -2702,6 +2702,150 @@ describe("run-pattern", () => {
     });
   });
 
+  describe("unbounded read schemas", () => {
+    // A schema open at any position is the instruction to descend every key a
+    // value carries and follow every link it reaches, which against a space
+    // holding a large piece graph is work with no ceiling on the thread that
+    // asked for it. Each case here asserts the refusal lands before the work
+    // it would have started.
+
+    it("returns an error naming the open position in a caller's `resultSchema`", async () => {
+      const spy = spyOnRunPersistent();
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: DOUBLING_PATTERN_SOURCE,
+        resultSchema: {
+          type: "object",
+          properties: { entries: { type: "object" } },
+        },
+        inputs: { n: 21 },
+      });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("run_pattern resultSchema");
+      expect(output.message).toContain("`/properties/entries`");
+      expect(output.message).toContain("Declare the properties you need");
+      expect(spy.calls).toBe(0);
+    });
+
+    it("refuses a caller's `resultSchema` before compiling the source", async () => {
+      // Source that cannot compile, with an open `resultSchema`. A compile
+      // error in the message would mean the compile ran first; naming the
+      // schema is what says the gate is ahead of it.
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: "this is not a pattern and will not compile(((",
+        resultSchema: { type: "object" },
+      });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("run_pattern resultSchema");
+    });
+
+    it("returns an error naming the open position in the pattern's result schema", async () => {
+      const spy = spyOnRunPersistent();
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: [
+          "import { computed, pattern } from 'commonfabric';",
+          "interface Input { n: number; }",
+          "// deno-lint-ignore no-explicit-any",
+          "interface Output { value: any; }",
+          "export default pattern<Input, Output>(({ n }) => ({",
+          "  value: computed(() => ({ n })),",
+          "}));",
+          "",
+        ].join("\n"),
+        inputs: { n: 21 },
+      });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("the pattern's result schema");
+      expect(output.message).toContain("leaves an object open");
+      expect(spy.calls).toBe(0);
+    });
+
+    it("returns an error naming the input whose read position is open", async () => {
+      const space = pieces.getSpace();
+      const seed = runtime.getCell(
+        space,
+        "run-pattern-open-input-seed",
+        { type: "object", properties: { n: { type: "number" } } } as const,
+      );
+      const { error } = await runtime.editWithRetry((tx) => {
+        seed.withTx(tx).set({ n: 21 });
+      });
+      expect(error).toBeUndefined();
+      await runtime.idle();
+      const seedRef = createLLMFriendlyLink(
+        seed.getAsNormalizedFullLink(),
+        space,
+      );
+      const spy = spyOnRunPersistent();
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: [
+          "import { computed, pattern } from 'commonfabric';",
+          "// deno-lint-ignore no-explicit-any",
+          "interface Input { registry: any; }",
+          "interface Output { found: boolean; }",
+          "export default pattern<Input, Output>(({ registry }) => ({",
+          "  found: computed(() => registry !== undefined),",
+          "}));",
+          "",
+        ].join("\n"),
+        inputs: { registry: seedRef },
+      });
+      const output = result.output as RunPatternToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain('input "registry"');
+      expect(output.message).toContain("leaves an object open");
+      expect(spy.calls).toBe(0);
+    });
+
+    it("runs a pattern whose every read position is closed", async () => {
+      // The gate is on the positions that have no ceiling, not on reading
+      // through a reference: this input is read at a declared shape and runs.
+      const space = pieces.getSpace();
+      const seed = runtime.getCell(
+        space,
+        "run-pattern-closed-input-seed",
+        { type: "object", properties: { n: { type: "number" } } } as const,
+      );
+      const { error } = await runtime.editWithRetry((tx) => {
+        seed.withTx(tx).set({ n: 21 });
+      });
+      expect(error).toBeUndefined();
+      await runtime.idle();
+      const seedRef = createLLMFriendlyLink(
+        seed.getAsNormalizedFullLink(),
+        space,
+      );
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: [
+          "import { computed, pattern } from 'commonfabric';",
+          "interface Seed { n: number; }",
+          "interface Input { seed: Seed; }",
+          "interface Output { doubled: number; }",
+          "export default pattern<Input, Output>(({ seed }) => ({",
+          "  doubled: computed(() => seed.n * 2),",
+          "}));",
+          "",
+        ].join("\n"),
+        inputs: { seed: seedRef },
+        resultSchema: {
+          type: "object",
+          properties: { doubled: { type: "number" } },
+          required: ["doubled"],
+        },
+      });
+      const output = result.output as RunPatternToolSuccessOutput;
+      expect(output.status).toBe("ok");
+      expect(output.value).toEqual({ doubled: 42 });
+    });
+  });
+
   describe("live-cell input validation from a cold session", () => {
     // Two replicas on one loopback server: the writer seeds and pushes, the
     // reader session starts cold, never having pulled what the input's

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -2742,17 +2742,24 @@ describe("run-pattern", () => {
       expect(output.message).toContain("run_pattern resultSchema");
     });
 
-    it("returns an error naming the open position in the pattern's result schema", async () => {
+    it("returns an error naming an open field of the pattern's result schema", async () => {
+      // The result shape the stalling run declared: fields named, one of them
+      // the whole of whatever it holds.
       const spy = spyOnRunPersistent();
       const engine = createEngine();
       const result = await engine.invokeBuiltinTool("run_pattern", {
         sourceText: [
           "import { computed, pattern } from 'commonfabric';",
           "interface Input { n: number; }",
-          "// deno-lint-ignore no-explicit-any",
-          "interface Output { value: any; }",
+          "interface Output {",
+          "  displayName: string;",
+          "  mailDatabase: object;",
+          "  found: boolean;",
+          "}",
           "export default pattern<Input, Output>(({ n }) => ({",
-          "  value: computed(() => ({ n })),",
+          "  displayName: 'Mailbox',",
+          "  mailDatabase: computed(() => ({ n })),",
+          "  found: computed(() => n > 0),",
           "}));",
           "",
         ].join("\n"),
@@ -2761,8 +2768,29 @@ describe("run-pattern", () => {
       const output = result.output as RunPatternToolErrorOutput;
       expect(output.status).toBe("error");
       expect(output.message).toContain("the pattern's result schema");
+      expect(output.message).toContain("`/properties/mailDatabase`");
       expect(output.message).toContain("leaves an object open");
       expect(spy.calls).toBe(0);
+    });
+
+    it("runs a pattern that declares nothing about its result", async () => {
+      // A root naming no field declares nothing about the value, and what the
+      // read returns is what the pattern itself computed. That is a different
+      // claim from a named field left unbounded, and it is not refused.
+      const engine = createEngine();
+      const result = await engine.invokeBuiltinTool("run_pattern", {
+        sourceText: [
+          "import { computed, pattern } from 'commonfabric';",
+          "interface Input { n: number; }",
+          "export default pattern<Input, object>(({ n }) => ({",
+          "  doubled: computed(() => n * 2),",
+          "}));",
+          "",
+        ].join("\n"),
+        inputs: { n: 21 },
+      });
+      const output = result.output as RunPatternToolSuccessOutput;
+      expect(output.status).toBe("ok");
     });
 
     it("returns an error naming the input whose read position is open", async () => {

--- a/packages/cf-harness/test/schema-read-bound.test.ts
+++ b/packages/cf-harness/test/schema-read-bound.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "@std/testing/bdd";
 
 import type { JSONSchema } from "@commonfabric/api";
 import {
+  isDatabaseArgumentPosition,
   unboundedSchemaPosition,
   unboundedSchemaPositionMessage,
 } from "../src/schema-read-bound.ts";
@@ -308,6 +309,102 @@ describe("schema-read-bound", () => {
         pointer: "/properties/a~1b~0c",
         reason: "open-object",
       });
+    });
+  });
+
+  describe("allowOpenRoot", () => {
+    // A root that names nothing declares nothing about the value, which is a
+    // different claim from a field its author named and left unbounded. A
+    // caller that can tell the two apart asks for the second alone.
+
+    it("returns `undefined` for a root that declares nothing", () => {
+      expect(
+        unboundedSchemaPosition({ type: "object" }, { allowOpenRoot: true }),
+      ).toBeUndefined();
+    });
+
+    it("returns `undefined` for a root opened by `additionalProperties: true`", () => {
+      // The same openness, written the other way: it is the root's own, so it
+      // is not reported again at the keyword that states it.
+      expect(
+        unboundedSchemaPosition({
+          type: "object",
+          additionalProperties: true,
+        }, { allowOpenRoot: true }),
+      ).toBeUndefined();
+    });
+
+    it("returns `undefined` for the `true` schema", () => {
+      expect(unboundedSchemaPosition(true, { allowOpenRoot: true }))
+        .toBeUndefined();
+    });
+
+    it("returns the position of an open field within a declared shape", () => {
+      // The shape that stalled the console: a result declaring its fields,
+      // one of which is the whole of whatever it holds.
+      expect(
+        unboundedSchemaPosition({
+          type: "object",
+          properties: {
+            displayName: { type: "string" },
+            mailDatabase: { type: "object" },
+            found: { type: "boolean" },
+          },
+        }, { allowOpenRoot: true }),
+      ).toEqual({
+        pointer: "/properties/mailDatabase",
+        reason: "open-object",
+      });
+    });
+
+    it("returns a recursive `$ref` whatever the root declares", () => {
+      // A cycle is unbounded wherever it sits, so allowing an open root does
+      // not allow one.
+      expect(
+        unboundedSchemaPosition({
+          type: "object",
+          properties: { piece: { $ref: "#/$defs/piece" } },
+          $defs: {
+            piece: {
+              type: "object",
+              properties: { next: { $ref: "#/$defs/piece" } },
+            },
+          },
+        }, { allowOpenRoot: true })?.reason,
+      ).toBe("recursive-ref");
+    });
+  });
+
+  describe("isDatabaseArgumentPosition()", () => {
+    it("returns `true` for a position declaring the `sqlite` cell kind", () => {
+      expect(isDatabaseArgumentPosition({
+        $ref: "#/$defs/SqliteDatabase",
+        asCell: ["sqlite"],
+      })).toBe(true);
+    });
+
+    it("returns `true` for the object form of the entry", () => {
+      expect(isDatabaseArgumentPosition({
+        $ref: "#/$defs/SqliteDatabase",
+        asCell: [{ kind: "sqlite", scope: "session" }],
+      })).toBe(true);
+    });
+
+    it("returns `false` for a plain cell position", () => {
+      // A `Cell<T>` reads back `T`'s value and is as open as `T` is, which is
+      // what keeps it gated while a database handle is not.
+      expect(isDatabaseArgumentPosition({
+        type: "object",
+        asCell: ["cell"],
+      })).toBe(false);
+    });
+
+    it("returns `false` for a position declaring no cell at all", () => {
+      expect(isDatabaseArgumentPosition({ type: "object" })).toBe(false);
+    });
+
+    it("returns `false` for no schema", () => {
+      expect(isDatabaseArgumentPosition(undefined)).toBe(false);
     });
   });
 

--- a/packages/cf-harness/test/schema-read-bound.test.ts
+++ b/packages/cf-harness/test/schema-read-bound.test.ts
@@ -1,0 +1,389 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { JSONSchema } from "@commonfabric/api";
+import {
+  unboundedSchemaPosition,
+  unboundedSchemaPositionMessage,
+} from "../src/schema-read-bound.ts";
+
+describe("schema-read-bound", () => {
+  describe("unboundedSchemaPosition()", () => {
+    it("returns `undefined` for no schema", () => {
+      expect(unboundedSchemaPosition(undefined)).toBeUndefined();
+    });
+
+    it("returns `undefined` for a schema whose every object position names its properties", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: {
+          total: { type: "number" },
+          rows: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: { name: { type: "string" } },
+            },
+          },
+        },
+      })).toBeUndefined();
+    });
+
+    it("returns the root position for the empty schema", () => {
+      expect(unboundedSchemaPosition({})).toEqual({
+        pointer: "",
+        reason: "open-object",
+      });
+    });
+
+    it("returns the root position for the `true` schema", () => {
+      expect(unboundedSchemaPosition(true)).toEqual({
+        pointer: "",
+        reason: "open-object",
+      });
+    });
+
+    it("returns `undefined` for the `false` schema", () => {
+      expect(unboundedSchemaPosition(false)).toBeUndefined();
+    });
+
+    it("returns the position of an `object` declaring no properties", () => {
+      // The shape a TypeScript `value: object` compiles to, nested where the
+      // console's stalling run had it: an entry list whose value position is
+      // the whole of whatever the entry holds.
+
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: {
+          entries: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                value: { type: "object" },
+              },
+            },
+          },
+        },
+      })).toEqual({
+        pointer: "/properties/entries/items/properties/value",
+        reason: "open-object",
+      });
+    });
+
+    it("returns the position of an explicit `additionalProperties: true`", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { piece: { type: "string" } },
+        additionalProperties: true,
+      })).toEqual({ pointer: "", reason: "open-object" });
+    });
+
+    it("returns `undefined` for properties with `additionalProperties` unset", () => {
+      // The traverser descends only the named properties in this case, so the
+      // position is closed even though the value may carry more keys.
+
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { piece: { type: "string" } },
+      })).toBeUndefined();
+    });
+
+    it("returns `undefined` for an `additionalProperties` schema that names its own properties", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        additionalProperties: {
+          type: "object",
+          properties: { count: { type: "number" } },
+        },
+      })).toBeUndefined();
+    });
+
+    it("returns the position inside an open `additionalProperties` schema", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        additionalProperties: { type: "object" },
+      })).toEqual({
+        pointer: "/additionalProperties",
+        reason: "open-object",
+      });
+    });
+
+    it("returns `undefined` for a typed position that cannot hold an object", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { note: { type: "string" }, count: { type: "number" } },
+      })).toBeUndefined();
+    });
+
+    it("returns the position of an untyped property", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { note: { description: "anything at all" } },
+      })).toEqual({
+        pointer: "/properties/note",
+        reason: "open-object",
+      });
+    });
+
+    it("returns `undefined` for a union that excludes `object`", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { note: { type: ["string", "null"] } },
+      })).toBeUndefined();
+    });
+
+    it("returns the position of a union admitting `object`", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { note: { type: ["string", "object"] } },
+      })).toEqual({
+        pointer: "/properties/note",
+        reason: "open-object",
+      });
+    });
+
+    it("returns `undefined` for a combinator whose arms each close the position", () => {
+      expect(unboundedSchemaPosition({
+        anyOf: [
+          { type: "object", properties: { a: { type: "number" } } },
+          { type: "object", properties: { b: { type: "number" } } },
+        ],
+      })).toBeUndefined();
+    });
+
+    it("returns the position of the open arm of a combinator", () => {
+      expect(unboundedSchemaPosition({
+        anyOf: [
+          { type: "object", properties: { a: { type: "number" } } },
+          { type: "object" },
+        ],
+      })).toEqual({ pointer: "/anyOf/1", reason: "open-object" });
+    });
+
+    it("returns the position of an open object inside a `$defs` body", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { piece: { $ref: "#/$defs/piece" } },
+        $defs: { piece: { type: "object" } },
+      })).toEqual({ pointer: "/$defs/piece", reason: "open-object" });
+    });
+
+    it("returns `undefined` for a `$ref` chain that terminates", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { piece: { $ref: "#/$defs/piece" } },
+        $defs: {
+          piece: {
+            type: "object",
+            properties: { name: { $ref: "#/$defs/name" } },
+          },
+          name: { type: "string" },
+        },
+      })).toBeUndefined();
+    });
+
+    it("returns the reference site for a self-referential `$ref`", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { piece: { $ref: "#/$defs/piece" } },
+        $defs: {
+          piece: {
+            type: "object",
+            properties: { mentioned: { $ref: "#/$defs/piece" } },
+          },
+        },
+      })).toEqual({
+        pointer: "/properties/piece",
+        reason: "recursive-ref",
+        ref: "#/$defs/piece",
+      });
+    });
+
+    it("returns the definition entered twice for a mutually recursive pair", () => {
+      // The registry shape that stalled the console: `mentioned` and
+      // `backlinks` both refer back through the piece array.
+
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { pieces: { $ref: "#/$defs/pieceList" } },
+        $defs: {
+          pieceList: {
+            type: "array",
+            items: { $ref: "#/$defs/piece" },
+          },
+          piece: {
+            type: "object",
+            properties: {
+              backlinks: { $ref: "#/$defs/pieceList" },
+            },
+          },
+        },
+      })).toEqual({
+        pointer: "/properties/pieces",
+        reason: "recursive-ref",
+        ref: "#/$defs/pieceList",
+      });
+    });
+
+    it("returns `undefined` for a definition two siblings share", () => {
+      // A diamond is not a cycle: both properties reach `name`, and neither
+      // reaches anything that reaches back.
+
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: {
+          first: { $ref: "#/$defs/name" },
+          second: { $ref: "#/$defs/name" },
+        },
+        $defs: { name: { type: "string" } },
+      })).toBeUndefined();
+    });
+
+    it("returns `undefined` for a `$ref` naming no declared definition", () => {
+      // An unresolved reference drives no read of its own, and what the
+      // traverser does with it is not this check's claim to make.
+
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { piece: { $ref: "#/$defs/absent" } },
+        $defs: { present: { type: "string" } },
+      })).toBeUndefined();
+    });
+
+    it("returns `undefined` for a recursive reference into an external schema", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { piece: { $ref: "https://example.test/piece#" } },
+      })).toBeUndefined();
+    });
+
+    it("resolves a percent-encoded reference to the definition it names", () => {
+      // A `$ref` is a URI, so the fragment is decoded before the pointer is
+      // split: `%2F` is a separator and `~1` is the name's own slash.
+
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { piece: { $ref: "#%2F$defs%2Fa~1b" } },
+        $defs: {
+          "a/b": {
+            type: "object",
+            properties: { next: { $ref: "#/$defs/a~1b" } },
+          },
+        },
+      })).toEqual({
+        pointer: "/properties/piece",
+        reason: "recursive-ref",
+        ref: "#/$defs/a/b",
+      });
+    });
+
+    it("reports a recursive `$ref` ahead of an open object", () => {
+      // Both are present; the cycle is the one named, so the message a caller
+      // gets is about one position at a time.
+
+      expect(
+        unboundedSchemaPosition({
+          type: "object",
+          properties: {
+            open: { type: "object" },
+            piece: { $ref: "#/$defs/piece" },
+          },
+          $defs: {
+            piece: {
+              type: "object",
+              properties: { next: { $ref: "#/$defs/piece" } },
+            },
+          },
+        })?.reason,
+      ).toBe("recursive-ref");
+    });
+
+    it("escapes a property name carrying a pointer separator", () => {
+      expect(unboundedSchemaPosition({
+        type: "object",
+        properties: { "a/b~c": { type: "object" } },
+      })).toEqual({
+        pointer: "/properties/a~1b~0c",
+        reason: "open-object",
+      });
+    });
+  });
+
+  describe("unboundedSchemaPositionMessage()", () => {
+    it("names the label, the pointer and what closing the position takes", () => {
+      const message = unboundedSchemaPositionMessage(
+        "run_pattern resultSchema",
+        {
+          pointer: "/properties/value",
+          reason: "open-object",
+        },
+      );
+      expect(message).toContain("run_pattern resultSchema");
+      expect(message).toContain("`/properties/value`");
+      expect(message).toContain("Declare the properties you need");
+    });
+
+    it("says the position is the root when the pointer is empty", () => {
+      expect(unboundedSchemaPositionMessage("run_pattern resultSchema", {
+        pointer: "",
+        reason: "open-object",
+      })).toContain("at its root");
+    });
+
+    it("names the reference on the cycle for a recursive position", () => {
+      const message = unboundedSchemaPositionMessage(
+        "the pattern's result schema",
+        {
+          pointer: "/properties/piece",
+          reason: "recursive-ref",
+          ref: "#/$defs/piece",
+        },
+      );
+      expect(message).toContain("`#/$defs/piece` is reachable from itself");
+      expect(message).toContain("`/properties/piece`");
+    });
+  });
+
+  describe("a schema the check passes", () => {
+    it("returns `undefined` for each of the shapes a bounded run declares", () => {
+      // The four shapes that ran without stalling alongside the one that did:
+      // a scalar result, a declared row list, a handle position, and a result
+      // naming the framework's own keys.
+
+      const bounded: readonly JSONSchema[] = [
+        { type: "object", properties: { total: { type: "number" } } },
+        {
+          type: "object",
+          properties: {
+            rows: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  subject: { type: "string" },
+                  receivedAt: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        {
+          type: "object",
+          properties: { db: { type: "string", asCell: ["cell"] } },
+        },
+        {
+          type: "object",
+          properties: {
+            $NAME: { type: "string" },
+            found: { type: "boolean" },
+          },
+        },
+      ];
+      for (const schema of bounded) {
+        expect(unboundedSchemaPosition(schema)).toBeUndefined();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Checkpoint 1, the "console never blocks" slice. Ben's ruling: a long turn blocking status, cancel, the index proxy and the Weaver pill is bad engineering, not a design program. Fix the engineering.

This PR is the two bounded gates and the `run-state.json` split. The Worker carrier is deferred to its own thread; the seam analysis for it is written and named in the C1 report.

## A read at a schema position that bounds nothing is refused

`packages/cf-harness/src/schema-read-bound.ts` decides, from a schema's structure alone, whether it bounds the read it drives — which is what lets it answer before any read happens. Two positions do not bound one: an object position with no `properties` and no `additionalProperties` (JSON Schema makes that equivalent to `additionalProperties: true`, and `runner/src/traverse.ts:5044-5047` says so in as many words), and a `$ref` on a cycle. The position is named as a JSON Pointer so whoever wrote the schema can close it.

Applied at `run_pattern`'s read sites:

- the caller's own `resultSchema`, **before the compile** — a test pins this by passing source that cannot compile alongside an open schema, and asserting the message names the schema rather than the compile;
- the compiled pattern's result schema, which the release measurement reads at on every run;
- each live-cell input's own read schema, which is where a reference onto a large graph arrives.

`describe_handle` is asked about every reference a model holds, and deciding whether one is a database was its single open read — `asSchema({type:"object", additionalProperties:true}).get()` against an arbitrary referent (`describe-handle.ts:421`). It now reads the marker property first, at a schema naming `id` alone, and opens the value only once that has answered. The marker schema is exported and a test asserts it is bounded by the same check the gate uses, so widening it back goes red.

### Two narrowings, both found by running the suite against main rather than by reading

Reviewers should look hardest here — these are the places the gate was wrong before it was right.

**A `SqliteDb` argument position is exempt.** It declares `additionalProperties: true` over the handle's own record (id, revision, table declarations), and that record is the whole of what reading the position returns; the rows stay in the database file, which nothing on this path opens. The `sqlite` cell kind is what tells it from a `Cell<T>`, whose read is of `T`'s value and is as open as `T` is. Without this, every pattern written against an injected store is refused.

**A result schema open at its ROOT is exempt; an open field inside a declared shape is not.** A pattern declaring `object` for its whole result declares nothing about it, and what the read returns is what the pattern itself computed. A position inside a declared shape is the other case — a field its author named and left unbounded, which is where a reference into a graph the pattern does not own arrives. That second one is precisely the shape that stalled run `98ca55ae`: the result schema the log records is `{displayName, mailDatabase, found}` with `mailDatabase` open. Only it is refused.

## `cellLabels` out of `run-state.json`

A run's state is rewritten whole whenever anything about the run advances, and it was carrying a record per cell the run touched — 104 MB of a 193 MB `run-state.json` for one turn, duplicating `cell-labels.json` sitting beside it.

`HarnessCellLabelsSummary` is what the state holds now: the snapshot's findings about itself, whose size is fixed. The `read` against `unavailable` distinction the snapshot exists to keep survives a store that persists no file, which is what the inline copy was there for. The audit follows the records rather than the summary — AUD-25 reads what a snapshot says about a cell, so it has the artifact or it has nothing, and a state naming a snapshot with no artifact beside it is reported by AUD-24 as a read whose evidence is gone.

## Proof

Each verified by its own exit code from the repo root, never through a pipe.

- `deno fmt --check` → 0
- `deno lint packages/cf-harness` → 0
- `deno task check` (pinned deno 2.9.4) → 0, 46 groups
- `deno task test` in `packages/cf-harness` → **1001 passed (2679 steps), 23 failed**

Those 23 are the tree's own: main at `3cdf2ab489` fails the identical 23 (1000 passed / 23 failed), measured on a pristine checkout of that commit and diffed test-name by test-name. **Zero regressions.** The intermediate cuts of the gate had 19, which is how the two narrowings above were found.

The gate module's tests were checked against mutation: breaking open-object detection, and breaking cycle detection, each turn the suite red, so they are not vacuous.

## A finding worth recording

`worker.terminate()` does **not** stop a Deno worker wedged in synchronous JS — measured on deno 2.8.3 in two shapes (a tight numeric loop, and recursion-with-allocation, which is what the traverse does). It returns in 0 ms, the worker's OS thread keeps burning a full core, and the process never exits; `Deno.exit(0)` does reap it. The main thread stays fully responsive throughout — health-shaped requests answered in 2 ms while a worker pinned a core — so a Worker delivers the non-blocking guarantee and a hard kill is the thing it does not deliver. Ben's call was to take the Worker and file the child-process carrier as the follow-up, with the wedged worker named in `/api/status` and the run record rather than left silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)