### PR TITLE
docs(server-execution): record the cell-scopes question as answered

### DIFF
--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -1237,10 +1237,14 @@ Tasks:
       scopes.md §1) — and its run-supply half (one instance per
       demanding principal, materialized on demand, ragged below the
       space→user hop) RULED 2026-08-16 and LANDED by fan-out stages A
-      and B 2026-08-16/17 (scopes.md §2; verification-coverage.md OW17
-      CLOSED; `packages/runner/src/scheduler/fan-out.ts`). The one
-      residual is session-data GC (scopes.md §8 item 2), tracked as a
-      deferred design, not as a blocker. Q6's non-quota remainder —
+      and B 2026-08-16/17 (scopes.md §2; verification-coverage.md OW17,
+      CLOSED as a row — its flagged residuals, the served-host wish
+      pin, the sidecar per-demander refinement, and the unstamped
+      non-sqlite effect writebacks, stay owed THERE, as refinements to
+      the built mechanism; `packages/runner/src/scheduler/fan-out.ts`).
+      What the scopes review itself still owes is session-data GC
+      (scopes.md §8 item 2), a deferred design, not a blocker. Q6's
+      non-quota remainder —
       per-run identity for served effects — RULED 2026-08-02, R-Q6b:
       service-identity envelope, attribution within the derived
       commit (protocol.md §1/§7; runtime-mapping.md N57 resolved).

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -1229,10 +1229,18 @@ Tasks:
       notice (events.md §5, speculation.md §5); effect run cardinality
       follows cell scopes, quota attribution deferred (README §3.8,
       §6).
-- [ ] Owner + spec review of cell SCOPES (`user`/`session`) end to
-      end — v1's scope confusion must not carry into v2; blocks the
+- [x] Owner + spec review of cell SCOPES (`user`/`session`) end to
+      end — v1's scope confusion must not carry into v2; answered the
       user/session-derived-state question (README §6 Q7, was ledger
-      L10; runtime-mapping.md N56). Q6's non-quota remainder —
+      L10; runtime-mapping.md N56): the SpaceServer derives EVERY
+      instance of every scoped node — RULED 2026-08-02 (batch 3,
+      scopes.md §1) — and its run-supply half (one instance per
+      demanding principal, materialized on demand, ragged below the
+      space→user hop) RULED 2026-08-16 and LANDED by fan-out stages A
+      and B 2026-08-16/17 (scopes.md §2; verification-coverage.md OW17
+      CLOSED; `packages/runner/src/scheduler/fan-out.ts`). The one
+      residual is session-data GC (scopes.md §8 item 2), tracked as a
+      deferred design, not as a blocker. Q6's non-quota remainder —
       per-run identity for served effects — RULED 2026-08-02, R-Q6b:
       service-identity envelope, attribution within the derived
       commit (protocol.md §1/§7; runtime-mapping.md N57 resolved).

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -469,23 +469,30 @@ live in the governing detail docs — offline discharge and
 conflict-dropped events in events.md §5 + speculation.md §5, the
 durable event shape (complete as specced) and its
 integrity-provenance follow-up in events.md §1, reconciliation UX in
-speculation.md §4, sqlite clearance in builtins.md §2. Two former
-questions dropped outright: the 34× suite-context mechanism (v1-run
-minutiae; the flat-accumulation requirement stands — plan Phase 6)
-and cross-space read clearance (Phase 5 builds it by construction).
-Still open:
+speculation.md §4, sqlite clearance in builtins.md §2, and cell
+scopes (Q7 — who derives and commits user- and session-scoped
+derived state) in scopes.md: the SpaceServer derives EVERY instance
+of every scoped node, and scope keys instances, never authority
+(RULED 2026-08-02, batch 3; runtime-mapping.md N56). Its run-supply
+half — a node narrowed to `user` runs once per demanding principal,
+`session` once per session-deep principal, materialized on demand —
+was RULED 2026-08-16 and landed by fan-out stages A and B (scopes.md
+§2; verification-coverage.md OW17, CLOSED). Q6's non-quota remainder,
+which that review had inherited (was ledger L10), is ruled — R-Q6b
+(§3.8; protocol.md §1, §7). Two former questions dropped outright:
+the 34× suite-context mechanism (v1-run minutiae; the
+flat-accumulation requirement stands — plan Phase 6) and cross-space
+read clearance (Phase 5 builds it by construction). Still open:
 
 1. **Quota attribution for server-run effects (Q6 residual — later).**
    §3.8 settles authority and identity (R-Q6b) and cell scopes settle
    run cardinality; the one deferred question is whose quota a served
    effect's run is charged against.
-2. **Cell scopes (`user`/`session`), end to end (Q7).** Who derives
-   and commits user- and session-scoped derived state under the flag
-   (runtime-mapping.md N56)? Plan Phase 0 carries an owner + spec
-   review of cell scopes end to end — v1's scope confusion must not
-   carry into v2; that review blocks this question. Q6's non-quota
-   remainder, which the review had inherited (was ledger L10), is
-   now ruled — R-Q6b (§3.8; protocol.md §1, §7).
+2. **Session-data GC (scopes.md §8 item 2).** The mechanism that
+   retires a retired session's scoped instances, which must also
+   cover the basis rows narrowing strands at `space` and `user:<p>`
+   keys. A deferred design, not a gap in the built mechanism
+   (verification-coverage.md §1).
 
 ## 7. Relationship to prior documents
 

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -477,7 +477,8 @@ of every scoped node, and scope keys instances, never authority
 half — a node narrowed to `user` runs once per demanding principal,
 `session` once per session-deep principal, materialized on demand —
 was RULED 2026-08-16 and landed by fan-out stages A and B (scopes.md
-§2; verification-coverage.md OW17, CLOSED). Q6's non-quota remainder,
+§2; verification-coverage.md OW17, CLOSED as a row, its flagged
+residuals owed there as refinements). Q6's non-quota remainder,
 which that review had inherited (was ledger L10), is ruled — R-Q6b
 (§3.8; protocol.md §1, §7). Two former questions dropped outright:
 the 34× suite-context mechanism (v1-run minutiae; the
@@ -492,7 +493,8 @@ read clearance (Phase 5 builds it by construction). Still open:
    retires a retired session's scoped instances, which must also
    cover the basis rows narrowing strands at `space` and `user:<p>`
    keys. A deferred design, not a gap in the built mechanism
-   (verification-coverage.md §1).
+   (verification-coverage.md §1); the mechanism's own flagged
+   residuals are OW17's, in the register.
 
 ## 7. Relationship to prior documents
 

--- a/docs/specs/server-side-execution/runtime-mapping.md
+++ b/docs/specs/server-side-execution/runtime-mapping.md
@@ -459,15 +459,19 @@ row weighed (session-scoped derivations as client-speculation-only,
 scoped state reclassified authored-adjacent) are rejected — scoped
 derived state stays derived and server-committed, keeping today's
 reload persistence. The persisted-state context ladder (row 60)
-stays tripwired. The Phase 0 review continues (README §6 Q7, was
-ledger L10). The 2026-08-02 scout pass verified scopes.md's anchors
+stays tripwired. The Phase 0 review is complete apart from the
+session-data GC design (README §6, was ledger L10): the run-supply
+half — a narrowed node runs once per demanding principal,
+materialized on demand — was RULED 2026-08-16 and landed by fan-out
+stages A and B (scopes.md §2; verification-coverage.md OW17 CLOSED).
+The 2026-08-02 scout pass verified scopes.md's anchors
 and recorded in scopes.md §7 the five assumptions of main's scope
 machinery that a SpaceServer breaks (M1–M5: per-identity scope
 discovery; scope-NAME in-memory keying; no all-principals write
 path; scope-NAME wake keys; no session-data GC); scopes.md §8 lists
-what the review still owes (after the batch-4 closures: basis-index
-DDL authoring + session-data GC design); row 57's identity
-remainder is RESOLVED (N57, R-Q6b).
+what the review still owes — the session-data GC design, the
+basis-index DDL having been authored in serving-loop.md §3b; row
+57's identity remainder is RESOLVED (N57, R-Q6b).
 
 **N57 (identity/authority) — RESOLVED 2026-08-02 (R-Q6b).** Today
 one runtime = one `userIdentityDID` (`runtime.ts:669`) and all

--- a/docs/specs/server-side-execution/runtime-mapping.md
+++ b/docs/specs/server-side-execution/runtime-mapping.md
@@ -463,7 +463,8 @@ stays tripwired. The Phase 0 review is complete apart from the
 session-data GC design (README §6, was ledger L10): the run-supply
 half — a narrowed node runs once per demanding principal,
 materialized on demand — was RULED 2026-08-16 and landed by fan-out
-stages A and B (scopes.md §2; verification-coverage.md OW17 CLOSED).
+stages A and B (scopes.md §2; verification-coverage.md OW17, CLOSED as
+a row with its flagged residuals owed there).
 The 2026-08-02 scout pass verified scopes.md's anchors
 and recorded in scopes.md §7 the five assumptions of main's scope
 machinery that a SpaceServer breaks (M1–M5: per-identity scope

--- a/docs/specs/server-side-execution/scopes.md
+++ b/docs/specs/server-side-execution/scopes.md
@@ -1,13 +1,14 @@
 # v2 detail: cell scopes — instances, never authority
 
 Normative spec for scope semantics wherever scoped state appears
-(plan Phases 1–5; the Phase 0 scopes review owns this doc and is in
-progress). Drafted from the owner rulings of 2026-08-02, batch 3
+(plan Phases 1–5; the Phase 0 scopes review owns this doc, and owes
+only §8 item 2). Drafted from the owner rulings of 2026-08-02, batch 3
 (S1–S5 below), with the batch-4 closures folded in (§2 fan-out
 composition; §7 M3 and floor); anchors verified by the
-scope-mechanics scout pass of 2026-08-02 (§Anchors, §7). Read
-[README.md](README.md) §3.8 and §6 Q7 first; assumes
-[serving-loop.md](serving-loop.md) vocabulary.
+scope-mechanics scout pass of 2026-08-02 (§Anchors, §7); the demand
+semantics of §2 ruled 2026-08-16 and built by fan-out stages A and B
+(verification-coverage.md OW17). Read [README.md](README.md) §3.8
+first; assumes [serving-loop.md](serving-loop.md) vocabulary.
 MUST/NEVER language is binding on implementers.
 
 ## Anchors (scout pass 2026-08-02; re-verified 2026-08-05)
@@ -480,7 +481,7 @@ snapshots across principals; the v2 basis index is per-instance and
 shares nothing across principals, so nothing is left to floor.
 Nothing of the floor survives as per-instance keying evidence.
 
-## 8. Open — scout + owner (what the Phase 0 review still owes)
+## 8. Open — the one design the Phase 0 review still owes
 
 Closed by the scout pass, 2026-08-02: widen-back (NO — §2
 Permanence) and the redirect's on-disk shape (§Anchors). Closed by


### PR DESCRIPTION
## Summary

`docs/specs/server-side-execution/README.md` §6 listed **cell scopes end to end (Q7)** — who derives and commits user- and session-scoped derived state under the flag — as still open and blocked on the Phase 0 scopes review. It is answered:

- **Ruled 2026-08-02** (batch 3, runtime-mapping.md N56; scopes.md §1): the SpaceServer derives EVERY instance of every scoped node; scope keys instances, never authority.
- **Run-supply half ruled 2026-08-16** (a narrowed node runs once per demanding principal, materialized on demand) and **landed by fan-out stages A and B** 2026-08-16/17 — verification-coverage.md OW17 CLOSED; `packages/runner/src/scheduler/fan-out.ts`, pinned by `executor-fan-out.test.ts` including the ragged user/session arm.

Four live documents still described it as open. This PR re-tenses them:

- `README.md` §6 — Q7 moves from "still open" into the closed-questions preamble; the residual, **session-data GC** (scopes.md §8 item 2), takes its slot as the deferred design it is.
- `docs/plans/server-execution-v2.md` — the Phase 0 "Owner + spec review of cell SCOPES" checkbox is ticked with the rulings and landings that closed it.
- `runtime-mapping.md` N56 — "The Phase 0 review continues" → complete apart from the GC design; the basis-index DDL is no longer listed as owed (authored in serving-loop.md §3b, scopes.md §8 item 1 CLOSED).
- `scopes.md` — header no longer says the review "is in progress" or points at §6 Q7; §8 heading names the one owed design.

Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

