### PR TITLE
fix(test-selection): write a manifest's figures as they were measured

### DIFF
--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -239,13 +239,12 @@ past that anchor until `MAX_EXECUTIONS` stops it. So a test that has been
 seen to disagree at all is run at least twice, because one execution
 cannot tell a pass from a lucky pass.
 
-A share the manifest records is rounded, and a share that is not zero is
-held above zero rather than rounded to it. Zero is the one point the
-count steps at, between running a test once and running it at least
-twice, and a rounding that reached zero would take that step on the
-strength of how many times a test had run. Above zero the count follows
-the size of the share, and so does the exclusion, which a share held just
-above zero leaves far under `FLAKE_EXCLUSION_RATE`.
+Zero is the one point the count steps at, between running a test once and
+running it at least twice, which is why the manifest records a share as
+it was measured rather than to a few places. A share written to four
+places reaches zero once a test has twenty thousand runs behind one
+disagreement, and the step would then be taken on how often the test ran
+rather than on whether it had ever disagreed.
 
 The line runs past `FLAKE_EXCLUSION_RATE`, which the exclusion rule makes
 sensible rather than contradictory. A test that flaky is not selected, so

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -28,10 +28,13 @@ import {
 import { parseManifest, serializeManifest } from "./manifest.ts";
 import type { Suite } from "../test-topology/suite.ts";
 import {
+  costSeconds,
   daysBetween,
   emptyState,
   flakeRate,
   type IdentityState,
+  sealDay,
+  value,
 } from "./score.ts";
 import {
   COST_WINDOW_DAYS,
@@ -813,17 +816,29 @@ describe("what buildManifest() does with the states it is given", () => {
     expect(manifest.entries[0]!.repeats).toBe(FLAKE_MIN_EXECUTIONS);
   });
 
-  it("holds a share that is not zero above the precision it records", () => {
-    // One disagreement among enough runs that the share rounds to
-    // nothing. Zero is what says a test has never been seen to disagree,
-    // so the execution count would read this as a test that never has.
+  it("records a share as measured, however small it is", () => {
+    // One disagreement among a hundred thousand runs. Zero is what says
+    // a test has never been seen to disagree, and the execution count
+    // steps at it, so a share written to a few places would read this as
+    // a test that never has and run it once.
     const state = emptyState();
     state.runsByDay["2026-08-20"] = 100_000;
     state.failuresByDay["2026-08-20"] = 1;
     state.flakesByDay["2026-08-20"] = 1;
     const entry = built(new Map([[KEY, state]])).entries[0]!;
-    expect(entry.flakeRate).toBeGreaterThan(0);
+    expect(entry.flakeRate).toBe(1 / 100_000);
     expect(entry.repeats).toBe(FLAKE_MIN_EXECUTIONS);
+  });
+
+  it("records a cost and a score as measured", () => {
+    // Both are compared against thresholds, and a lane's budget is a sum
+    // of costs, so what is written is what was worked out.
+    const state = emptyState();
+    state.runsByDay["2026-08-20"] = 3;
+    sealDay(state, "2026-08-20", [37, 41, 43]);
+    const entry = built(new Map([[KEY, state]])).entries[0]!;
+    expect(entry.cost).toBe(costSeconds(state, "2026-08-20"));
+    expect(entry.score).toBe(value(entry.inputs, "2026-08-20"));
   });
 
   it("carries the counts the share was taken from", () => {

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -497,15 +497,6 @@ export interface BuildInput {
   calibration?: Partial<Calibration>;
 }
 
-/** Decimal places a manifest records a flake share to. */
-const SHARE_PLACES = 4;
-
-/** A number with the digits past `places` dropped. */
-function round(value: number, places: number): number {
-  const scale = 10 ** places;
-  return Math.round(value * scale) / scale;
-}
-
 /**
  * The last day this identity is known to have run. The run counts are
  * kept per day and aged rather than kept forever, so an identity nothing
@@ -531,29 +522,21 @@ export function buildManifest(input: BuildInput): Manifest {
     const surface = input.surfaces.get(key) ?? recordSurface(test, undefined);
     const inputs = scoreInputs(state, input.today);
     const evidence = flakeCounts(state, input.today);
-    // Rounded before anything reads it, so the figure the manifest
-    // carries is the figure every decision here was taken on, and a
-    // consumer applying the same threshold reaches the same answer. A
-    // share that is not zero is held above zero, because zero is the one
-    // point the execution count steps at: once below it, at least twice
-    // above. A rounding that reached zero would take that step on how
-    // many times the test had run.
-    const measured = flakeRate(state, input.today);
-    const rate = measured === 0
-      ? 0
-      : Math.max(round(measured, SHARE_PLACES), 10 ** -SHARE_PLACES);
-    // Rounded because the digits past these are noise, and because a
-    // manifest carries one entry per identity: at twenty thousand of them
-    // the difference between a rounded float and a full one is megabytes.
-    inputs.catches = round(inputs.catches, 2);
-    inputs.churn = round(inputs.churn, 6);
+    // Every figure here is written as it was measured. Thresholds are
+    // compared against these, so a figure rounded on the way in decides
+    // at the rounding rather than at the threshold: a share rounded to
+    // four places reaches zero once a test has twenty thousand runs
+    // behind one disagreement, and zero is what the execution count
+    // steps at. Reading these is what rounds them, and a reader that
+    // shows one to a person rounds it there.
+    const rate = flakeRate(state, input.today);
     const ran = lastRun(state);
     entries.push({
       test,
       suite: surface.suite,
       unit: surface.unit,
-      cost: round(costSeconds(state, input.today), 3),
-      score: round(value(inputs, input.today), 4),
+      cost: costSeconds(state, input.today),
+      score: value(inputs, input.today),
       inputs,
       flakeRate: rate,
       flakeEvidence: evidence,


### PR DESCRIPTION
PROBLEM

The publisher rounded every number it wrote: the flake share to four places, the score to four, the cost to three, churn to six, catches to two. Every threshold in selection is compared against those written figures rather than against what was measured, so each rounding decided at the rounding rather than at the threshold.

One of them decided something nobody chose. The execution count steps at a share of zero, between running a test once and running it at least twice, and a share written to four places reaches zero once a test has twenty thousand runs behind a single disagreement. Whether a test known to disagree with itself ran twice therefore turned on how often it ran.

Two of the roundings did nothing anybody wanted either. `inputs.churn` was rounded before `value()` read it, so the rounding fed the score rather than being recorded beside it. `inputs.catches` is a sum of integer counts weighted 2, 1 and 1.5, so it is always a multiple of a half and rounding it to two places could never change it.

The reason given was size. A manifest of twenty thousand entries is about 257KB gzipped rounded and about 299KB unrounded, so the comment's "megabytes" was wrong by about two orders of magnitude; gzip already recovers most of what the rounding was for.

SOLUTION

Write what was measured. `explain` and the wall already round for display, which is where rounding belongs.

That drops the clamp that held a share above zero, which existed only to patch the boundary the rounding created, and the `round` helper with it. `Math.round` stays in `executionsFor`, where an execution count has to be a whole number.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

