### PR TITLE
fix(cf-harness): drain a run's pattern index events before exiting

### DIFF
--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -1057,10 +1057,11 @@ export class CfHarnessEngine {
 
   /**
    * Sends everything this session's ledger still holds and waits for every
-   * write it has made. Called once, when the session's prompt loop finishes;
-   * a session that never reaches it publishes nothing, which `ledger.ts`
-   * states as the cost it is, and loses whichever writes were still in
-   * flight.
+   * write it has made. Called once, when the session's prompt loop finishes.
+   * A session that never reaches it keeps whatever the ledger already sent —
+   * a displaced iteration, a dependency, a report — and loses the entries
+   * still held, which `ledger.ts` states as the cost it is, along with
+   * whichever writes were in flight.
    */
   async flushPatternIndexLedger(): Promise<void> {
     await this.#patternIndexLedger?.flush();

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -110,9 +110,9 @@ import {
   type HarnessPatternIndexClientFactory,
 } from "./pattern-index/client.ts";
 import {
-  createPatternIndexPublicationLedger,
-  type PatternIndexPublicationLedger,
-} from "./pattern-index/publish-ledger.ts";
+  createPatternIndexLedger,
+  type PatternIndexLedger,
+} from "./pattern-index/ledger.ts";
 import {
   cacheHarnessSkillsShAcquisitionClientFactory,
   createHarnessSkillsShAcquisitionClientFactory,
@@ -512,7 +512,7 @@ export class CfHarnessEngine {
     HarnessSkillsShAcquisitionClientFactory;
   #docsCorpus?: Promise<HarnessDocsCorpus>;
   #exploreQueryRunner?: HarnessExploreQueryRunner;
-  #patternIndexPublications?: PatternIndexPublicationLedger;
+  #patternIndexLedger?: PatternIndexLedger;
   readonly #taskText?: string;
   readonly #inputCells: readonly HarnessInputCellSpec[];
   readonly #patternRefs: readonly HarnessPatternRefSpec[];
@@ -1046,22 +1046,24 @@ export class CfHarnessEngine {
    * duplicates were being produced at. Created on first use and only when the
    * run can reach an index at all.
    */
-  get patternIndexPublications(): PatternIndexPublicationLedger | undefined {
+  get patternIndexLedger(): PatternIndexLedger | undefined {
     const factory = this.#patternIndexClientFactory;
     if (factory === undefined) return undefined;
-    this.#patternIndexPublications ??= createPatternIndexPublicationLedger(
+    this.#patternIndexLedger ??= createPatternIndexLedger(
       factory,
     );
-    return this.#patternIndexPublications;
+    return this.#patternIndexLedger;
   }
 
   /**
-   * Sends everything this session's ledger still holds. Called once, when the
-   * session's prompt loop finishes; a session that never reaches it publishes
-   * nothing, which `publish-ledger.ts` states as the cost it is.
+   * Sends everything this session's ledger still holds and waits for every
+   * write it has made. Called once, when the session's prompt loop finishes;
+   * a session that never reaches it publishes nothing, which `ledger.ts`
+   * states as the cost it is, and loses whichever writes were still in
+   * flight.
    */
-  async flushPatternIndexPublications(): Promise<void> {
-    await this.#patternIndexPublications?.flush();
+  async flushPatternIndexLedger(): Promise<void> {
+    await this.#patternIndexLedger?.flush();
   }
 
   /**
@@ -2239,7 +2241,7 @@ export class CfHarnessEngine {
           getPatternIndexClient: this.#patternIndexClientFactory,
           patternIndexPublishEnabled: this.patternIndexPublishEnabled,
           patternIndexPublishDiscoverable: this.patternIndexPublishDiscoverable,
-          patternIndexPublications: this.patternIndexPublications,
+          patternIndexLedger: this.patternIndexLedger,
         }
         : {}),
       ...(this.docsCorpusAvailable

--- a/packages/cf-harness/src/pattern-index/ledger.ts
+++ b/packages/cf-harness/src/pattern-index/ledger.ts
@@ -1,14 +1,28 @@
 import type {
   HarnessPatternIndexClientFactory,
+  PatternIndexEventType,
   PatternIndexPublishRequest,
 } from "./client.ts";
 import { PATTERN_DISCOVERABILITY_REASONS } from "./publish-render-gate.ts";
 
 /**
- * One session's contributions to the pattern index, retaining one candidate
- * per capability rather than publishing every iteration as a candidate.
+ * Everything one session sends to the pattern index: the patterns it authored,
+ * and the events its runs report about the patterns they ran.
  *
- * ## The problem this exists for
+ * Each write is sent behind the one sent before it, and no caller waits for
+ * any of them. So the index sees this session's writes in the order they were
+ * sent — a dependency before the entry naming it, a run's `instantiated`
+ * before the terminal event that follows it — while what a session contributes
+ * to a shared catalog costs the run that contributed it nothing. A publication
+ * is held rather than sent when it is staged, for the reason below.
+ *
+ * `flush` is the session's one wait for all of it. The harness process ends
+ * through `Deno.exit`, which does not let a pending request finish, so a write
+ * nothing waits for is a write that can be cut off in flight; the prompt loop
+ * reaches `flush` before the process gets there. Nothing bounds that wait: a
+ * session whose index has stopped answering ends when its last request does.
+ *
+ * ## The problem holding a publication exists for
  *
  * A pattern-author that iterates runs the same capability three or four times
  * before it is happy. Each successful run published, and since the source
@@ -55,7 +69,7 @@ import { PATTERN_DISCOVERABILITY_REASONS } from "./publish-render-gate.ts";
  * index ranks a search against — so two entries this key cannot tell apart
  * are two entries a search cannot tell apart either.
  */
-export interface PatternIndexPublicationLedger {
+export interface PatternIndexLedger {
   /**
    * Holds `request` as this session's offer for its capability, publishing
    * anything it displaces as non-discoverable. Never throws and never awaits:
@@ -64,12 +78,22 @@ export interface PatternIndexPublicationLedger {
   stage(request: PatternIndexPublishRequest): void;
 
   /**
+   * Sends `eventType` for `patternId`, behind everything written before it.
+   * Never throws and never awaits: the run has said what it did with the
+   * pattern and is done with the report.
+   */
+  record(patternId: string, eventType: PatternIndexEventType): void;
+
+  /**
    * Publishes everything still held, ordered so that a held entry another
    * held entry names among its `dependencies` goes first. A request whose
    * turn never comes is still published, after everything that could be
    * ordered — nothing here produces a cycle, since a dependency is the
    * content-addressed identity of something that already compiled, but the
    * ordering does not assume it.
+   *
+   * Resolves once every write this session made has been answered, the
+   * publications above among them.
    */
   flush(): Promise<void>;
 }
@@ -91,17 +115,16 @@ export const patternCapabilityKey = (
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
-export const createPatternIndexPublicationLedger = (
+export const createPatternIndexLedger = (
   getClient: HarnessPatternIndexClientFactory,
   options: { onError?: (message: string) => void } = {},
-): PatternIndexPublicationLedger => {
+): PatternIndexLedger => {
   const onError = options.onError ??
     ((message: string) => console.error(message));
   const held = new Map<string, PatternIndexPublishRequest>();
   const publishedByKey = new Map<string, string>();
-  // Publications are serialized behind one chain so a dependency staged
-  // before its dependent is also SENT before it, without any caller awaiting
-  // a publish.
+  // Every write is serialized behind one chain, so a write is sent once the
+  // write before it has been answered, without any caller awaiting either.
   let chain: Promise<void> = Promise.resolve();
 
   const send = (
@@ -146,6 +169,20 @@ export const createPatternIndexPublicationLedger = (
   };
 
   return {
+    record(patternId, eventType) {
+      chain = chain.then(async () => {
+        try {
+          const client = await getClient();
+          await client.recordEvent({ patternId, eventType });
+        } catch (error) {
+          onError(
+            `run_pattern could not record the ${eventType} event for pattern index entry "${patternId}": ${
+              errorMessage(error)
+            }`,
+          );
+        }
+      });
+    },
     stage(request) {
       const dependencies = new Set(request.dependencies ?? []);
       if (dependencies.size > 0) {

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -2928,16 +2928,21 @@ export class CfHarnessPromptLoop {
   }
 
   /**
-   * Runs the loop, then sends whatever this session staged for the pattern
-   * index.
+   * Runs the loop, then sends whatever this session owes the pattern index:
+   * the pattern it staged for publication, and the reports its runs made
+   * about the indexed patterns they ran.
    *
    * The flush belongs here rather than at each `run_pattern` because the
    * ledger publishes once per capability per SESSION, and a session's last
-   * word on a capability is only known once the session is over. It runs on
-   * the failure paths too: a run that ends in an error still authored
-   * whatever it authored, and the alternative is silently discarding it.
-   * A flush failure is logged by the ledger and never displaces the loop's
-   * own result or its error.
+   * word on a capability is only known once the session is over. A report is
+   * sent as soon as the run makes it, and is waited for here because the
+   * process ends by exiting rather than by running out of work, so a report
+   * nothing waits for is a report that can be cut off in flight. The flush
+   * runs on the failure paths too: a run that ends in an error still authored
+   * whatever it authored and still ran whatever it ran, and the alternative
+   * is silently discarding it. The ledger catches and logs each write's own
+   * failure, so the flush answers with nothing to displace the loop's own
+   * result or its error.
    */
   async runTranscript(
     options: RunHarnessTranscriptOptions,
@@ -2945,7 +2950,7 @@ export class CfHarnessPromptLoop {
     try {
       return await this.#runTranscript(options);
     } finally {
-      await this.engine.flushPatternIndexPublications();
+      await this.engine.flushPatternIndexLedger();
     }
   }
 

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -51,7 +51,6 @@ import {
   validateAndSanitizeStructuredResult,
 } from "../structured-result.ts";
 import type {
-  HarnessPatternIndexClientFactory,
   PatternIndexEventType,
   PatternIndexPublishRequest,
 } from "../pattern-index/client.ts";
@@ -493,31 +492,6 @@ export const sealedPositionLink = (
 
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
-
-/**
- * Reports what a run did with an indexed pattern, without letting the report
- * bear on the run. The index ranks on these events, so a failure to record
- * one costs ranking accuracy and nothing else — it is logged and dropped
- * rather than turned into a tool error for a pattern that ran. Resolves after
- * either path, so callers can preserve report order without awaiting it as part
- * of the run.
- */
-const recordPatternIndexEvent = async (
-  getClient: HarnessPatternIndexClientFactory,
-  patternId: string,
-  eventType: PatternIndexEventType,
-): Promise<void> => {
-  try {
-    const client = await getClient();
-    await client.recordEvent({ patternId, eventType });
-  } catch (error) {
-    console.error(
-      `run_pattern could not record the ${eventType} event for pattern index entry "${patternId}": ${
-        errorMessage(error)
-      }`,
-    );
-  }
-};
 
 /**
  * The entry path `compileAndSavePattern` wraps bare source under. Written out
@@ -1020,11 +994,18 @@ export const runPatternTool: HarnessToolDefinition<
     if (sourceText === undefined && patternId === undefined) {
       return errorOutput("error", RUN_PATTERN_NO_PROGRAM_MESSAGE);
     }
-    // The run's index client, held once: which of the index paths below run
-    // is decided by the call and by whether the run has an index at all, and
-    // both questions are settled here rather than at each of them.
+    // The run's index client and its ledger, held once: which of the index
+    // paths below run is decided by the call and by whether the run has an
+    // index at all, and both questions are settled here rather than at each of
+    // them. A run configured for an index has both, so a `patternId` without
+    // either is refused here rather than reaching a path that would drop what
+    // it had to say.
     const getPatternIndexClient = context.getPatternIndexClient;
-    if (patternId !== undefined && getPatternIndexClient === undefined) {
+    const patternIndexLedger = context.patternIndexLedger;
+    if (
+      patternId !== undefined &&
+      (getPatternIndexClient === undefined || patternIndexLedger === undefined)
+    ) {
       return errorOutput(
         "error",
         "run_pattern patternId requires a pattern index; configure --pattern-index-url, or pass sourceText instead",
@@ -1367,26 +1348,17 @@ export const runPatternTool: HarnessToolDefinition<
     // built without an instantiation recorder asks nothing.
     const instantiationStart = session.instantiations?.sequence() ?? 0;
 
-    let patternIndexEventTail: Promise<void> | undefined;
-
     /**
      * Reports this invocation's outcome to the index, when the pattern came
      * from there. A cancelled run reports nothing: it neither succeeded nor
-     * failed, and the index ranks on what a pattern did. Reports start in call
-     * order without being awaited by the run, so a terminal event cannot
-     * overtake `instantiated`.
+     * failed, and the index ranks on what a pattern did. The report goes to
+     * the session's ledger, which sends it in call order without the run
+     * awaiting it and holds the session's one wait for it — the run is over
+     * long before the process is.
      */
     const recordOutcome = (eventType: PatternIndexEventType): void => {
-      if (patternId !== undefined && getPatternIndexClient !== undefined) {
-        const record = () =>
-          recordPatternIndexEvent(
-            getPatternIndexClient,
-            patternId,
-            eventType,
-          );
-        patternIndexEventTail = patternIndexEventTail === undefined
-          ? record()
-          : patternIndexEventTail.then(record);
+      if (patternId !== undefined) {
+        patternIndexLedger?.record(patternId, eventType);
       }
     };
 
@@ -1970,11 +1942,10 @@ export const runPatternTool: HarnessToolDefinition<
     // spelled twice because the type cannot say they arrive together. There is
     // deliberately no second publish path: one that skipped the ledger would
     // put back the per-iteration duplicates the ledger exists to prevent.
-    const publications = context.patternIndexPublications;
     if (
       patternId === undefined &&
       getPatternIndexClient !== undefined &&
-      publications !== undefined &&
+      patternIndexLedger !== undefined &&
       context.patternIndexPublishEnabled === true &&
       description !== undefined && description !== ""
     ) {
@@ -2056,7 +2027,7 @@ export const runPatternTool: HarnessToolDefinition<
               }
               : { discoverable: true }),
           };
-          publications.stage(request);
+          patternIndexLedger.stage(request);
         }
       }
     }

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -23,7 +23,7 @@ import type { HarnessHandleTable } from "../contracts/handle-table.ts";
 import type { HarnessFabricSession } from "../fabric-session.ts";
 import type { openProbeRuntime } from "../pattern-index/probe-runtime.ts";
 import type { PatternIndexClient } from "../pattern-index/client.ts";
-import type { PatternIndexPublicationLedger } from "../pattern-index/publish-ledger.ts";
+import type { PatternIndexLedger } from "../pattern-index/ledger.ts";
 import type { SkillsShAcquisitionClient } from "../skills-sh/acquisition.ts";
 import type { SkillsShSearchClient } from "../skills-sh/search-client.ts";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
@@ -143,13 +143,15 @@ export interface HarnessToolContext {
   patternIndexPublishDiscoverable?: boolean;
 
   /**
-   * Where a pattern this run authored is held until the session ends. The
-   * ledger publishes once per capability rather than once per successful run
-   * — see `pattern-index/publish-ledger.ts`. Absent when the run has no
-   * index, and absent for a tool invoked outside the engine, which publishes
-   * as it goes instead.
+   * Where this run's writes to the pattern index go: a pattern it authored is
+   * held there until the session ends, so the ledger publishes once per
+   * capability rather than once per successful run, and a report about an
+   * indexed pattern it ran is sent from there — see
+   * `pattern-index/ledger.ts`. Absent when the run has no index, and absent
+   * for a tool invoked outside the engine, which neither publishes nor
+   * reports.
    */
-  patternIndexPublications?: PatternIndexPublicationLedger;
+  patternIndexLedger?: PatternIndexLedger;
 
   /**
    * What this run was asked to do, in the words it was asked in. A published

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -144,9 +144,9 @@ export interface HarnessToolContext {
 
   /**
    * Where this run's writes to the pattern index go: a pattern it authored is
-   * held there until the session ends, so the ledger publishes once per
-   * capability rather than once per successful run, and a report about an
-   * indexed pattern it ran is sent from there — see
+   * held there until the session ends, so search is offered one candidate per
+   * capability while the index still records every iteration, and a report
+   * about an indexed pattern it ran is sent from there — see
    * `pattern-index/ledger.ts`. Absent when the run has no index, and absent
    * for a tool invoked outside the engine, which neither publishes nor
    * reports.

--- a/packages/cf-harness/test/ledger.test.ts
+++ b/packages/cf-harness/test/ledger.test.ts
@@ -5,11 +5,11 @@ import type { HarnessFetch } from "../src/contracts/http-fetch.ts";
 import { PatternIndexClient } from "../src/pattern-index/client.ts";
 import type { PatternIndexPublishRequest } from "../src/pattern-index/client.ts";
 import {
-  createPatternIndexPublicationLedger,
+  createPatternIndexLedger,
   patternCapabilityKey,
-} from "../src/pattern-index/publish-ledger.ts";
+} from "../src/pattern-index/ledger.ts";
 
-const signer = await Identity.fromPassphrase("cf-harness publish ledger");
+const signer = await Identity.fromPassphrase("cf-harness pattern index ledger");
 
 interface RecordedCall {
   fn: string;
@@ -23,7 +23,9 @@ interface RecordedCall {
  * hang on for one — and it is a real event, which is what
  * `docs/development/waiting-in-tests.md` asks for in place of a sleep.
  */
-const stubClient = (options: { fail?: boolean; created?: boolean } = {}) => {
+const stubClient = (
+  options: { fail?: boolean; created?: boolean; failFirstEvent?: boolean } = {},
+) => {
   const calls: RecordedCall[] = [];
   const waiters: { fn: string; count: number; resolve: () => void }[] = [];
   const answered: Record<string, number> = {};
@@ -47,6 +49,16 @@ const stubClient = (options: { fail?: boolean; created?: boolean } = {}) => {
       announce(fn);
       return Promise.resolve(response);
     };
+    if (
+      fn === "recordEvent" && options.failFirstEvent === true &&
+      calls.filter((call) => call.fn === "recordEvent").length === 1
+    ) {
+      return answer(
+        new Response(JSON.stringify({ error: "index is down" }), {
+          status: 500,
+        }),
+      );
+    }
     if (fn === "publishPattern" && options.fail === true) {
       return answer(
         new Response(JSON.stringify({ error: "index is down" }), {
@@ -101,7 +113,12 @@ const request = (
 const publishes = (calls: RecordedCall[]) =>
   calls.filter((call) => call.fn === "publishPattern");
 
-describe("pattern index publication ledger", () => {
+const eventTypes = (calls: RecordedCall[]) =>
+  calls.filter((call) => call.fn === "recordEvent").map((call) =>
+    call.body.eventType
+  );
+
+describe("pattern index ledger", () => {
   describe("patternCapabilityKey()", () => {
     it("reads two spellings of one description as one capability", () => {
       expect(patternCapabilityKey(request("a"))).toBe(
@@ -129,7 +146,7 @@ describe("pattern index publication ledger", () => {
   describe("stage() and flush()", () => {
     it("publishes nothing until the session ends", async () => {
       const { calls, getClient } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(request("one"));
       expect(publishes(calls)).toEqual([]);
       await ledger.flush();
@@ -138,7 +155,7 @@ describe("pattern index publication ledger", () => {
 
     it("offers search the last of a capability's iterations and records the rest", async () => {
       const { calls, getClient } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(request("first"));
       ledger.stage(request("second"));
       ledger.stage(request("third"));
@@ -164,7 +181,7 @@ describe("pattern index publication ledger", () => {
       // the displaced one has to be gone BEFORE the flush — measured before
       // it, since after it the two sends are indistinguishable.
       const { calls, getClient, settled } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(request("first"));
       ledger.stage(request("second"));
       // `stage` does not await, so the displaced send rides the ledger's own
@@ -184,7 +201,7 @@ describe("pattern index publication ledger", () => {
 
     it("offers search each of a session's distinct capabilities", async () => {
       const { calls, getClient } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(request("table"));
       ledger.stage(request("doubler", { description: "Doubles a number" }));
       await ledger.flush();
@@ -199,7 +216,7 @@ describe("pattern index publication ledger", () => {
       // What a person reads later should say what was found. Being displaced
       // is the less informative of the two facts.
       const { calls, getClient } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(
         request("first", {
           nonDiscoverable: { reason: "render gate: broken" },
@@ -218,7 +235,7 @@ describe("pattern index publication ledger", () => {
       // hold, so a session composing an atom it authored earlier has to send
       // that atom first.
       const { calls, getClient } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(request("doubler", { description: "Doubles a number" }));
       ledger.stage(
         request("quadrupler", {
@@ -240,7 +257,7 @@ describe("pattern index publication ledger", () => {
 
     it("names a dependency-published entry as the lineage of its next iteration", async () => {
       const { calls, getClient } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(request("first"));
       ledger.stage(
         request("other", {
@@ -263,7 +280,7 @@ describe("pattern index publication ledger", () => {
       // dependency this session never staged must still be sent rather than
       // held forever waiting for its turn.
       const { calls, getClient } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(
         request("composite", { dependencies: ["never-staged-here"] }),
       );
@@ -280,7 +297,7 @@ describe("pattern index publication ledger", () => {
       // still sends, because holding a contribution forever is worse than
       // sending it in an order the index may refuse.
       const { calls, getClient } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(
         request("one", { description: "One", dependencies: ["two"] }),
       );
@@ -295,7 +312,7 @@ describe("pattern index publication ledger", () => {
     it("reports a failed publication without throwing it at the session", async () => {
       const errors: string[] = [];
       const { getClient } = stubClient({ fail: true });
-      const ledger = createPatternIndexPublicationLedger(getClient, {
+      const ledger = createPatternIndexLedger(getClient, {
         onError: (message) => errors.push(message),
       });
       ledger.stage(request("one"));
@@ -306,7 +323,7 @@ describe("pattern index publication ledger", () => {
 
     it("records a created event for an entry the index did not hold", async () => {
       const { calls, getClient } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(request("one"));
       await ledger.flush();
       expect(
@@ -318,7 +335,7 @@ describe("pattern index publication ledger", () => {
 
     it("records no created event for an entry the index already held", async () => {
       const { calls, getClient } = stubClient({ created: false });
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(request("one"));
       await ledger.flush();
       expect(calls.filter((call) => call.fn === "recordEvent")).toEqual([]);
@@ -326,7 +343,7 @@ describe("pattern index publication ledger", () => {
 
     it("publishes a dependency first even when it was staged second", async () => {
       const { calls, getClient } = stubClient();
-      const ledger = createPatternIndexPublicationLedger(getClient);
+      const ledger = createPatternIndexLedger(getClient);
       ledger.stage(
         request("composite", {
           description: "Composes the doubler",
@@ -340,6 +357,42 @@ describe("pattern index publication ledger", () => {
         "doubler",
         "composite",
       ]);
+    });
+  });
+
+  describe("record() and flush()", () => {
+    it("sends an event without the caller waiting for it", async () => {
+      const { calls, getClient } = stubClient();
+      const ledger = createPatternIndexLedger(getClient);
+      ledger.record("pat-doubler", "instantiated");
+      expect(calls).toEqual([]);
+      await ledger.flush();
+      expect(eventTypes(calls)).toEqual(["instantiated"]);
+    });
+
+    it("reports a refused event without throwing it at the session", async () => {
+      const errors: string[] = [];
+      const { getClient } = stubClient({ failFirstEvent: true });
+      const ledger = createPatternIndexLedger(getClient, {
+        onError: (message) => errors.push(message),
+      });
+      ledger.record("pat-doubler", "run_succeeded");
+      await ledger.flush();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("could not record the run_succeeded event");
+      expect(errors[0]).toContain("pat-doubler");
+    });
+
+    it("sends the event written after one the index refused", async () => {
+      const errors: string[] = [];
+      const { calls, getClient } = stubClient({ failFirstEvent: true });
+      const ledger = createPatternIndexLedger(getClient, {
+        onError: (message) => errors.push(message),
+      });
+      ledger.record("pat-doubler", "instantiated");
+      ledger.record("pat-doubler", "run_succeeded");
+      await ledger.flush();
+      expect(eventTypes(calls)).toEqual(["instantiated", "run_succeeded"]);
     });
   });
 });

--- a/packages/cf-harness/test/run-pattern-pattern-index.test.ts
+++ b/packages/cf-harness/test/run-pattern-pattern-index.test.ts
@@ -443,17 +443,18 @@ describe("run-pattern over the pattern index", () => {
     });
 
   /**
-   * Runs the tool and then sends what the session staged for the index, which
-   * is what the prompt loop does when a session ends. A publication is held
-   * until then so a session that iterates retains one candidate per capability
-   * rather than one per successful run.
+   * Runs the tool and then sends what the session owes the index, which is
+   * what the prompt loop does when a session ends. A publication is held until
+   * then so a session that iterates retains one candidate per capability
+   * rather than one per successful run, and a run's events are waited for
+   * there because a run does not wait for them itself.
    */
   const runAndFlush = async (
     engine: CfHarnessEngine,
     input: Record<string, unknown>,
   ) => {
     const result = await engine.invokeBuiltinTool("run_pattern", input);
-    await engine.flushPatternIndexPublications();
+    await engine.flushPatternIndexLedger();
     return result;
   };
 
@@ -914,6 +915,52 @@ describe("run-pattern over the pattern index", () => {
         index.calls.filter((call) => call.fn === "recordEvent")
           .map((call) => call.body.eventType),
       ).toEqual(["instantiated", "run_failed"]);
+    });
+
+    it("waits at the session's flush for the events a finished run reported", async () => {
+      // Holding the first event signature keeps every event this run reports
+      // queued behind it, so what has reached the index when the run is over
+      // is a fact rather than a race. Identify event requests from the proof
+      // itself so changes to how the lookup is signed cannot silently bypass
+      // the gate.
+      const firstEventSignature = Promise.withResolvers<void>();
+      let recordEventSignatureCount = 0;
+      const patternIndexSigner: FirstPartyHttpSigner = {
+        did: () => signer.did(),
+        async sign(payload) {
+          const proof = new TextDecoder().decode(payload);
+          if (!proof.includes("\npath: /recordEvent\n")) {
+            return { ok: new Uint8Array(64) };
+          }
+          recordEventSignatureCount += 1;
+          if (recordEventSignatureCount === 1) {
+            await firstEventSignature.promise;
+          }
+          return { ok: new Uint8Array(64) };
+        },
+      };
+      const index = stubIndex({ "pat-doubler": INDEXED_PATTERN });
+      const engine = createEngine(index, { patternIndexSigner });
+      await engine.invokeBuiltinTool("run_pattern", {
+        patternId: "pat-doubler",
+        inputs: { n: 21 },
+        resultSchema: DOUBLED_RESULT_SCHEMA,
+      });
+
+      // The run is over and both of its events are still in flight: reporting
+      // is not part of the run.
+      expect(index.calls.filter((call) => call.fn === "recordEvent")).toEqual(
+        [],
+      );
+
+      // The session's flush is what waits for them, and it is the last thing
+      // that runs before the harness process exits.
+      firstEventSignature.resolve();
+      await engine.flushPatternIndexLedger();
+      expect(
+        index.calls.filter((call) => call.fn === "recordEvent")
+          .map((call) => call.body.eventType),
+      ).toEqual(["instantiated", "run_succeeded"]);
     });
 
     it("publishes nothing when the run opted out of publishing", async () => {

--- a/packages/cf-harness/test/run-pattern-publish-gate.test.ts
+++ b/packages/cf-harness/test/run-pattern-publish-gate.test.ts
@@ -311,7 +311,7 @@ describe("run_pattern publish render gate", () => {
   ): Promise<RunPatternToolSuccessOutput> => {
     const engine = createEngine(index);
     const result = await engine.invokeBuiltinTool("run_pattern", input);
-    await engine.flushPatternIndexPublications();
+    await engine.flushPatternIndexLedger();
     return result.output as RunPatternToolSuccessOutput;
   };
 
@@ -327,8 +327,8 @@ describe("run_pattern publish render gate", () => {
       runId: `publish-gate-${crypto.randomUUID()}`,
       fabricSessionFactory: () => Promise.resolve({ pieces, identity: signer }),
     });
-    expect(engine.patternIndexPublications).toBeUndefined();
-    await engine.flushPatternIndexPublications();
+    expect(engine.patternIndexLedger).toBeUndefined();
+    await engine.flushPatternIndexLedger();
 
     const result = await engine.invokeBuiltinTool("run_pattern", {
       sourceText: DOUBLER,
@@ -371,7 +371,7 @@ describe("run_pattern publish render gate", () => {
       inputs: { n: 21 },
       description: "Doubles a number",
     });
-    await engine.flushPatternIndexPublications();
+    await engine.flushPatternIndexLedger();
     expect((result.output as RunPatternToolSuccessOutput).status).toBe("ok");
     expect(calls.some((call) => call.fn === "publishPattern")).toBe(true);
   });
@@ -473,7 +473,7 @@ describe("run_pattern publish render gate", () => {
       description: "Sortable table that reads its cells",
       hashtags: ["table"],
     });
-    await engine.flushPatternIndexPublications();
+    await engine.flushPatternIndexLedger();
     const output = result.output as RunPatternToolSuccessOutput;
 
     expect(output.patternPublication?.status).toBe("discoverable");
@@ -512,7 +512,7 @@ describe("run_pattern publish render gate", () => {
       inputs: {},
       description: "Renders a rating",
     });
-    await engine.flushPatternIndexPublications();
+    await engine.flushPatternIndexLedger();
     const output = result.output as RunPatternToolSuccessOutput;
 
     expect(output.patternPublication?.reason).toBe("ui-rendered");
@@ -612,7 +612,7 @@ describe("run_pattern publish render gate", () => {
         { signal: AbortSignal },
       ],
     );
-    await engine.flushPatternIndexPublications();
+    await engine.flushPatternIndexLedger();
     return result.output as RunPatternToolSuccessOutput & { message?: string };
   };
 
@@ -733,7 +733,7 @@ describe("run_pattern publish render gate", () => {
       inputs: { rows: [{ name: "Avery", score: 12 }] },
       description: "Sortable table that reads its cells",
     });
-    await engine.flushPatternIndexPublications();
+    await engine.flushPatternIndexLedger();
     const output = result.output as RunPatternToolSuccessOutput;
     expect(output.patternPublication?.reason).toBe("probe-failed");
     expect(output.patternPublication?.status).toBe("recorded");
@@ -788,7 +788,7 @@ describe("run_pattern publish render gate", () => {
       inputs: { n: 3 },
       description: "Doubles a number and shows it",
     });
-    await engine.flushPatternIndexPublications();
+    await engine.flushPatternIndexLedger();
     const output = result.output as RunPatternToolSuccessOutput;
 
     // A verdict, not `probe-failed` — the composed import resolved inside the
@@ -812,7 +812,7 @@ describe("run_pattern publish render gate", () => {
         hashtags: ["table"],
       });
     }
-    await engine.flushPatternIndexPublications();
+    await engine.flushPatternIndexLedger();
 
     const calls = published(index);
     expect(calls).toHaveLength(2);
@@ -840,7 +840,7 @@ describe("run_pattern publish render gate", () => {
       inputs: { n: 21 },
       description: "Doubles a number",
     });
-    await engine.flushPatternIndexPublications();
+    await engine.flushPatternIndexLedger();
 
     const calls = published(index);
     expect(calls).toHaveLength(2);


### PR DESCRIPTION
A run whose pattern came from the index reports what it did with it: `instantiated`, and then whichever of `run_succeeded` and `run_failed` it reached. The index ranks patterns on those events. `run_pattern` started each report without awaiting it and chained it onto the report before it, so the index would see them in the order they happened, and it kept that chain in a local variable nothing ever read. The harness process ends through `Deno.exit`, which does not let a pending request finish, so a report still in flight at that moment never arrives. The terminal event is the one at risk: it starts last, and serializing the two events means it starts only once `instantiated` has been answered.

Reporting stays off the run's critical path, which is what the comments around it say it is for, so something other than the run has to wait for the reports. The publication ledger is already that: it holds a session's authored patterns, sends each write behind the one before it, and the prompt loop flushes it once, in a `finally`, when the session ends. It also already sends an event of its own, the `created` event of a new entry.

So the ledger carries the events too. `PatternIndexLedger` takes a `record` beside its `stage`, both on the one chain, and its `flush` waits for everything the session sent. Ordering, which the local chain in `run_pattern` used to provide, is now a property of that one chain, and it holds across runs rather than only within one. The prompt loop's `finally` is unchanged as the drain point, so every path that reaches the exit has already waited.

The name moved with the contents: an object that also reports what a run did with a pattern is not a publication ledger, so `PatternIndexPublicationLedger` in `pattern-index/publish-ledger.ts` becomes `PatternIndexLedger` in `pattern-index/ledger.ts`, `flushPatternIndexPublications` becomes `flushPatternIndexLedger`, and the test file moves alongside.

`run_pattern` now refuses a `patternId` when the context carries an index client without a ledger, rather than running the pattern and silently reporting nothing. The engine hands both over together, so this is the same condition the client check already states, as the file says where the publish path checks for the ledger.

Verified by isolating each property against a test that holds the first event's signature open, so that both of a finished run's events are provably still in flight when the tool returns. With `record` writing to a chain of its own that nothing drains, which is the shape this commit replaces, the new test "waits at the session's flush for the events a finished run reported" fails while the ordering test passes. With `record` sending concurrently rather than chaining, the ordering test fails as well. The ordering test itself, "reports an indexed run whose piece carries a session-only pointer as failed", is unchanged.

The cf-harness suite passes (1023 tests), as do `deno fmt --check`, `deno lint`, `deno check` over the package, `deno task check-no-waitfor`, and `deno task check-skill-facts`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

