### PR TITLE
fix(memory): fence runtimes with incompatible expression result IDs

### DIFF
--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -51,6 +51,7 @@ The client MUST declare its protocol version in the first WebSocket message:
   "protocol": "memory",
   "flags": {
     "modernCellRep": true,
+    "stableExpressionResultIds": true,
     "messageCompressionV1": true,
     "syncSchemaTableV2": true,
     "verdictCatchUpMarkers": true,
@@ -70,6 +71,7 @@ If the server accepts the protocol, it returns:
   "protocol": "memory",
   "flags": {
     "modernCellRep": true,
+    "stableExpressionResultIds": true,
     "messageCompressionV1": true,
     "syncSchemaTableV2": true,
     "verdictCatchUpMarkers": true,
@@ -91,6 +93,25 @@ If the server accepts the protocol, it returns:
 If the server does not support the requested version or the required data-model
 flags do not match what it implements, it returns a typed error response and
 does not mark the connection ready.
+
+`stableExpressionResultIds` declares the expression result identity contract:
+`ifElse`, `when`, and `unless` key their result stores on the owning piece and
+output spot. It is inherent to the build, and an absent marker means false.
+The server accepts a wire-compatible `hello` without this marker, but refuses
+every `session.open` on that connection with `SessionRevokedError`, before
+authorization, store opening, or session restoration. A reconnecting client
+treats this verdict as terminal for the session, dropping its pending commits
+and watches. Refusing at session admission uses that terminal path even in
+clients that retry server-rejected handshakes.
+
+A client requires the server to advertise the same marker in `hello.ok` and
+otherwise fails the connection permanently. This prevents a runtime from
+joining a server that admits incompatible expression writers. Browser tabs
+must reload and CLI clients must update to a build carrying the marker.
+Backend replacement must disconnect existing sockets so their next session
+open passes through admission; publishing shell assets alone does not apply
+the gate to workers already running in tabs. This changes admission, not the
+stored document format, and requires no document migration.
 
 `hello` and `hello.ok` are always ordinary memory text messages. When both
 peers advertise `messageCompressionV1`, either peer may send later messages as
@@ -368,9 +389,10 @@ Rules:
 ### 4.2.1 Client → Server: JSON Request Envelope
 
 The current wire protocol uses JSON message envelopes serialized at the wire
-boundary with the shared flag-dispatched value codec. The advertised `flags`
-reflect the active runtime/storage configuration and the connection MUST fail
-loudly if the client and server disagree. `session.open` currently carries the
+boundary with the shared flag-dispatched value codec. The `modernCellRep` flag
+MUST match between peers; optional capabilities govern accepted operations,
+and `stableExpressionResultIds` governs session admission as described above.
+`session.open` currently carries the
 only signed authorization material in this pass; `transact` carries just the
 semantic commit body. Per-commit signed UCAN envelopes remain deferred.
 
@@ -381,6 +403,7 @@ interface HelloMessage {
   protocol: "memory";
   flags: {
     modernCellRep: boolean;
+    stableExpressionResultIds?: boolean;
     messageCompressionV1?: boolean;
     syncSchemaTableV2?: boolean;
     entityIdListing?: boolean;

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -43,6 +43,17 @@ Preconditions cover what the read set cannot express on its own: that an earlier
 commit from the same session has landed, that an entity is absent, or that an
 entity's value hashes to a specific value.
 
+## Runtime compatibility
+
+The `stableExpressionResultIds` marker in `hello` and `hello.ok` identifies
+runtimes whose expression result stores use stable output coordinates. The
+server refuses session admission without it, and the client refuses a server
+that does not enforce it. Existing incompatible tabs need a reload and CLI
+checkouts need an update. Backend replacement must disconnect existing sockets
+so they pass through admission again; document contents do not need migration.
+The [protocol specification](../../docs/specs/memory-v2/04-protocol.md)
+describes the terminal refusal and its reconnect behavior.
+
 ## Layout
 
 - `v2.ts` — the protocol vocabulary: documents, operations, commits, queries,

--- a/packages/memory/test/expression-result-compatibility.test.ts
+++ b/packages/memory/test/expression-result-compatibility.test.ts
@@ -1,0 +1,248 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  type HelloMessage,
+  MEMORY_PROTOCOL,
+  parseMemoryProtocolFlags,
+  type ServerMessage,
+  wireMemoryProtocolFlags,
+} from "../v2.ts";
+import { connect, loopback, type Transport } from "../v2/client.ts";
+import { Server, SessionRegistry } from "../v2/server.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
+
+const SPACE = "did:key:z6Mk-expression-result-compatibility";
+
+describe("expression-result-compatibility", () => {
+  it("requires an explicitly advertised identity contract", () => {
+    const flags = getMemoryProtocolFlags();
+    expect(flags.stableExpressionResultIds).toBe(true);
+    expect(parseMemoryProtocolFlags(wireMemoryProtocolFlags(flags))).toEqual(
+      flags,
+    );
+    expect(parseMemoryProtocolFlags({})?.stableExpressionResultIds).toBe(false);
+    expect(
+      parseMemoryProtocolFlags({ stableExpressionResultIds: false })
+        ?.stableExpressionResultIds,
+    ).toBe(false);
+    expect(parseMemoryProtocolFlags({ stableExpressionResultIds: "true" }))
+      .toBeNull();
+  });
+
+  for (const marker of [undefined, false]) {
+    it(`refuses session admission when the marker is ${marker}`, async () => {
+      const sessions = new SessionRegistry();
+      let authorizationCalls = 0;
+      const server = new Server({
+        ...testSessionOpenServerOptions,
+        store: new URL(`memory://expression-result-compatibility-${marker}`),
+        sessions,
+        authorizeSessionOpen() {
+          authorizationCalls++;
+          return SPACE;
+        },
+      });
+      const messages: ServerMessage[] = [];
+      const connection = server.connect((message) => messages.push(message));
+      const { stableExpressionResultIds: _marker, ...flags } =
+        getMemoryProtocolFlags();
+      try {
+        await connection.receive(encodeMemoryBoundary({
+          type: "hello",
+          protocol: MEMORY_PROTOCOL,
+          flags: {
+            ...flags,
+            ...(marker === undefined
+              ? {}
+              : { stableExpressionResultIds: marker }),
+          },
+        }));
+        const hello = messages.shift();
+        expect(hello?.type).toBe("hello.ok");
+        if (hello?.type !== "hello.ok") throw new Error("Expected hello.ok");
+
+        await connection.receive(encodeMemoryBoundary({
+          type: "session.open",
+          requestId: "open",
+          space: SPACE,
+          session: { sessionId: "stale-session" },
+          invocation: {
+            aud: hello.sessionOpen?.audience,
+            challenge: hello.sessionOpen?.challenge.value,
+          },
+          authorization: {},
+        }));
+        expect(messages.shift()).toMatchObject({
+          type: "response",
+          requestId: "open",
+          error: { name: "SessionRevokedError" },
+        });
+        expect(authorizationCalls).toBe(0);
+        expect(sessions.sessionsForSpace(SPACE)).toEqual([]);
+      } finally {
+        connection.close();
+        await server.close();
+      }
+    });
+  }
+
+  it("reads and writes through a matching client and server", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://expression-result-compatibility-matching"),
+    });
+    const client = await connect({ transport: loopback(server) });
+    try {
+      const session = await client.mount(SPACE, {}, testSessionOpenAuthFactory);
+      const id = "of:fid1:expression-result";
+      await session.transact({
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id, value: { value: "glazed" } }],
+      });
+      const result = await session.queryGraph({
+        roots: [{ id, selector: { path: [], schema: false } }],
+      });
+      expect(result.entities).toEqual([{
+        id,
+        branch: "",
+        seq: 1,
+        document: { value: "glazed" },
+      }]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("refuses a server that does not enforce the identity contract", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://expression-result-compatibility-missing-server"),
+    });
+    const transport = loopback(server);
+    try {
+      await expect(connect({
+        transport: {
+          ...transport,
+          setReceiver(receiver) {
+            transport.setReceiver((payload) => {
+              const message = decodeMemoryBoundary(payload) as ServerMessage;
+              if (message.type === "hello.ok") {
+                const { stableExpressionResultIds: _marker, ...flags } =
+                  message.flags;
+                receiver(encodeMemoryBoundary({ ...message, flags }));
+              } else {
+                receiver(payload);
+              }
+            });
+          },
+        },
+      })).rejects.toMatchObject({ name: "ProtocolError", permanent: true });
+    } finally {
+      await transport.close();
+      await server.close();
+    }
+  });
+
+  it("terminates a refused resume without replaying commits or watches", async () => {
+    const before = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://expression-result-compatibility-before"),
+    });
+    const after = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://expression-result-compatibility-after"),
+    });
+    let receiver = (_payload: string) => {};
+    let closeReceiver = (_error?: Error) => {};
+    let connection = before.connect((message) =>
+      receiver(encodeMemoryBoundary(message))
+    );
+    let replaced = false;
+    let holdCommit = false;
+    const held = Promise.withResolvers<void>();
+    const afterMessages: string[] = [];
+    const transport: Transport = {
+      async send(payload) {
+        const message = decodeMemoryBoundary(payload) as { type: string };
+        if (replaced) {
+          afterMessages.push(message.type);
+          if (message.type === "hello") {
+            const hello = decodeMemoryBoundary(payload) as HelloMessage;
+            const { stableExpressionResultIds: _marker, ...flags } =
+              hello.flags;
+            payload = encodeMemoryBoundary({ ...hello, flags });
+          }
+        }
+        if (holdCommit && message.type === "transact") {
+          held.resolve();
+          return;
+        }
+        await connection.receive(payload);
+      },
+      close() {
+        connection.close();
+        return Promise.resolve();
+      },
+      setReceiver(next) {
+        receiver = next;
+      },
+      setCloseReceiver(next) {
+        closeReceiver = next;
+      },
+    };
+    const client = await connect({ transport });
+    try {
+      const session = await client.mount(SPACE, {}, testSessionOpenAuthFactory);
+      await session.watchSet([{
+        id: "root",
+        kind: "graph",
+        query: {
+          roots: [{
+            id: "of:fid1:expression-result",
+            selector: { path: [], schema: false },
+          }],
+        },
+      }]);
+      holdCommit = true;
+      const pending = session.transact({
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:fid1:expression-result",
+          value: { value: "stale result" },
+        }],
+      });
+      const refusal = expect(pending).rejects.toMatchObject({
+        name: "SessionRevokedError",
+      });
+      await held.promise;
+      connection.close();
+      connection = after.connect((message) =>
+        receiver(encodeMemoryBoundary(message))
+      );
+      replaced = true;
+      holdCommit = false;
+      closeReceiver(new Error("backend replaced"));
+      await client.restoreConnection();
+      await refusal;
+      await expect(session.watchAdd([])).rejects.toMatchObject({
+        name: "SessionRevokedError",
+      });
+      expect(afterMessages).toEqual(["hello", "session.open"]);
+    } finally {
+      await client.close();
+      await before.close();
+      await after.close();
+    }
+  });
+});

--- a/packages/memory/test/v2-client.test.ts
+++ b/packages/memory/test/v2-client.test.ts
@@ -784,6 +784,7 @@ Deno.test("memory v2 client fails closed without entity identifier capabilities"
       ...HELLO_OK,
       flags: {
         modernCellRep: getMemoryProtocolFlags().modernCellRep,
+        stableExpressionResultIds: true,
       },
     }),
   });
@@ -3426,6 +3427,7 @@ Deno.test("memory v2 client rejects hello.ok when flags disagree", async () => {
           protocol: MEMORY_PROTOCOL,
           flags: {
             modernCellRep: !getMemoryProtocolFlags().modernCellRep,
+            stableExpressionResultIds: true,
           },
         }));
       }
@@ -3446,9 +3448,8 @@ Deno.test("memory v2 client rejects hello.ok when flags disagree", async () => {
 });
 
 Deno.test("memory v2 client stores the server's advertised flags (capability handshake)", async () => {
-  // An OLD server's hello.ok omits sqliteCommitRowLabelEval: the parsed
-  // server flags must read false (the runner's write gate then keeps failing
-  // closed), while a current server's advertisement reads true.
+  // Omitting sqliteCommitRowLabelEval leaves the parsed capability false,
+  // which keeps the runner's write gate closed. Advertising it yields true.
   const transportWithFlags = (flags: unknown): Transport => {
     let receiver = (_payload: string) => {};
     return {
@@ -3488,6 +3489,7 @@ Deno.test("memory v2 client stores the server's advertised flags (capability han
   const legacy = await connect({
     transport: transportWithFlags({
       modernCellRep: getMemoryProtocolFlags().modernCellRep,
+      stableExpressionResultIds: true,
     }),
   });
   try {
@@ -3516,6 +3518,7 @@ Deno.test("memory v2 client keeps compression disabled when the server omits the
           protocol: MEMORY_PROTOCOL,
           flags: {
             modernCellRep: getMemoryProtocolFlags().modernCellRep,
+            stableExpressionResultIds: true,
           },
           sessionOpen: {
             audience: TEST_SESSION_OPEN_AUDIENCE,

--- a/packages/memory/test/v2-sync-schema-table.test.ts
+++ b/packages/memory/test/v2-sync-schema-table.test.ts
@@ -831,6 +831,7 @@ Deno.test("memory server negotiates schema-table v2 sync frames per connection",
     const space = `did:key:z6Mk-sync-schema-table-${mode}`;
     const clientFlags = mode === "v2" ? flags : {
       modernCellRep: flags.modernCellRep,
+      stableExpressionResultIds: true,
       commitPreconditions: flags.commitPreconditions,
       ...(mode === "legacy" ? { syncSchemaTable: true } : {}),
     };

--- a/packages/memory/test/v2.test.ts
+++ b/packages/memory/test/v2.test.ts
@@ -138,6 +138,7 @@ describe("memory v2 flags", () => {
 
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: false,
+      stableExpressionResultIds: true,
       commitPreconditions: false,
       applyOp: true,
       operationCodecs: ["codemirror-changeset@1"],
@@ -160,6 +161,7 @@ describe("memory v2 flags", () => {
 
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: true,
+      stableExpressionResultIds: true,
       commitPreconditions: true,
       applyOp: true,
       operationCodecs: ["codemirror-changeset@1"],
@@ -184,6 +186,7 @@ describe("memory v2 flags", () => {
     assert(compatibleMemoryProtocolFlags(
       {
         modernCellRep: true,
+        stableExpressionResultIds: true,
         commitPreconditions: true,
         applyOp: true,
         syncSchemaTableV2: true,
@@ -198,6 +201,7 @@ describe("memory v2 flags", () => {
       },
       {
         modernCellRep: true,
+        stableExpressionResultIds: true,
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
@@ -221,6 +225,7 @@ describe("parseMemoryProtocolFlags", () => {
   it("accepts the modernCellRep key", () => {
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: true }), {
       modernCellRep: true,
+      stableExpressionResultIds: false,
       commitPreconditions: false,
       applyOp: false,
       syncSchemaTableV2: false,
@@ -235,6 +240,7 @@ describe("parseMemoryProtocolFlags", () => {
     });
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: false }), {
       modernCellRep: false,
+      stableExpressionResultIds: false,
       commitPreconditions: false,
       applyOp: false,
       syncSchemaTableV2: false,
@@ -256,6 +262,7 @@ describe("parseMemoryProtocolFlags", () => {
       }),
       {
         modernCellRep: false,
+        stableExpressionResultIds: false,
         commitPreconditions: true,
         applyOp: false,
         syncSchemaTableV2: false,
@@ -296,6 +303,7 @@ describe("parseMemoryProtocolFlags", () => {
       }),
       {
         modernCellRep: false,
+        stableExpressionResultIds: false,
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: true,
@@ -316,6 +324,7 @@ describe("parseMemoryProtocolFlags", () => {
       parseMemoryProtocolFlags({ messageCompressionV1: true }),
       {
         modernCellRep: false,
+        stableExpressionResultIds: false,
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
@@ -338,6 +347,7 @@ describe("parseMemoryProtocolFlags", () => {
       }),
       {
         modernCellRep: false,
+        stableExpressionResultIds: false,
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
@@ -368,6 +378,7 @@ describe("parseMemoryProtocolFlags", () => {
       }),
       {
         modernCellRep: false,
+        stableExpressionResultIds: false,
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
@@ -391,6 +402,7 @@ describe("parseMemoryProtocolFlags", () => {
       }),
       {
         modernCellRep: false,
+        stableExpressionResultIds: false,
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
@@ -411,6 +423,7 @@ describe("parseMemoryProtocolFlags", () => {
       parseMemoryProtocolFlags({ entityIdListing: true }),
       {
         modernCellRep: false,
+        stableExpressionResultIds: false,
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
@@ -435,6 +448,7 @@ describe("parseMemoryProtocolFlags", () => {
       }),
       {
         modernCellRep: false,
+        stableExpressionResultIds: false,
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
@@ -484,6 +498,7 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(
       parseMemoryProtocolFlags({
         modernCellRep: true,
+        stableExpressionResultIds: false,
         commitPreconditions: "true",
       }),
       null,

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1079,6 +1079,14 @@ export type SessionOpenResult = {
 
 export type MemoryProtocolFlags = {
   modernCellRep: boolean;
+
+  /**
+   * Expression result stores are keyed on their owning piece and output spot.
+   * Servers require this marker when admitting a session; clients require it
+   * from servers so incompatible writers cannot share their computed cells.
+   */
+  stableExpressionResultIds: boolean;
+
   commitPreconditions: boolean;
 
   /** The server integrates durable collaborative operation streams. */
@@ -1165,6 +1173,10 @@ export type MemoryProtocolFlags = {
  */
 export type WireMemoryProtocolFlags = {
   modernCellRep?: boolean;
+
+  /** Expression result identity contract required for session admission. */
+  stableExpressionResultIds?: boolean;
+
   commitPreconditions?: boolean;
   applyOp?: boolean;
   operationCodecs?: readonly string[];
@@ -1946,6 +1958,7 @@ export function resetOwnWriteEchoConfig(): void {
 
 export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   modernCellRep: getModernCellRepConfig(),
+  stableExpressionResultIds: true,
   commitPreconditions: getCommitPreconditionsConfig(),
   applyOp: true,
   operationCodecs: [CODEMIRROR_CHANGESET_CODEC],
@@ -1975,10 +1988,8 @@ export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
 });
 
 /**
- * Commit preconditions and the other capability flags are optional
- * capabilities, not data-model wire contracts. Peers with different
- * capability flags can still share memory data; the server's flags control
- * what is accepted on that connection.
+ * Compares data-model wire contracts. Capability flags govern accepted
+ * operations separately; `stableExpressionResultIds` governs session admission.
  */
 export const compatibleMemoryProtocolFlags = (
   left: MemoryProtocolFlags,
@@ -1993,6 +2004,14 @@ export const parseMemoryProtocolFlags = (
   value: unknown,
 ): MemoryProtocolFlags | null => {
   if (!isObjectNotArray(value)) {
+    return null;
+  }
+
+  const stableExpressionResultIds = value.stableExpressionResultIds;
+  if (
+    stableExpressionResultIds !== undefined &&
+    typeof stableExpressionResultIds !== "boolean"
+  ) {
     return null;
   }
 
@@ -2102,6 +2121,7 @@ export const parseMemoryProtocolFlags = (
 
   return {
     modernCellRep: modernCellRep === true,
+    stableExpressionResultIds: stableExpressionResultIds === true,
     commitPreconditions: commitPreconditions === true,
     applyOp: applyOp === true,
     ...(operationCodecs === undefined
@@ -2136,6 +2156,7 @@ export const wireMemoryProtocolFlags = (
   flags: MemoryProtocolFlags,
 ): WireMemoryProtocolFlags => ({
   modernCellRep: flags.modernCellRep,
+  stableExpressionResultIds: flags.stableExpressionResultIds,
   commitPreconditions: flags.commitPreconditions,
   applyOp: flags.applyOp,
   ...(flags.operationCodecs === undefined

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -534,6 +534,13 @@ export class Client {
       const helloOk = parseHelloOk(message);
       if (helloOk !== null) {
         const expectedFlags = getMemoryProtocolFlags();
+        if (!helloOk.flags.stableExpressionResultIds) {
+          this.#helloPending.reject(permanentProtocolError(
+            "The memory server does not enforce stable expression result " +
+              "identities. Update the server before connecting this runtime.",
+          ));
+          return;
+        }
         if (!compatibleMemoryProtocolFlags(helloOk.flags, expectedFlags)) {
           // A data-model wire-contract mismatch: this client and server cannot
           // talk at all, and no retry changes that. Mark it permanent so a

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -780,6 +780,7 @@ class Connection {
   #ready = false;
   #closed = false;
   #syncSchemaTable = false;
+  #stableExpressionResultIds = false;
   #sessions = new Map<string, SessionHandle>();
   #sessionOpenChallenge: SessionOpenChallengeState | null = null;
   #receiving: Promise<void> = Promise.resolve();
@@ -807,6 +808,11 @@ class Connection {
     const sendStart = performance.now();
     this.#sendRaw(prepared);
     timing.time(sendStart, "memory", "response", "sendRaw");
+  }
+
+  /** Whether the peer declared the expression result identity contract. */
+  get stableExpressionResultIds(): boolean {
+    return this.#stableExpressionResultIds;
   }
 
   hasSession(space: string, sessionId: string): boolean {
@@ -1054,6 +1060,8 @@ class Connection {
       }
       const clientFlags = parseMemoryProtocolFlags(parsed.flags);
       const serverFlags = parseMemoryProtocolFlags(response.flags);
+      this.#stableExpressionResultIds =
+        clientFlags?.stableExpressionResultIds === true;
       this.#syncSchemaTable = clientFlags?.syncSchemaTableV2 === true &&
         serverFlags?.syncSchemaTableV2 === true;
       this.#ready = true;
@@ -3129,6 +3137,18 @@ export class Server {
   ): Promise<ResponseMessage<SessionOpenResult>> {
     try {
       const authContext = connection.sessionOpenAuthContext(message);
+      // Refuse at session admission: reconnecting peers understand this verdict
+      // as terminal for the session and discard its pending commits and watches.
+      if (!connection.stableExpressionResultIds) {
+        return respondTypedError<SessionOpenResult>(
+          message.requestId,
+          toError(
+            "SessionRevokedError",
+            "This runtime uses incompatible expression result identities. " +
+              "Reload the browser tab or update the CLI checkout.",
+          ),
+        );
+      }
       const principal = await this.options.authorizeSessionOpen(
         message,
         authContext,


### PR DESCRIPTION
Estuary's Topics slowdown is driven by runtimes repeatedly replacing shared computed links with incompatible expression result-store IDs. In three sampled cells, the new IDs exactly match #7153's output-spot derivation, while the competing writer restores the values stored before the deployment. Subscriber refreshes amplify those writes into long publication-lock waits; the observed burst included 968 commits in one minute.

Require a build-inherent `stableExpressionResultIds` marker before admitting a memory session. A wire-compatible older client can complete `hello`, but `session.open` returns `SessionRevokedError` before authorization, store opening, or session restoration. This uses the terminal restore path already present in the deployed clients, preventing them from replaying pending commits or rebuilding watches. A new client also refuses a server that does not advertise enforcement.

Rejecting only at `hello` is insufficient to stop old clients' reconnect attempts: those clients can retry server-returned handshake errors. The session-admission refusal avoids that behavior without changing their running code.

### Validation

- Full memory package check and suite: 613 tests passed, with 557 substeps.
- Repository `deno task check`, `deno fmt --check`, and `deno lint` passed. The memory protocol documentation check passed all 62 code blocks.
- Regression cases cover missing/false/invalid markers, matching-client reads and writes, a server without enforcement, and rejection during reconnect with an outstanding commit and registered watch.
- A separate local check ran the actual pre-deploy client source at `f0532742b`: after simulated backend replacement it sent only `hello` and `session.open`, rejected its pending commit, and did not restore watches or replay writes. The initial test transport supplied the marker to allow its first mount; the reconnect forwarded its unchanged legacy hello.
- The proposed build reproduces the same three production target fingerprints as the deployed #7153 derivation. No production service or stored document was changed during validation.

### Rollout and limits

- This is a deployment-wide admission gate, affecting all spaces and older CLI/background clients as well as browser tabs. It also excludes today's unmarked build, even though that build already contains #7153.
- Deploy matching backend and shell builds, and replace/disconnect every old memory backend connection. Publishing shell assets alone cannot affect an already-running worker. Mixed backend versions can refuse new clients during the transition.
- Old sessions stop working until their tab reloads or their CLI/background runtime updates. Pending, unconfirmed operations in a refused session are rejected; coordinate the transition around in-progress edits. Old clients may display the existing generic session-revocation message.
- No document migration, link rewriting, ACL change, or rollback is required. This prevents incompatible runtime cohorts from sustaining the write storm; it does not optimize the underlying refresh/lock amplification or certify arbitrary clients that falsely advertise the marker.

Prepared by Codex/Astra on behalf of Gideon. Production deployment remains a separate step.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

