### PR TITLE
fix(runner): snapshot programs before compilation caching

### DIFF
--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -24,7 +24,7 @@ The status corrections in this register are bounded to the rows below:
 | --- | --- |
 | OW18 / OW45 source freshness | Tenure activation ensures root existence; explicit opens follow source, including served wish-sidecar opens. |
 | OW28 | Open: no served compile outbox/completion path or real-host completion regression test. |
-| OW28-createRef | Open: distinct schema-backed program values can collide in the compile cache, including under OFF. |
+| OW28-createRef | Closed: the compile cache snapshots program content, separates source-only evaluation from persistent compilation, and persists shared compiles into each requested space. |
 | OW28-supersession-family / OW28-instance-family | Investigation follow-ups; reproduce current residuals and reconcile the instance family with OW53. |
 | OW30 | Stream sibling validation is fixed; the non-Stream counter/container observation remains unresolved. |
 | OW31 residual (vii) | Read-triggered remount is implemented; automatic replay of the entire watch set remains separate. |
@@ -2597,16 +2597,21 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   changes despite the PR's closing claim. A closed sibling PR does not
   discharge this row. Trigger: third in the plan's ordered flip gates;
   required before a renewed ON rollout.
-- OW28-createRef — OPEN: program-value hashing at the compile-cache boundary.
-  `PatternManager.compileOrGetPattern` keys `createRef({ src: program })`.
-  With a schema-backed query-result proxy, different nested source contents
-  can select the same cached Pattern in a warm process. A controlled probe
-  through the real cache method compiles A only for proxy values A then B;
-  plain-object A/B controls compile separately. This applies under OFF,
-  independently of OW28's serving port. Owed: normalize the resolved program
-  at the cache boundary using the canonical value machinery and add a
-  regression proving a same-cell program edit selects the new contents.
-  Trigger: a warm-process same-node program edit, including a code editor.
+- OW28-createRef — CLOSED: program-value hashing at the compile-cache boundary.
+  `PatternManager.compileOrGetPattern` snapshots the complete resolved program
+  with `snapshotQueryResult` and uses that same detached value for its key and
+  compiler input. Source-only evaluation and persistent compilation use
+  separate cache entries. Concurrent persistent requests share compilation
+  across spaces and register closure replication into every requested space;
+  replicated data files retain their compiled-cache data marker.
+
+  `pattern-manager.test.ts` proves that a same-cell program edit selects the new
+  contents, identical content shares a result across addresses, and a delayed
+  compile retains the program's source and options. `compile-cache-space-aware.test.ts`
+  proves a fresh runtime loads a follower space's piece and attached data
+  from the compiled cache, with recompilation refused, for persistent and
+  source-only pending/cached leaders. This cache boundary is shared by OFF and
+  the served compiler; closing it does not discharge OW28's serving port.
 - OW28-supersession-family — INVESTIGATE: LLM completion abandonment when
   inputs change A→B→A during A's in-flight effect. The preserved OW28 branch
   reports that run-counter cancellation abandons a completion to which the

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -24,7 +24,7 @@ The status corrections in this register are bounded to the rows below:
 | --- | --- |
 | OW18 / OW45 source freshness | Tenure activation ensures root existence; explicit opens follow source, including served wish-sidecar opens. |
 | OW28 | Open: no served compile outbox/completion path or real-host completion regression test. |
-| OW28-createRef | Closed: the compile cache snapshots program content, separates source-only evaluation from persistent compilation, and persists shared compiles into each requested space. |
+| OW28-createRef | Closed: the compile cache snapshots program content, separates compilation with and without a space, and persists shared compiles into each requested space when CFC is enforced. |
 | OW28-supersession-family / OW28-instance-family | Investigation follow-ups; reproduce current residuals and reconcile the instance family with OW53. |
 | OW30 | Stream sibling validation is fixed; the non-Stream counter/container observation remains unresolved. |
 | OW31 residual (vii) | Read-triggered remount is implemented; automatic replay of the entire watch set remains separate. |
@@ -2600,18 +2600,21 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
 - OW28-createRef — CLOSED: program-value hashing at the compile-cache boundary.
   `PatternManager.compileOrGetPattern` snapshots the complete resolved program
   with `snapshotQueryResult` and uses that same detached value for its key and
-  compiler input. Source-only evaluation and persistent compilation use
-  separate cache entries. Concurrent persistent requests share compilation
-  across spaces and register closure replication into every requested space;
-  replicated data files retain their compiled-cache data marker.
+  compiler input. Requests with and without a space use separate cache entries.
+  With CFC enforcement, concurrent requests share compilation across spaces and
+  register closure replication into every requested space; replicated data
+  files retain their compiled-cache data marker. With CFC disabled, requests
+  share compilation without scheduling closure replication.
 
   `pattern-manager.test.ts` proves that a same-cell program edit selects the new
   contents, identical content shares a result across addresses, and a delayed
   compile retains the program's source and options. `compile-cache-space-aware.test.ts`
   proves a fresh runtime loads a follower space's piece and attached data
   from the compiled cache, with recompilation refused, for persistent and
-  source-only pending/cached leaders. This cache boundary is shared by OFF and
-  the served compiler; closing it does not discharge OW28's serving port.
+  source-only pending/cached leaders. It also proves concurrent and cached
+  CFC-disabled calls share compilation without issuing replication. This cache
+  boundary is shared by OFF and the served compiler; closing it does not
+  discharge OW28's serving port.
 - OW28-supersession-family — INVESTIGATE: LLM completion abandonment when
   inputs change A→B→A during A's in-flight effect. The preserved OW28 branch
   reports that run-counter cancellation abandons a completion to which the

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -842,7 +842,11 @@ retained source roots, and attached data-file names. Query-result views with
 identical content share a compiled pattern across cell addresses. Changing a
 program's content selects the cache entry for that content and compiles it on a
 miss. Changes to the caller's input after a request begins do not change the
-program being compiled.
+program being compiled. When concurrent requests target different spaces, the
+shared compile registers source and compiled closure replication into each
+requested space. Those writes participate in the runtime's durability barrier.
+Source-only requests and requests that name a persistence space use separate
+cache entries, so a source-only result cannot satisfy a durable compile.
 
 ## Contributing
 

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -835,6 +835,15 @@ The Runtime coordinates several core services:
 All services receive the Runtime instance as a dependency, enabling proper
 isolation and testability without global state.
 
+`PatternManager.compileOrGetPattern()` snapshots its program input before
+starting compilation. Its in-memory cache and concurrent-request deduplication
+use that complete program content: source files, entry point and export,
+retained source roots, and attached data-file names. Query-result views with
+identical content share a compiled pattern across cell addresses. Changing a
+program's content selects the cache entry for that content and compiles it on a
+miss. Changes to the caller's input after a request begins do not change the
+program being compiled.
+
 ## Contributing
 
 See the project's main contribution guide for details on development workflow,

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -842,11 +842,12 @@ retained source roots, and attached data-file names. Query-result views with
 identical content share a compiled pattern across cell addresses. Changing a
 program's content selects the cache entry for that content and compiles it on a
 miss. Changes to the caller's input after a request begins do not change the
-program being compiled. When concurrent requests target different spaces, the
-shared compile registers source and compiled closure replication into each
-requested space. Those writes participate in the runtime's durability barrier.
-Source-only requests and requests that name a persistence space use separate
-cache entries, so a source-only result cannot satisfy a durable compile.
+program being compiled. Requests with and without a space use separate cache
+entries, so a source-only result cannot satisfy a durable compile. With CFC
+enforcement, concurrent requests targeting different spaces register source and
+compiled closure replication into each requested space. Those writes participate
+in the runtime's durability barrier. With CFC disabled, compilation still uses
+the requested space for fabric imports but does not replicate closures.
 
 ## Contributing
 

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -388,8 +388,8 @@ type ProgramCompilation = {
 
 /**
  * Helper for the program caches, which hashes a detached program in its
- * compilation context. Source-only evaluation and persistent compilation use
- * separate entries because only the latter produces a durable closure.
+ * compilation context. Space-aware compilation uses a separate entry because it
+ * resolves fabric imports in that space and can produce a durable closure.
  */
 function programCompilationKey(
   program: RuntimeProgram,
@@ -397,7 +397,7 @@ function programCompilationKey(
 ): string {
   return toURI(
     createRef(
-      { src: program, persistent: space !== undefined },
+      { src: program, spaceScoped: space !== undefined },
       "pattern source",
     ),
   );
@@ -435,7 +435,7 @@ export class PatternManager {
    */
   #failedCompileCacheRecoveries = new Set<string>();
 
-  /** Compilations in progress, keyed by program content and persistence context. */
+  /** Compilations in progress, keyed by program content and compilation context. */
   readonly #inProgressCompilations = new Map<string, ProgramCompilation>();
 
   /**
@@ -463,13 +463,11 @@ export class PatternManager {
   #coldLoadNegativeMemo = new ColdLoadNegativeMemo();
 
   /**
-   * Content hash → the compiled pattern and the space its closure was first
-   * written into. The space is tracked so a cross-space cache hit can replicate
-   * the source/compiled closure into the requested space (see
-   * `compileOrGetPattern()`): identical source dedupes the expensive TS
-   * compile, but every space holding a piece that points at the pattern still
-   * needs the closure persisted there to reload by `{ identity, symbol }` in a
-   * fresh runtime.
+   * Compiled patterns keyed by program content and compilation context.
+   * Requests with and without a space use separate entries; identical programs
+   * within a context share compilation. With CFC enforcement, a space-aware
+   * entry also records the space holding its closure, so a cross-space cache
+   * hit can replicate it into the requested space for fresh-runtime reloads.
    */
   #compiledByContent = new Map<
     string,
@@ -3153,14 +3151,14 @@ export class PatternManager {
   /**
    * Compiles a pattern from source, or returns a cached/in-flight result.
    * Snapshots the program at entry and deduplicates by its content and
-   * persistence context, including when the input is a query-result view.
+   * compilation context, including when the input is a query-result view.
    *
    * @param input - Source code string or RuntimeProgram to compile
-   * @param space - When provided, routes the ESM compile through the
-   *   content-addressed cell cache in this space (CT-1623): cold compiles write
-   *   their module set back, and subsequent loads of the same source skip the TS
-   *   compile. Without it, compilation evaluates without writing a durable
-   *   compiled closure.
+   * @param space - Resolves fabric imports within this space. With CFC
+   *   enforcement, routes the ESM compile through its content-addressed cell
+   *   cache: cold compiles write their module set back, and subsequent loads of
+   *   the same source skip the TS compile. Without a space or enforcement,
+   *   compilation evaluates without writing a durable compiled closure.
    * @returns The compiled pattern (from cache, in-flight compilation, or new)
    */
   compileOrGetPattern(
@@ -3181,33 +3179,39 @@ export class PatternManager {
     // and the asynchronous compiler consume the same program snapshot.
     program = snapshotQueryResult(program);
 
-    // Identical programs in the same persistence context share one evaluation.
+    // Identical programs in the same compilation context share one evaluation.
     const dedupeKey = programCompilationKey(program, space);
+    const persistenceSpace = this.#runtime.cfcEnforcementMode === "disabled"
+      ? undefined
+      : space;
 
     const cached = this.#compiledByContent.get(dedupeKey);
     if (cached) {
       // Refresh recency (FIFO ~LRU).
       this.#compiledByContent.delete(dedupeKey);
       this.#compiledByContent.set(dedupeKey, cached);
-      // The content cache is space-agnostic, but a piece persisted in `space`
-      // needs the source/compiled closure IN that space to reload by
-      // { identity, symbol } in a fresh runtime (the meta-cell fallback is
-      // gone). When this hit serves a different space than the one we first
-      // compiled into, replicate the closure there — cheap (no TS recompile),
-      // with persistence writes deduplicated and tracked in `#compileCacheWrites`.
-      if (space && cached.space && space !== cached.space) {
-        this.replicatePatternToSpace(cached.pattern, space, cached.space);
+      // A persistent cross-space hit needs the closure in its requested space
+      // to reload by { identity, symbol } in a fresh runtime. Replication reuses
+      // the compiled modules and tracks writes in `#compileCacheWrites`.
+      if (
+        persistenceSpace && cached.space && persistenceSpace !== cached.space
+      ) {
+        this.replicatePatternToSpace(
+          cached.pattern,
+          persistenceSpace,
+          cached.space,
+        );
       }
       return Promise.resolve(cached.pattern);
     }
 
     const inProgress = this.#inProgressCompilations.get(dedupeKey);
     if (inProgress) {
-      if (space) inProgress.spaces.add(space);
+      if (persistenceSpace) inProgress.spaces.add(persistenceSpace);
       return inProgress.promise;
     }
 
-    const spaces = new Set(space ? [space] : []);
+    const spaces = new Set(persistenceSpace ? [persistenceSpace] : []);
     // Pass the cell-cache context when a space is available so nested/dynamic
     // compiles benefit from the cache too.
     const compilationPromise = this.compilePattern(
@@ -3215,13 +3219,20 @@ export class PatternManager {
       space ? { space } : undefined,
     )
       .then((pattern) => {
-        this.#compiledByContent.set(dedupeKey, { pattern, space });
+        this.#compiledByContent.set(dedupeKey, {
+          pattern,
+          space: persistenceSpace,
+        });
         // Register follower persistence before the shared promise resolves.
         // Replications remain independently tracked: their supplier waits must
         // be able to await this compile without forming a cycle.
-        if (space) {
+        if (persistenceSpace) {
           for (const targetSpace of spaces) {
-            this.replicatePatternToSpace(pattern, targetSpace, space);
+            this.replicatePatternToSpace(
+              pattern,
+              targetSpace,
+              persistenceSpace,
+            );
           }
         }
         while (this.#compiledByContent.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -54,6 +54,7 @@ import type {
 } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
 import type { PatternCoverageCollector } from "./pattern-coverage.ts";
+import { snapshotQueryResult } from "./query-result-proxy.ts";
 import type { MemorySpace, Runtime, ServerRunInfo } from "./runtime.ts";
 
 import {
@@ -3124,8 +3125,9 @@ export class PatternManager {
   }
 
   /**
-   * Compile a pattern from source, or return a cached/in-flight result.
-   * Provides single-flight deduplication based on program content.
+   * Compiles a pattern from source, or returns a cached/in-flight result.
+   * Snapshots the program at entry and deduplicates by that content, including
+   * when the input is a query-result view.
    *
    * @param input - Source code string or RuntimeProgram to compile
    * @param space - When provided, routes the ESM compile through the
@@ -3138,7 +3140,6 @@ export class PatternManager {
     input: string | RuntimeProgram,
     space?: MemorySpace,
   ): Promise<Pattern> {
-    // Normalize to RuntimeProgram
     let program: RuntimeProgram;
     if (typeof input === "string") {
       program = {
@@ -3148,6 +3149,10 @@ export class PatternManager {
     } else {
       program = input;
     }
+
+    // Query views name cells to `createRef()`. Detach their contents so the key
+    // and the asynchronous compiler consume the same program snapshot.
+    program = snapshotQueryResult(program);
 
     // Content-hash key (createRef as a pure digest, NOT a cell id). Identical
     // source returns the same compiled instance; concurrent compiles share one

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -377,6 +377,32 @@ type ParkedReplication = {
   delegated: WritebackDelegation | undefined;
 };
 
+/** A shared compilation and the spaces requesting its durable closure. */
+type ProgramCompilation = {
+  /** Compile and initial persistence completion shared by all callers. */
+  readonly promise: Promise<Pattern>;
+
+  /** Spaces whose closures are registered for replication on completion. */
+  readonly spaces: Set<MemorySpace>;
+};
+
+/**
+ * Helper for the program caches, which hashes a detached program in its
+ * compilation context. Source-only evaluation and persistent compilation use
+ * separate entries because only the latter produces a durable closure.
+ */
+function programCompilationKey(
+  program: RuntimeProgram,
+  space?: MemorySpace,
+): string {
+  return toURI(
+    createRef(
+      { src: program, persistent: space !== undefined },
+      "pattern source",
+    ),
+  );
+}
+
 export class PatternManager {
   #runtime: Runtime;
 
@@ -409,15 +435,8 @@ export class PatternManager {
    */
   #failedCompileCacheRecoveries = new Set<string>();
 
-  /**
-   * Single-flight dedup and in-memory result cache for `compileOrGetPattern()`,
-   * keyed by a content hash of the program (_not_ a cell id, _not_ the retired
-   * `patternId`) so identical source returns one shared, already-compiled
-   * pattern instance. The hash is computed with `createRef()` purely as a
-   * stable digest function — no `pattern:` cell is ever minted. Bounded FIFO to
-   * cap memory.
-   */
-  readonly #inProgressCompilations = new Map<string, Promise<Pattern>>();
+  /** Compilations in progress, keyed by program content and persistence context. */
+  readonly #inProgressCompilations = new Map<string, ProgramCompilation>();
 
   /**
    * Single-flight dedup for the expensive tail of `loadPatternByIdentity()`
@@ -754,7 +773,7 @@ export class PatternManager {
       string,
       Promise<Pattern | undefined>
     >;
-    readonly inProgressCompilations: Map<string, Promise<Pattern>>;
+    readonly inProgressCompilations: Map<string, ProgramCompilation>;
     maxEvaluatedModuleCacheSize: number;
     readonly modulesByIdentity: Map<string, { exports: Exports }>;
     readonly persistedCompileCacheClosures: Map<string, string>;
@@ -918,7 +937,10 @@ export class PatternManager {
    */
   async pendingPatternWorkSettled(): Promise<void> {
     await Promise.allSettled([
-      ...this.#inProgressCompilations.values(),
+      ...Array.from(
+        this.#inProgressCompilations.values(),
+        ({ promise }) => promise,
+      ),
       ...this.#inProgressByIdentityLoads.values(),
       ...this.#compileCacheWrites,
     ]);
@@ -1382,7 +1404,10 @@ export class PatternManager {
       // `#parkedFailedReplications` and the register's RULING block), so
       // the short-circuit stays exactly as cheap and mask-free as
       // designed while no rescueable interleaving is lost.
-      const inFlightCompilations = [...this.#inProgressCompilations.values()];
+      const inFlightCompilations = Array.from(
+        this.#inProgressCompilations.values(),
+        ({ promise }) => promise,
+      );
       const inFlightLoads = [...this.#inProgressByIdentityLoads.values()];
       if (inFlightCompilations.length > 0 || inFlightLoads.length > 0) {
         logger.warn("closure-replication-await-inflight", () => [
@@ -1432,6 +1457,7 @@ export class PatternManager {
         filename: doc.filename,
         source: doc.code,
         js: compiled?.code ?? "",
+        ...(compiled?.kind === "data" ? { isData: true } : {}),
         ...(compiled?.sourceMap !== undefined
           ? { sourceMap: compiled.sourceMap }
           : {}),
@@ -3126,14 +3152,15 @@ export class PatternManager {
 
   /**
    * Compiles a pattern from source, or returns a cached/in-flight result.
-   * Snapshots the program at entry and deduplicates by that content, including
-   * when the input is a query-result view.
+   * Snapshots the program at entry and deduplicates by its content and
+   * persistence context, including when the input is a query-result view.
    *
    * @param input - Source code string or RuntimeProgram to compile
    * @param space - When provided, routes the ESM compile through the
    *   content-addressed cell cache in this space (CT-1623): cold compiles write
    *   their module set back, and subsequent loads of the same source skip the TS
-   *   compile. Without it (e.g. tests), compilation is uncached as before.
+   *   compile. Without it, compilation evaluates without writing a durable
+   *   compiled closure.
    * @returns The compiled pattern (from cache, in-flight compilation, or new)
    */
   compileOrGetPattern(
@@ -3154,10 +3181,8 @@ export class PatternManager {
     // and the asynchronous compiler consume the same program snapshot.
     program = snapshotQueryResult(program);
 
-    // Content-hash key (createRef as a pure digest, NOT a cell id). Identical
-    // source returns the same compiled instance; concurrent compiles share one
-    // evaluation.
-    const dedupeKey = toURI(createRef({ src: program }, "pattern source"));
+    // Identical programs in the same persistence context share one evaluation.
+    const dedupeKey = programCompilationKey(program, space);
 
     const cached = this.#compiledByContent.get(dedupeKey);
     if (cached) {
@@ -3177,8 +3202,12 @@ export class PatternManager {
     }
 
     const inProgress = this.#inProgressCompilations.get(dedupeKey);
-    if (inProgress) return inProgress;
+    if (inProgress) {
+      if (space) inProgress.spaces.add(space);
+      return inProgress.promise;
+    }
 
+    const spaces = new Set(space ? [space] : []);
     // Pass the cell-cache context when a space is available so nested/dynamic
     // compiles benefit from the cache too.
     const compilationPromise = this.compilePattern(
@@ -3187,6 +3216,14 @@ export class PatternManager {
     )
       .then((pattern) => {
         this.#compiledByContent.set(dedupeKey, { pattern, space });
+        // Register follower persistence before the shared promise resolves.
+        // Replications remain independently tracked: their supplier waits must
+        // be able to await this compile without forming a cycle.
+        if (space) {
+          for (const targetSpace of spaces) {
+            this.replicatePatternToSpace(pattern, targetSpace, space);
+          }
+        }
         while (this.#compiledByContent.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {
           const oldest = this.#compiledByContent.keys().next().value;
           if (oldest === undefined) break;
@@ -3198,7 +3235,10 @@ export class PatternManager {
         this.#inProgressCompilations.delete(dedupeKey);
       });
 
-    this.#inProgressCompilations.set(dedupeKey, compilationPromise);
+    this.#inProgressCompilations.set(dedupeKey, {
+      promise: compilationPromise,
+      spaces,
+    });
     return compilationPromise;
   }
 

--- a/packages/runner/test/compile-cache-space-aware.test.ts
+++ b/packages/runner/test/compile-cache-space-aware.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { spy } from "@std/testing/mock";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 
@@ -103,6 +104,59 @@ describe("compileOrGetPattern persists the closure per requested space", () => {
       await rt1.dispose();
     }
   });
+
+  for (const follower of ["concurrent", "cached"]) {
+    it(`shares a ${follower} compile without replication when CFC is disabled`, async () => {
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+        cfcEnforcementMode: "disabled",
+      });
+      const release = Promise.withResolvers<void>();
+      const replication = spy(
+        runtime.patternManager,
+        "replicatePatternToSpace",
+      );
+      try {
+        const compilePattern = runtime.patternManager.compilePattern.bind(
+          runtime.patternManager,
+        );
+        let compileCount = 0;
+        runtime.patternManager.compilePattern = async (program, context) => {
+          compileCount++;
+          await release.promise;
+          return await compilePattern(program, context);
+        };
+        const compilationA = runtime.patternManager.compileOrGetPattern(
+          PROGRAM,
+          spaceA,
+        );
+        if (follower === "cached") {
+          release.resolve();
+          await compilationA;
+        }
+        const compilationB = runtime.patternManager.compileOrGetPattern(
+          PROGRAM,
+          spaceB,
+        );
+        release.resolve();
+        const [patternA, patternB] = await Promise.all([
+          compilationA,
+          compilationB,
+        ]);
+        await runtime.patternManager.flushCompileCacheWrites();
+        expect(patternB).toBe(patternA);
+        expect(compileCount).toBe(1);
+        expect(
+          replication.calls.filter(({ args }) => args[1] !== args[2]),
+        ).toHaveLength(0);
+      } finally {
+        release.resolve();
+        replication.restore();
+        await runtime.dispose();
+      }
+    });
+  }
 
   for (
     const leader of ["persistent", "source-only pending", "source-only cached"]

--- a/packages/runner/test/compile-cache-space-aware.test.ts
+++ b/packages/runner/test/compile-cache-space-aware.test.ts
@@ -103,4 +103,105 @@ describe("compileOrGetPattern persists the closure per requested space", () => {
       await rt1.dispose();
     }
   });
+
+  for (
+    const leader of ["persistent", "source-only pending", "source-only cached"]
+  ) {
+    it(`reloads attached data from the compiled cache after a ${leader} leader`, async () => {
+      const rt1 = newRuntime();
+      const rt2 = newRuntime();
+      const release = Promise.withResolvers<void>();
+      try {
+        const program: RuntimeProgram = {
+          main: "/main.tsx",
+          files: [
+            {
+              name: "/main.tsx",
+              contents: [
+                "import { dataFile, pattern } from 'commonfabric';",
+                "const data = JSON.parse(dataFile('./data.json'));",
+                "export default pattern(() => ({ label: data.label }));",
+              ].join("\n"),
+            },
+            { name: "/data.json", contents: '{"label":"hello"}' },
+          ],
+          dataFiles: ["/data.json"],
+        };
+        const sourceA = rt1.getCell<RuntimeProgram>(spaceA, "source", {
+          type: "object",
+          additionalProperties: true,
+        });
+        const sourceB = rt1.getCell<RuntimeProgram>(spaceB, "source", {
+          type: "object",
+          additionalProperties: true,
+        });
+        await Promise.all([sourceA.sync(), sourceB.sync()]);
+        await rt1.editWithRetry((tx) => sourceA.withTx(tx).set(program));
+        await rt1.editWithRetry((tx) => sourceB.withTx(tx).set(program));
+        expect(sourceA.get()).toEqual(program);
+        expect(sourceB.get()).toEqual(program);
+
+        const compilePattern = rt1.patternManager.compilePattern.bind(
+          rt1.patternManager,
+        );
+        let compileCount = 0;
+        rt1.patternManager.compilePattern = async (program, context) => {
+          compileCount++;
+          await release.promise;
+          return await compilePattern(program, context);
+        };
+        const compilationA = rt1.patternManager.compileOrGetPattern(
+          sourceA.get(),
+          leader === "persistent" ? spaceA : undefined,
+        );
+        if (leader === "source-only cached") {
+          release.resolve();
+          await compilationA;
+        }
+        const compilationB = rt1.patternManager.compileOrGetPattern(
+          sourceB.get(),
+          spaceB,
+        );
+        release.resolve();
+        const [patternA, patternB] = await Promise.all([
+          compilationA,
+          compilationB,
+        ]);
+        if (leader === "persistent") {
+          expect(compileCount).toBe(1);
+          expect(patternB).toBe(patternA);
+        }
+
+        const resultCell = rt1.getCell<{ label: string }>(
+          spaceB,
+          "concurrent-compile piece",
+        );
+        await resultCell.sync();
+        await rt1.editWithRetry((tx) => {
+          rt1.run(tx, patternB, {}, resultCell.withTx(tx));
+        });
+        await resultCell.pull();
+        await rt1.idle();
+        await rt1.patternManager.flushCompileCacheWrites();
+        await storageManager.synced();
+
+        rt2.harness.compileResolvedToRecordGraph = () => {
+          throw new Error(
+            "A persisted closure must reload without recompiling",
+          );
+        };
+        const reloaded = rt2.getCellFromLink(
+          resultCell.getAsNormalizedFullLink(),
+        );
+        await reloaded.sync();
+        expect(await rt2.start(reloaded)).toBe(true);
+        await reloaded.pull();
+        expect(reloaded.key("label").get()).toBe("hello");
+      } finally {
+        release.resolve();
+        await rt2.dispose();
+        await rt1.dispose();
+      }
+    });
+  }
 });

--- a/packages/runner/test/executor-space-root-ensure.test.ts
+++ b/packages/runner/test/executor-space-root-ensure.test.ts
@@ -32,6 +32,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { getLogger } from "@commonfabric/utils/logger";
 import type { FabricValue, JSONSchema } from "@commonfabric/api";
 import type { Signer, URI } from "@commonfabric/memory/interface";
 import {
@@ -696,6 +697,87 @@ describe("SpaceServer space-root ensure (OW45 arm-B stage 1)", () => {
     const reader = clientRuntime(readerSigner);
     const root = await resolveRootEventually(reader);
     expect(getPatternSource(root)).toBe(HOME_PATTERN_SOURCE);
+  });
+
+  it("skips demand loading after parking during a root source fetch", async () => {
+    // A source fetch can outlive its serving tenure. Resume it only after park
+    // has disposed the runtime, and observe the wave's next settle boundary.
+    await seedAcl({ [space]: "OWNER" });
+    const fetchStarted = Promise.withResolvers<void>();
+    const finishFetch = Promise.withResolvers<Response>();
+    const resumedWave = Promise.withResolvers<void>();
+    let demandReads = 0;
+    const facade = new Proxy(server, {
+      get(target, property, receiver) {
+        if (property === "demandedInstancesForSpace") {
+          return (
+            ...args: Parameters<typeof server.demandedInstancesForSpace>
+          ) => {
+            demandReads++;
+            return target.demandedInstancesForSpace(...args);
+          };
+        }
+        if (property === "idle") {
+          return async () => {
+            await target.idle();
+            resumedWave.resolve();
+          };
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const warningsBefore = getLogger("space-server")
+      .countsByKey["structure-load-pass-failed"]?.warn ?? 0;
+    const created = new SpaceServer({
+      space,
+      server: facade,
+      engine,
+      serviceIdentity: serviceSigner.did(),
+      createRuntime: () => {
+        const manager = EmulatedStorageManager.connectTo(server, {
+          as: serviceSigner,
+        });
+        const runtime = new Runtime({
+          apiUrl: new URL("http://toolshed.test"),
+          storageManager: manager,
+          fetch: () => {
+            fetchStarted.resolve();
+            return finishFetch.promise;
+          },
+          servingPosture: true,
+          experimental: { serverExecution: true },
+        });
+        return Promise.resolve({
+          runtime,
+          dispose: async () => {
+            await runtime.dispose();
+            await manager.close();
+          },
+        });
+      },
+      localSeqRef: sinkLocalSeq,
+      stats,
+      policy: { flushDeadlineMs: 2_000, idleParkMs: 600_000 },
+    });
+    spaceServer = created;
+    try {
+      expect(await created.activate()).toBe(true);
+      await fetchStarted.promise;
+      await created.park("source fetch interrupted");
+      await created.whenParked;
+      expect(created.active).toBe(false);
+      finishFetch.reject(new Error("source fetch interrupted"));
+      await resumedWave.promise;
+      expect(stats.rootEnsure.failures).toBe(1);
+      expect(demandReads).toBe(0);
+      expect(
+        getLogger("space-server").countsByKey["structure-load-pass-failed"]
+          ?.warn ?? 0,
+      ).toBe(warningsBefore);
+    } finally {
+      finishFetch.resolve(new Response(null, { status: 503 }));
+    }
   });
 
   it("a WEDGED ensure hits its deadline: counted failure, lease kept serving, no park (F2)", async () => {

--- a/packages/runner/test/pattern-manager.test.ts
+++ b/packages/runner/test/pattern-manager.test.ts
@@ -415,6 +415,127 @@ describe("PatternManager.compileOrGetPattern", () => {
     expect(getPatternProgram(second)?.files[0].contents).toContain("tripled");
   });
 
+  it("caches query-result programs by content across cell updates and addresses", async () => {
+    const schema = {
+      type: "object",
+      properties: {
+        main: { type: "string" },
+        files: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              contents: { type: "string" },
+            },
+            required: ["name", "contents"],
+          },
+        },
+      },
+      required: ["main", "files"],
+    } as const;
+    const source = runtime.getCell<RuntimeProgram>(space, "compile-source");
+    const otherSource = runtime.getCell<RuntimeProgram>(space, "other-source");
+    await Promise.all([source.sync(), otherSource.sync()]);
+    await runtime.editWithRetry((writeTx) => {
+      source.withTx(writeTx).set(simpleProgram);
+      otherSource.withTx(writeTx).set(simpleProgram);
+    });
+
+    const [first, sameContent] = await Promise.all([
+      runtime.patternManager.compileOrGetPattern(source.asSchema(schema).get()),
+      runtime.patternManager.compileOrGetPattern(
+        otherSource.asSchema(schema).get(),
+      ),
+    ]);
+    expect(getPatternProgram(first)).toEqual(simpleProgram);
+
+    await runtime.editWithRetry((writeTx) => {
+      source.withTx(writeTx).set(differentProgram);
+    });
+    const changed = await runtime.patternManager.compileOrGetPattern(
+      source.asSchema(schema).get(),
+    );
+    expect(changed).not.toBe(first);
+    expect(sameContent).toBe(first);
+    expect(getPatternProgram(changed)).toEqual(differentProgram);
+    expect(getPatternProgram(first)).toEqual(simpleProgram);
+    expect(await runtime.patternManager.compileOrGetPattern(differentProgram))
+      .toBe(changed);
+  });
+
+  for (const inputKind of ["plain object", "query result"]) {
+    it(`compiles a detached ${inputKind} snapshot across an asynchronous wait`, async () => {
+      const program = {
+        main: "/main.ts",
+        mainExport: "chosen",
+        files: [
+          {
+            name: "/main.ts",
+            contents: [
+              "import { pattern } from 'commonfabric';",
+              "import { value } from './helper.ts';",
+              "export const chosen = pattern(() => ({ value }));",
+            ].join("\n"),
+          },
+          { name: "/helper.ts", contents: "export const value = 42;" },
+          { name: "/retained.ts", contents: "export const retained = true;" },
+          { name: "/data.txt", contents: "attached data" },
+        ],
+        dataFiles: ["/data.txt"],
+        sourceRoots: ["/retained.ts"],
+      };
+      const source = runtime.getCell<RuntimeProgram>(
+        space,
+        "delayed-source",
+        { type: "object", additionalProperties: true },
+      );
+      await source.sync();
+      await runtime.editWithRetry((writeTx) =>
+        source.withTx(writeTx).set(program)
+      );
+      const expected = {
+        ...program,
+        files: program.files.map((file) => ({ ...file })),
+        dataFiles: [...program.dataFiles],
+        sourceRoots: [...program.sourceRoots],
+      };
+      const compilePattern = runtime.patternManager.compilePattern.bind(
+        runtime.patternManager,
+      );
+      const release = Promise.withResolvers<void>();
+      runtime.patternManager.compilePattern = async (input, context) => {
+        await release.promise;
+        return await compilePattern(input, context);
+      };
+
+      const compilation = runtime.patternManager.compileOrGetPattern(
+        inputKind === "query result" ? source.get() : program,
+      );
+      const duplicate = runtime.patternManager.compileOrGetPattern(expected);
+      program.main = "/missing.ts";
+      program.mainExport = "missing";
+      program.files[0].contents = "invalid source";
+      program.dataFiles[0] = "/missing.txt";
+      program.sourceRoots[0] = "/missing-root.ts";
+      await runtime.editWithRetry((writeTx) =>
+        source.withTx(writeTx).set(program)
+      );
+      release.resolve();
+
+      const [compiled, duplicateCompiled] = await Promise.all([
+        compilation,
+        duplicate,
+      ]);
+      expect(duplicate).toBe(compilation);
+      expect(getPatternProgram(compiled)).toEqual(expected);
+      expect(duplicateCompiled).toBe(compiled);
+      expect(await runtime.patternManager.compileOrGetPattern(expected)).toBe(
+        compiled,
+      );
+    });
+  }
+
   it("single-flight: concurrent calls share one compilation", async () => {
     // Start multiple compilations concurrently
     const [first, second, third] = await Promise.all([

--- a/packages/runner/test/scheduler-idle-pattern-work.test.ts
+++ b/packages/runner/test/scheduler-idle-pattern-work.test.ts
@@ -158,7 +158,7 @@ describe("idleWithPendingCommits covers pattern work (OW45 S-B)", () => {
     const compileGate = Promise.withResolvers<unknown>();
     compileManager.inProgressCompilations.set(
       "ow45-synthetic-compile",
-      compileGate.promise as Promise<never>,
+      { promise: compileGate.promise as Promise<never>, spaces: new Set() },
     );
     expect(runtime.patternManager.hasPendingPatternWork()).toBe(true);
     let compileBarrierResolved = false;
@@ -199,7 +199,7 @@ describe("idleWithPendingCommits covers pattern work (OW45 S-B)", () => {
     });
     manager.inProgressCompilations.set(
       "ow45-rejecting-compile",
-      tracked as Promise<never>,
+      { promise: tracked as Promise<never>, spaces: new Set() },
     );
     expect(runtime.patternManager.hasPendingPatternWork()).toBe(true);
     let resolved = false;


### PR DESCRIPTION
Programs passed through `compileAndRun` can be query-result views. Hashing those views directly keys the compilation cache by cell address: editing source in the same cell returns the earlier compiled pattern, while equal source in different cells compiles twice. `compileOrGetPattern()` now uses the canonical query snapshot so the key and asynchronous compiler consume the same detached program content.

Requests with and without a space use separate cache entries. With CFC enforcement, concurrent requests retain every requested space and register source/compiled closure replication before the shared compile resolves. Replication preserves attached-data markers so fresh runtimes can load the compiled closure without recompiling. With CFC disabled, callers share the in-memory compilation without replicating an unwritten closure; the compiler still receives the requested space for fabric imports. The runner README and `OW28-createRef` coverage status describe the resulting contract.

Regressions use real runtime queries and the real compiler: same-cell edits, cross-address and plain-object reuse, delayed complete-program snapshots, simultaneous cross-space callers, source-only leaders both pending and cached, warm reload of an attached data file, and disabled-mode callers without replication. These cases were verified red before their respective fixes.

CI also exposed inconsistent coverage of the existing park-during-fetch guard in `SpaceServer`. A deterministic lifecycle test now controls that ordering; the isolated case covers the guard, and removing the guard makes the test fail.

Validation: the full runner suite passes (1,399 tests, 8,633 steps), and the subsequently added lifecycle fixture passes all 10 cases. Repository-wide formatting, lint, and type checks pass. Independent `cf-review` reviewed the implementation and follow-ups; all findings are incorporated. The fresh-runtime regressions refuse cold recompilation and fail when the compilation-context key or attached-data marker is removed.
