### PR TITLE
fix(runtime-client): a loopback site-table entry is not a route a remote page can use

### DIFF
--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -9,6 +9,7 @@ export { Runtime } from "./runtime.ts";
 export {
   fabricAuthorityMatchesSpaceHost,
   type FabricSpaceHostOptions,
+  isLoopbackHostname,
   normalizeSpaceHost,
   spaceHostFromFabricAuthority,
   SpaceHostValidationError,

--- a/packages/runner/src/space-host.ts
+++ b/packages/runner/src/space-host.ts
@@ -73,7 +73,7 @@ export const fabricAuthorityMatchesSpaceHost = (
 };
 
 /** Returns whether `hostname` names the local machine. */
-function isLoopbackHostname(hostname: string): boolean {
+export function isLoopbackHostname(hostname: string): boolean {
   return hostname === "localhost" || hostname === "localhost." ||
     hostname === "[::1]" ||
     /^127(?:\.\d{1,3}){3}$/.test(hostname);

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -911,6 +911,14 @@ export class RuntimeProcessor {
    * each space that contains only an HTTP or HTTPS origin. Fire-and-forget:
    * resolution hints are an enhancement, never a boot dependency.
    *
+   * One entry is read rather than registered. A loopback origin names the
+   * toolshed as the machine that wrote the row sees it, so it is no route for a
+   * page that reached the toolshed by another name — and a browser refuses the
+   * `ws://` socket it implies from an `https` page. When the entry is loopback
+   * and this runtime's `apiUrl` is not, the space stays on `apiUrl`, and the
+   * row retires any earlier row for that space. A page that did reach loopback
+   * registers it as usual.
+   *
    * ORDERING CONTRACT for embedders: push a newly learned hint through the
    * RegisterSpaceHost IPC before relying on that space, and proceed only when
    * registration succeeds. The first hint can replace a provisional
@@ -973,6 +981,10 @@ export class RuntimeProcessor {
                       `(${host.toString()}); using ${this.#runtime.apiUrl.toString()}`,
                   );
                 }
+                // The table is last-row-wins, so this row also retires an
+                // earlier non-loopback row for the same space: the space has
+                // since moved to the writer's own toolshed.
+                latestEntries.delete(entry.did);
                 continue;
               }
               latestEntries.set(entry.did, {

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -59,6 +59,7 @@ import {
   type IOperationStorageCapability,
   isCell,
   isCellResult,
+  isLoopbackHostname,
   markDurableReadTx,
   normalizeSpaceHost,
   PatternCoverageCollector,
@@ -953,6 +954,25 @@ export class RuntimeProcessor {
                   `[RuntimeProcessor] Ignoring invalid site-table entry for ${entry.did}:`,
                   error.message,
                 );
+                continue;
+              }
+              // A loopback entry names the toolshed from the machine that
+              // wrote it, so a page served from anywhere else cannot reach it
+              // — and a browser on an https page refuses the ws:// socket it
+              // implies. Leave those spaces on the URL this runtime already
+              // reached its toolshed at.
+              if (
+                isLoopbackHostname(host.hostname) &&
+                !isLoopbackHostname(this.#runtime.apiUrl.hostname)
+              ) {
+                const key = `${entry.did}|${host.toString()}`;
+                if (!this.#siteTableWarned.has(key)) {
+                  this.#siteTableWarned.add(key);
+                  console.debug(
+                    `[RuntimeProcessor] Ignoring loopback site-table entry for ${entry.did} ` +
+                      `(${host.toString()}); using ${this.#runtime.apiUrl.toString()}`,
+                  );
+                }
                 continue;
               }
               latestEntries.set(entry.did, {

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -5392,6 +5392,66 @@ describe("runtime-processor", () => {
         }
       });
 
+      it("lets a later loopback row retire an earlier route for the same space", async () => {
+        // The table is last-row-wins. A space that has moved to the writer's own
+        // toolshed says so with a loopback row, and the earlier row must not go
+        // on being applied — skipping the loopback row alone would leave it.
+
+        const { runtime } = createRuntime(
+          undefined,
+          new URL("https://host.ts.net:8001/"),
+        );
+        const registered: Array<[string, string]> = [];
+        let sawOther = () => {};
+        const otherRegistered = new Promise<void>((resolve) => {
+          sawOther = resolve;
+        });
+        const registerSpaceHost = runtime.registerSpaceHost.bind(runtime);
+        const movedSpace = "did:key:z6Mk-moved" as MemorySpace;
+        const otherSpace = "did:key:z6Mk-other" as MemorySpace;
+        Object.assign(runtime, {
+          registerSpaceHost: (space: string, host: string) => {
+            registered.push([space, host]);
+            if (space === otherSpace) sawOther();
+            return registerSpaceHost(space as MemorySpace, host);
+          },
+        });
+        const userDid = runtime.userIdentityDID;
+        const table = runtime.getCell(
+          userDid,
+          siteTableCause(userDid),
+          siteTableSchema,
+        );
+        const tx = runtime.edit();
+        table.withTx(tx).set([
+          { did: movedSpace, host: "http://was-remote.test/" },
+          { did: movedSpace, host: "http://localhost:8001/" },
+          { did: otherSpace, host: "http://host-other.test/" },
+        ]);
+        await tx.commit();
+
+        const cc = new PiecesController(
+          { as: cfcSigner, space: userDid },
+          runtime,
+        );
+        const processor = buildProcessor({
+          runtime,
+          cc,
+          space: userDid,
+          identity: cfcSigner,
+        });
+        try {
+          processor.watchSiteTable();
+          await otherRegistered;
+          expect(registered).toEqual([[otherSpace, "http://host-other.test/"]]);
+          expect(runtime.hostForSpace(movedSpace).toString()).toBe(
+            "https://host.ts.net:8001/",
+          );
+        } finally {
+          await processor.dispose();
+        }
+      });
+
       it("registers a loopback entry when the page reached loopback too", async () => {
         const { runtime } = createRuntime();
         const registered: Array<[string, string]> = [];

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -124,7 +124,10 @@ class SharedV2StorageManager extends V2Storage.StorageManager {
   }
 }
 
-const createRuntime = (actingPrincipal?: string) => {
+const createRuntime = (
+  actingPrincipal?: string,
+  apiUrl = new URL("http://localhost/"),
+) => {
   const server = new MemoryV2Server.Server({
     authorizeSessionOpen(message) {
       const principal = (message.authorization as { principal?: unknown })
@@ -140,7 +143,7 @@ const createRuntime = (actingPrincipal?: string) => {
     memoryHost: new URL("memory://"),
   }, server);
   const runtime = new Runtime({
-    apiUrl: new URL("http://localhost/"),
+    apiUrl,
     storageManager,
     ...(actingPrincipal === undefined ? {} : {
       trustSnapshotProvider: () => ({
@@ -5313,6 +5316,129 @@ describe("runtime-processor", () => {
             .toBe(false);
           expect(runtime.mappedHostFor(tableRoute)).toBe(
             "http://host-a-new.test/",
+          );
+        } finally {
+          await processor.dispose();
+        }
+      });
+
+      it("leaves a loopback entry on apiUrl when the page did not reach loopback", async () => {
+        // loom's daemon writes its own toolshed URL into the table, so a space
+        // it serves reads as `http://localhost:8001`. A page served over the
+        // tailnet cannot reach that, and WebKit refuses the ws:// socket it
+        // implies from an https page — every pane then fails with "No data at
+        // cell". The entry means "the toolshed this runtime is talking to".
+
+        const { runtime } = createRuntime(
+          undefined,
+          new URL("https://host.ts.net:8001/"),
+        );
+        const registered: Array<[string, string]> = [];
+        let sawRemote = () => {};
+        const remoteRegistered = new Promise<void>((resolve) => {
+          sawRemote = resolve;
+        });
+        const registerSpaceHost = runtime.registerSpaceHost.bind(runtime);
+        const loopbackSpace = "did:key:z6Mk-loopback" as MemorySpace;
+        const remoteSpace = "did:key:z6Mk-remote" as MemorySpace;
+        Object.assign(runtime, {
+          registerSpaceHost: (space: string, host: string) => {
+            registered.push([space, host]);
+            if (space === remoteSpace) sawRemote();
+            return registerSpaceHost(space as MemorySpace, host);
+          },
+        });
+        const userDid = runtime.userIdentityDID;
+        const table = runtime.getCell(
+          userDid,
+          siteTableCause(userDid),
+          siteTableSchema,
+        );
+        const tx = runtime.edit();
+        table.withTx(tx).set([
+          { did: loopbackSpace, host: "http://localhost:8001/" },
+          { did: remoteSpace, host: "http://host-remote.test/" },
+        ]);
+        await tx.commit();
+
+        const cc = new PiecesController(
+          { as: cfcSigner, space: userDid },
+          runtime,
+        );
+        const processor = buildProcessor({
+          runtime,
+          cc,
+          space: userDid,
+          identity: cfcSigner,
+        });
+        try {
+          processor.watchSiteTable();
+          // The non-loopback entry still registers, and the loop decides both
+          // in one pass, so its arrival is when the loopback one has been
+          // decided too.
+          await remoteRegistered;
+          expect(registered).toEqual([[
+            remoteSpace,
+            "http://host-remote.test/",
+          ]]);
+          expect(registered.map(([space]) => space)).not.toContain(
+            loopbackSpace,
+          );
+          expect(runtime.hostForSpace(loopbackSpace).toString()).toBe(
+            "https://host.ts.net:8001/",
+          );
+        } finally {
+          await processor.dispose();
+        }
+      });
+
+      it("registers a loopback entry when the page reached loopback too", async () => {
+        const { runtime } = createRuntime();
+        const registered: Array<[string, string]> = [];
+        let sawLoopback = () => {};
+        const loopbackRegistered = new Promise<void>((resolve) => {
+          sawLoopback = resolve;
+        });
+        const registerSpaceHost = runtime.registerSpaceHost.bind(runtime);
+        Object.assign(runtime, {
+          registerSpaceHost: (space: string, host: string) => {
+            registered.push([space, host]);
+            sawLoopback();
+            return registerSpaceHost(space as MemorySpace, host);
+          },
+        });
+        const userDid = runtime.userIdentityDID;
+        const loopbackSpace = "did:key:z6Mk-loopback-local" as MemorySpace;
+        const table = runtime.getCell(
+          userDid,
+          siteTableCause(userDid),
+          siteTableSchema,
+        );
+        const tx = runtime.edit();
+        table.withTx(tx).set([
+          { did: loopbackSpace, host: "http://localhost:8001/" },
+        ]);
+        await tx.commit();
+
+        const cc = new PiecesController(
+          { as: cfcSigner, space: userDid },
+          runtime,
+        );
+        const processor = buildProcessor({
+          runtime,
+          cc,
+          space: userDid,
+          identity: cfcSigner,
+        });
+        try {
+          processor.watchSiteTable();
+          await loopbackRegistered;
+          expect(registered).toEqual([[
+            loopbackSpace,
+            "http://localhost:8001/",
+          ]]);
+          expect(runtime.hostForSpace(loopbackSpace).toString()).toBe(
+            "http://localhost:8001/",
           );
         } finally {
           await processor.dispose();


### PR DESCRIPTION
## Why

A site-table entry says **where a space lives, as the machine that wrote it sees it**. It is a hint about the space, not a route this page can necessarily use.

loom's daemon writes its own toolshed URL, so a space it serves is recorded as `http://localhost:8001`. The worker read that as a route at boot (`runtime-processor.ts`, the `latestEntries` → `registerSpaceHost` loop) and re-registered the space's host, which sends the space's websocket to `ws://localhost:8001`. A page served over the tailnet cannot reach that, and **WebKit refuses the insecure loopback socket outright from an https page** — so every pattern pane in the Weaver over the tailnet failed with `No data at cell`. Chromium exempts localhost from that rule, which is why this survived so long: it is invisible in the browser most of us test in.

**Evidence (proved headlessly, both directions).** With the table saying `http://localhost:8001`, a tailnet (https) page re-routes the space to `ws://localhost:8001` and WebKit blocks it — visible in the Safari console and in a Chromium socket capture. Rewriting the table to `https://<host>.ts.net:8001` moves the failure rather than fixing it: a **localhost** page then re-routes to `wss://<host>.ts.net:8001`, that connection fails repeatedly, and the same `sync-load-failure → No data at cell` follows. So a site-table host that differs from the runtime's own `apiUrl` **for the same toolshed** breaks the route in either direction.

Loopback is the case where that is decidable without guessing: it is only meaningful on the writer's own machine, so an entry naming it carries no usable information for a page that reached the toolshed by another name.

## What

One rule, in that read. When the entry's host is loopback (`localhost`, `127.0.0.0/8`, `::1`, any port) **and** this runtime's `apiUrl` is not loopback, the entry is not registered as a route: it is read as "the same toolshed this runtime is already talking to", and the space stays on `apiUrl`. Logged once at debug.

A page that did reach loopback keeps today's behavior exactly — there the entry and the runtime agree, and the route is real.

`isLoopbackHostname` already existed in `packages/runner/src/space-host.ts`, private, and is what `spaceHostFromFabricAuthority` derives loopback routes with. It is exported rather than restated, so the two cannot drift into disagreeing about what loopback is.

Nothing else changed: no docs beyond the one comment at the rule.

## Test plan

Two cases in `packages/runtime-client/test/backends/runtime-processor.test.ts`, beside the existing `watchSiteTable()` test:

- a table with a loopback entry and a **non-loopback** `apiUrl` (`https://host.ts.net:8001/`) leaves that space routed to `apiUrl`, and never calls `registerSpaceHost` for it — while a non-loopback entry in the same table still registers, which is what makes the assertion about the loopback one meaningful rather than a race;
- the same entry with a **loopback** `apiUrl` still registers and still routes to `http://localhost:8001/`.

Both wait on a deferred resolved from the `registerSpaceHost` fake rather than polling.

**Proved able to fail:** with the rule's condition forced off, the first case fails on the route assertion; restored, both pass.

Gates, each by its own exit code from the repo root on the pinned Deno: `deno fmt --check`, `deno lint`, `deno task check`, and `deno task test` in `packages/runner` and `packages/runtime-client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

