### PR TITLE
docs(shuttle): three leads from using the shell, recorded as candidates

### DIFF
--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -222,3 +222,25 @@ decisions point here where they defer.
    is not the persisted cross-process ambience the non-goals rule out,
    and the line between the two is drawn here on purpose: resume hands
    one shuttle its own past, never another tool the session's present.
+   `ls <target>` reads a child without standing on it, the way `get`
+   already does — `arity` has the `optional` arm and the listing takes a
+   place, so what wants deciding is whether listing a child renumbers the
+   handles, since decision 17 says a listing does and that would retire a
+   `%n` the person was about to use. And a colored prompt, to tell a
+   command from its output in scrollback: the escapes are zero-width, so
+   every width computation on a painted string goes through
+   `visibleWidth`, or the cursor arithmetic that reads terminal columns
+   rather than code points lands in the wrong one at a wrap.
+7. **Completion that walks a path.** Completion is place-relative: it
+   offers what stands where shuttle stands, so a path typed into a target
+   — `get %1/zones/0/n` — completes nothing, which is exactly when a
+   person most wants it, the segments being unguessable. Making it
+   operand-relative means resolving a partial operand and listing under
+   it. The question to rule first is whether completing across a handle
+   **substitutes** it: `%n` is a reference only until the next listing
+   (decision 17), so a line still carrying `%1` says less than it seems
+   to — and rewriting two characters into a sixty-character handle is a
+   worse line to read and to edit. A third reading resolves the handle to
+   find candidates without rewriting what is shown. Whatever is ruled
+   holds for every verb taking a path operand, `get`, `set`, `edit` and
+   `link` alike; a completion rule with one exception is one that drifts.


### PR DESCRIPTION
## Why

Three notes from the first real session at the shuttle prompt. None of them is a
defect — the shell does what it says in each case — so they belong with the
ranked leads in `futures.md`, whose own preamble calls them "candidates … to be
ruled when their turn comes." The issue tracker is for what is wrong.

I had filed these as issues (#7237, #7238, #7239) before checking where they
belonged; this supersedes them and they are closed pointing here.

## What Changed

`docs/plans/shuttle/futures.md`, "Candidates, ranked":

- **`ls <target>` and a colored prompt** join candidate 6, "small muscle
  memory", each recorded with the thing that must be decided rather than
  assumed. `ls` of a child renumbers the handles, because decision 17 says a
  listing does — so it would retire a `%n` the person was about to use. And a
  painted prompt's escapes are zero-width, while the cursor arithmetic reads
  terminal columns rather than code points, so measuring a painted string
  naively lands the cursor in the wrong column at a wrap.
- **Completion that walks a path** becomes candidate 7. It is the one that wants
  a ruling before an implementation: completing across `%n` either substitutes
  the handle or leaves it. Both readings hold — a handle is a reference only
  until the next listing, and sixty characters where two were typed is a worse
  line to read and to edit — and there is a third that resolves the handle to
  find candidates without rewriting what is shown. Whatever is ruled has to hold
  for `get`, `set`, `edit` and `link` alike, since a completion rule with one
  exception is one that drifts.

Text only. No decision is made here and nothing is built.

## Test plan

- `deno fmt --check` — `Checked 5902 files`, clean.
- `deno task check-docs` — `All 597 checked code block(s) passed.`
- Line wrapping verified not to regress: the count of over-79-column lines is 9
  on `origin/main` and 9 on this branch, and the longest line added is 74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

