### PR TITLE
docs: a clone whose links leave the space refuses the check and restore paths

### DIFF
--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -296,6 +296,17 @@ These are all failures that actually happened, not hypotheticals:
   creates space stores on demand, so a link to another space silently
   manufactures an empty local one. A pattern with cross-space reads will look
   cleaner on a clone than in production.
+- **`setsrc --check` and `piece restore` refuse a clone whose links leave the
+  space.** A voter or member link into a home space the snapshot does not
+  carry reads as absent on the clone (the point above), and the review those two
+  commands run judges the stored value strictly: `votes: 0: voter: value does
+  not match type object`, for the deployed source as much as for the candidate.
+  The apply path's setup defers such a link as a placeholder instead, so
+  rehearse the update with `setsrc` itself and read its receipt; on a clone of
+  this shape `--check` vouches for nothing. Nor can the CLI plant the missing
+  link by hand — `cf cell set` of a link into a profile is refused with "source
+  has no durable schema contract" — so a rehearsal that needs a participant
+  with a profile creates one through the UI against the clone.
 - **A clone tests the store and the runtime, not the deployment.** CDN and shell
   versions, and concurrent human traffic, are all absent.
   [`staging-space-copy.md`](staging-space-copy.md) is what covers that gap, at


### PR DESCRIPTION
## What

One bullet in `docs/development/space-clone-rehearsal.md`, under "Things that will mislead you": on a clone of a space whose voter or member links point into home spaces the snapshot does not carry, `setsrc --check` and `piece restore` refuse every source, the deployed one included (`votes: 0: voter: value does not match type object`), because the review those commands run judges the absent link strictly. The apply path's setup defers such a link as a placeholder, so the rehearsal has to go through `setsrc` itself and its receipt. The CLI also cannot plant the missing link by hand (`cf cell set` of a link into a profile is refused with "source has no durable schema contract"), so a participant with a profile is created through the UI against the clone.

## Why

Hit while rehearsing #7175 on a clone of team-lunch; the refusal reads as a defect in the candidate source until the deployed source is fed to the same check and refused identically. The runbook's cross-space bullet already says such links read as empty; this is the consequence for the two commands that judge them.

## Verification

- `deno task check-docs`: all 596 checked code blocks pass.
- `deno fmt --check` repo-wide clean (`docs/` is outside the formatter's targets; the new lines are wrapped at 80).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

