### PR TITLE
fix(js-compiler): avoid JSX factory shadowing

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -47,6 +47,14 @@ These string-level steps run in `transformCfDirective()`
 (`src/core/cf-helpers.ts`) before any AST transformer, because symbol binding
 happens before the transformer pipeline runs.
 
+TypeScript's subsequent JSX emit uses `__cfHelpers.h` for elements and
+`__cfHelpers.h.fragment` for fragment tags
+(`packages/js-compiler/typescript/options.ts`). Both resolve through the
+reserved helper binding, so authored locals and parameters named `h` retain
+their ordinary meaning inside JSX-producing scopes. The forwarding `h()`
+function remains available for explicit calls and keeps the helper import
+live during binding.
+
 Legacy stored-envelope compatibility is deliberately separate from
 `transformCfDirective()` (#4574, CT-1838):
 

--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -2,6 +2,7 @@ import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
 import { StaticCache } from "@commonfabric/static";
+import { transformCfDirective } from "@commonfabric/ts-transformers";
 
 import {
   CompilerError,
@@ -143,6 +144,58 @@ async function resolveAndCompileToModules(
 }
 
 describe("TypeScriptCompiler", () => {
+  describe("JSX factory binding", () => {
+    for (const extension of ["tsx", "jsx"]) {
+      it(`evaluates elements and fragments with local and parameter bindings named \`h\` in .${extension}`, async () => {
+        const name = `/main.${extension}`;
+        const compiler = new TypeScriptCompiler(types);
+        const source = `
+export function render() {
+  const h = [0, 1, 2];
+  return <div>{h.map((h) => <><span>{h}</span><br /></>)}</div>;
+}
+`;
+        const modules = await resolveAndCompileToModules(
+          compiler,
+          new InMemoryProgram(name, {
+            ...fabricTypeModules,
+            [name]: transformCfDirective(source, name),
+          }),
+          { runtimeModules: FABRIC_RUNTIME_MODULES },
+        );
+        const factory = Object.assign(
+          (name: string, props: unknown, ...children: unknown[]) => ({
+            name,
+            props,
+            children,
+          }),
+          { fragment: "fragment" },
+        );
+        const exports: { render?: () => unknown } = {};
+        new Function("exports", "require", modules.get(name)!.js)(
+          exports,
+          (specifier: string) => {
+            expect(specifier).toBe("commonfabric");
+            return { __cfHelpers: { h: factory } };
+          },
+        );
+
+        expect(exports.render!()).toEqual({
+          name: "div",
+          props: null,
+          children: [[0, 1, 2].map((value) => ({
+            name: "fragment",
+            props: null,
+            children: [
+              { name: "span", props: null, children: [value] },
+              { name: "br", props: null, children: [] },
+            ],
+          }))],
+        });
+      });
+    }
+  });
+
   it("registers virtual environment types as default libraries", async () => {
     const compiler = new TypeScriptCompiler(types);
     const resolved = await compiler.resolveProgram(
@@ -542,11 +595,13 @@ declare namespace JSX {
   }
 }
 
-declare function h(
-  tag: string,
-  props: Record<string, unknown> | null,
-  ...children: unknown[]
-): unknown;
+declare const __cfHelpers: {
+  h(
+    tag: string,
+    props: Record<string, unknown> | null,
+    ...children: unknown[]
+  ): unknown;
+};
 
 class Counter {
   @tracked accessor count = 1;

--- a/packages/js-compiler/typescript/options.ts
+++ b/packages/js-compiler/typescript/options.ts
@@ -83,7 +83,8 @@ export const getCompilerOptions = (): CompilerOptions => {
     //
 
     jsx: JsxEmit.React,
-    jsxFactory: "h",
+    // The reserved helper binding keeps authored locals out of JSX dispatch.
+    jsxFactory: "__cfHelpers.h",
     jsxFragmentFactory: "__cfHelpers.h.fragment",
     target: TARGET,
     // `lib` should autoapply, but we need to manage default libraries since


### PR DESCRIPTION
JSX elements emitted bare `h(...)` calls, so a local variable or callback parameter named `h` could make a pattern compile successfully and then fail with `h is not a function` at runtime. Route element creation through the reserved `__cfHelpers.h` binding, matching the existing namespaced fragment factory.

Adds execution regressions for local and parameter shadowing, nested fragments, and self-closing elements in both `.tsx` and `.jsx`. Updates the compiler fixture's factory declaration and the transformer behavior spec.

Closes #7236.

Validation:
- Confirmed both new execution tests fail before the fix and pass afterward.
- Full `packages/js-compiler` test suite: 16 passed, 162 steps.
- Focused runner compilation, module evaluation, and pretransform suites: 10 passed, 54 steps.
- A production runtime probe of JSX inside `computed()` with a local `h` produced all three expected button nodes.
- Repo-wide `deno task check`, `deno fmt --check`, and `deno lint` passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

