### PR TITLE
docs(test-selection): keep measuring a flaky test on the default branch

### DIFF
--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -605,10 +605,11 @@ itself.
   across attempts.
 - **A test too flaky for a change that failed every one of its runs at
   this commit and passed every one at the parent.** Those failures do not
-  fail the run, so the note is the only thing that carries them to a
-  person. It says the test is one the store has seen disagreeing with
-  itself, that the run stayed green, and that one bad runner produces the
-  same record, since every run of a test at a commit shares a lane. The
+  fail the run, so the lane's job summary is the only other place they
+  appear, and nobody reads the summary of a run that passed. It says the
+  test is one the store has seen disagreeing with itself, that the run
+  stayed green, and that one bad runner produces the same record, since
+  every run of a test at a commit shares a lane. The
   extra runs are what make the observation possible, so this note is
   silent until they land.
 - **A rename that discarded history**, with the number of catches it

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -603,6 +603,14 @@ itself.
   every test in the missing part look new — which passed and failed at
   this one commit, across the repeats a lane runs, across shards and
   across attempts.
+- **A test too flaky for a change that failed every one of its runs at
+  this commit and passed every one at the parent.** Those failures do not
+  fail the run, so the note is the only thing that carries them to a
+  person. It says the test is one the store has seen disagreeing with
+  itself, that the run stayed green, and that one bad runner produces the
+  same record, since every run of a test at a commit shares a lane. The
+  extra runs are what make the observation possible, so this note is
+  silent until they land.
 - **A rename that discarded history**, with the number of catches it
   would bring back and the line to append to
   `tasks/test-identity-aliases.jsonl`. Four things have to hold: the

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -474,6 +474,19 @@ nothing has been recorded twice with no unit.
 A run folding into an empty aggregate has nothing to compare against, and
 says neither.
 
+## What the run on the default branch does with a flaky test
+
+A test whose flake share is above `FLAKE_EXCLUSION_RATE` is not selected
+for a change. Where it may be run without its neighbours, the run on the
+default branch runs it as many times as its share asks for and does not
+fail for it, so it goes on being measured while it is out of changes, and
+a green run of the default branch can carry a failure of one of these
+tests and still deploy. `explain <identity>` says of any test whether the
+newest manifest withholds it and how many runs it is given. The lanes are
+what carry this, so it describes what lands with them rather than what runs
+today, and the reasoning behind each part is in [the
+plan](../plans/pull-request-test-selection.md#an-excluded-test-still-runs-on-main).
+
 ## What the wall shows
 
 Two tiles read the newest manifest. The flake tile reports how many tests
@@ -533,7 +546,7 @@ A commit whose subject names a number that is not a pull request gets
 nothing. An issue takes comments the same way a pull request does, so
 the number is looked up before anything is written.
 
-The comment carries up to six notes, and it carries a note only when the
+The comment carries up to seven notes, and it carries a note only when the
 run found something the pull request's own run could not have found for
 itself.
 

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1,10 +1,11 @@
 # Choosing which tests a pull request runs
 
 Status: in progress. Part one is built. Part two is built apart from its
-continuous-integration configuration and the coverage work; part three has
-the reporter and nothing else. [The work](#the-work) carries the detail.
-The record store this plan consumes is live and holds the data the design
-needs; the gaps it does not yet hold are listed under [What the store is
+continuous-integration configuration, the coverage work and the full run's
+treatment of flaky tests; part three has the reporter and nothing else.
+[The work](#the-work) carries the detail. The record store this plan
+consumes is live and holds the data the design needs; the gaps it does not
+yet hold are listed under [What the store is
 missing](#what-the-store-is-missing) and closed by the first part of the
 work.
 
@@ -170,7 +171,10 @@ belong.
    being covered.
 5. Tests that need the same setup are grouped so the setup is paid once
    for the group.
-6. A push to `main` still runs every test.
+6. A push to `main` still runs every test, and every failure fails the
+   run, apart from the tests measurement has shown too noisy to judge a
+   change by, which run there more often than anywhere else and report
+   rather than fail.
 7. Selection is recomputed every few hours, and what it produces is not
    stored in git.
 8. Adding a test, a kind of test, or a configuration of existing tests
@@ -187,7 +191,9 @@ belong.
     introduced it, without turning that into a record of who broke what.
 11. Flaky tests are found, and the finding is used: to run intermittent
     things more often where that catches more, and to keep tests too
-    noisy to judge from blocking anybody.
+    noisy to judge from blocking anybody. A test kept out of pull
+    requests for being flaky goes on being measured on `main`, often
+    enough that its share can rise as well as fall.
 12. Every dial is in one documented place, and a pull request can opt out
     of selection entirely and run everything.
 
@@ -1610,9 +1616,13 @@ shows it, and it appears on a work queue. This replaces the usual
 quarantine list, and it is better than one in three ways: it is derived
 from measurement rather than from somebody's judgement at one moment, it
 needs no owner or expiry to stop it rotting, and it reverses on its own as
-the test goes back to passing. The exception is a change that edits the test
-itself, or that the test's suite maps onto its unit, which is very likely
-a fix and has to be allowed to prove itself.
+the test goes back to passing. That last property is the one the exclusion
+would otherwise take away from itself, since a test it holds out of pull
+requests is left with runs that can only lower its share; [An excluded test
+still runs on `main`](#an-excluded-test-still-runs-on-main) is what keeps
+it. The exception is a change that edits the test itself, or that the
+test's suite maps onto its unit, which is very likely a fix and has to be
+allowed to prove itself.
 
 **The rule reaches a repository gate as well.** Formatting, linting and
 the drift guard are tests of the tree, and the rule says nothing about
@@ -1862,8 +1872,10 @@ Two things follow from knowing it.
 **Too flaky to judge by, so not selected.** Above the threshold, an item
 leaves the pull-request selectable set entirely, for the reason in [The
 rule that keeps a test out](#the-rule-that-keeps-a-test-out). It keeps
-running on `main`, and it keeps appearing on the deflake work queue until
-somebody fixes it.
+running on `main`, repeated there and unable to turn the run red, and it
+keeps appearing on the deflake work queue until somebody fixes it. [An
+excluded test still runs on `main`](#an-excluded-test-still-runs-on-main)
+says what that costs and what it buys.
 
 **Below the threshold, some items are run more than once.** Repeats raise
 the chance of catching something intermittent: a regression that shows up
@@ -1888,7 +1900,11 @@ repository bans retry loops, because a retry lets something that should
 have failed pass on a later attempt, and the error is then missed. Repeats
 run the other way: every repeat must pass, and any failure among them
 fails the lane. Three runs of a test is strictly stricter than one, never
-laxer. Nothing is retried and nothing is masked.
+laxer. Nothing is retried and nothing is masked. The identities [an
+excluded test still runs on `main`](#an-excluded-test-still-runs-on-main)
+covers are laxer than one gating run rather than stricter, which is the
+trade that section argues; they are still not retries, since no run is
+re-attempted and no result is discarded.
 
 That does mean a flaky item below the threshold fails pull requests more
 often in proportion to how often it is repeated. That is the honest cost,
@@ -1898,6 +1914,166 @@ tests too noisy to be worth it.
 Repeats also generate the cleanest flake data there is — several
 observations at one commit in one environment — so the measurement
 sharpens itself.
+
+### An excluded test still runs on `main`
+
+The exclusion takes a test out of pull requests, and pull requests are
+where a test is run more than once. What is left is one run per `main`
+push, and a test run once per commit is seen to disagree with itself only
+when somebody re-runs the job, since the pass and the failure have to sit
+at one commit. So its share falls with almost every run it gets and rises
+almost never. The exclusion is meant to reverse as a test goes back to
+passing, and for the tests it holds the evidence points one way by
+construction.
+
+The score moves at the same time. A `main` failure that the next `main`
+run passes at a later commit is credited as a catch, and with nothing
+beside it at its own commit that is what each of an excluded test's
+spurious failures becomes. So the test returns to pull requests with a
+share near nothing and a score raised by its own noise.
+
+Two rules answer this. They are separable, and only the second carries any
+risk, so they are argued separately.
+
+**An excluded identity whose independence is established runs on `main` as
+many times as its share asks for.** [The line that decides the
+count](#flakes-and-repeats) already runs past the exclusion rate, so
+nothing new decides anything; what changes is that the mandatory pass
+places such an identity with that count rather than with the single run it
+gives every mandatory identity. Any share above the threshold asks for at
+least four runs, so this is at least three further runs at each commit.
+
+Those further runs are what let a share rise as well as fall. They also
+put a pass beside a spurious failure at its own commit, which classifies
+it as a disagreement rather than crediting it as a catch, so both
+paragraphs above close on one mechanism.
+
+**The independence flag is a precondition and not a detail.** A repeat
+invokes the identity's file with every other identity skipped, and an
+identity without the flag may not have its siblings skipped, so its file
+would have to be invoked whole several times. Every sibling in that file
+would then run several times, and every sibling still gates, so a file
+holding one flaky test would fail lanes several times as often for tests
+that are not flaky at all. So an identity without the flag keeps its
+single run, and gains the measurement when the flag is established. [The
+`main`-side check that establishes it](#establishing-it) is already part
+of this design, and this gives it a second thing to be worth.
+
+With the flag, the identity is skipped in its file's own invocation and
+run alone the whole count of times. Every run of it at that commit is then
+the same shape, and the same shape the independence check uses. Without
+that, an identity would run once beside its siblings and again alone, and
+a test sensitive to the difference would be recorded as disagreeing with
+itself at every commit, which would pin its exclusion in place for good.
+
+**What these runs cannot separate is a bad machine.** All of an identity's
+runs at one commit go in one lane, so they run on one runner, and a runner
+that fails one of them fails all of them. That is not a disagreement, and
+the rule that reads a failure across many sources as the environment
+covers catches rather than disagreements and has one source to read on
+`main` anyway. So a bad lane and a genuine regression produce the same
+record here. That is the gap [flakes and repeats](#flakes-and-repeats)
+already names, and these runs sit inside it rather than widening it.
+
+What this costs is runner time. Each run is an invocation of its own, so
+the cost model charges every one its invocation rather than charging the
+file once, and the floor `--lane-count` starts its search from has to
+count them as well, which today it does not. Most of the cost then arrives
+as more lanes. Not all of it: one identity's runs go in one lane, so an
+expensive identity multiplied past the bound its job is killed at cannot
+be helped by adding lanes. The mandatory pass has to give up runs until
+what is left fits, down to one, which is what the discretionary passes
+already do and what the mandatory pass does not.
+
+**A failure of an excluded test does not fail the run.** This is the
+second rule and it is a different question, which is what a `main` failure
+of a test nobody can act on should do. `main` already goes red for these
+tests, once per commit; the first rule multiplies that by the count. A
+`main` build that goes red for a test too noisy to judge a change by tells
+nobody anything they did not already know, and several times per commit it
+tells them nothing several times.
+
+The rule is for tests and not for repository gates. Formatting, linting,
+the cycle check and the drift guard are withheld from pull requests by the
+same threshold as everything else, and a gate is exactly where this must
+not reach: a gate's failure is a statement about the tree rather than
+about one change, and the drift guard is what this design leans on to
+notice a suite that has silently stopped running. So the lane reads a
+`reason` of `flaky` on a withheld entry whose unit is a test, and every
+other withheld entry gates as it does today. Reading membership of the
+withheld set instead would make every reason somebody adds later
+non-gating without anybody deciding it.
+
+The lane sorts a batch's failures by identity rather than by batch,
+because a batch holds many identities and its runner reports one exit
+status for all of them, and it has the batch's records by the time it
+decides, since it gathers them immediately after the batch.
+
+**A batch is excused only when it accounted for every identity it was
+asked to run.** "No gating failure among the ones that recorded" is not
+the condition, because a batch that runs a withheld test, records its
+failure and then dies satisfies it while having run almost nothing. So the
+lane compares the batch's records against the identities it planned for
+that batch, and a batch missing any of them fails the lane whatever its
+failures were. That is the record spec's own rule, that a conclusion rests
+on a record that is there and never on one that is missing. A lane that
+could not read a manifest has no withheld set, so nothing is run more than
+once and every failure gates.
+
+The plan a lane receives gains a `nonGating` list rather than reporting
+these in `withheld`. `withheld` means the plan declined to run something,
+and a run that ran a test ten times should not say in its own summary that
+no lane chose it.
+
+Three things elsewhere have to move with this rule.
+
+- **Coverage.** A covered package whose lane held a non-gating failure is
+  reported rather than having a baseline published from it, which is the
+  rule the per-package gate already applies to a package with a failing
+  test. Coverage measured through a failing suite says nothing either way.
+- **The pending-failure list.** A `main` failure waits in `pendingMain`
+  until a later `main` run judges it, and nothing ages that list. Today a
+  broken test turns `main` red and somebody fixes it; under this rule an
+  excluded test can stay broken indefinitely and its pending failures
+  accumulate without bound. `pendingMain` joins the windows `trimWindows`
+  ages.
+- **Re-runs.** A red `main` is what prompts somebody to re-run a job, and
+  a re-run is one of the two ways a same-commit observation happens at
+  all. Taking the red away takes that path away with it. The first rule
+  more than replaces what it produced, but the loss is real, and it is one
+  the first rule has to cover for the second to be affordable.
+
+Nothing is masked. Every run is recorded, every failure is scored by the
+same rules as any other, the job summary names each non-gating failure and
+the identity it belongs to, and the wall and the deflake work queue read
+exactly these records. The failure no longer fails the build, and only for
+tests whose measured share says they cannot tell a good change from a bad
+one.
+
+**The first rule alone is a real option, and it is worth saying why it was
+not taken.** Running an excluded identity several times on `main` and
+still failing the run for it buys the whole measurement fix: the share can
+rise, and a spurious failure stops being credited as a catch. It needs no
+exception to "an execution is not a retry", no sorting of failures, and it
+puts nothing at risk. What it costs is `main` going red several times as
+often for tests nobody can act on, which is the thing this is being asked
+to stop. That is the trade, stated plainly, and the second rule is the
+side of it this design takes.
+
+The second rule gives up more than whether the build is red. The build,
+attestation, coverage and deploy jobs depend on `full-tests`, so a full run
+that stays green ships. A test that is both too flaky for pull
+requests and genuinely broken therefore deploys, where its failure would
+otherwise have held the deploy.
+
+The reporter is what carries that case to a person: an excluded identity
+that failed every one of its runs at this commit and passed every one at
+the parent. The comment says what the observation is and what it is not,
+because a bad lane produces the same record, and only a person looking can
+say which it was. That is weak evidence and it is the only evidence there
+is, which is the honest position for a test whose failures nobody could
+act on before this rule either.
+
 
 ## Packing
 
@@ -2496,7 +2672,8 @@ What the runner does, in order:
    values are the whole of the difference between the two runs.
 5. Print the plan to the job summary: which batches, which items, what
    each is expected to cost, why each was chosen, which items were
-   withheld and why, and which manifest the plan came from.
+   withheld and why, which of them a failure would not fail the lane for,
+   and which manifest the plan came from.
 6. Set up the union of the capabilities the batches need, recording each
    one's duration.
 7. Run each batch execution with fresh spool and JUnit output paths,
@@ -2508,12 +2685,24 @@ What the runner does, in order:
    variant before another execution can reuse any runner-owned path. Then
    convert the coverage this lane produced into one report per workspace
    member and upload it for `Status` to join.
-9. Exit non-zero if any batch failed, or if any repeat of any item failed.
+9. Exit non-zero if any batch failed, or if any repeat of any item
+   failed. A failure the full run's non-gating rule covers is left out of
+   that, and a batch that did not account for every identity it was asked
+   to run is never left out of it. [An excluded test still runs on
+   `main`](#an-excluded-test-still-runs-on-main) says which failures those
+   are and how the runner tells them apart.
 
 ## The full run on `main`
 
 A push to `main` still runs everything, and it runs it through the same
 topology so that the two paths cannot drift.
+
+The full run does one thing a pull request does not. An identity too flaky
+for pull requests is run here as many times as its share asks for, and its
+failures do not fail the run, so the measurement that decides whether it is
+still flaky keeps going while the test is out of pull requests. [An
+excluded test still runs on `main`](#an-excluded-test-still-runs-on-main)
+is the whole of that rule.
 
 `deno.yml` gains a small `plan-full` job that runs on push and emits one
 integer: how many lanes the run needs. It gets that from `deno run -A
@@ -2627,6 +2816,16 @@ excludes both, a future edit that gets an `if:` wrong — reports a green
 `Status` on a pull request that ran no tests at all. That is the one
 failure mode of this whole design that would be silent, so it is asserted
 directly rather than reasoned about.
+
+A labelled pull request gets the full run's treatment of a flaky test as
+well, since it is the same job: the excluded identities are run several
+times on it and cannot fail it. That follows from the label running what
+`main` runs, and it has one edge worth knowing about. The label runs the
+full jobs instead of the five lanes rather than beside them, so a change
+that fixes a flaky test and also carries the label gets no gating run of
+the test it fixes. The ordinary five-lane path is where that fix proves
+itself, because there the exception for a change that edits a test makes
+it mandatory and gating.
 
 The natural users are a change nobody wants to be wrong about, a change to
 the topology or to the test machinery itself, and the moment somebody
@@ -3019,6 +3218,13 @@ pull request's own run could not have:
   the three.
 - **A new test that turned out to be flaky**, when a test the pull request
   added has since disagreed with itself.
+- **A test too flaky for pull requests that failed every one of its runs
+  at this commit and passed every one at the parent.** Those failures do
+  not fail the run, so this comment is the only thing that carries them to
+  a person. It says the test is a known flaky one, that the run stayed
+  green, and that the same record is what one bad runner produces, since
+  every run of an identity at a commit shares a lane. Weak evidence, named
+  as weak, is what there is.
 - **A rename that discarded history**, with the alias line to append and
   the number of catches it would bring back. See [Renames, and the alias
   file](#renames-and-the-alias-file).
@@ -3071,6 +3277,19 @@ score so the next change in that area runs it. If the rate turns out to be
 intolerable, the escape hatch is a merge queue, which restores the
 guarantee at the cost of merge latency. This plan does not propose one; it
 notes that the option exists and that nothing here forecloses it.
+
+**A test too flaky for pull requests cannot turn `main` red, so a real
+regression inside one is missed and a green run ships.** The test still
+runs, more often than it did before, and every result is recorded and
+scored. What no longer happens is the build stopping for it, and the build
+is what the deploy depends on. The reporter carries the one observation
+that is left, and names what it cannot tell apart. I'd guess this is the
+better trade, on two grounds neither of which is measured here: a failure
+of a test whose share says it fails on its own says very little about the
+commit it failed at, and a `main` that goes red for tests nobody can act
+on is one people learn to read past, which costs the signal for everything
+else on it. Running these tests several times and keeping every failure
+gating is the alternative, and it is set out beside the rule.
 
 **Outside a covered package, a change to a source file does not pull in
 the tests that execute it.** Selection knows which test files a change
@@ -3156,6 +3375,11 @@ is pinned to the commit's date. And if none of that settles it,
 | A fork pull request | Works unchanged. The manifest is world-readable, and the existing member gate decides whether the fork's records ship. |
 | A re-run of one failed lane | Runs the same set, because the manifest is resolved by the commit's date, which no attempt changes. |
 | Both `pr-tests` and `full-tests` skip | `Status` fails. Its second clause requires one of them to have succeeded, so a pull request that ran no tests can never report green. |
+| A test too flaky for pull requests fails on `main` | The run stays green and the job summary names the failure and its identity. The records are scored as any others, so the failure feeds the share, the wall, and the deflake work queue. |
+| A batch on `main` does not account for every identity it was asked to run | The lane fails. Nothing has shown the failures it did record to be the whole of what went wrong, and missing evidence is read as a real failure. |
+| A test too flaky for pull requests genuinely regresses | `main` stays green and the change ships. The regression is found when somebody deflakes the test, or from the reporter's comment where every run failed at the commit and every run passed at its parent. That comment says a bad runner produces the same record. |
+| A repository gate goes above the flake threshold | It leaves pull requests as any test does, and it goes on failing `main`. The non-gating rule is for tests, so a gate never stops gating the branch it is a gate on. |
+| A bad runner fails every run of an excluded identity at one commit | No disagreement is recorded, the failure waits for the next `main` run, and a pass at a later commit credits a catch the test did not earn. This is the environmental gap the flake rules already carry, and these runs sit inside it. |
 | `main` is broken and stays broken | Nothing holds a test back for having failed on `main`, so a pull request that selects the broken test fails on it. The failure belongs to the default branch, and fixing it there is what clears it. |
 | The reporter cannot find the pull request behind a `main` commit | It logs the commit and posts nothing. A direct push to `main` with no pull request behind it is the ordinary case for this. |
 | The reporter would comment on a test that is known flaky | It says so in the comment rather than implying the change caused it. |
@@ -3263,6 +3487,20 @@ three. And the baseline walk is tested against recorded chains of `main`
 commits: a rise against an ancestor fails, a rise against a run the merge
 base does not contain reports, and a package with no baseline reports.
 
+The full run's treatment of a flaky test is tested at both ends. In
+`plan()`, a withheld and independent identity is placed under the
+`everything` policy with the count its share asks for and named in
+`nonGating`; a withheld identity without the independence flag is placed
+once; a withheld gate is named in neither; and an identity whose runs do
+not fit gives them up until they do rather than putting its lane past the
+bound. In the lane runner, a fixture of batch results and records proves
+four cases: a batch failing only on non-gating identities does not fail the
+lane, a batch failing on one other identity does, a batch failing on a
+non-gating identity in one run and not another does not, and a batch that
+recorded no outcome for some identity it was asked to run fails the lane
+whatever its failures were. The last is the one worth writing first,
+because getting it wrong turns a batch that died early into a green run.
+
 The reporter's attribution is where a bug would be most costly, because a
 wrong comment lands on a person. It is tested against recorded pairs of
 consecutive `main` runs, and the property that matters is the negative
@@ -3287,7 +3525,8 @@ test-selection`. Its modes are also how the system is tested by hand.
   with their dates and sources, its flake rate, and which item it maps to.
   A suite-level measurement instead says that it is not selectable. For an
   item identity, the output says whether the current manifest selects it,
-  withholds it, or repeats it. The argument accepts the canonical three- or
+  how many runs it gives it, and whether it withholds it from pull
+  requests. The argument accepts the canonical three- or
   four-part identity key, and the output always names a present variant.
   This is what somebody uses to answer "why did my test not run?", which
   is the question this system will be asked most often and the one it
@@ -3544,6 +3783,33 @@ exercised on the branch on its own.
       and repeats.
 - [ ] `deno.yml`: `plan-full` and `full-tests` on push, with the build,
       attestation, coverage and deploy jobs repointed at them.
+- [ ] The full run's treatment of a test too flaky for pull requests.
+      `tasks/test-selection/plan.ts` places a withheld, independent
+      identity with the count `executionsFor` already returns for its
+      share rather than the single run the mandatory pass gives, skips it
+      in its file's own invocation so every run of it at one commit shares
+      one shape, gives up runs until what is left fits rather than putting
+      a lane past its bound, and returns a `nonGating` list beside
+      `withheld` naming the identities whose failures do not fail the run.
+      A withheld identity without the independence flag keeps its single
+      run, and a withheld repository gate is in neither list.
+      `tasks/ci-lane.ts` reads each batch's gathered records, exits
+      non-zero only where a failing identity is outside `nonGating`, fails
+      the lane whenever a batch did not account for every identity it was
+      asked to run, and names every non-gating failure in the job summary.
+      The manifest gains no field and `executionsFor` needs no change: its
+      line already runs past the exclusion rate. `fullLaneCount`'s work
+      sum counts the extra runs, which it does not today, so the floor its
+      search starts from is not an underestimate.
+- [ ] `pendingMain` joins the windows `trimWindows` ages. A `main` failure
+      waits there until a later run judges it, and an excluded test that
+      stays broken no longer turns `main` red, so nothing bounds what
+      accumulates.
+- [ ] A covered package whose lane held a non-gating failure is reported
+      rather than having a baseline published from it, the same way the
+      per-package gate already reports a package with a failing test.
+- [ ] `explain <identity>` gains the runs it is given and whether it is
+      withheld, replacing the three-way answer that no longer partitions.
 - [ ] Repository-wide coverage measurement moves to the full run and stops
       failing anything.
 - [ ] `tasks/write-coverage-lcov.ts` converts each workspace member's
@@ -3614,6 +3880,11 @@ exercised on the branch on its own.
       selected run only samples. The gate publishes that figure, so the
       note is silent until the gate lands and needs nothing further
       then.
+- [ ] The reporter's note for a test too flaky for pull requests that
+      failed every one of its runs at this commit and passed every one at
+      the parent. It needs the full run's extra runs to exist before it can
+      say anything, and it says the test is a known flaky one and that the
+      run stayed green.
 - [ ] The per-package coverage gate, in two halves. `tasks/ci-lane.ts`
       makes every item of a covered package the diff touches mandatory,
       keeps those items out of later passes and out of repeats, and

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -173,8 +173,9 @@ belong.
    for the group.
 6. A push to `main` still runs every test, and every failure fails the
    run, apart from the tests measurement has shown too noisy to judge a
-   change by, which run there more often than anywhere else and report
-   rather than fail.
+   change by, which report rather than fail. Those of them that can be
+   run without their neighbours run there more often than anywhere else,
+   which is what keeps their measurement going.
 7. Selection is recomputed every few hours, and what it produces is not
    stored in git.
 8. Adding a test, a kind of test, or a configuration of existing tests

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -193,7 +193,8 @@ belong.
 11. Flaky tests are found, and the finding is used: to run intermittent
     things more often where that catches more, and to keep tests too
     noisy to judge from blocking anybody. A test kept out of pull
-    requests for being flaky goes on being measured on `main`, often
+    requests for being flaky goes on being measured on `main`, and where
+    it can be run without its neighbours it is measured there often
     enough that its share can rise as well as fall.
 12. Every dial is in one documented place, and a pull request can opt out
     of selection entirely and run everything.
@@ -3221,11 +3222,11 @@ pull request's own run could not have:
   added has since disagreed with itself.
 - **A test too flaky for pull requests that failed every one of its runs
   at this commit and passed every one at the parent.** Those failures do
-  not fail the run, so this comment is the only thing that carries them to
-  a person. It says the test is a known flaky one, that the run stayed
-  green, and that the same record is what one bad runner produces, since
-  every run of an identity at a commit shares a lane. Weak evidence, named
-  as weak, is what there is.
+  not fail the run, so the lane's job summary is the only other place they
+  appear, and nobody reads the summary of a run that passed. It says the
+  test is a known flaky one, that the run stayed green, and that the same
+  record is what one bad runner produces, since every run of an identity at
+  a commit shares a lane. Weak evidence, named as weak, is what there is.
 - **A rename that discarded history**, with the alias line to append and
   the number of catches it would bring back. See [Renames, and the alias
   file](#renames-and-the-alias-file).

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -204,7 +204,11 @@ Above `FLAKE_EXCLUSION_RATE` an identity leaves the selectable set
 entirely: it is too noisy to judge a change by. It keeps running on the
 default branch, it appears on the wall, and the exclusion reverses on its
 own as those runs stop disagreeing, which is what makes this better than a
-quarantine list somebody has to remember to empty.
+quarantine list somebody has to remember to empty. Reversing on evidence
+takes one thing of the default branch in return, which [what the default
+branch does with an excluded
+identity](#what-the-default-branch-does-with-an-excluded-identity) sets
+out.
 
 A disagreement's weight halves every `FLAKE_HALF_LIFE_RUNS` runs that
 follow it, because a sum cannot tell two histories apart that nobody would
@@ -259,7 +263,79 @@ exclusion is what bounds which tests pay it.
 
 **An execution is not a retry.** Every one must pass, and any failure
 among them fails the run. Five runs of a test is strictly stricter than
-one, never laxer. Nothing is retried and nothing is masked.
+one, never laxer. Nothing is retried and nothing is masked. Where a
+consumer takes the second rule below, an excluded identity's runs on the
+default branch are laxer than the one gating run it would otherwise get.
+They are still not retries, since no run is re-attempted and no result is
+discarded.
+
+### What the default branch does with an excluded identity
+
+An identity run once per commit is seen to disagree with itself only when
+somebody re-runs the job, so every run an excluded identity gets on the
+default branch lowers its share and almost none can raise it. Left there,
+the exclusion reverses on runs that were incapable of keeping it in place,
+and each of the identity's spurious failures, judged by the next run that
+passed at a later commit, is credited as a catch. The identity returns to
+changes with a share near nothing and a score raised by its own noise. Two
+rules answer this, and a consumer may apply the first without the second.
+
+**An excluded identity that may be run without its neighbours runs as many
+times as its share asks for.** The count is the one the line already gives
+that share, which runs past the exclusion rate. Several runs at one commit
+are what let a share rise as well as fall, and they also put a pass beside
+a spurious failure at its own commit, which classifies it as a
+disagreement rather than crediting it as a catch.
+
+Every run of it at that commit takes one invocation shape, since a
+consumer that runs the identity once beside its neighbours and again on
+its own has arranged for a test sensitive to that difference to disagree
+with itself at every commit, and the exclusion would then never reverse.
+An identity that may not be run without its neighbours therefore keeps its
+single run: running its whole unit several times would run every
+neighbour several times, and a neighbour that is not flaky would fail the
+run several times as often for it.
+
+What several runs at one commit cannot separate is a bad machine. A
+consumer that runs them together runs them on one machine, so a machine
+that fails one fails all, which is no disagreement at all. The rule that
+reads a failure across many sources as the environment covers catches
+rather than disagreements, and a default branch offers one source to read.
+
+**A failure of an excluded identity does not fail the run.** This is a
+separate decision and it is the one that carries risk: the branch already
+fails for these identities once per commit, and the first rule multiplies
+that. A consumer decides it per identity and never per invocation, since
+one invocation reports one status for many identities.
+
+It is a rule for tests. An identity that is a repository gate goes on
+failing the run whatever its share, because a gate's failure is a
+statement about the tree rather than about one change. A consumer reads
+the withheld entry's reason rather than its membership of the set, so a
+reason added later does not become non-gating without anybody deciding it.
+
+An invocation is excused only when it accounted for every identity it was
+asked to run, since one that recorded a withheld failure and then stopped
+has run almost nothing while satisfying any weaker test. That is the rule
+under [what a run owes the change behind
+it](#what-a-run-on-the-default-branch-owes-the-change-behind-it) applied
+here, that a conclusion rests on a record that is there and never on one
+that is missing. A consumer with no manifest has no withheld set, so it
+runs nothing more than once and gates on everything.
+
+Two things follow for a consumer that takes the second rule. A run
+carrying a non-gating failure reports success, so whatever that success
+releases is released, and a measurement taken through the failing unit —
+coverage among them — is reported rather than compared. And a failure that
+waits for a later run to judge it now waits without a red branch to
+prompt anybody, so whatever holds those waiting failures is bounded rather
+than left to grow.
+
+Nothing is masked by either rule. Every run is recorded, every failure is
+classified by the rules under [what the score
+measures](#what-the-score-measures), and a non-gating failure is named in
+what the run reports. The failure no longer fails the run, and only for
+identities already held to be unable to say whether a change is good.
 
 ## What must run, and what must not
 
@@ -270,7 +346,10 @@ its author cannot act on.
 
 It comes back the moment the change edits the test itself, or its suite
 maps the change onto its unit, since that is very likely a fix and has to
-be allowed to prove itself.
+be allowed to prove itself. Under the full policy it is not kept out at
+all; [what the default branch does with an excluded
+identity](#what-the-default-branch-does-with-an-excluded-identity) says
+how it runs there.
 
 Two rules force a test in.
 
@@ -397,10 +476,14 @@ known about, and in particular is not a run that skipped every test.
 
 A test that both passed and failed at one commit is that test
 disagreeing with itself, which is flake evidence rather than a catch, and
-it is not a first failure. That a test is new is likewise a claim about
-the store rather than about one run: an identity the store has never seen
-is new, and an identity absent from one run's records is only absent from
-that run.
+it is not a first failure. An excluded identity that failed every one of
+its runs at a commit and passed every one at the parent is the one
+statement about such a test that several runs at one commit make
+available, and a consumer reporting it says that the test is a known flaky
+one and that the run was not failed by it. That a test is new is likewise
+a claim about the store rather than about one run: an identity the store
+has never seen is new, and an identity absent from one run's records is
+only absent from that run.
 
 Whether a change's own run ran a test is settled by that run's records
 and by nothing else. The manifest it resolved answers the next question,
@@ -448,10 +531,12 @@ The policy is an input because one function serves both the run on the
 default branch and the run on a change. It takes two values. The budgeted
 policy spends a bounded amount on the tests worth the most, by the rules
 under [what must run](#what-must-run-and-what-must-not) and the score
-above them. The full policy requires every identity, so the rule that
-keeps a test out has nothing to act on and the discretionary part of the
-packing finds nothing left to take; everything after that behaves the
-same for both. A consumer that packs the two runs through different code
+above them. The full policy requires every identity, so the discretionary
+part of the packing finds nothing left to take; everything after that
+behaves the same for both. The rule that keeps a test out still names a
+set under the full policy, but it names the identities that are run
+several times and cannot fail the run rather than identities left out of
+it. A consumer that packs the two runs through different code
 will drift, and what it drifts into is running different sets of tests in
 the two places that are meant to agree.
 


### PR DESCRIPTION
PROBLEM

The exclusion rule takes a test out of changes, and changes are where a test is run more than once. What is left is one run per push to the default branch, and a test run once per commit is seen to disagree with itself only when somebody re-runs the job, since the pass and the failure have to sit at one commit. So its share falls with almost every run it gets and rises almost never. The exclusion is meant to reverse as a test goes back to passing, and for the tests it holds the evidence points one way by construction. The score moves with it: each spurious failure, judged by the next run that passed at a later commit, is credited as a catch. The test returns to changes with a share near nothing and a score raised by its own noise.

SOLUTION

Two rules, argued separately because they are separable and only the second carries risk.

An excluded identity that may be run without its neighbours runs on the default branch as many times as its share asks for. The line that decides the count already runs past the exclusion rate, so nothing new decides anything; what changes is that the mandatory pass places such an identity with that count. Those runs let a share rise as well as fall, and they put a pass beside a spurious failure at its own commit, which classifies it as a disagreement rather than crediting it as a catch. An identity without the independence flag keeps its single run, since running its whole unit several times would run every neighbour several times and neighbours still gate.

A failure of an excluded test does not fail the run. That is for tests and not for repository gates, read from a withheld entry's reason rather than its membership of the set. A batch is excused only when it accounted for every identity it was asked to run.

DESIGN DISCUSSION

Nothing is masked. Every run is recorded, every failure is scored by the ordinary rules, the job summary names each non-gating failure, and the wall and the deflake queue read those records.

The first rule alone is a real option and the plan says so: it buys the whole measurement fix, needs no exception to "an execution is not a retry", and risks nothing. What it costs is the default branch going red several times as often for tests nobody can act on, which is the thing this is being asked to stop.

The second rule's price is named rather than left out. The build, attestation, coverage and deploy jobs depend on the full run, so a green run carrying a non-gating failure ships. What several runs at one commit cannot separate is a bad machine, since they share a lane, so the reporter's note says what its observation is not. And a red default branch is what prompts a job re-run, which is one of the two ways a same-commit observation happens at all.

Three things move with the rule, each an unstarted work item beside the continuous-integration configuration they land with: a covered package whose lane held a non-gating failure is reported rather than compared, `pendingMain` joins the windows that are aged, and the floor `fullLaneCount` starts its search from counts the extra runs.

The plan gains a `nonGating` list rather than overloading `withheld`, which means a plan declined to run something. The operating guide gets two sentences and a link, since the reasoning belongs in the plan.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

