### PR TITLE
fix(runner): carry enclosing `$defs` into sub-schemas through one shared helper

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -109,6 +109,7 @@ import {
   storedCfcMetadataAppliesToPath,
 } from "./cfc/metadata.ts";
 import { cfcConfidentialityForObservationNode } from "./cfc/observation.ts";
+import { cfcSchemaWithInheritedDefs } from "./cfc/schema-refs.ts";
 import { recordSinkRequestPolicyInput } from "./cfc/sink-request.ts";
 import {
   isRendererTrustedEvent,
@@ -737,14 +738,9 @@ export function elementSchemaFor(
       index < prefixItems.length
     ? prefixItems[index]
     : arraySchema.items;
-  if (!isObjectNotArray(covering)) {
-    return covering as JSONSchema | undefined;
-  }
-  const defs = arraySchema.$defs;
-  if (defs && !("$defs" in covering)) {
-    return { ...covering, $defs: defs } as JSONSchema;
-  }
-  return covering as JSONSchema;
+  return covering === undefined
+    ? undefined
+    : cfcSchemaWithInheritedDefs(covering, arraySchema.$defs);
 }
 
 /** Parse the explicit column list from `INSERT INTO t (a, b, c) VALUES ...`,

--- a/packages/runner/src/cfc/schema-refs.ts
+++ b/packages/runner/src/cfc/schema-refs.ts
@@ -268,6 +268,36 @@ export const findCfcSchemaRefs = (
   addRefs(refSet, summarizeCfcSchemaRefs(schema).all);
 };
 
+/**
+ * Return `schema` carrying the definitions its local refs resolve against.
+ *
+ * A fragment evaluated apart from the schema that encloses it — a union arm, a
+ * property, a definition body — no longer reaches the `$defs` its
+ * `#/$defs/<name>` refs name. This attaches `inheritedDefinitions` when the
+ * fragment has such a ref and declares no `$defs` of its own. A fragment whose
+ * refs are all embedded or external comes back as the same object, since those
+ * resolve against their own documents.
+ *
+ * A fragment that declares its own `$defs` also comes back as the same object,
+ * and a ref under a child that declares its own does not count, because CFC
+ * schemas treat a nested `$defs` as a new `#/` scope (see
+ * `cfcSchemaChildRoot()`). JSON Schema does not: there `#` is the root of the
+ * schema resource, which only `$id` changes, so a nested `$defs` never shadows
+ * the root's. The two readings differ only where a nested `$defs` redefines a
+ * name the root also defines.
+ */
+export const cfcSchemaWithInheritedDefs = (
+  schema: JSONSchema,
+  inheritedDefinitions: SchemaDefinitions | undefined,
+): JSONSchema =>
+  // A definition map is a non-array record; an array would resolve indices
+  // as member names.
+  isObjectOrArray(schema) && schema.$defs === undefined &&
+    isObjectNotArray(inheritedDefinitions) &&
+    summarizeCfcSchemaRefs(schema).localDefinitions.size > 0
+    ? { ...schema, $defs: inheritedDefinitions }
+    : schema;
+
 const definitionIndexFor = (
   definitions: SchemaDefinitions,
 ): { index: DefinitionIndex; cacheable: boolean } => {
@@ -503,14 +533,9 @@ const resolveExternalCfcSchemaRef = (
       `${parsed.taggedHash}#/$defs/${parsed.defName}`,
     ]);
     view = undefined;
-  } else if (isObjectOrArray(member) && member.$defs === undefined) {
-    // Same rule as resolveCfcSchemaRefUncached: only local refs need the
-    // group's definition scope attached.
-    view = summarizeCfcSchemaRefs(member).localDefinitions.size > 0
-      ? internSchema({ ...member, $defs: document.$defs })
-      : member;
   } else {
-    view = member;
+    const scoped = cfcSchemaWithInheritedDefs(member, document.$defs);
+    view = scoped === member ? member : internSchema(scoped);
   }
   views.set(parsed.defName, view);
   return view;
@@ -624,20 +649,10 @@ const resolveCfcSchemaRefUncached = (
     ]);
     return undefined;
   }
-  if (isObjectOrArray(schemaCursor)) {
-    // Only LOCAL refs need the containing document's definition scope;
-    // embedded and external refs resolve against their own documents, so a
-    // target carrying only those stays as it is.
-    const { localDefinitions } = summarizeCfcSchemaRefs(schemaCursor);
-    if (localDefinitions.size > 0 && schemaCursor.$defs === undefined) {
-      schemaCursor = {
-        ...schemaCursor,
-        ...(isObjectOrArray(fullSchema) && fullSchema.$defs &&
-          { $defs: fullSchema.$defs }),
-      };
-    }
-  }
-  return schemaCursor as JSONSchema;
+  return cfcSchemaWithInheritedDefs(
+    schemaCursor as JSONSchema,
+    isObjectOrArray(fullSchema) ? fullSchema.$defs : undefined,
+  );
 };
 
 // resolveCfcSchemaRefs results per (frozen schemaObj, frozen fullSchema)

--- a/packages/runner/src/cfc/schema-refs.ts
+++ b/packages/runner/src/cfc/schema-refs.ts
@@ -268,35 +268,63 @@ export const findCfcSchemaRefs = (
   addRefs(refSet, summarizeCfcSchemaRefs(schema).all);
 };
 
+// Whether `schema` can take `inheritedDefinitions` at all: an object schema
+// with no `$defs` of its own, offered a definition map. A definition map is a
+// non-array record; an array would resolve indices as member names.
+const canInheritDefs = (
+  schema: JSONSchema,
+  inheritedDefinitions: SchemaDefinitions | undefined,
+): schema is JSONSchemaObj =>
+  isObjectOrArray(schema) && schema.$defs === undefined &&
+  isObjectNotArray(inheritedDefinitions);
+
+// Whether a local `#/$defs/<name>` ref in `schema` would resolve against
+// inherited definitions. A ref under a child that declares its own `$defs`
+// does not count: CFC schemas treat a nested `$defs` as a new `#/` scope (see
+// `cfcSchemaChildRoot()`). JSON Schema does not — there `#` is the root of the
+// schema resource, which only `$id` changes, so a nested `$defs` never shadows
+// the root's — and the two readings differ only where a nested `$defs`
+// redefines a name the root also defines.
+const hasLocalDefinitionRef = (schema: JSONSchema): boolean =>
+  summarizeCfcSchemaRefs(schema).localDefinitions.size > 0;
+
 /**
  * Return `schema` carrying the definitions its local refs resolve against.
  *
  * A fragment evaluated apart from the schema that encloses it — a union arm, a
- * property, a definition body — no longer reaches the `$defs` its
- * `#/$defs/<name>` refs name. This attaches `inheritedDefinitions` when the
- * fragment has such a ref and declares no `$defs` of its own. A fragment whose
- * refs are all embedded or external comes back as the same object, since those
- * resolve against their own documents.
+ * property, an array's element schema — no longer reaches the `$defs` its
+ * `#/$defs/<name>` refs name. This attaches `inheritedDefinitions` to a
+ * fragment that declares no `$defs` of its own.
  *
- * A fragment that declares its own `$defs` also comes back as the same object,
- * and a ref under a child that declares its own does not count, because CFC
- * schemas treat a nested `$defs` as a new `#/` scope (see
- * `cfcSchemaChildRoot()`). JSON Schema does not: there `#` is the root of the
- * schema resource, which only `$id` changes, so a nested `$defs` never shadows
- * the root's. The two readings differ only where a nested `$defs` redefines a
- * name the root also defines.
+ * A deep-frozen fragment is scanned for such a ref first, and comes back as
+ * the same object when it has none — its refs are all embedded or external,
+ * which resolve against their own documents — so identity-keyed caches keep
+ * hitting. The scan memoizes by identity, which is what makes it cheap there.
+ * A fragment that is not deep-frozen gets the definitions without the scan:
+ * unmemoized, the scan walks the whole subtree on every call, and an unfrozen
+ * object is never a cache key, so nothing is lost by attaching definitions
+ * the fragment turns out not to need.
  */
 export const cfcSchemaWithInheritedDefs = (
   schema: JSONSchema,
   inheritedDefinitions: SchemaDefinitions | undefined,
 ): JSONSchema =>
-  // A definition map is a non-array record; an array would resolve indices
-  // as member names.
-  isObjectOrArray(schema) && schema.$defs === undefined &&
-    isObjectNotArray(inheritedDefinitions) &&
-    summarizeCfcSchemaRefs(schema).localDefinitions.size > 0
+  canInheritDefs(schema, inheritedDefinitions) &&
+    (!isDeepFrozen(schema) || hasLocalDefinitionRef(schema))
     ? { ...schema, $defs: inheritedDefinitions }
     : schema;
+
+// The resolver's form of the same: a resolved definition body takes the
+// document's definitions only when a local ref needs them, frozen or not. Its
+// result is the canonical view of that definition, and `$defs` it does not
+// need would change what that view hashes to.
+const definitionBodyWithDefs = (
+  body: JSONSchema,
+  documentDefinitions: SchemaDefinitions | undefined,
+): JSONSchema =>
+  canInheritDefs(body, documentDefinitions) && hasLocalDefinitionRef(body)
+    ? { ...body, $defs: documentDefinitions }
+    : body;
 
 const definitionIndexFor = (
   definitions: SchemaDefinitions,
@@ -534,7 +562,7 @@ const resolveExternalCfcSchemaRef = (
     ]);
     view = undefined;
   } else {
-    const scoped = cfcSchemaWithInheritedDefs(member, document.$defs);
+    const scoped = definitionBodyWithDefs(member, document.$defs);
     view = scoped === member ? member : internSchema(scoped);
   }
   views.set(parsed.defName, view);
@@ -649,7 +677,7 @@ const resolveCfcSchemaRefUncached = (
     ]);
     return undefined;
   }
-  return cfcSchemaWithInheritedDefs(
+  return definitionBodyWithDefs(
     schemaCursor as JSONSchema,
     isObjectOrArray(fullSchema) ? fullSchema.$defs : undefined,
   );

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -74,6 +74,7 @@ import {
   ContextualFlowControl,
   resolveExternalRootRefForStructure,
 } from "./cfc.ts";
+import { cfcSchemaWithInheritedDefs } from "./cfc/schema-refs.ts";
 import { findAndInlineDataUriLinks } from "./data-uri.ts";
 import type { EntityKind } from "./entity-kind.ts";
 import { MAX_PATH_RESOLUTION_LENGTH, resolveLink } from "./link-resolution.ts";
@@ -346,16 +347,14 @@ function narrowChildSchema(schema: JSONSchema, key: string): JSONSchema {
 // picks the `asCell` branch and hands back a cell handle, so `Cell<T> |
 // undefined` is a handle rather than something read through. The depth bound
 // terminates a declaration that refers to itself, which resolves to itself
-// however many times it is followed. A `$ref` resolves against the nearest
-// enclosing `$defs`, and a union's arms carry none of their own, so the scope
-// the union was declared in travels down to every arm as `inheritedDefs`.
+// however many times it is followed. A union's arms carry no `$defs` of their
+// own, so each is checked carrying the union's, where a `$ref` inside it
+// resolves.
 function isReferenceOnlySchema(
   schema: JSONSchema | undefined,
   depth: number = 4,
-  inheritedDefs?: JSONSchemaObj["$defs"],
 ): boolean {
   if (depth <= 0 || !isObjectOrArray(schema)) return false;
-  const defs = schema.$defs ?? inheritedDefs;
   if (schema.asCell !== undefined) return true;
   // `unknown` is the deliberate request for reference semantics — a value
   // compared by identity rather than read through, opaque at this hop and
@@ -368,13 +367,9 @@ function isReferenceOnlySchema(
     return true;
   }
   if ("$ref" in schema) {
-    const scoped = schema.$defs === undefined && defs !== undefined
-      ? { ...schema, $defs: defs }
-      : schema;
     return isReferenceOnlySchema(
-      resolveSchemaRefsCanonical(scoped as JSONSchemaObj),
+      resolveSchemaRefsCanonical(schema as JSONSchemaObj),
       depth - 1,
-      defs,
     );
   }
   // Both keywords together describe one set of alternatives the run may
@@ -386,7 +381,12 @@ function isReferenceOnlySchema(
     ? [...anyOf, ...oneOf]
     : anyOf ?? oneOf;
   if (arms !== undefined && arms.length > 0) {
-    return arms.some((arm) => isReferenceOnlySchema(arm, depth - 1, defs));
+    return arms.some((arm) =>
+      isReferenceOnlySchema(
+        cfcSchemaWithInheritedDefs(arm, schema.$defs),
+        depth - 1,
+      )
+    );
   }
   return false;
 }
@@ -7968,14 +7968,10 @@ export class Runner {
       return;
     }
 
-    const eventDependencySchema: JSONSchema = {
-      type: "object",
-      properties: { $event: eventSchema as JSONSchema },
-      ...(argumentSchema.$defs !== undefined &&
-        { $defs: argumentSchema.$defs }),
-      ...(argumentSchema.definitions !== undefined &&
-        { definitions: argumentSchema.definitions }),
-    };
+    const eventDependencySchema = cfcSchemaWithInheritedDefs(
+      { type: "object", properties: { $event: eventSchema as JSONSchema } },
+      argumentSchema.$defs,
+    );
     const inputsCell = this.#runtime.getImmutableCell(
       resultCell.space,
       { $event: event },
@@ -8142,23 +8138,9 @@ export class Runner {
   ): NormalizedFullLink[] {
     const links: NormalizedFullLink[] = [];
     const seen = new WeakMap<object, Set<unknown>>();
-    const rootSchema = argumentSchema;
-
-    const schemaWithRootDefinitions = (
-      schema: JSONSchema | undefined,
-    ): JSONSchema | undefined => {
-      if (!isObjectOrArray(schema) || !isObjectOrArray(rootSchema)) {
-        return schema;
-      }
-      return {
-        ...schema,
-        ...(schema.$defs === undefined && rootSchema.$defs !== undefined &&
-          { $defs: rootSchema.$defs }),
-        ...(schema.definitions === undefined &&
-          rootSchema.definitions !== undefined &&
-          { definitions: rootSchema.definitions }),
-      };
-    };
+    const rootDefinitions = isObjectOrArray(argumentSchema)
+      ? argumentSchema.$defs
+      : undefined;
 
     const visit = (schema: unknown, currentValue: unknown): void => {
       // Sigil-only: the value is post-unwrap, where the only `$alias`
@@ -8169,9 +8151,11 @@ export class Runner {
         const link = parseLink(currentValue, resultCell);
         links.push({
           ...link,
-          schema: link.schema ?? schemaWithRootDefinitions(
-            schema as JSONSchema | undefined,
-          ),
+          schema: link.schema ??
+            (schema === undefined ? undefined : cfcSchemaWithInheritedDefs(
+              schema as JSONSchema,
+              rootDefinitions,
+            )),
         });
         return;
       }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -346,12 +346,16 @@ function narrowChildSchema(schema: JSONSchema, key: string): JSONSchema {
 // picks the `asCell` branch and hands back a cell handle, so `Cell<T> |
 // undefined` is a handle rather than something read through. The depth bound
 // terminates a declaration that refers to itself, which resolves to itself
-// however many times it is followed.
+// however many times it is followed. A `$ref` resolves against the nearest
+// enclosing `$defs`, and a union's arms carry none of their own, so the scope
+// the union was declared in travels down to every arm as `inheritedDefs`.
 function isReferenceOnlySchema(
   schema: JSONSchema | undefined,
   depth: number = 4,
+  inheritedDefs?: JSONSchemaObj["$defs"],
 ): boolean {
   if (depth <= 0 || !isObjectOrArray(schema)) return false;
+  const defs = schema.$defs ?? inheritedDefs;
   if (schema.asCell !== undefined) return true;
   // `unknown` is the deliberate request for reference semantics — a value
   // compared by identity rather than read through, opaque at this hop and
@@ -364,9 +368,13 @@ function isReferenceOnlySchema(
     return true;
   }
   if ("$ref" in schema) {
+    const scoped = schema.$defs === undefined && defs !== undefined
+      ? { ...schema, $defs: defs }
+      : schema;
     return isReferenceOnlySchema(
-      resolveSchemaRefsCanonical(schema as JSONSchemaObj),
+      resolveSchemaRefsCanonical(scoped as JSONSchemaObj),
       depth - 1,
+      defs,
     );
   }
   // Both keywords together describe one set of alternatives the run may
@@ -378,7 +386,7 @@ function isReferenceOnlySchema(
     ? [...anyOf, ...oneOf]
     : anyOf ?? oneOf;
   if (arms !== undefined && arms.length > 0) {
-    return arms.some((arm) => isReferenceOnlySchema(arm, depth - 1));
+    return arms.some((arm) => isReferenceOnlySchema(arm, depth - 1, defs));
   }
   return false;
 }

--- a/packages/runner/src/schema-view.ts
+++ b/packages/runner/src/schema-view.ts
@@ -50,6 +50,7 @@ import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { toCell } from "./back-to-cell.ts";
 import { type Cell, createCell } from "./cell.ts";
 import { ContextualFlowControl } from "./cfc.ts";
+import { cfcSchemaWithInheritedDefs } from "./cfc/schema-refs.ts";
 import {
   type CfcLabelView,
   rebaseCfcLabelView,
@@ -274,7 +275,8 @@ const preferAsCellBranch = (schema: JSONSchema): JSONSchema => {
 };
 
 /**
- * A branch with its `$ref` resolved, against the union's `$defs` or its own.
+ * A branch with its `$ref` resolved in its definition scope: its own `$defs`,
+ * or the union's when it declares none.
  *
  * A branch that will not resolve narrows to `false` — nothing matches it. It
  * cannot be left as it was: a bare `$ref` declares no `type` and no `required`,
@@ -290,28 +292,19 @@ const resolveBranch = (
   parent: JSONSchemaObj,
 ): JSONSchema => {
   if (!isObjectOrArray(branch) || !("$ref" in branch)) return branch;
-  const roots = [
-    ...(isObjectOrArray(parent.$defs)
-      ? [{ $defs: parent.$defs } as JSONSchemaObj]
-      : []),
-    branch as JSONSchemaObj,
-  ];
-  for (const root of roots) {
-    try {
-      const resolved = ContextualFlowControl.resolveSchemaRefsOrThrow(
-        branch as JSONSchemaObj,
-        root,
-      );
-      // A boolean target is a resolution, not a failure to resolve: `true`
-      // matches everything and `false` matches nothing, which is what the
-      // definition said. Only exhausting the roots is a failure, and the
-      // resolver throws rather than returning a boolean for that.
-      if (isObjectOrArray(resolved) || typeof resolved === "boolean") {
-        return resolved;
-      }
-    } catch {
-      // Try the next root; the warning below covers exhausting them.
+  try {
+    const resolved = ContextualFlowControl.resolveSchemaRefsOrThrow(
+      cfcSchemaWithInheritedDefs(branch, parent.$defs) as JSONSchemaObj,
+    );
+    // A boolean target is a resolution, not a failure to resolve: `true`
+    // matches everything and `false` matches nothing, which is what the
+    // definition said. The resolver throws rather than returning a boolean for
+    // a ref it cannot resolve.
+    if (isObjectOrArray(resolved) || typeof resolved === "boolean") {
+      return resolved;
     }
+  } catch {
+    // The warning below covers a ref that does not resolve.
   }
   // Worth saying out loud: an unresolvable ref means a schema document that
   // did not replicate, not data that happens not to match.

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -55,6 +55,7 @@ import {
   ContextualFlowControl,
   resolveExternalRootRefForStructure,
 } from "./cfc.ts";
+import { cfcSchemaWithInheritedDefs } from "./cfc/schema-refs.ts";
 import {
   type CfcLabelView,
   cfcLabelViewForDereference,
@@ -143,7 +144,7 @@ const asCellCompoundCandidates = (
   if (branches.length > 0) {
     const { anyOf: _anyOf, oneOf: _oneOf, ...baseSchema } = schema;
     for (const branch of branches) {
-      const branchWithDefs = branchWithParentDefs(schema, branch);
+      const branchWithDefs = cfcSchemaWithInheritedDefs(branch, schema.$defs);
       const resolved = resolveSchema(branchWithDefs) ?? branchWithDefs;
       const merged = combineSchema(baseSchema as JSONSchemaObj, resolved);
       if (
@@ -229,46 +230,6 @@ const labelViewForLink = (
   return rebaseCfcLabelView(baseView, link.path);
 };
 
-const containsLocalRef = (
-  schema: JSONSchema,
-  seen: Set<JSONSchema> = new Set(),
-): boolean => {
-  if (!isObjectOrArray(schema) || seen.has(schema)) {
-    return false;
-  }
-  seen.add(schema);
-  if (typeof schema.$ref === "string" && schema.$ref.startsWith("#/")) {
-    return true;
-  }
-  return Object.entries(schema).some(([key, value]) => {
-    if (key === "$defs" || key === "definitions") {
-      return false;
-    }
-    if (Array.isArray(value)) {
-      return value.some((item) => containsLocalRef(item as JSONSchema, seen));
-    }
-    return containsLocalRef(value as JSONSchema, seen);
-  });
-};
-
-const branchWithParentDefs = (
-  parent: JSONSchemaObj,
-  branch: JSONSchema,
-): JSONSchema => {
-  if (
-    !isObjectOrArray(branch) ||
-    branch.$defs !== undefined ||
-    !isObjectOrArray(parent.$defs) ||
-    !containsLocalRef(branch)
-  ) {
-    return branch;
-  }
-  return {
-    ...branch,
-    $defs: parent.$defs,
-  } satisfies JSONSchemaObj;
-};
-
 const matchesConcreteValue = (
   schema: JSONSchema,
   value: unknown,
@@ -304,8 +265,8 @@ const matchesConcreteValue = (
       matchesConcreteValue(
         combineSchema(
           rest as JSONSchemaObj,
-          resolveSchema(branchWithParentDefs(resolved, branch)) ??
-            branchWithParentDefs(resolved, branch),
+          resolveSchema(cfcSchemaWithInheritedDefs(branch, resolved.$defs)) ??
+            cfcSchemaWithInheritedDefs(branch, resolved.$defs),
         ),
         value,
       )
@@ -317,8 +278,8 @@ const matchesConcreteValue = (
       matchesConcreteValue(
         combineSchema(
           rest as JSONSchemaObj,
-          resolveSchema(branchWithParentDefs(resolved, branch)) ??
-            branchWithParentDefs(resolved, branch),
+          resolveSchema(cfcSchemaWithInheritedDefs(branch, resolved.$defs)) ??
+            cfcSchemaWithInheritedDefs(branch, resolved.$defs),
         ),
         value,
       )
@@ -329,7 +290,7 @@ const matchesConcreteValue = (
     return Object.entries(resolved.properties).every(([key, childSchema]) =>
       value[key] === undefined ||
       matchesConcreteValue(
-        branchWithParentDefs(resolved, childSchema),
+        cfcSchemaWithInheritedDefs(childSchema, resolved.$defs),
         value[key],
       )
     );
@@ -346,7 +307,7 @@ const matchesConcreteValue = (
       value,
       (childSchema, childValue) =>
         matchesConcreteValue(
-          branchWithParentDefs(resolved, childSchema),
+          cfcSchemaWithInheritedDefs(childSchema, resolved.$defs),
           childValue,
         ),
     );
@@ -466,8 +427,8 @@ const selectMatchingCompoundBranch = (
   const baseSchema = rest as JSONSchemaObj;
   const matches = branches.flatMap((branch) => {
     const resolvedBranch =
-      resolveSchema(branchWithParentDefs(schema, branch)) ??
-        branchWithParentDefs(schema, branch);
+      resolveSchema(cfcSchemaWithInheritedDefs(branch, schema.$defs)) ??
+        cfcSchemaWithInheritedDefs(branch, schema.$defs);
     const merged = combineSchema(baseSchema, resolvedBranch);
     return matchesConcreteValue(merged, value) ? [merged] : [];
   });
@@ -511,7 +472,7 @@ export function resolveSchemaForValue(
   for (const [key, childSchema] of Object.entries(narrowed.properties)) {
     const childValue = value[key];
     const resolvedChild = resolveSchemaForValue(
-      branchWithParentDefs(narrowed, childSchema),
+      cfcSchemaWithInheritedDefs(childSchema, narrowed.$defs),
       childValue,
     );
     if (resolvedChild !== undefined && resolvedChild !== childSchema) {
@@ -812,7 +773,10 @@ export function processDefaultValue(
       }
       // Thread the array schema's $defs so a $ref slot resolves during
       // recursive default processing (PR #4969 review).
-      return branchWithParentDefs(resolvedSchema, covering as JSONSchema);
+      return cfcSchemaWithInheritedDefs(
+        covering as JSONSchema,
+        resolvedSchema.$defs,
+      );
     };
 
     const result = defaultValue.map((item, i) =>

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -70,6 +70,7 @@ import type {
 } from "./builder/types.ts";
 import { isOpaqueReference, opaqueReference } from "./back-to-cell.ts";
 import { ContextualFlowControl } from "./cfc.ts";
+import { cfcSchemaWithInheritedDefs } from "./cfc/schema-refs.ts";
 import { dataUriFromValueWithResolvedLinks } from "./data-uri.ts";
 import type { LastNode } from "./link-resolution.ts";
 import {
@@ -5678,7 +5679,7 @@ function schemaTypeValidity(
     let match: TypeValidity.True | TypeValidity.Unknown | undefined;
     for (const option of schemaObj.allOf) {
       const valid = schemaTypeValidity(
-        schemaWithDefs(schemaObj, option),
+        cfcSchemaWithInheritedDefs(option, schemaObj.$defs),
         valueType,
       );
       // ignore undefined result (unknown type), but if any option returns
@@ -5705,7 +5706,7 @@ function schemaTypeValidity(
         break;
       }
       const valid = schemaTypeValidity(
-        schemaWithDefs(schemaObj, option),
+        cfcSchemaWithInheritedDefs(option, schemaObj.$defs),
         valueType,
       );
       if (valid === TypeValidity.False) {
@@ -5732,7 +5733,7 @@ function schemaTypeValidity(
         break;
       }
       const valid = schemaTypeValidity(
-        schemaWithDefs(schemaObj, option),
+        cfcSchemaWithInheritedDefs(option, schemaObj.$defs),
         valueType,
       );
       if (valid === TypeValidity.False) {
@@ -5794,15 +5795,4 @@ export function schemaAcceptsType(
   valueType: JSONSchemaTypes,
 ): boolean {
   return schemaTypeValidity(schema, valueType) !== TypeValidity.False;
-}
-
-function schemaWithDefs(parent: JSONSchemaObj, option: JSONSchema): JSONSchema {
-  // We need to preserve any parent $defs in the branch
-  if (!parent.$defs || !isObjectOrArray(option)) {
-    return option;
-  }
-  return {
-    ...option,
-    $defs: parent.$defs,
-  };
 }

--- a/packages/runner/test/cell-arrays.test.ts
+++ b/packages/runner/test/cell-arrays.test.ts
@@ -9,6 +9,7 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Writable } from "@commonfabric/api";
 import type { FabricValue } from "@commonfabric/data-model";
+import { internSchema } from "@commonfabric/data-model-schema";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -645,17 +646,21 @@ describe("plain-schema array traversal", () => {
 //
 
 describe("elementSchemaFor tuple (prefixItems) schemas", () => {
-  const tupleArraySchema = {
-    type: "array",
-    prefixItems: [
-      { $ref: "#/$defs/Point" },
-      { type: "number" },
-    ],
-    items: { type: "string" },
-    $defs: {
-      Point: { type: "object", properties: { x: { type: "number" } } },
-    },
-  } as const satisfies JSONSchema;
+  // Interned, as a cell's schema is: a slot with no local ref then comes back
+  // without `$defs`. An unfrozen schema would have them attached unscanned.
+  const tupleArraySchema = internSchema(
+    {
+      type: "array",
+      prefixItems: [
+        { $ref: "#/$defs/Point" },
+        { type: "number" },
+      ],
+      items: { type: "string" },
+      $defs: {
+        Point: { type: "object", properties: { x: { type: "number" } } },
+      },
+    } as const satisfies JSONSchema,
+  ) as JSONSchema;
 
   it("picks the slot schema for a covered index, threading $defs", () => {
     expect(elementSchemaFor(tupleArraySchema, 0)).toEqual({

--- a/packages/runner/test/cell-arrays.test.ts
+++ b/packages/runner/test/cell-arrays.test.ts
@@ -664,32 +664,18 @@ describe("elementSchemaFor tuple (prefixItems) schemas", () => {
         Point: { type: "object", properties: { x: { type: "number" } } },
       },
     });
-    expect(elementSchemaFor(tupleArraySchema, 1)).toEqual({
-      type: "number",
-      $defs: {
-        Point: { type: "object", properties: { x: { type: "number" } } },
-      },
-    });
+    // A slot with no local ref needs no definitions.
+    expect(elementSchemaFor(tupleArraySchema, 1)).toEqual({ type: "number" });
   });
 
   it("picks items past the tuple slots", () => {
-    expect(elementSchemaFor(tupleArraySchema, 2)).toEqual({
-      type: "string",
-      $defs: {
-        Point: { type: "object", properties: { x: { type: "number" } } },
-      },
-    });
+    expect(elementSchemaFor(tupleArraySchema, 2)).toEqual({ type: "string" });
   });
 
   it("treats an index-less element as rest-region (items)", () => {
     // elementById is id-keyed: tuple slots are positional and cannot be
     // id-addressed, so the element falls under `items`.
-    expect(elementSchemaFor(tupleArraySchema)).toEqual({
-      type: "string",
-      $defs: {
-        Point: { type: "object", properties: { x: { type: "number" } } },
-      },
-    });
+    expect(elementSchemaFor(tupleArraySchema)).toEqual({ type: "string" });
   });
 
   it("yields undefined for a pure tuple (no items) without an index", () => {

--- a/packages/runner/test/cfc-schema-inherited-defs.bench.ts
+++ b/packages/runner/test/cfc-schema-inherited-defs.bench.ts
@@ -1,0 +1,251 @@
+/**
+ * Guards the cost of carrying an enclosing schema's `$defs` into a sub-schema
+ * (`cfcSchemaWithInheritedDefs`) at the sites that do it on every read: the
+ * union-arm loop in `schemaTypeValidity`, `elementSchemaFor`, and value
+ * narrowing.
+ *
+ * Every case puts `$defs` on the parent, since the helper does nothing
+ * otherwise, and runs in two regimes from two separate builds of one shape. An
+ * interned schema is what a cell's schema is in production, and there the
+ * helper's local-ref scan memoizes by identity. A plain literal that nothing
+ * has interned is what a schema passed straight to the API is, and there the
+ * scan cannot memoize, so the helper must not scan it. `internSchema` freezes
+ * its argument in place, which is why the two regimes never share an object.
+ */
+
+import type { SchemaPathSelector } from "@commonfabric/api";
+import { type FabricValue, isDeepFrozen } from "@commonfabric/data-model";
+import { internSchema } from "@commonfabric/data-model-schema";
+import type {
+  Entity,
+  Revision,
+  State,
+  URI,
+} from "@commonfabric/memory/interface";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { elementSchemaFor } from "../src/cell.ts";
+import { resolveSchemaForValue } from "../src/schema.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { StoreObjectManager } from "../src/storage/query.ts";
+import {
+  createDefaultTraversalContext,
+  IMemorySpaceValueAttestation,
+  ManagedStorageTransaction,
+  schemaAcceptsType,
+  SchemaObjectTraverser,
+} from "../src/traverse.ts";
+
+const TEST_SCOPE_IDENTITY = {
+  principal: "did:test:alice",
+  sessionId: "session-1",
+};
+
+const defs = () => ({
+  Point: { type: "object", properties: { x: { type: "number" } } },
+  Name: { type: "string" },
+});
+
+// An arm with no local ref, `width` properties wide and `depth` levels deep,
+// so a scan has all of it to walk before finding nothing to attach.
+function wideArm(width: number, depth: number, tag: string): JSONSchema {
+  const properties: Record<string, JSONSchema> = {};
+  for (let i = 0; i < width; i++) {
+    properties[`${tag}${i}`] = depth === 0
+      ? { type: "number" }
+      : wideArm(width, depth - 1, `${tag}${i}_`);
+  }
+  return { type: "object", properties, required: [`${tag}0`] };
+}
+
+const union = (arms: JSONSchema[]): JSONSchema =>
+  ({ $defs: defs(), anyOf: arms }) as JSONSchema;
+
+// Three arms of ~155 nodes each.
+const largeRefFree = () =>
+  union([wideArm(5, 2, "a"), wideArm(5, 2, "b"), wideArm(5, 2, "c"), {
+    type: "null",
+  }]);
+// The generated optional-handle shape: a `$ref` arm plus the absent case.
+const refArm = () => union([{ $ref: "#/$defs/Point" }, { type: "null" }]);
+
+const arrayOfLarge = () =>
+  ({ type: "array", items: wideArm(5, 2, "e"), $defs: defs() }) as JSONSchema;
+
+const objectOfRefs = () =>
+  ({
+    type: "object",
+    $defs: defs(),
+    properties: {
+      p: { $ref: "#/$defs/Point" },
+      n: { $ref: "#/$defs/Name" },
+      plain: wideArm(3, 1, "q"),
+    },
+  }) as JSONSchema;
+
+type Regime = "interned" | "literal";
+type Case = { regime: Regime; schema: JSONSchema };
+
+const regimes = (make: () => JSONSchema): Case[] => {
+  const literal = make();
+  const interned = internSchema(make()) as JSONSchema;
+  if (isDeepFrozen(literal) || !isDeepFrozen(interned)) {
+    throw new Error("regime mix-up");
+  }
+  return [
+    { regime: "interned", schema: interned },
+    { regime: "literal", schema: literal },
+  ];
+};
+
+// A body reads its schema many times, so a regime that drifted — a subject
+// that interned its input in place — would silently measure the other one.
+const assertRegime = ({ regime, schema }: Case): void => {
+  if (isDeepFrozen(schema) !== (regime === "interned")) {
+    throw new Error(`regime drifted: ${regime}`);
+  }
+};
+
+for (const c of regimes(largeRefFree)) {
+  Deno.bench(`large ref-free arms, ${c.regime}`, { group: "arm scope" }, () => {
+    assertRegime(c);
+    for (let i = 0; i < 100; i++) schemaAcceptsType(c.schema, "object");
+  });
+}
+
+for (const c of regimes(refArm)) {
+  Deno.bench(`$ref arm, ${c.regime}`, { group: "arm scope" }, () => {
+    assertRegime(c);
+    for (let i = 0; i < 100; i++) schemaAcceptsType(c.schema, "object");
+  });
+}
+
+for (const c of regimes(arrayOfLarge)) {
+  Deno.bench(
+    `large ref-free items, ${c.regime}`,
+    { group: "element scope" },
+    () => {
+      assertRegime(c);
+      for (let i = 0; i < 1000; i++) elementSchemaFor(c.schema, 3);
+    },
+  );
+}
+
+// `resolveSchema` interns its input in place, so only the interned regime is
+// meaningful here.
+const objectValue = { p: { x: 1 }, n: "n", plain: { q0: { q0_0: 1 } } };
+const [objectOfRefsInterned] = regimes(objectOfRefs);
+Deno.bench("refs + plain property", { group: "value narrowing" }, () => {
+  for (let i = 0; i < 10; i++) {
+    resolveSchemaForValue(objectOfRefsInterned.schema, objectValue);
+  }
+});
+
+function getTraverser(
+  store: Map<string, Revision<State>>,
+  selector: SchemaPathSelector,
+): SchemaObjectTraverser<FabricValue> {
+  const manager = new StoreObjectManager(store);
+  const managedTx = new ManagedStorageTransaction(manager);
+  const tx = new ExtendedStorageTransaction(managedTx);
+  return new SchemaObjectTraverser(
+    tx,
+    selector,
+    createDefaultTraversalContext(TEST_SCOPE_IDENTITY),
+  );
+}
+
+function makeDoc(
+  store: Map<string, Revision<State>>,
+  uri: string,
+  value: FabricValue,
+): IMemorySpaceValueAttestation {
+  const type = "application/json" as const;
+  const revision: Revision<State> = {
+    the: type,
+    of: uri as Entity,
+    is: { value },
+    since: 1,
+  };
+  store.set(`${revision.of}/${revision.the}`, revision);
+  return {
+    address: {
+      space: "did:null:null" as `did:${string}:${string}`,
+      id: uri as URI,
+      type,
+      path: ["value"],
+    },
+    value,
+  };
+}
+
+// A 3-level discriminated document whose arms are `$ref`s into root `$defs`,
+// the shape the schema generator emits.
+const sectionOrHeader = () => ({
+  anyOf: [{ $ref: "#/$defs/Section" }, { $ref: "#/$defs/Header" }],
+});
+const traversalSchema = () =>
+  ({
+    $defs: {
+      Text: {
+        type: "object",
+        properties: { type: { const: "text" }, content: { type: "string" } },
+        required: ["type"],
+      },
+      Image: {
+        type: "object",
+        properties: {
+          type: { const: "image" },
+          src: { type: "string" },
+          alt: { type: "string" },
+        },
+        required: ["type"],
+      },
+      Section: {
+        type: "object",
+        properties: {
+          type: { const: "section" },
+          item: {
+            anyOf: [{ $ref: "#/$defs/Text" }, { $ref: "#/$defs/Image" }],
+          },
+        },
+        required: ["type"],
+      },
+      Header: {
+        type: "object",
+        properties: { type: { const: "header" }, title: { type: "string" } },
+        required: ["type"],
+      },
+    },
+    anyOf: [
+      {
+        type: "object",
+        properties: { type: { const: "container" }, child: sectionOrHeader() },
+        required: ["type"],
+      },
+      {
+        type: "object",
+        properties: { type: { const: "page" }, body: sectionOrHeader() },
+        required: ["type"],
+      },
+    ],
+  }) as JSONSchema;
+
+const traversalDocValue = {
+  type: "container",
+  child: { type: "section", item: { type: "text", content: "hello" } },
+};
+
+// The traverser interns its schema, so only the interned regime is
+// meaningful here.
+const [traversalInterned] = regimes(traversalSchema);
+Deno.bench("$ref arms, 3 levels", { group: "traversal" }, (b) => {
+  const store = new Map<string, Revision<State>>();
+  const doc = makeDoc(store, "of:bench-inherited-defs", traversalDocValue);
+  b.start();
+  for (let i = 0; i < 10; i++) {
+    getTraverser(store, { path: ["value"], schema: traversalInterned.schema })
+      .traverse(doc);
+  }
+  b.end();
+});

--- a/packages/runner/test/cfc.test.ts
+++ b/packages/runner/test/cfc.test.ts
@@ -1030,12 +1030,25 @@ describe("cfcSchemaWithInheritedDefs()", () => {
     });
   });
 
-  it("returns a fragment with no local ref as the same object", () => {
+  it("returns a deep-frozen fragment with no local ref as the same object", () => {
+    const plain = deepFreeze({
+      type: "object",
+      properties: { count: { type: "number" } },
+    }) as JSONSchema;
+    expect(cfcSchemaWithInheritedDefs(plain, definitions)).toBe(plain);
+  });
+
+  it("attaches the inherited definitions to a fragment that is not deep-frozen without scanning it for a local ref", () => {
+    // The scan memoizes only by identity of a deep-frozen object, so an
+    // unfrozen fragment is given the definitions whether or not it needs them.
     const plain: JSONSchema = {
       type: "object",
       properties: { count: { type: "number" } },
     };
-    expect(cfcSchemaWithInheritedDefs(plain, definitions)).toBe(plain);
+    expect(cfcSchemaWithInheritedDefs(plain, definitions)).toEqual({
+      ...plain,
+      $defs: definitions,
+    });
   });
 
   it("returns a fragment that declares its own `$defs` as the same object", () => {
@@ -1046,13 +1059,13 @@ describe("cfcSchemaWithInheritedDefs()", () => {
     expect(cfcSchemaWithInheritedDefs(own, definitions)).toBe(own);
   });
 
-  it("returns the same object when the only local ref sits under a child that declares its own `$defs`", () => {
-    const fragment: JSONSchema = {
+  it("returns a deep-frozen fragment as the same object when its only local ref sits under a child that declares its own `$defs`", () => {
+    const fragment = deepFreeze({
       type: "object",
       properties: {
         inner: { $ref: "#/$defs/Name", $defs: { Name: { type: "number" } } },
       },
-    };
+    }) as JSONSchema;
     expect(cfcSchemaWithInheritedDefs(fragment, definitions)).toBe(fragment);
   });
 

--- a/packages/runner/test/cfc.test.ts
+++ b/packages/runner/test/cfc.test.ts
@@ -25,6 +25,7 @@ import { deepFreeze } from "@commonfabric/data-model";
 import type { JSONSchema } from "../src/builder/types.ts";
 import { cfcAtom, ContextualFlowControl } from "../src/cfc.ts";
 import {
+  cfcSchemaWithInheritedDefs,
   findCfcSchemaRefs,
   pruneCfcSchemaDefinitions,
   resolveCfcSchemaRef,
@@ -1000,5 +1001,73 @@ describe("ContextualFlowControl.resolveSchemaRefsOrThrow", () => {
     };
     expect(() => ContextualFlowControl.resolveSchemaRefsOrThrow(schema))
       .toThrow(/Failed to resolve \$ref/);
+  });
+});
+
+describe("cfcSchemaWithInheritedDefs()", () => {
+  const definitions: Record<string, JSONSchema> = {
+    Name: { type: "string" },
+  };
+
+  it("attaches the inherited definitions to a fragment whose `$ref` names one, so the ref resolves", () => {
+    const scoped = cfcSchemaWithInheritedDefs(
+      { $ref: "#/$defs/Name" },
+      definitions,
+    );
+    expect(scoped).toEqual({ $ref: "#/$defs/Name", $defs: definitions });
+    expect(resolveCfcSchemaRefs(scoped as JSONSchemaObj)).toMatchObject({
+      type: "string",
+    });
+  });
+
+  it("attaches them when the local ref sits in a nested arm", () => {
+    const arm: JSONSchema = {
+      oneOf: [{ $ref: "#/$defs/Name" }, { type: "null" }],
+    };
+    expect(cfcSchemaWithInheritedDefs(arm, definitions)).toEqual({
+      ...arm,
+      $defs: definitions,
+    });
+  });
+
+  it("returns a fragment with no local ref as the same object", () => {
+    const plain: JSONSchema = {
+      type: "object",
+      properties: { count: { type: "number" } },
+    };
+    expect(cfcSchemaWithInheritedDefs(plain, definitions)).toBe(plain);
+  });
+
+  it("returns a fragment that declares its own `$defs` as the same object", () => {
+    const own: JSONSchema = {
+      $ref: "#/$defs/Name",
+      $defs: { Name: { type: "number" } },
+    };
+    expect(cfcSchemaWithInheritedDefs(own, definitions)).toBe(own);
+  });
+
+  it("returns the same object when the only local ref sits under a child that declares its own `$defs`", () => {
+    const fragment: JSONSchema = {
+      type: "object",
+      properties: {
+        inner: { $ref: "#/$defs/Name", $defs: { Name: { type: "number" } } },
+      },
+    };
+    expect(cfcSchemaWithInheritedDefs(fragment, definitions)).toBe(fragment);
+  });
+
+  it("returns the fragment as the same object when there is nothing to inherit", () => {
+    const ref: JSONSchema = { $ref: "#/$defs/Name" };
+    expect(cfcSchemaWithInheritedDefs(ref, undefined)).toBe(ref);
+    expect(cfcSchemaWithInheritedDefs(true, definitions)).toBe(true);
+  });
+
+  it("returns the fragment as the same object when the inherited definitions are an array", () => {
+    const ref: JSONSchema = { $ref: "#/$defs/0" };
+    const arrayDefinitions = [{ type: "string" }] as unknown as Record<
+      string,
+      JSONSchema
+    >;
+    expect(cfcSchemaWithInheritedDefs(ref, arrayDefinitions)).toBe(ref);
   });
 });

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -323,6 +323,40 @@ describe("syncArgumentLinkTargets", () => {
     expect(syncedIds).toContain(id(behindMissing));
   });
 
+  it("resolves a `$ref` in a union arm against the union's `$defs`", async () => {
+    const { make, commit } = docBuilder("ref in arm");
+    const behindArm = make("behind arm", { n: 1 });
+    const viaArm = make("via arm", { child: behindArm });
+    const behindNested = make("behind nested", { n: 2 });
+    const viaNested = make("via nested", { child: behindNested });
+    const root = make("root", { arm: viaArm, nested: viaNested });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: {
+        // The shape a generated optional handle takes when the handle type is
+        // hoisted into `$defs`. The arms carry no `$defs` of their own.
+        arm: {
+          anyOf: [{ "$ref": "#/$defs/Handle" }, { type: "undefined" }],
+        },
+        nested: {
+          anyOf: [
+            { oneOf: [{ "$ref": "#/$defs/Handle" }] },
+            { type: "undefined" },
+          ],
+        },
+      },
+      "$defs": {
+        Handle: { type: "object", asCell: ["cell"] },
+      },
+    } as JSONSchema);
+    expect(syncedIds).toContain(id(viaArm));
+    expect(syncedIds).not.toContain(id(behindArm));
+    // The scope reaches an arm of an arm, not only the first level.
+    expect(syncedIds).toContain(id(viaNested));
+    expect(syncedIds).not.toContain(id(behindNested));
+  });
+
   it("descends a subtree once when two declared paths link to it", async () => {
     const { make, commit } = docBuilder("diamond");
     const leaf = make("leaf", { n: 1 });

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -36,6 +36,7 @@ import {
   mergeAnyOfBranchSchemas,
   mergeAnyOfMatches,
   PointerCycleTracker,
+  schemaAcceptsType,
   type SchemaMemo,
   SchemaObjectTraverser,
   schemaTrackerCoversSelector,
@@ -4683,5 +4684,25 @@ describe("SchemaObjectTraverser schema memo keys", () => {
 
     expect(large.idLength).toBeGreaterThan(small.idLength * 3);
     expect(perVisit(large)).toBeLessThan(perVisit(small) * 1.1);
+  });
+});
+
+describe("schemaAcceptsType()", () => {
+  it("returns `true` when a union arm's `$ref` names a definition only the union declares", () => {
+    expect(schemaAcceptsType({
+      $defs: { Name: { type: "string" } },
+      anyOf: [{ $ref: "#/$defs/Name" }],
+    }, "string")).toBe(true);
+  });
+
+  it("returns `true` when a union arm's own `$defs` define its `$ref` as the type and the union's define it otherwise", () => {
+    // The arm declares its own scope, so its `$ref` names the string there,
+    // not the number the union defines under the same name. That is the CFC
+    // reading of a nested `$defs`; JSON Schema resolves `#/$defs/Name`
+    // against the root's.
+    expect(schemaAcceptsType({
+      $defs: { Name: { type: "number" } },
+      anyOf: [{ $ref: "#/$defs/Name", $defs: { Name: { type: "string" } } }],
+    }, "string")).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

`isReferenceOnlySchema` decides whether the argument link-target pre-sync holds a link as a handle (sync the target, stop) or reads through it. When it checked the arms of an `anyOf`/`oneOf`, it passed each arm on bare. An arm such as `{ $ref: "#/$defs/Handle" }` then had no `$defs` to resolve against, so it resolved to nothing and counted as "not a reference". The pre-sync read through an optional handle it should only have synced.

That was one instance of a pattern. Seven places take a sub-schema out of its enclosing schema and re-attach the enclosing `$defs` by hand, each with its own rule:

| Copy | When it attached | The sub-schema's own `$defs` | Legacy `definitions` |
|---|---|---|---|
| `branchWithParentDefs` (`schema.ts`) | When an unmemoized walk found a `#/` ref | Kept | — |
| `schemaWithDefs` (`traverse.ts`) | Always | Overwritten by the parent's | — |
| `schemaWithRootDefinitions` (`runner.ts`) | Always | Kept | Carried |
| `resolveBranch` (`schema-view.ts`) | Tried the parent's `$defs` before the branch's own | Parent's won | — |
| `elementSchemaFor` (`cell.ts`) | Always | Kept | — |
| The `$event` dependency schema (`runner.ts`) | Always | — | Carried |
| The resolver itself, twice (`cfc/schema-refs.ts`) | When the target has a local definition ref | Kept | — |

## Changes

- **Shared helper.** `cfcSchemaWithInheritedDefs(schema, inheritedDefinitions)` in `cfc/schema-refs.ts` uses the resolver's rule. It attaches the inherited `$defs` only when the fragment has a local `#/$defs/<name>` ref and declares no `$defs` of its own. Otherwise it returns the same object, so identity-keyed caches keep hitting. The ref check reuses the module's memoized ref summary.
- **Every copy above now calls it.** `branchWithParentDefs`, `containsLocalRef`, `schemaWithDefs` and the `schemaWithRootDefinitions` closure are deleted.
- **The original fix.** `isReferenceOnlySchema` hands each union arm the union's `$defs` through the helper, so a `$ref` inside an arm, at any depth, resolves.

## Behavior changes

- **A union arm's own `$defs` take precedence over the union's**, in `schemaTypeValidity` and `resolveBranch`. That now matches `schemaAtPath` and `cfcSchemaChildRoot`. It is the CFC reading of a nested `$defs`: JSON Schema resolves `#/$defs/<name>` against the resource root, which only `$id` changes. The helper's comment says so, and a follow-up will make the runner refuse or ignore nested `$defs` scopes. The two readings differ only when a nested `$defs` redefines a name the root also defines.
- **A deep-frozen sub-schema with no local ref no longer gets `$defs` attached.** So `elementSchemaFor` on an interned array schema returns ref-free element schemas without them, and a link to such an element carries a smaller schema. Refs resolve the same way. A sub-schema that is not deep-frozen gets the definitions without being scanned (see Performance); the resolver's own output stays precise either way.
- **The legacy `definitions` keyword is no longer carried.** The resolver only follows `#/$defs/<name>`.
- **An array-valued `$defs` is never attached**, since an array would resolve indices as member names.

## Performance

The helper's local-ref scan (`summarizeCfcSchemaRefs`) memoizes by identity only for a deep-frozen schema. Measured with a throwaway `deno bench` file run against the merge base and this branch in separate worktrees, five interleaved rounds, on an Apple M2 (Deno 2.9.4); microseconds per 100 calls, best of five:

| Case | Regime | base | before guard | after guard |
|---|---|---:|---:|---:|
| `schemaAcceptsType`, 3 arms × ~155 nodes, ref-free | interned | 50.5 | 44.7 | 47.3 |
| | unfrozen literal | 50.5 | 12,007 | 52.4 |
| `schemaAcceptsType`, `$ref` arm + null | interned | 72.8 | 76.2 | 79.5 |
| | unfrozen literal | 119.0 | 189.7 | 125.4 |
| `elementSchemaFor`, ~155-node ref-free `items` | interned | 1.5 | 1.3 | 2.3 |
| | unfrozen literal | 0.9 | 3,923 | 6.3 |
| traversal, 3-level discriminated via `$ref` arms | either | 1,657 | 1,653 | 1,658 |

p75 ratios track the min ratios within a few percent on every row. On interned input the helper is a WeakMap hit, cheaper than the spread it replaced; the only measurable cost is a fixed ~60–100 ns per call, visible where the arm is tiny. On a wholly unfrozen tree the unmemoized scan walked the subtree on every call, hence the middle column. The last commit skips the scan for a fragment that is not deep-frozen and attaches the definitions unconditionally there: an unfrozen object is never a cache key, so attaching definitions it does not need loses nothing. Production paths hand these sites interned schemas (cell link schemas are interned at creation, `resolveSchema` interns in place, `schemaWithProperties` keeps merged arms interned), so the unfrozen regime is reachable from a literal passed straight to the API, which today means tests.

The resolver keeps the precise scan for a resolved definition body whether or not it is frozen: that body is the definition's canonical view, which `resolveSchema` interns, and `$defs` it does not need would change what it hashes to. The resolver already scanned unfrozen input, so nothing regresses there.

## Tests

- `sync-argument-link-targets.test.ts`: a `$ref` directly in an `anyOf` arm, and one nested a union deeper, both naming an `asCell` definition in the root `$defs`. The case fails without the fix, because the document behind the handle gets synced.
- `cfc.test.ts`: unit cases for `cfcSchemaWithInheritedDefs`, including the array-valued `$defs` case (fails against a check that accepts arrays) and the unfrozen fragment taking definitions without a scan.
- `traverse.test.ts`: `schemaAcceptsType()` cases for an arm's `$ref` resolving against the union's `$defs`, and for an arm's own `$defs` winning. The second fails against the previous `traverse.ts`.
- `cell-arrays.test.ts`: the `elementSchemaFor` fixture is interned, as a cell's schema is, and three expectations no longer include `$defs` on ref-free element schemas.
- `cfc-schema-inherited-defs.bench.ts`: a trimmed version of the measurement above, under `packages/runner/test/` so the scheduled bench job tracks both regimes at the three hot sites.
- `deno task test` in `packages/runner` passes on the final branch (1,409 tests, 8,701 steps). Repo-wide `deno fmt --check` and `deno lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

