### PR TITLE
fix(dashboard): keep the CI progress record its caller is about to open

### DIFF
--- a/packages/dashboard/ci-job-history.test.ts
+++ b/packages/dashboard/ci-job-history.test.ts
@@ -3648,31 +3648,43 @@ Deno.test("selected-run metadata keeps only the most recent Gantt selection", as
   }
 });
 
-Deno.test("CI Gantt retains a bounded set of completed progress records", async () => {
-  const directory = await Deno.makeTempDir({
-    prefix: "ci-gantt-progress-limit-test-",
+const GANTT_PROGRESS_RUN_BASE = 40_000;
+
+// Starts one Gantt collection more than the progress-record cap holds. Each
+// selects a run of its own and each fails at its jobs request, so every record
+// reaches a terminal phase. `hold` names the runs whose metadata request waits
+// at the gate `release` opens, and `started` resolves once every collection
+// has reached its metadata request.
+async function overfillGanttProgressRecords(
+  prefix: string,
+  hold: (runId: number) => boolean,
+  body: (collection: {
+    collector: RateLimitedCiJobHistoryCollector;
+    ids: string[];
+    results: Promise<GanttSelection>[];
+    release: () => void;
+    started: Promise<void>;
+  }) => Promise<void>,
+): Promise<void> {
+  const directory = await Deno.makeTempDir({ prefix });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
   });
-  let releaseMetadata!: () => void;
-  const metadataGate = new Promise<void>((resolve) => {
-    releaseMetadata = resolve;
-  });
-  let metadataStarted = 0;
-  let markAllMetadataStarted!: () => void;
-  const allMetadataStarted = new Promise<void>((resolve) => {
-    markAllMetadataStarted = resolve;
+  let reached = 0;
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
   });
   const collector = new RateLimitedCiJobHistoryCollector(
     new CiJobHistoryStore(`${directory}/history.json`),
     async <T>(path: string): Promise<T> => {
       const metadata = path.match(/\/actions\/runs\/(\d+)\/attempts\/1$/);
       if (metadata) {
-        const id = Number(metadata[1]);
-        metadataStarted++;
-        if (metadataStarted === PROGRESS_RECORD_MAX + 1) {
-          markAllMetadataStarted();
-        }
-        await metadataGate;
-        return workflowRun(id, NOW, {
+        const runId = Number(metadata[1]);
+        if (++reached === PROGRESS_RECORD_MAX + 1) markStarted();
+        if (hold(runId)) await gate;
+        return workflowRun(runId, NOW, {
           head_sha: HEAD_SHA,
           path: `.github/workflows/${CI_WORKFLOW}`,
         }) as T;
@@ -3696,37 +3708,70 @@ Deno.test("CI Gantt retains a bounded set of completed progress records", async 
           limit: 1,
           mainOnly: true,
           headSha: HEAD_SHA,
-          selectedRuns: [{ runId: 40_000 + index, runAttempt: 1 }],
+          selectedRuns: [{
+            runId: GANTT_PROGRESS_RUN_BASE + index,
+            runAttempt: 1,
+          }],
         },
         NOW,
       );
       ids.push(refresh.progress.id);
       results.push(refresh.result);
     }
-    await allMetadataStarted;
-    assertEquals(collector.progress(ids[0])?.phase, "discovering");
-    assertEquals(collector.progress(ids.at(-1)!)?.phase, "discovering");
-    releaseMetadata();
-    const outcomes = await Promise.allSettled(results);
-    assert(outcomes.every((outcome) => outcome.status === "rejected"));
-    // One record over the cap is dropped, and only a record that has reached a
-    // terminal phase can be the one dropped. The newest is always kept.
-    //
-    // Which one is dropped is not fixed. Trimming takes the first terminal
-    // record in insertion order, so it depends on the order these collections
-    // finish, and they finish in the order their file reads and GitHub
-    // responses complete rather than the order they started.
-    const retained = ids.filter((id) => collector.progress(id) !== null);
-    assertEquals(retained.length, PROGRESS_RECORD_MAX);
-    assert(retained.every((id) => collector.progress(id)?.phase === "error"));
-    assertEquals(collector.progress(ids.at(-1)!)?.phase, "error");
+    await body({ collector, ids, results, release, started });
   } finally {
-    releaseMetadata();
+    release();
     await Promise.allSettled(results);
     console.error = originalError;
     await Deno.remove(directory, { recursive: true });
   }
-});
+}
+
+Deno.test("CI Gantt retains a bounded set of completed progress records", () =>
+  overfillGanttProgressRecords(
+    "ci-gantt-progress-limit-test-",
+    () => true,
+    async ({ collector, ids, results, release, started }) => {
+      await started;
+      assertEquals(collector.progress(ids[0])?.phase, "discovering");
+      assertEquals(collector.progress(ids.at(-1)!)?.phase, "discovering");
+      release();
+      const outcomes = await Promise.allSettled(results);
+      assert(outcomes.every((outcome) => outcome.status === "rejected"));
+      // One record over the cap is dropped, and only a record that has reached
+      // a terminal phase can be the one dropped. The newest is always kept.
+      //
+      // Which one is dropped is not fixed. Trimming takes the first terminal
+      // record in insertion order, so it depends on the order these
+      // collections finish, and they finish in the order their file reads and
+      // GitHub responses complete rather than the order they started.
+      const retained = ids.filter((id) => collector.progress(id) !== null);
+      assertEquals(retained.length, PROGRESS_RECORD_MAX);
+      assert(retained.every((id) => collector.progress(id)?.phase === "error"));
+      assertEquals(collector.progress(ids.at(-1)!)?.phase, "error");
+    },
+  ));
+
+Deno.test("CI Gantt trimming spares the progress record handed out last", () =>
+  overfillGanttProgressRecords(
+    "ci-gantt-progress-newest-test-",
+    // Holding every collection but the newest makes the newest the first to
+    // fail, and so the only record trimming has to choose from when an older
+    // collection fails after it.
+    (runId) => runId !== GANTT_PROGRESS_RUN_BASE + PROGRESS_RECORD_MAX,
+    async ({ collector, ids, results, release }) => {
+      const newest = ids.at(-1)!;
+      await assertRejects(() => results.at(-1)!, Error, "jobs unavailable");
+      assertEquals(collector.progress(newest)?.phase, "error");
+      release();
+      await Promise.allSettled(results);
+      // The newest record is exempt, so the set comes down to the cap by
+      // dropping one of the collections that failed after it.
+      assertEquals(collector.progress(newest)?.phase, "error");
+      const retained = ids.filter((id) => collector.progress(id) !== null);
+      assertEquals(retained.length, PROGRESS_RECORD_MAX);
+    },
+  ));
 
 Deno.test("a selected-run Gantt repairs cached responses with no drawable jobs", async () => {
   const directory = await Deno.makeTempDir({

--- a/packages/dashboard/ci-job-history.ts
+++ b/packages/dashboard/ci-job-history.ts
@@ -1047,6 +1047,7 @@ export class CiJobHistoryCollector {
   #snapshotRevisions = new Map<string, number>();
   #progressById = new Map<string, CiJobProgressRecord>();
   #progressByKey = new Map<string, CiJobProgressRecord>();
+  #newestProgress: CiJobProgressRecord | null = null;
   #progressSequence = 0;
   #refreshedAt = new Map<string, { at: number; revision: number }>();
   #refreshFailureAt = new Map<CiHistorySourceKey, number>();
@@ -1123,6 +1124,7 @@ export class CiJobHistoryCollector {
     };
     this.#progressByKey.set(key, record);
     this.#progressById.set(state.id, record);
+    this.#newestProgress = record;
     this.#trimProgressRecords(record);
     return record;
   }
@@ -1151,11 +1153,15 @@ export class CiJobHistoryCollector {
 
   #trimProgressRecords(preserve: CiJobProgressRecord): void {
     if (this.#progressByKey.size <= PROGRESS_RECORD_MAX) return;
+    // The record created most recently is exempt. Its progress id may have
+    // been handed to a caller that has not opened the progress stream yet,
+    // and that stream answers `unknown progress id` for a record this loop
+    // has taken.
     for (const [key, record] of this.#progressByKey) {
       if (this.#progressByKey.size <= PROGRESS_RECORD_MAX) break;
       const terminal = record.state.phase === "complete" ||
         record.state.phase === "error";
-      if (record !== preserve && terminal) {
+      if (record !== preserve && record !== this.#newestProgress && terminal) {
         this.#progressByKey.delete(key);
         this.#progressById.delete(record.state.id);
       }


### PR DESCRIPTION
PROBLEM Starting a CI Gantt collection hands the caller a progress id, and the caller opens a progress stream naming that id in a later request. The collector holds at most 256 progress records, and trimming takes the first record in creation order that has reached a terminal phase. A collection reaching one before every older collection is therefore that record, so the next collection to finish takes it away and the stream its caller opens answers `unknown progress id`.

The test covering the cap asserts the newest record survives, but its 257 collections are released together, so which record trimming takes is a race. It failed in CI run 34419136311.

SOLUTION Exempt the record created most recently, held in a field assigned where records are created. A trim now takes an older finished record or none at all. The cap was already soft, in that a set with nothing finished in it stays over the cap until something finishes, and this exempts one more record on the same terms.

Add a test that holds every collection but the newest, so the newest is the first to reach a terminal phase and is the only record trimming has to choose from. It fails without the exemption. Both tests that overfill the record set share one helper, taking the predicate that says which runs wait.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

