### PR TITLE
fix(cli): synchronize stored projection children before startup

### DIFF
--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -82,7 +82,7 @@ export const LINK_MARKER_KEY = "$link";
 const CONCISE_ADDRESS_SUFFIX = "@";
 
 /** A phase of `deriveSelectedValue`, named for the operation like every other
- * label. The six are strict siblings, so they add up; what they must not be
+ * label. The phases are strict siblings, so they add up; what they must not be
  * added to is whichever phase encloses the selection — `getCellValue.selection`
  * on `cf cell get`, and on `cf piece call` and `cf wish` nothing yet. */
 const timeSelectionPhase = <T>(
@@ -3419,10 +3419,24 @@ export async function deriveSelectedValue(
     // A session-local projection can reuse space-scoped mapped children.
     // The committed argument lets synchronized startup resolve their identities
     // and load their execution state before the coordinator initializes them.
-    await timeSelectionPhase(
-      "start",
-      () => runtime.runSynced(result.withTx(), installedPattern ?? mainPattern),
-    );
+    await timeSelectionPhase("start", async () => {
+      const committedResult = result.withTx();
+      try {
+        await runtime.runner.syncStoredPieceCells(
+          committedResult,
+          installedPattern ?? mainPattern,
+        );
+        if (!await runtime.start(committedResult)) {
+          throw new Error("projection did not start");
+        }
+      } catch (error) {
+        throw new CellSelectionError(
+          `Could not apply get transform: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    });
     // pull() is the readiness boundary for this output: it drives transitive
     // computations, waits for linked documents those reads discover, and
     // re-idles after each arrival. Nothing downstream re-checks it: the

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -3393,7 +3393,7 @@ export async function deriveSelectedValue(
   if (installedPattern === undefined) reads.patterns.set(readKey, mainPattern);
   const errors = runtimeErrorLog(runtime);
   const errorCountBefore = errors.length;
-  const result = runtime.run(
+  const result = await runtime.setup(
     tx,
     installedPattern ?? mainPattern,
     {
@@ -3416,6 +3416,13 @@ export async function deriveSelectedValue(
         `Could not apply get transform: ${committed.error}`,
       );
     }
+    // A session-local projection can reuse space-scoped mapped children.
+    // The committed argument lets synchronized startup resolve their identities
+    // and load their execution state before the coordinator initializes them.
+    await timeSelectionPhase(
+      "start",
+      () => runtime.runSynced(result.withTx(), installedPattern ?? mainPattern),
+    );
     // pull() is the readiness boundary for this output: it drives transitive
     // computations, waits for linked documents those reads discover, and
     // re-idles after each arrival. Nothing downstream re-checks it: the

--- a/packages/cli/test/fixtures/projection-replay-process.ts
+++ b/packages/cli/test/fixtures/projection-replay-process.ts
@@ -1,3 +1,10 @@
+/**
+ * Runs one projection against a persistent synthetic store. Takes three
+ * positional arguments: mode (`seed`, `read`, or `change`), store directory,
+ * and frame-log path. Writes one JSON line to stdout containing the selected
+ * values, runtime errors, and storage effects for the parent test to inspect.
+ */
+
 import { toFileUrl } from "@std/path";
 
 import { Identity } from "@commonfabric/identity";
@@ -32,9 +39,14 @@ interface Frame {
 }
 
 const [mode, directory, framesPath] = Deno.args;
+if (Deno.args.length !== 3 || !directory || !framesPath) {
+  throw new Error("Expected replay mode, store directory, and frame-log path");
+}
 if (mode !== "seed" && mode !== "read" && mode !== "change") {
   throw new Error(`Unknown replay mode: \`${mode}\``);
 }
+// The logger appends frames; an empty observation window is a valid log.
+await Deno.writeTextFile(framesPath, "");
 const signer = await Identity.fromPassphrase("cli-projection-replay");
 const space = signer.did();
 const server = newLoopbackServer({
@@ -63,7 +75,8 @@ const schema = { type: "array", items: itemSchema } as const;
 
 /** Reads the structural frame log captured by this process. */
 async function readFrames(): Promise<Frame[]> {
-  return (await Deno.readTextFile(framesPath)).trim().split("\n")
+  return (await Deno.readTextFile(framesPath)).split("\n")
+    .filter((line) => line.trim().length > 0)
     .map((line) => JSON.parse(line) as Frame);
 }
 
@@ -106,7 +119,9 @@ try {
   await runtime.idle();
   await storageManager.synced();
   const frames = (await readFrames()).slice(before);
-  const requests = frames.filter((frame) => frame.type === "transact");
+  const requests = frames.filter((frame) =>
+    frame.dir === "out" && frame.type === "transact"
+  );
   const responses = new Map(
     frames.filter((frame) => frame.dir === "in" && frame.requestId)
       .map((frame) => [frame.requestId, frame]),

--- a/packages/cli/test/fixtures/projection-replay-process.ts
+++ b/packages/cli/test/fixtures/projection-replay-process.ts
@@ -1,0 +1,134 @@
+import { toFileUrl } from "@std/path";
+
+import { Identity } from "@commonfabric/identity";
+import { type URI } from "@commonfabric/memory/interface";
+import { Runtime } from "@commonfabric/runner";
+import {
+  EmulatedStorageManager,
+  newLoopbackServer,
+} from "@commonfabric/runner/storage/cache.deno";
+
+import {
+  deriveSelectedValue,
+  parseSelectProjection,
+} from "../../lib/cell-selection.ts";
+
+/** The frame fields needed to observe projection writes and storage verdicts. */
+interface Frame {
+  /** Direction relative to the client. */
+  dir: string;
+
+  /** Protocol message type. */
+  type: string;
+
+  /** Identity joining a request to its response. */
+  requestId?: string;
+
+  /** Storage rejection carried by a response. */
+  error?: { name: string; message: string };
+
+  /** Write operations in a transaction request. */
+  commit?: { operations: { id: URI; scope: string }[] };
+}
+
+const [mode, directory, framesPath] = Deno.args;
+if (mode !== "seed" && mode !== "read" && mode !== "change") {
+  throw new Error(`Unknown replay mode: \`${mode}\``);
+}
+const signer = await Identity.fromPassphrase("cli-projection-replay");
+const space = signer.did();
+const server = newLoopbackServer({
+  store: toFileUrl(`${directory}/`),
+  subscriptionRefreshDelayMs: 0,
+});
+const storageManager = EmulatedStorageManager.connectTo(server, { as: signer });
+const errors: string[] = [];
+const runtime = new Runtime({
+  apiUrl: new URL("https://example.com"),
+  storageManager,
+  experimental: { serverExecution: false },
+  errorHandlers: [(error) => errors.push(error.message)],
+});
+const itemSchema = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    createdAt: { type: "number" },
+    lastActivityAt: { type: "number" },
+    commentCount: { type: "number" },
+  },
+  required: ["title", "createdAt", "lastActivityAt", "commentCount"],
+} as const;
+const schema = { type: "array", items: itemSchema } as const;
+
+/** Reads the structural frame log captured by this process. */
+async function readFrames(): Promise<Frame[]> {
+  return (await Deno.readTextFile(framesPath)).trim().split("\n")
+    .map((line) => JSON.parse(line) as Frame);
+}
+
+try {
+  if (mode === "seed") {
+    const tx = runtime.edit();
+    const rows = Array.from({ length: 8 }, (_, index) => {
+      const row = runtime.getCell(space, { row: index }, itemSchema, tx);
+      row.set({
+        title: `Row ${index}`,
+        createdAt: index,
+        lastActivityAt: index,
+        commentCount: index,
+      });
+      return row.getAsLink();
+    });
+    runtime.getCell<unknown>(space, "survey", schema, tx).setRaw(rows);
+    const committed = await tx.commit();
+    if (committed.error) throw committed.error;
+    await storageManager.synced();
+  }
+  if (mode === "change") {
+    const row = runtime.getCell(space, { row: 3 }, itemSchema);
+    await row.pull();
+    const tx = runtime.edit();
+    row.withTx(tx).key("title").set("Updated row");
+    row.withTx(tx).key("commentCount").set(99);
+    const committed = await tx.commit();
+    if (committed.error) throw committed.error;
+    await storageManager.synced();
+  }
+  const source = runtime.getCell(space, "survey", schema);
+  await source.pull();
+  const before = (await readFrames()).length;
+  const value = await deriveSelectedValue(runtime, space, source, {
+    projection: parseSelectProjection(
+      "@,title,createdAt,lastActivityAt,commentCount",
+    ),
+  });
+  await runtime.idle();
+  await storageManager.synced();
+  const frames = (await readFrames()).slice(before);
+  const requests = frames.filter((frame) => frame.type === "transact");
+  const responses = new Map(
+    frames.filter((frame) => frame.dir === "in" && frame.requestId)
+      .map((frame) => [frame.requestId, frame]),
+  );
+  console.log(JSON.stringify({
+    value,
+    errors,
+    rejected: requests.flatMap((request) => {
+      const error = responses.get(request.requestId)?.error;
+      return error ? [error] : [];
+    }),
+    unanswered: requests.filter((request) =>
+      !responses.has(request.requestId)
+    ).length,
+    mutableSharedWrites: requests.flatMap((request) =>
+      request.commit?.operations ?? []
+    ).filter((operation) =>
+      operation.scope === "space" && !operation.id.startsWith("cid:")
+    ).length,
+  }));
+} finally {
+  await runtime.dispose();
+  await storageManager.close();
+  await server.close();
+}

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+
 import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
 import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
@@ -2077,6 +2079,77 @@ describe("cf cell get transforms", () => {
       (runtime as any).edit = originalEdit;
     }
   });
+
+  it("returns the projection from its accepted setup without another setup commit", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "accepted-projection-setup",
+      { type: "object", properties: { id: { type: "number" } } },
+      tx,
+    );
+    source.set({ id: 1 });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    // The CLI owns the first setup transaction. Refuse any subsequent owned
+    // setup so a swallowed rejection cannot masquerade as an empty result.
+    const originalEditWithRetry = runtime.editWithRetry;
+    runtime.editWithRetry = () =>
+      Promise.resolve({
+        error: {
+          name: "StorageTransactionAborted",
+          message: "forced setup rejection",
+          reason: "forced setup rejection",
+        },
+      });
+    try {
+      expect(
+        await deriveSelectedValue(runtime, space, source, {
+          projection: parseSelectProjection("id"),
+        }),
+      ).toEqual({ id: 1 });
+    } finally {
+      runtime.editWithRetry = originalEditWithRetry;
+    }
+  });
+
+  for (const failure of ["sync", "start", "missing"] as const) {
+    it(`reports projection startup failure: ${failure}`, async () => {
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        space,
+        "projection-startup-failure",
+        { type: "object", properties: { id: { type: "number" } } },
+        tx,
+      );
+      source.set({ id: 1 });
+      expect((await tx.commit()).ok).toBeDefined();
+
+      using injected = failure === "sync"
+        ? stub(
+          runtime.runner,
+          "syncStoredPieceCells",
+          () => Promise.reject(new Error("dependency sync failed")),
+        )
+        : stub(
+          runtime,
+          "start",
+          () =>
+            failure === "start"
+              ? Promise.reject("pattern start failed")
+              : Promise.resolve(false),
+        );
+      const message = failure === "sync"
+        ? "dependency sync failed"
+        : failure === "start"
+        ? "pattern start failed"
+        : "projection did not start";
+      await expect(deriveSelectedValue(runtime, space, source, {
+        projection: parseSelectProjection("id"),
+      })).rejects.toThrow(`Could not apply get transform: ${message}`);
+      expect(injected.calls).toHaveLength(1);
+    });
+  }
 
   it("returns projection-ordered output without a storage-wide sync", async () => {
     const setup = runtime.edit();

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import { stub } from "@std/testing/mock";
+import { spy, stub } from "@std/testing/mock";
 
 import type { FabricValue } from "@commonfabric/data-model";
 import { Identity } from "@commonfabric/identity";
@@ -2080,7 +2080,7 @@ describe("cf cell get transforms", () => {
     }
   });
 
-  it("returns the projection from its accepted setup without another setup commit", async () => {
+  it("sets up the projection once and returns its result without runtime-owned setup", async () => {
     const tx = runtime.edit();
     const source = runtime.getCell(
       space,
@@ -2091,26 +2091,24 @@ describe("cf cell get transforms", () => {
     source.set({ id: 1 });
     expect((await tx.commit()).ok).toBeDefined();
 
-    // The CLI owns the first setup transaction. Refuse any subsequent owned
-    // setup so a swallowed rejection cannot masquerade as an empty result.
-    const originalEditWithRetry = runtime.editWithRetry;
-    runtime.editWithRetry = () =>
+    // Count caller-provided setup and refuse runtime-owned setup so neither
+    // path can silently introduce a second setup transaction.
+    using setups = spy(runtime, "setup");
+    using ownedSetups = stub(runtime, "editWithRetry", () =>
       Promise.resolve({
         error: {
           name: "StorageTransactionAborted",
           message: "forced setup rejection",
           reason: "forced setup rejection",
         },
-      });
-    try {
-      expect(
-        await deriveSelectedValue(runtime, space, source, {
-          projection: parseSelectProjection("id"),
-        }),
-      ).toEqual({ id: 1 });
-    } finally {
-      runtime.editWithRetry = originalEditWithRetry;
-    }
+      }));
+    expect(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: parseSelectProjection("id"),
+      }),
+    ).toEqual({ id: 1 });
+    expect(setups.calls).toHaveLength(1);
+    expect(ownedSetups.calls).toHaveLength(0);
   });
 
   for (const failure of ["sync", "start", "missing"] as const) {

--- a/packages/cli/test/projection-replay.test.ts
+++ b/packages/cli/test/projection-replay.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Runs projections in separate processes over one store. A fresh process resets
+ * the CLI's transform discriminator while its mapped children remain stored.
+ */
+
+import { expect } from "@std/expect";
+import { fromFileUrl, join } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+
+/** A projected survey row, including its canonical source address. */
+interface Row {
+  /** Source cell address. */
+  $link: string;
+
+  /** Selected title. */
+  title: string;
+
+  /** Selected creation timestamp. */
+  createdAt: number;
+
+  /** Selected activity timestamp. */
+  lastActivityAt: number;
+
+  /** Selected comment count. */
+  commentCount: number;
+}
+
+/** The values and storage effects observed by one projection process. */
+interface ReplayResult {
+  /** Rows returned by the selection. */
+  value: Row[];
+
+  /** Runtime execution failures. */
+  errors: string[];
+
+  /** Rejected projection commits. */
+  rejected: { name: string; message: string }[];
+
+  /** Commit requests with no response when the projection settled. */
+  unanswered: number;
+
+  /** Shared write operations excluding immutable content-addressed documents. */
+  mutableSharedWrites: number;
+}
+
+const root = fromFileUrl(new URL("../../../", import.meta.url));
+const fixture = fromFileUrl(
+  new URL("./fixtures/projection-replay-process.ts", import.meta.url),
+);
+
+/** Runs one projection with a fresh process-local transform registry. */
+async function replay(
+  directory: string,
+  mode: "seed" | "read" | "change",
+): Promise<ReplayResult> {
+  const frames = join(directory, `${mode}.jsonl`);
+  const output = await runDenoCommandWithTemporaryLock({
+    root,
+    args: (lock) => [
+      "run",
+      "--quiet",
+      "--frozen",
+      `--lock=${lock}`,
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-ffi",
+      fixture,
+      mode,
+      join(directory, "store"),
+      frames,
+    ],
+    env: { CF_MEMORY_FRAME_LOG: frames },
+  });
+  expect(output.success, new TextDecoder().decode(output.stderr)).toBe(true);
+  return JSON.parse(new TextDecoder().decode(output.stdout)) as ReplayResult;
+}
+
+describe("CLI projection replay", () => {
+  it("reuses stored mapped children without conflicting and reads source updates", async () => {
+    const directory = await Deno.makeTempDir({ prefix: "projection-replay-" });
+    try {
+      const seed = await replay(directory, "seed");
+      expect(seed.value).toHaveLength(8);
+      expect(seed.mutableSharedWrites).toBeGreaterThan(0);
+      expect(seed.rejected).toEqual([]);
+      expect(seed.unanswered).toBe(0);
+      expect(seed.errors).toEqual([]);
+
+      const cold = await replay(directory, "read");
+      expect(cold.value).toEqual(seed.value);
+      expect(cold.mutableSharedWrites).toBe(0);
+      expect(cold.rejected).toEqual([]);
+      expect(cold.unanswered).toBe(0);
+      expect(cold.errors).toEqual([]);
+
+      const changed = await replay(directory, "change");
+      expect(changed.value).toEqual(
+        seed.value.map((row, index) =>
+          index === 3 ? { ...row, title: "Updated row", commentCount: 99 } : row
+        ),
+      );
+      expect(changed.rejected).toEqual([]);
+      expect(changed.unanswered).toBe(0);
+      expect(changed.errors).toEqual([]);
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+});

--- a/packages/cli/test/projection-replay.test.ts
+++ b/packages/cli/test/projection-replay.test.ts
@@ -79,11 +79,23 @@ async function replay(
 }
 
 describe("CLI projection replay", () => {
-  it("reuses stored mapped children without conflicting and reads source updates", async () => {
+  it("reuses stored mapped children without shared writes and reads source updates", async () => {
+    // This single-client store pins redundant writes, which cause conflicts
+    // with concurrent clients on a shared server. Rejection counts here check
+    // storage health; they do not exercise multi-client contention.
+
     const directory = await Deno.makeTempDir({ prefix: "projection-replay-" });
     try {
       const seed = await replay(directory, "seed");
-      expect(seed.value).toHaveLength(8);
+      expect(seed.value).toEqual(
+        Array.from({ length: 8 }, (_, index) => ({
+          $link: expect.any(String),
+          title: `Row ${index}`,
+          createdAt: index,
+          lastActivityAt: index,
+          commentCount: index,
+        })),
+      );
       expect(seed.mutableSharedWrites).toBeGreaterThan(0);
       expect(seed.rejected).toEqual([]);
       expect(seed.unanswered).toBe(0);


### PR DESCRIPTION
A fresh CLI process running `cell get … index --step --select @,title,createdAt,lastActivityAt,commentCount` initializes mapped projection children before loading their stored execution state. The projection parent is session-scoped, but its mapped children reuse space-scoped identities. On the 245-topic Estuary board this produces a stale-basis rejection followed by hundreds of rejected dependent commits and retries.

Stage and explicitly commit the projection setup, then call `syncStoredPieceCells` and `start` to load the existing child execution state before starting the coordinator. The committed argument is necessary to derive those child identities. Startup uses that accepted setup directly, with no second setup transaction whose rejected verdict could be logged and ignored by `runSynced`. Dependency-sync errors, start errors, and a start returning `false` become `CellSelectionError`s. Output readiness, projection schemas, and canonical source addresses are preserved.

A regression test runs three separate CLI projection processes over one persistent synthetic store: initial creation, cold replay, and replay after a source edit. Cold replay returns identical values without rewriting mutable shared state; the third process returns the edited source values. The unsynchronized implementation fails this test with 32 shared write operations on cold replay. This is a single-client guard against redundant writes; it does not reproduce multi-client contention. Initial projected values are checked field by field, and frame measurements count only outgoing transaction requests.

A fault-injection test also verifies that an accepted projection starts without a redundant setup commit. On the initial PR implementation, forcing that second setup to reject returns `undefined` without throwing; the revised startup returns the expected projection. Separate cases cover dependency synchronization failure, a thrown start failure, and a missing start.

Validation:

- Repository `deno fmt --check`, `deno lint`, and `deno task check` pass.
- Full CLI package `deno task test` passes, including existing transform and CFC label tests. Local execution uses `env -u NO_COLOR TERM=xterm-256color DENO_JOBS=4` because the agent terminal otherwise forces color off; the same two color-test failures reproduce on unchanged main.

The measurements below were collected on commit `a6c7eec35a19971e4eb8055e71c505b9164945a1`, which used synchronized startup through `runSynced`. The direct-start revision is covered by the same cold-replay regression test but has not been re-benchmarked against the live server. These timings are evidence for dependency synchronization, not measurements of the revised head.

- Client machine: Apple M5 Max, macOS arm64, Deno 2.9.4.
- Five interleaved baseline/patched diagnostic pairs against one unchanged Estuary deployment returned identical JSON for all 245 topics. Both clients use base `6f0da47b213ccbdda8e8110198e9dbadd589eedb`; the server is `a5ed830f06827ce1b9bc0dfbe0b6a023315f3268`, with server execution disabled.

| Instrumented boundary | Baseline median (min–max) | Patched median (min–max) |
| --- | --- | --- |
| Complete selection phase, including synchronized startup | 5.712s (4.037–6.526) | 1.307s (1.251–1.913) |
| Process wall time, including imports and profile output | 11.140s (9.832–11.661) | 5.996s (5.970–10.331) |
| Piece runtime startup, before selection | 3.006s (2.989–4.863) | 3.087s (2.980–4.508) |

The first pair also encountered unrelated startup conflict activity, and the first patched read populated previously absent projection children. All four subsequent patched runs made two accepted commits and had no rejections; their paired baselines made 493 commit requests, with two stale-read and 490 dependent rejections. The first pair remains included in the table.

A second comparison used ordinary `deno task cf` invocations with optional timing traces, frame logging, and CPU profiling disabled. Five interleaved pairs (alternating which arm goes first) again returned identical 245-topic JSON against the same deployment:

| Ordinary CLI process wall, including launcher and imports | Minimum of five | Median | Range |
| --- | --- | --- | --- |
| Baseline | 7.982s | 9.433s | 7.982–11.169s |
| Patched | 5.081s | 5.964s | 5.081–7.226s |

The ordinary command's median is about 37% lower. These remain observations on a live shared server with uncontrolled other clients.

These are instrumented diagnostics on a live shared server, not a claim of guaranteed end-to-end latency. Other clients were uncontrolled. The remaining broad startup transfer (~19 MiB of uncompressed protocol data overall) is a separate performance opportunity.

Prepared by Codex/Astra on behalf of Gideon (@mathpirate).
