### PR TITLE
perf(topics): materialize mention arrays once per backlink join

### DIFF
--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -261,6 +261,9 @@ export function mentionListsOf<M>(
  * topic appears once, which is every test a board can set up. Handing this
  * function a duplicated list is what tells the two apart.
  *
+ * Mention membership is checked before source identity: a source with no
+ * matching mention contributes no edge and needs no identity comparison.
+ *
  * `equals` resolves BOTH sides before comparing, so it answers "do these name
  * the same document" whether each side arrived as a cell or as the raw link a
  * read left behind. A method call on the value would depend on which it is.
@@ -271,8 +274,8 @@ export function mentionedBy<T extends object>(
   mentions: readonly (readonly (object | undefined)[] | undefined)[],
 ): T[] {
   return list.filter((other, from) =>
-    !equals(other, topic) &&
-    mentions[from]?.some((mention) => equals(mention, topic))
+    mentions[from]?.some((mention) => equals(mention, topic)) &&
+    !equals(other, topic)
   );
 }
 
@@ -290,11 +293,9 @@ export function mentionedBy<T extends object>(
  * thread, verbs, or rendered UI. It reads the shape of the graph and nothing
  * else.
  *
- * Matching is a linear scan of `.equals` rather than a lookup keyed by id, and
- * that is the point rather than a concession: a cell reference is the identity,
- * so there is no id to key by and none has to be minted, kept in step, or
- * migrated when a piece moves. At board scale the scan is O(topics × mentions)
- * comparisons of already-resolved links, which is nothing.
+ * Matching uses `equals` so aliases and scoped references keep their canonical
+ * identity semantics. The scan runs over plain arrays and compares source
+ * identity only after finding a matching mention.
  *
  * Each row is addressed by the topic it describes — `Writable.for(topic)` — so
  * a row keeps its identity wherever it sits in the array and however the board
@@ -320,18 +321,17 @@ const crossrefTable = lift(
     // element read through the reactive array resolves a link every time, so
     // reading it there costs a link resolution per topic per topic.
     const list = Array.from(sources);
-    // Each topic's mention list, read once, for the same reason.
-    const mentions = mentionListsOf(list);
+    // Materialize each mention array once; scanning a reactive array resolves
+    // its elements again for every destination topic.
+    const mentions = mentionListsOf(list).map((refs) =>
+      refs === undefined ? undefined : Array.from(refs)
+    );
     list.forEach((topic) => {
       // An entry with nothing behind it yet (mid-sync) has no identity to
       // address a row by, and `Writable.for(undefined)` is not a cause. It gets
       // no row rather than a junk one — the lookup is by identity, not by
       // position, so a shorter table costs nothing.
       if (!topic) return;
-      // A linear scan, deliberately. A cell reference is the identity, so there
-      // is no id to key a map by — and nothing to mint, keep in step, or
-      // migrate when a piece moves. At board scale this is a few hundred
-      // comparisons of already-resolved links.
       const inbound = mentionedBy(topic, list, mentions);
       // Addressed by the topic it describes, so a row keeps its identity
       // wherever it sits and however the board is reordered. That is what lets

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -592,6 +592,17 @@ export default pattern(() => {
         .length === 2
   );
 
+  const assert_repeated_mentions_contribute_one_edge_per_source_entry = assert(
+    () => {
+      const inbound = mentionedBy(
+        twinB,
+        [twinA, twinB, twinA],
+        [[undefined, twinB, twinB], [twinB], undefined],
+      );
+      return inbound.length === 1 && equals(inbound[0], twinA);
+    },
+  );
+
   // A source mid-sync reads back as undefined, and taking `.mentions` of that
   // throws — which killed the pivot and, with it, the append that produced the
   // half-written source. The first two entries are what a settled board looks
@@ -1201,6 +1212,10 @@ export default pattern(() => {
       { action: action_seed_row_universe },
       { assertion: assert_row_universe_accepted },
       { assertion: assert_self_mention_inert_through_a_twin },
+      {
+        assertion:
+          assert_repeated_mentions_contribute_one_edge_per_source_entry,
+      },
       { assertion: assert_mention_lists_tolerate_a_mid_sync_source },
       { action: action_mention_subject_gets_a_link },
       { assertion: assert_plain_link_is_no_mention },


### PR DESCRIPTION
The Topics backlink pivot repeatedly scans reactive mention arrays once per destination topic. Reading the array once with `mentionListsOf` retains a reactive array, so its elements are still resolved repeatedly during the join. The helper also compares source identity before knowing whether that source mentions the destination, including sources with empty mention lists.

Materialize each mention array once inside the pivot's lift, then check mention membership before the self-reference comparison. Canonical `equals` comparisons and `Writable.for(topic)` row identities are preserved. The array copies are rebuilt on every reactive evaluation; there is no retained cache.

The existing Topics tests cover adding/removing mentions, duplicate topic references, self-mention exclusion, mid-sync sources, UI behavior, and multi-user updates. A new assertion covers repeated mentions mixed with an undefined entry, a self-mention, and an unavailable source list: a matching source contributes one inbound edge.

Validation:

- All six Topics `cf test` entries pass: multi-user, naming, render-shape, rejection cases, main Topics, and view identity.
- Full patterns package `deno task test`, including browser tests, passes.
- Repository `deno task check`, `deno fmt --check`, and `deno lint` pass.
- `cf check main.tsx --show-transformed --no-run` passes; the emitted lift retains plain JavaScript array materialization and short-circuiting.

On an Apple M5 Max running Deno 2.9.4 (macOS arm64), a local loopback benchmark compiles the production join helpers and mention-materialization expression with their real `ReadonlyCell`/`ComparableCell` input shapes. It uses synthetic cells shaped from a bounded reference-only read of Estuary: 245 source topics, 41 nonempty mention lists, 65 mentions. A trigger change recomputes the join, and the timed interval ends after pull, runtime idle, and storage synchronization. It excludes compilation/setup, UI, per-topic row writes, network latency, and the rest of topic creation. Idempotency rechecking is disabled. One warmup per arm precedes five interleaved samples; output is identical in every arm.

| Compiled join variant | Minimum of five | Median | Range |
| --- | --- | --- | --- |
| Baseline | 189.3ms | 193.3ms | 189.3–199.6ms |
| Comparison reorder only | 154.7ms | 157.5ms | 154.7–163.1ms |
| Reorder + materialize mention arrays | 41.4ms | 43.9ms | 41.4–52.9ms |

This establishes a ~4.4× improvement in the isolated reactive calculation, not a measured speedup for the full CLI create operation. The live board's full execution graph and alias lineage are not reproduced by this fixture. Applying the change to an existing board requires a Topics pattern source update; merging the library repository alone does not update that board.

Prepared by Codex/Astra on behalf of Gideon (@mathpirate).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

