### PR TITLE
feat(runtime-client): expose worker read-statistics control

### DIFF
--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -49,6 +49,16 @@ Use access counts and run counts to test collection-size scaling after a
 single-element edit. Pair them with runtime benchmarks: these counters measure
 reactive read work, not the cost of arithmetic or maintaining an aggregate tree.
 
+### Worker read accounting
+
+`RuntimeClient.setReadStatsEnabled(true)` enables reactive action read counters
+in the addressed worker. Await the request before starting the measured
+interaction. Use `setTelemetryEnabled(true)` to receive completion events, or
+read the action statistics through the existing graph diagnostics. Turning read
+accounting off leaves cumulative statistics available and stops collecting new
+samples. This control applies to that worker; it does not configure a server or
+another browser's runtime.
+
 ## Architecture
 
 The Runner has been refactored to eliminate singleton patterns in favor of

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -194,6 +194,7 @@ import {
   type SetLoggerEnabledRequest,
   type SetLoggerLevelRequest,
   type SetMemoryMessageCompressionRequest,
+  type SetReadStatsEnabledRequest,
   type SetSettleStatsEnabledRequest,
   type SetTelemetryEnabledRequest,
   type SettleStatsHistoryResponse,
@@ -2591,6 +2592,11 @@ export class RuntimeProcessor {
     this.#runtime.scheduler.setEventPreflightTelemetryEnabled(request.enabled);
   }
 
+  /** Sets body accounting independently of telemetry transport. */
+  setReadStatsEnabled(request: SetReadStatsEnabledRequest): void {
+    this.#runtime.scheduler.setReadStatsEnabled(request.enabled);
+  }
+
   /** Changes memory-message compression for every remote storage session. */
   async setMemoryMessageCompression(
     request: SetMemoryMessageCompressionRequest,
@@ -2916,6 +2922,8 @@ export class RuntimeProcessor {
         return this.setLoggerEnabled(request);
       case RequestType.SetTelemetryEnabled:
         return this.setTelemetryEnabled(request);
+      case RequestType.SetReadStatsEnabled:
+        return this.setReadStatsEnabled(request);
       case RequestType.SetMemoryMessageCompression:
         return await this.setMemoryMessageCompression(request);
       case RequestType.ResetLoggerBaselines:

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -276,6 +276,9 @@ export enum RequestType {
   /** Turns telemetry notifications on or off. */
   SetTelemetryEnabled = "runtime:setTelemetryEnabled",
 
+  /** Enables read measurements on subsequent reactive action bodies. */
+  SetReadStatsEnabled = "runtime:setReadStatsEnabled",
+
   /** Changes memory WebSocket compression without reconnecting. */
   SetMemoryMessageCompression = "runtime:setMemoryMessageCompression",
 
@@ -1579,6 +1582,13 @@ export type SetTelemetryEnabledRequest = BaseRequest & {
   enabled: boolean;
 };
 
+/** The {@link RequestType.SetReadStatsEnabled} request. */
+export type SetReadStatsEnabledRequest = BaseRequest & {
+  type: RequestType.SetReadStatsEnabled;
+  /** Whether subsequent reactive bodies record read counts. */
+  enabled: boolean;
+};
+
 /** The {@link RequestType.SetMemoryMessageCompression} request. */
 export type SetMemoryMessageCompressionRequest = BaseRequest & {
   type: RequestType.SetMemoryMessageCompression;
@@ -2843,6 +2853,7 @@ export type IPCClientRequest =
   | SetLoggerLevelRequest
   | SetLoggerEnabledRequest
   | SetTelemetryEnabledRequest
+  | SetReadStatsEnabledRequest
   | SetMemoryMessageCompressionRequest
   | SetForwardWorkerConsoleRequest
   | ResetLoggerBaselinesRequest
@@ -3559,6 +3570,10 @@ export type Commands = {
   };
   [RequestType.SetTelemetryEnabled]: {
     request: SetTelemetryEnabledRequest;
+    response: EmptyResponse;
+  };
+  [RequestType.SetReadStatsEnabled]: {
+    request: SetReadStatsEnabledRequest;
     response: EmptyResponse;
   };
   [RequestType.SetMemoryMessageCompression]: {

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -997,6 +997,17 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     });
   }
 
+  /**
+   * Measures subsequent reactive action bodies in the worker. Read samples
+   * appear in action statistics and in completion events when telemetry is on.
+   */
+  async setReadStatsEnabled(enabled: boolean): Promise<void> {
+    await this.#conn.request<RequestType.SetReadStatsEnabled>({
+      type: RequestType.SetReadStatsEnabled,
+      enabled,
+    });
+  }
+
   /** Changes memory WebSocket compression without reconnecting. */
   async setMemoryMessageCompression(enabled: boolean): Promise<void> {
     await this.#conn.request<RequestType.SetMemoryMessageCompression>({

--- a/packages/runtime-client/test/read-accounting.test.ts
+++ b/packages/runtime-client/test/read-accounting.test.ts
@@ -1,0 +1,79 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import {
+  type Action,
+  Runtime,
+  RuntimeTelemetryEvent,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { RuntimeClient } from "@/runtime-client.ts";
+import type { IPCClientRequest } from "@/protocol/mod.ts";
+import { buildProcessor } from "./backends/build-processor.ts";
+
+describe("worker read accounting", () => {
+  it("enables and disables real runtime samples through the client request route", async () => {
+    const signer = await Identity.fromPassphrase("worker-read-accounting");
+    const storage = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    try {
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "source", undefined, tx).set({ value: 7 });
+      await tx.commit();
+      const processor = buildProcessor({
+        runtime,
+        telemetry: runtime.telemetry,
+      });
+      const connection = {
+        on: () => {},
+        request: (message: IPCClientRequest) =>
+          processor.handleRequest(message),
+      } as unknown as never;
+      const client = new (RuntimeClient as unknown as {
+        new (connection: never, options: unknown): RuntimeClient;
+      })(connection, undefined);
+      const measured: boolean[] = [];
+      runtime.telemetry.addEventListener("telemetry", (event) => {
+        if (
+          event instanceof RuntimeTelemetryEvent &&
+          event.marker.type === "scheduler.run.complete"
+        ) {
+          measured.push(event.marker.reads !== undefined);
+        }
+      });
+
+      for (const enabled of [false, true, false]) {
+        measured.length = 0;
+        await client.setReadStatsEnabled(enabled);
+        const action: Action = (tx) => {
+          const data = runtime.getCell<{ value: number }>(
+            signer.did(),
+            "source",
+            undefined,
+            tx,
+          ).get();
+          expect(data.value).toBe(7);
+          expect(data.value).toBe(7);
+        };
+        runtime.scheduler.subscribe(action, {
+          reads: [],
+          shallowReads: [],
+          writes: [],
+        }, { isEffect: true });
+        runtime.scheduler.queueExecution();
+        await runtime.idle();
+        const reads = runtime.scheduler.getActionStats(action)?.reads;
+        if (enabled) expect(reads?.proxyAccesses).toBe(2);
+        expect(measured).toEqual([enabled]);
+        runtime.scheduler.unsubscribe(action);
+      }
+    } finally {
+      await runtime.dispose();
+      await storage.close();
+    }
+  });
+});


### PR DESCRIPTION
## Why

Browser read-cost benchmarks need to enable accounting in the runtime worker that executes the interaction. The scheduler API shipped in #7246 is not reachable through RuntimeClient, so a browser cannot select a measured interval through its existing connection.

## What Changed

Expose `RuntimeClient.setReadStatsEnabled(boolean)` through the typed request protocol and processor dispatcher. Awaiting the request establishes the setting before the measured interaction. Accounting remains independent of telemetry transport and applies only to the addressed runtime.

## Test plan

- Full runtime-client suite: 30 tests / 650 steps passed on the rebased implementation.
- Real-runtime regression exercises client request routing with accounting disabled, enabled, and disabled again; measured runs report two accesses. The connection is a test double, so this does not claim physical worker-transport coverage.
- Antagonistic cf-review: no blocking findings.
- Repository formatting and lint passed. Repository type check passed all 46 groups. CI and latest Cubic review are required before merge.
