### PR TITLE
bench: measure rendered lunch-poll vote read scaling

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,8 +46,11 @@ jobs:
         run: deno task build-binaries toolshed
         env:
           COMMIT_SHA: ${{ github.sha }}
+          EXPERIMENTAL_SERVER_EXECUTION: "false"
 
       - name: 🔌 Start Toolshed server for the browser benchmark
+        env:
+          EXPERIMENTAL_SERVER_EXECUTION: "false"
         run: |
           chmod +x ./dist/toolshed
           # --background returns once the server has bound its port, so the
@@ -81,6 +84,7 @@ jobs:
         env:
           CF_LOG_LEVEL: silent
           API_URL: http://localhost:8000/
+          EXPERIMENTAL_SERVER_EXECUTION: "false"
         run: |
           mkdir -p bench-results
           deno bench --json -A --v8-flags=--expose-gc \
@@ -95,6 +99,7 @@ jobs:
             packages/patterns/integration/topic-board-navigation.bench.ts \
             packages/patterns/integration/topic-board-scale.bench.ts \
             packages/patterns/integration/lunch-poll-vote-burst.bench.ts \
+            packages/patterns/integration/lunch-poll-read-scale.bench.ts \
             > bench-results/results.json \
             2> >(tee bench-results/diagnostics.log >&2)
 

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -365,7 +365,8 @@ maximum per-run accesses, link traversals, and successful/failed event-commit
 markers from the browser worker. Accounting and telemetry are disabled before
 the timed change. These body counters exclude event-handler and commit-preparation
 reads; event-commit markers are counted separately and do not describe every
-storage transaction. Diagnostics go to stderr. Browser exceptions fail the run.
+storage transaction. Diagnostics go to stderr. Missing successful event commits, event-commit
+errors, and browser exceptions fail the run.
 
 The workflow pins the shell build, toolshed, and benchmark process to
 `EXPERIMENTAL_SERVER_EXECUTION=false`. This keeps its client-execution series

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -348,3 +348,45 @@ a question the workflow's list answers.
 half of the same property: it counts rolled-back writes instead of timing them,
 and requires none, so a regression that this benchmark shows as trend drift
 also fails a test.
+
+## Rendered lunch-poll read scaling
+
+`packages/patterns/integration/lunch-poll-read-scale.bench.ts` measures a vote
+change with the production lunch poll's cards and summary demanded by a browser.
+Its three series hold 74, 296, and 1184 votes over 14 options, with 8, 24, and 87
+voters respectively. Voter links point to separate entities in the same space.
+Seeding, navigation, sign-in, viewer selection, warmup, and teardown are outside
+the timed interval. The timer includes click-helper readiness, browser/protocol
+overhead, and a trusted green-vote click through view
+settlement and the matching selected button and summary swatch.
+
+An untimed yellow-vote change collects reactive-body runs, proxy accesses,
+maximum per-run accesses, link traversals, and successful/failed event-commit
+markers from the browser worker. Accounting and telemetry are disabled before
+the timed change. These body counters exclude event-handler and commit-preparation
+reads; event-commit markers are counted separately and do not describe every
+storage transaction. Diagnostics go to stderr. Browser exceptions fail the run.
+
+The workflow pins the shell build, toolshed, and benchmark process to
+`EXPERIMENTAL_SERVER_EXECUTION=false`. This keeps its client-execution series
+stable across changes to the product default. The benchmark checks toolshed
+metadata and the served shell posture before seeding. The contention benchmark
+remains a separate workload.
+
+For a local run, start matching client-execution dev servers as described in
+[Local dev servers](LOCAL_DEV_SERVERS.md), then run:
+
+```sh
+EXPERIMENTAL_SERVER_EXECUTION=false \
+API_URL=http://localhost:8000 FRONTEND_URL=http://localhost:5173 \
+CF_LOG_LEVEL=silent \
+deno bench --json -A \
+  packages/patterns/integration/lunch-poll-read-scale.bench.ts \
+  > /tmp/lunch-read-scale.json 2> /tmp/lunch-read-scale.log
+```
+
+Set `CF_READ_SCALE_ARTIFACT_DIR` to a local output directory to save one screenshot
+and the latest diagnostic sample per size, after the timed interval. The fixture
+uses a dedicated space and a synthetic viewer. It supplies repeatable local
+measurements; comparisons to a deployed board require matching its execution
+posture, data, and cross-space links.

--- a/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.test.tsx
+++ b/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.test.tsx
@@ -10,7 +10,7 @@ export default pattern(() => {
           poll.seed.send({ voteCount: 74, voterCount: 8, optionCount: 14 })
         ),
       },
-      { action: action(() => poll.claim.send({})) },
+      { action: action(() => poll.claim.send({ type: "click" })) },
       {
         assertion: assert(() =>
           poll.voteCount === 74 && poll.userCount === 8 &&

--- a/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.test.tsx
+++ b/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.test.tsx
@@ -1,0 +1,33 @@
+import { action, assert, pattern, TESTS } from "commonfabric";
+import Poll from "./main.tsx";
+
+export default pattern(() => {
+  const poll = Poll({});
+  return {
+    [TESTS]: [
+      {
+        action: action(() =>
+          poll.seed.send({ voteCount: 74, voterCount: 8, optionCount: 14 })
+        ),
+      },
+      { action: action(() => poll.claim.send({})) },
+      {
+        assertion: assert(() =>
+          poll.voteCount === 74 && poll.userCount === 8 &&
+          poll.optionCount === 14 && poll.isJoined
+        ),
+      },
+      {
+        action: action(() =>
+          poll.castVote.send({ optionId: "option-0", voteType: "yellow" })
+        ),
+      },
+      {
+        assertion: assert(() =>
+          poll.voteCount === 74 &&
+          poll.votes.filter((vote) => vote.voteType === "yellow").length === 1
+        ),
+      },
+    ],
+  };
+});

--- a/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.tsx
+++ b/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.tsx
@@ -63,7 +63,7 @@ const seed = handler<
   }
 });
 
-const claim = handler<Record<string, never>, {
+const claim = handler<Record<string, unknown>, {
   profiles: Writable<LunchProfile[]>;
   overrideViewer: Stream<ViewerOverride>;
 }>((_, { profiles, overrideViewer }) => {

--- a/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.tsx
+++ b/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.tsx
@@ -1,0 +1,99 @@
+import {
+  handler,
+  NAME,
+  pattern,
+  type Stream,
+  UI,
+  Writable,
+} from "commonfabric";
+import LunchPoll, {
+  type LunchProfile,
+  type Option,
+  type User,
+  type ViewerOverride,
+  type Vote,
+  voteKeyFor,
+} from "../../../lunch-poll/main.tsx";
+
+const seed = handler<
+  { voteCount: number; voterCount: number; optionCount: number },
+  {
+    profiles: Writable<LunchProfile[]>;
+    users: Writable<User[]>;
+    options: Writable<Option[]>;
+    votes: Writable<Vote[]>;
+  }
+>((
+  { voteCount, voterCount, optionCount },
+  { profiles, users, options, votes },
+) => {
+  if (
+    !Number.isSafeInteger(voteCount) || voteCount < 1 ||
+    !Number.isSafeInteger(voterCount) || voterCount < 1 ||
+    !Number.isSafeInteger(optionCount) || optionCount < 1 ||
+    voteCount > voterCount * optionCount
+  ) {
+    throw new Error(
+      "Seed sizes must be positive integers with enough vote keys",
+    );
+  }
+  if (votes.get().length > 0) throw new Error("Seed requires a fresh fixture");
+  options.set(Array.from({ length: optionCount }, (_, index) => ({
+    id: `option-${index}`,
+    title: `Lunch ${index}`,
+    addedByName: "Fixture",
+    imageUrl:
+      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E",
+  })));
+  users.set(Array.from({ length: voterCount }, (_, index) => {
+    const profile = profiles.elementById(String(index));
+    const name = `Voter ${index}`;
+    profile.set({ name });
+    profiles.addUnique(profile);
+    return { name, profile, color: "#2f6f4e" };
+  }));
+  for (let index = 0; index < voteCount; index++) {
+    const optionId = `option-${index % optionCount}`;
+    const voter = profiles.elementById(String(Math.floor(index / optionCount)));
+    const key = voteKeyFor(voter, optionId);
+    if (key === undefined) throw new Error("Fixture voter has no identity");
+    const vote = votes.elementById(key);
+    vote.set({ optionId, voter, voteType: "green", castAt: Date.now() });
+    votes.addUnique(vote);
+  }
+});
+
+const claim = handler<Record<string, never>, {
+  profiles: Writable<LunchProfile[]>;
+  overrideViewer: Stream<ViewerOverride>;
+}>((_, { profiles, overrideViewer }) => {
+  overrideViewer.send({ profile: profiles.elementById("0"), name: "Voter 0" });
+});
+
+export default pattern(() => {
+  const profiles = new Writable.perSpace<LunchProfile[]>([]);
+  const users = new Writable.perSpace<User[]>([]);
+  const options = new Writable.perSpace<Option[]>([]);
+  const votes = new Writable.perSpace<Vote[]>([]);
+  const poll = LunchPoll({ users, options, votes });
+  const claimViewer = claim({ profiles, overrideViewer: poll.overrideViewer });
+  return {
+    [NAME]: "Lunch poll read benchmark",
+    [UI]: (
+      <div>
+        <cf-button data-benchmark-claim onClick={claimViewer}>
+          Use fixture viewer
+        </cf-button>
+        {poll[UI]}
+      </div>
+    ),
+    seed: seed({ profiles, users, options, votes }),
+    claim: claimViewer,
+    castVote: poll.castVote,
+    voteCount: poll.voteCount,
+    optionCount: poll.optionCount,
+    userCount: poll.userCount,
+    isJoined: poll.isJoined,
+    votes: poll.votes,
+  };
+});

--- a/packages/patterns/integration/lunch-poll-read-scale.bench.ts
+++ b/packages/patterns/integration/lunch-poll-read-scale.bench.ts
@@ -1,0 +1,296 @@
+/**
+ * A rendered lunch-poll vote update across declared vote-list sizes.
+ * Setup and an instrumented diagnostic vote are outside the timed interval;
+ * timed votes run with read accounting disabled. This is the client-execution
+ * arm and requires a matching local toolshed and shell.
+ */
+
+import { Identity } from "@commonfabric/identity";
+import {
+  Browser,
+  env,
+  type Page,
+  waitForCondition,
+} from "@commonfabric/integration";
+import { login } from "@commonfabric/integration/shell-utils";
+import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
+import type { RuntimeClient } from "@commonfabric/runtime-client";
+import { join } from "@std/path";
+import { initializePiecesController } from "./pieces-controller.ts";
+import {
+  clickCfButton,
+  settleView,
+  waitForSettledText,
+} from "./cfc-browser-helpers.ts";
+import { waitForPieceView } from "./topics-navigation-helpers.ts";
+
+const SIZES = [74, 296, 1184];
+const OPTIONS = 14;
+const identity = await Identity.fromPassphrase(
+  "lunch poll read scale benchmark",
+  { implementation: "noble" },
+);
+const encoder = new TextEncoder();
+const note = (message: string) =>
+  Deno.stderr.writeSync(encoder.encode(`${message}\n`));
+
+/** Worker diagnostics collected over one untimed vote change. */
+interface ReadSample {
+  /** Completed reactive bodies carrying a read sample. */
+  runs: number;
+
+  /** Sum of reactive-body proxy accesses. */
+  accesses: number;
+
+  /** Largest reactive-body proxy-access count. */
+  maxAccesses: number;
+
+  /** Sum of reactive-body stored-link traversal attempts. */
+  linkHops: number;
+
+  /** Successful event-commit markers, including nested handlers. */
+  eventCommits: number;
+
+  /** Failed event-commit markers. */
+  eventCommitErrors: number;
+}
+
+/** Browser runtime handle and the current untimed diagnostic sample. */
+type DiagnosticGlobal = typeof globalThis & {
+  /** Shell's exposed runtime client. */
+  commonfabric?: { rt?: RuntimeClient };
+
+  /** Sample mutated by worker telemetry notifications. */
+  lunchReadSample?: ReadSample;
+};
+
+/** Verifies that the server, served shell, and seeding process execute locally. */
+async function verifyPosture(): Promise<void> {
+  const [metaResponse, statsResponse] = await Promise.all([
+    fetch(new URL("api/meta", env.API_URL)),
+    fetch(new URL("api/health/stats", env.API_URL)),
+  ]);
+  if (!metaResponse.ok || !statsResponse.ok) {
+    throw new Error("Posture probe failed");
+  }
+  const meta = await metaResponse.json();
+  const stats = await statsResponse.json();
+  if (
+    Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") !== "false" ||
+    meta.experimental?.serverExecution !== false || stats.servingLoop != null
+  ) {
+    throw new Error("Read-scale benchmark requires explicit client execution");
+  }
+  if (meta.shellServerExecutionDefine !== "false") {
+    const response = await fetch(new URL("scripts/index.js", env.FRONTEND_URL));
+    const source = await response.text();
+    if (
+      !response.ok ||
+      !source.includes(
+        'var EXPERIMENTAL_SERVER_EXECUTION_DEFINE = true ? "false" : void 0;',
+      )
+    ) {
+      throw new Error(
+        "Cannot verify that the served shell selects client execution",
+      );
+    }
+  }
+  note(
+    "[lunch-read-scale] verified toolshed, shell, and seed client: serverExecution=false",
+  );
+}
+
+const fixtures = new Map<
+  number,
+  Promise<{ spaceName: string; pieceId: string }>
+>();
+/** Seeds one dedicated space per size and releases the seeding runtime. */
+function fixture(voteCount: number) {
+  let created = fixtures.get(voteCount);
+  if (!created) {
+    created = (async () => {
+      await verifyPosture();
+      const spaceName = `${env.SPACE_NAME}-read-${voteCount}`;
+      const cc = await initializePiecesController({
+        space: spaceName,
+        apiUrl: new URL(env.API_URL),
+        identity,
+      });
+      try {
+        await cc.ensureDefaultPattern();
+        const root = join(import.meta.dirname!, "..");
+        const program = await resolveLocalProgram(
+          (resolver) => cc.runtime.harness.resolve(resolver),
+          {
+            main: join(
+              root,
+              "integration/fixtures/lunch-poll-read-scale/main.tsx",
+            ),
+            root,
+            testPaths: [
+              join(
+                root,
+                "integration/fixtures/lunch-poll-read-scale/main.test.tsx",
+              ),
+            ],
+          },
+        );
+        const piece = await cc.create<
+          {
+            seed: {
+              voteCount: number;
+              voterCount: number;
+              optionCount: number;
+            };
+          }
+        >(program, { start: true });
+        const result = cc.getResult<
+          {
+            seed: {
+              voteCount: number;
+              voterCount: number;
+              optionCount: number;
+            };
+          }
+        >(piece.getCell());
+        const stop = result.sink(() => {});
+        try {
+          const voterCount = Math.ceil(voteCount / OPTIONS) + 2;
+          const sent = await cc.runtime.editWithRetry((tx) =>
+            result.key("seed").withTx(tx).send({
+              voteCount,
+              voterCount,
+              optionCount: OPTIONS,
+            })
+          );
+          if (sent.error) throw new Error(sent.error.message);
+          await cc.runtime.settled(Infinity);
+          await cc.synced();
+          note(
+            `[lunch-read-scale] seeded ${voteCount} votes, ${voterCount} voters, ${OPTIONS} options`,
+          );
+        } finally {
+          stop();
+        }
+        return { spaceName, pieceId: piece.id };
+      } finally {
+        await cc.dispose();
+      }
+    })();
+    fixtures.set(voteCount, created);
+  }
+  return created;
+}
+
+/** Changes Lunch 0's vote and waits for its selected button and summary swatch. */
+async function vote(page: Page, color: "green" | "yellow"): Promise<void> {
+  await clickCfButton(
+    page,
+    `[data-option-title="Lunch 0"] cf-button[data-vote="${color}"]`,
+  );
+  await settleView(page);
+  await waitForCondition(
+    page,
+    (probe, expected: string) =>
+      probe.collect(
+        `[data-option-title="Lunch 0"] cf-button[data-vote="${expected}"]`,
+      ).some((button) => getComputedStyle(button).fontWeight === "700") &&
+      probe.collect('[data-vote-swatch-name="Voter 0"]').some((swatch) =>
+        getComputedStyle(swatch).backgroundColor ===
+          (expected === "green" ? "rgb(47, 138, 100)" : "rgb(212, 168, 47)") &&
+        swatch.parentElement?.parentElement?.firstElementChild?.textContent
+            ?.trim() === "Lunch 0"
+      ),
+    { args: [color] },
+  );
+  await settleView(page);
+}
+
+for (const voteCount of SIZES) {
+  Deno.bench({
+    name: `${voteCount} votes`,
+    group: "lunch poll rendered read scale",
+    n: 3,
+    warmup: 1,
+  }, async (b) => {
+    const target = await fixture(voteCount);
+    const browser = await Browser.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      const pageErrors: string[] = [];
+      page.addEventListener("pageerror", (event) => {
+        pageErrors.push(event.detail.message);
+      });
+      await page.goto(
+        `${env.FRONTEND_URL}${target.spaceName}/${target.pieceId}`,
+      );
+      await waitForPieceView(page, target.spaceName, target.pieceId);
+      await login(page, identity);
+      await waitForSettledText(page, "body", "Lunch 13");
+      await clickCfButton(page, "[data-benchmark-claim]");
+      await settleView(page);
+      note(`[lunch-read-scale] ${voteCount} votes: viewer ready`);
+      await vote(page, "yellow");
+      await vote(page, "green");
+      note(`[lunch-read-scale] ${voteCount} votes: warmup complete`);
+      await page.evaluate(async () => {
+        const scope = globalThis as DiagnosticGlobal;
+        const rt = scope.commonfabric?.rt;
+        if (!rt) throw new Error("No browser runtime");
+        scope.lunchReadSample = {
+          runs: 0,
+          accesses: 0,
+          maxAccesses: 0,
+          linkHops: 0,
+          eventCommits: 0,
+          eventCommitErrors: 0,
+        };
+        rt.on("telemetry", (marker) => {
+          const sample = scope.lunchReadSample!;
+          if (marker.type === "scheduler.event.commit") {
+            if (marker.error) sample.eventCommitErrors++;
+            else sample.eventCommits++;
+          }
+          if (marker.type !== "scheduler.run.complete" || !marker.reads) return;
+          sample.runs++;
+          sample.accesses += marker.reads.proxyAccesses;
+          sample.linkHops += marker.reads.linkResolutions;
+          sample.maxAccesses = Math.max(
+            sample.maxAccesses,
+            marker.reads.proxyAccesses,
+          );
+        });
+        await rt.setTelemetryEnabled(true);
+        await rt.setReadStatsEnabled(true);
+      });
+      await vote(page, "yellow");
+      const sample = await page.evaluate(async () => {
+        const scope = globalThis as DiagnosticGlobal;
+        await scope.commonfabric!.rt!.setReadStatsEnabled(false);
+        await scope.commonfabric!.rt!.setTelemetryEnabled(false);
+        return scope.lunchReadSample!;
+      });
+      if (sample.runs === 0) {
+        throw new Error("The demanded vote produced no measured worker runs");
+      }
+      note(`[lunch-read-scale] ${voteCount} votes: ${JSON.stringify(sample)}`);
+      b.start();
+      await vote(page, "green");
+      b.end();
+      if (pageErrors.length > 0) {
+        throw new Error(`Browser errors: ${pageErrors.join("; ")}`);
+      }
+      const artifactDir = Deno.env.get("CF_READ_SCALE_ARTIFACT_DIR");
+      if (artifactDir) {
+        await Deno.mkdir(artifactDir, { recursive: true });
+        await page.screenshot(join(artifactDir, `${voteCount}-votes.png`));
+        await Deno.writeTextFile(
+          join(artifactDir, `${voteCount}-votes.json`),
+          JSON.stringify({ voteCount, ...target, sample }, null, 2),
+        );
+      }
+    } finally {
+      await browser.close();
+    }
+  });
+}

--- a/packages/patterns/integration/lunch-poll-read-scale.bench.ts
+++ b/packages/patterns/integration/lunch-poll-read-scale.bench.ts
@@ -273,6 +273,13 @@ for (const voteCount of SIZES) {
       if (sample.runs === 0) {
         throw new Error("The demanded vote produced no measured worker runs");
       }
+      if (sample.eventCommits === 0 || sample.eventCommitErrors !== 0) {
+        throw new Error(
+          `The diagnostic vote did not commit cleanly: ${
+            JSON.stringify(sample)
+          }`,
+        );
+      }
       note(`[lunch-read-scale] ${voteCount} votes: ${JSON.stringify(sample)}`);
       b.start();
       await vote(page, "green");


### PR DESCRIPTION
## Why

The lunch-poll write-burst benchmark cannot show how much read work one vote causes while the tally is rendered. This implements the browser benchmark portion of design #7155 using the worker read-statistics control shipped in #7256.

## What Changed

- Seed 74, 296, and 1,184 keyed votes over 14 options and 8, 24, and 87 same-space voters, then drive the production lunch-poll UI through a real browser.
- Time a trusted vote change through selected-button and summary-swatch updates and full view settlement. Fixture setup, warmup, diagnostics, screenshots, and teardown stay outside the timed interval. Click-helper readiness and browser/protocol overhead remain inside it.
- Record reactive-body accesses, largest body, runs, link traversals, and event-commit success/error markers during a separate untimed vote. Disable accounting and telemetry before timing.
- Add the workload to the benchmark workflow and pin its existing client-execution posture across shell build, toolshed, and benchmark process. Preserve the write-burst workload.
- Provide optional screenshots and diagnostic artifacts for local observation; document reproduction and measurement boundaries.

## Test plan

- All three sizes complete in a real browser against isolated local client-execution servers. The strengthened vote/tally predicates pass; each diagnostic vote records two successful event commits and no event-commit errors. JSON output parses and carries all three series.
- Largest reactive body: 649 / 2,425 / 9,529 proxy accesses at the three sizes. These are observations, not optimized results. Four timing samples per size are exploratory local measurements; concurrent validation jobs and browser overhead preclude a product performance claim.
- Fixture type-check and both functional assertions pass. Patterns package test task, including the real-browser lane, passes. Repository type checks, formatting, and lint pass.
- Antagonistic review found no blocking correctness issue. CI and a clean latest Cubic review are required before merge.

Same-space synthetic data is deliberate. Deployed-board and cross-space comparisons remain A5 work. Read-budget regression ceilings will be connected after #7257 lands; this PR records trends and verifies fixture behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

