### PR TITLE
fix(runner): label-map absence assertions that could not fail

### DIFF
--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -458,23 +458,29 @@ replica has examined the document and also once a local write for it is
 pending, so a case turning on the first of those says in a comment that
 nothing has written the document yet.
 
-**A persisted label map reads as empty for four different states.** A test
+**A label-map absence assertion passes in four different states.** A test
 reaches the CFC label map through a chain like
 `replica.getDocument(id)?.cfc?.labelMap?.entries ?? []`. The `getDocument()`
-collapse above accounts for the first of the four. The rest of the chain adds
-three more: the document carries no `cfc` metadata, that metadata carries no
-`labelMap`, and the label map holds no matching entry. All four read as the
-same empty list. An assertion over that list saying some entry is absent
-therefore also passes when the label-map machinery persisted nothing
-whatsoever, and where no passing run stamps that document, the case cannot
-fail at all. Say which state is meant. A positive companion the same helper
-reads back from that same document closes all four at once: the entry is
-there, so the label map, the metadata and the document are there too. Where
-the run labels nothing on that document, the companion has to come from
-another one the run labels, and that closes only the last three — pair it with
-the value the document stores, which is what says the document is there at
-all. A run that labels nothing anywhere has only that second assertion to
-make.
+collapse above accounts for the first of the four. Two more come from the rest
+of the chain: the document carries no `cfc` metadata, and that metadata
+carries no `labelMap`. Each of the three yields the empty list the `??` hands
+back. The fourth is the one an absence assertion means — the label map is
+there and holds no matching entry — where `entries` may well be non-empty and
+it is the `find()` or `filter()` over it that comes back empty. All four look
+alike by the time the matcher runs, and where no passing run stamps that
+document, the case cannot fail at all.
+
+Say which state is meant. A positive companion the same helper reads back from
+that same document closes the first three: the entry is there, so the label
+map, the metadata and the document are there too, and the fourth is left as
+the claim. Where the run labels nothing on that document, no such companion
+exists, and naming the value the document stores is what there is. It rules
+out a missing document and nothing else, which leaves the two middle states
+standing — and those are what such a case asserts, since a document the run
+stamps nothing on is one carrying no metadata. A companion read from another
+document closes none of the three. It says the run stamped something
+somewhere, which is worth asserting where the case turns on a label that must
+not travel, and is not a substitute for pinning the document under assertion.
 
 ```ts
 // Shown at module scope.

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -458,6 +458,46 @@ replica has examined the document and also once a local write for it is
 pending, so a case turning on the first of those says in a comment that
 nothing has written the document yet.
 
+**A persisted label map reads as empty for four different states.** A test
+reaches the CFC label map through a chain like
+`replica.getDocument(id)?.cfc?.labelMap?.entries ?? []`. The `getDocument()`
+collapse above accounts for the first of the four. The rest of the chain adds
+three more: the document carries no `cfc` metadata, that metadata carries no
+`labelMap`, and the label map holds no matching entry. All four read as the
+same empty list. An assertion over that list saying some entry is absent
+therefore also passes when the label-map machinery persisted nothing
+whatsoever, and where no passing run stamps that document, the case cannot
+fail at all. Say which state is meant. A positive companion the same helper
+reads back from that same document closes all four at once: the entry is
+there, so the label map, the metadata and the document are there too. Where
+the run labels nothing on that document, the companion has to come from
+another one the run labels, and that closes only the last three — pair it with
+the value the document stores, which is what says the document is there at
+all. A run that labels nothing anywhere has only that second assertion to
+make.
+
+```ts
+// Shown at module scope.
+import { expect } from "@std/expect";
+
+type StoredEntry = { label: { confidentiality?: string[] } };
+
+declare const entriesOf: (id: string) => StoredEntry[];
+declare const storedDocument: (id: string) => { value?: unknown } | undefined;
+declare const sourceId: string;
+declare const copyId: string;
+
+// The stored value pins the copy document, and the source carries the atom
+// the copy must not.
+expect(storedDocument(copyId)?.value).toEqual({ reading: "37.77,-122.41" });
+expect(
+  entriesOf(sourceId).flatMap((e) => e.label.confidentiality ?? []),
+).toContain("secret");
+expect(
+  entriesOf(copyId).flatMap((e) => e.label.confidentiality ?? []),
+).not.toContain("secret");
+```
+
 ## What a claim ranges over
 
 A test exhibits instances. To exhibit an absence it has to exhaust the set the

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -3321,7 +3321,10 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         scope: "space",
         id: cell.getAsNormalizedFullLink().id,
         path: [],
-      }) as { cfc?: { labelMap?: { entries?: unknown[] } } };
+      }) as { value?: unknown; cfc?: { labelMap?: { entries?: unknown[] } } };
+      // The stored value pins the document the label map is read from, so
+      // the empty map below is that document's own.
+      expect(stored.value).toEqual({ items: [] });
       expect(stored.cfc?.labelMap?.entries ?? []).not.toContainEqual({
         path: ["items", "*"],
         label: {},

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -396,10 +396,13 @@ describe("CFC cross-space integrity", () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
-      await seedLabeledDoc(runtime, spaceA, "s1e-src", "37.77,-122.41", [{
-        path: [],
-        label: { integrity: ["gps-reading"] },
-      }]);
+      const srcId = await seedLabeledDoc(
+        runtime,
+        spaceA,
+        "s1e-src",
+        "37.77,-122.41",
+        [{ path: [], label: { integrity: ["gps-reading"] } }],
+      );
 
       // Actually READ the labeled source and write its MATERIALIZED value (not a
       // link) into space B — the "a handler read it and copied the bytes" path.
@@ -433,6 +436,12 @@ describe("CFC cross-space integrity", () => {
       expect((doc?.value as { reading?: string })?.reading).toBe(
         "37.77,-122.41",
       );
+      // The source carries the atom the copy must not, and the value read
+      // above pins the copy document the entries below are read from.
+      expect(
+        entriesFor(readDoc(storageManager, spaceA, srcId), [])
+          .flatMap((e) => e.label.integrity ?? []),
+      ).toContain("gps-reading");
       const integrity = entriesFor(doc, ["reading"])
         .flatMap((e) => e.label.integrity ?? []);
       expect(integrity).not.toContain("gps-reading");

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -1041,7 +1041,10 @@ describe("CFC existence channel (SC-4, freeze-at-creation)", () => {
       expect((await tx.commit()).ok).toBeDefined();
     };
     await overwrite({ copied: false });
-    const first = JSON.stringify(entriesOf(outId));
+    const firstEntries = entriesOf(outId);
+    // The frozen existence entry is there to re-derive.
+    expect(firstEntries.map((e) => e.observes)).toEqual(["shape"]);
+    const first = JSON.stringify(firstEntries);
     await overwrite({ copied: 3 });
     expect(JSON.stringify(entriesOf(outId))).toEqual(first);
   });

--- a/packages/runner/test/cfc-external-ingest.test.ts
+++ b/packages/runner/test/cfc-external-ingest.test.ts
@@ -51,17 +51,24 @@ describe("CFC external-ingest provenance mint (split-mint)", () => {
     return { storageManager, runtime };
   };
 
+  type StoredDocument = {
+    value?: unknown;
+    cfc?: { labelMap?: { entries: StoredEntry[] } };
+  } | undefined;
+
+  const storedDocument = (
+    storageManager: ReturnType<typeof StorageManager.emulate>,
+    id: string,
+  ): StoredDocument =>
+    (storageManager.open(space).replica as unknown as {
+      getDocument(id: string): StoredDocument;
+    }).getDocument(id);
+
   const entriesOf = (
     storageManager: ReturnType<typeof StorageManager.emulate>,
     id: string,
-  ): StoredEntry[] => {
-    const replica = storageManager.open(space).replica as unknown as {
-      getDocument(id: string): {
-        cfc?: { labelMap?: { entries: StoredEntry[] } };
-      } | undefined;
-    };
-    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
-  };
+  ): StoredEntry[] =>
+    storedDocument(storageManager, id)?.cfc?.labelMap?.entries ?? [];
 
   const ingestEntries = (
     storageManager: ReturnType<typeof StorageManager.emulate>,
@@ -399,6 +406,11 @@ describe("CFC external-ingest provenance mint (split-mint)", () => {
 
       const id =
         runtime.getCell(space, "ingest-c").getAsNormalizedFullLink().id;
+      // The stored value pins the document the marks are read from, so the
+      // empty mark list below is that document's own.
+      expect(storedDocument(storageManager, id)?.value).toEqual({
+        hello: "world",
+      });
       expect(ingestEntries(storageManager, id).length).toBe(0);
     } finally {
       await runtime.dispose();

--- a/packages/runner/test/cfc-flow-pointwise.test.ts
+++ b/packages/runner/test/cfc-flow-pointwise.test.ts
@@ -583,9 +583,13 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     await result.pull();
     await runtime.idle();
 
-    const sc = structureConfidentiality(
-      resolvedContainerId(result.key("kept")),
-    );
+    const containerId = resolvedContainerId(result.key("kept"));
+    // The kept element's own entry carries alice-secret, so the structure
+    // label below is read from a container that holds a label map.
+    expect(
+      entriesOf(containerId).flatMap((e) => e.label.confidentiality ?? []),
+    ).toContainEqual("alice-secret");
+    const sc = structureConfidentiality(containerId);
     expect(sc).not.toContainEqual("alice-secret");
     expect(sc).not.toContainEqual("bob-secret");
   });

--- a/packages/runner/test/cfc-inspect-conf-label-builtin.test.ts
+++ b/packages/runner/test/cfc-inspect-conf-label-builtin.test.ts
@@ -113,6 +113,23 @@ const storedConfidentialityOf = (
   }
 };
 
+const storedValueOf = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  runtime: Runtime,
+  result: Cell<any>,
+): unknown => {
+  const rtx = runtime.edit();
+  try {
+    const link = result.withTx(rtx).resolveAsCell()
+      .getAsNormalizedFullLink();
+    return (storageManager.open(link.space).replica as unknown as {
+      getDocument(id: string): { value?: unknown } | undefined;
+    }).getDocument(link.id)?.value;
+  } finally {
+    rtx.commit();
+  }
+};
+
 describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
@@ -409,7 +426,11 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       // protected metadata.
       expect(value).toEqual({ status: "notAvailable" });
 
-      // And nothing protected landed on the result doc.
+      // And nothing protected landed on the result doc. The stored value
+      // pins that document, so an empty confidentiality list is its own.
+      expect(storedValueOf(storageManager, runtime, result)).toEqual({
+        status: "notAvailable",
+      });
       const confidentiality = storedConfidentialityOf(runtime, result);
       expect(confidentiality).toEqual([]);
     });

--- a/packages/runner/test/cfc-label-introspection-channel.test.ts
+++ b/packages/runner/test/cfc-label-introspection-channel.test.ts
@@ -110,6 +110,14 @@ const makeRuntime = (options: {
   return { storageManager, runtime };
 };
 
+const storedDocument = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  id: string,
+): { value?: unknown } | undefined =>
+  (storageManager.open(signer.did()).replica as unknown as {
+    getDocument(id: string): { value?: unknown } | undefined;
+  }).getDocument(id);
+
 describe("CFC label-metadata observation channel (inv-12 Stage 2)", () => {
   it("recorded observations join the flow derivation with their population labels", async () => {
     const { storageManager, runtime } = makeRuntime();
@@ -282,12 +290,15 @@ describe("CFC label-metadata observation channel (inv-12 Stage 2)", () => {
       expect((await txA.commit()).ok).toBeDefined();
       await txB.commit();
 
+      const outAId = outA.getAsNormalizedFullLink().id;
       const check = runtime.edit();
-      const stored = readStoredCfcMetadata(check, {
-        space,
-        id: outA.getAsNormalizedFullLink().id,
-      });
+      const stored = readStoredCfcMetadata(check, { space, id: outAId });
       await check.commit();
+      // The stored value pins the document the metadata is read from, so an
+      // envelope carrying no derived entry is that document's own.
+      expect(storedDocument(storageManager, outAId)?.value).toEqual({
+        copied: "no-taint",
+      });
       expect(
         stored?.labelMap.entries.some((entry) => entry.origin === "derived"),
       ).not.toBe(true);

--- a/packages/runner/test/cfc-label-metadata-persist.test.ts
+++ b/packages/runner/test/cfc-label-metadata-persist.test.ts
@@ -338,6 +338,10 @@ describe("CFC persist-seam link-label re-derivation (inv-12 Stage 0)", () => {
       };
       const entries =
         replica.getDocument(persistedId)?.cfc?.labelMap?.entries ?? [];
+      // The re-derived link entry is there, carrying the source label, so the
+      // integrity check below runs over a label map that was written.
+      expect(entries.map((e) => e.path)).toEqual([["field"]]);
+      expect(entries[0].label.confidentiality).toEqual(["source-root"]);
       const allIntegrity = entries.flatMap((e) => e.label.integrity ?? []);
       expect(
         allIntegrity.some((a) => a?.type?.endsWith("/InjectionSafe")),

--- a/packages/runner/test/cfc-link-integrity-gate.test.ts
+++ b/packages/runner/test/cfc-link-integrity-gate.test.ts
@@ -97,6 +97,11 @@ describe("CFC link-write integrity gate", () => {
         replica.getDocument(persistedId)?.cfc?.labelMap?.entries ??
           [];
       const allIntegrity = entries.flatMap((e) => e.label.integrity ?? []);
+      // The rest of the carried view persisted, so the integrity check below
+      // runs over a label map that was written.
+      expect(entries.map((e) => e.label.confidentiality)).toContainEqual([
+        "leak",
+      ]);
       // The forged InjectionSafe must not have been persisted anywhere.
       expect(
         allIntegrity.some((a) => a?.type?.endsWith("/InjectionSafe")),

--- a/packages/runner/test/cfc-observation-classes.test.ts
+++ b/packages/runner/test/cfc-observation-classes.test.ts
@@ -99,14 +99,18 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
     return id;
   };
 
-  const entriesOf = (id: string): StoredEntry[] => {
-    const replica = storageManager!.open(space).replica as unknown as {
-      getDocument(id: string): {
-        cfc?: { labelMap?: { entries: StoredEntry[] } };
-      } | undefined;
-    };
-    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
-  };
+  type StoredDocument = {
+    value?: unknown;
+    cfc?: { labelMap?: { entries: StoredEntry[] } };
+  } | undefined;
+
+  const storedDocument = (id: string): StoredDocument =>
+    (storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): StoredDocument;
+    }).getDocument(id);
+
+  const entriesOf = (id: string): StoredEntry[] =>
+    storedDocument(id)?.cfc?.labelMap?.entries ?? [];
 
   const derivedConfidentiality = (id: string): unknown[] | undefined =>
     entriesOf(id).find((e) => e.origin === "derived")?.label.confidentiality;
@@ -158,7 +162,11 @@ describe("CFC observation classes (C1 read-shape plumbing)", () => {
       tx.prepareCfc();
     }
     expect((await tx.commit()).ok).toBeDefined();
-    return derivedConfidentiality(out.getAsNormalizedFullLink().id);
+    const outId = out.getAsNormalizedFullLink().id;
+    // The stored value pins the document the join is read from, so a caller
+    // finding no join is finding a document with no derived entry.
+    expect(storedDocument(outId)?.value).toEqual({ copied: true });
+    return derivedConfidentiality(outId);
   };
 
   it("value reads: legacy covering join is byte-identical; link-origin entries stay excluded", async () => {

--- a/packages/runner/test/cfc-persist-split.test.ts
+++ b/packages/runner/test/cfc-persist-split.test.ts
@@ -107,16 +107,15 @@ describe("CFC observation classes (C2 persist split)", () => {
     });
   };
 
-  const rawDocOf = (
-    id: string,
-  ): { cfc?: { labelMap?: { entries: StoredEntry[] } } } | undefined => {
-    const replica = storageManager!.open(space).replica as unknown as {
-      getDocument(id: string): {
-        cfc?: { labelMap?: { entries: StoredEntry[] } };
-      } | undefined;
-    };
-    return replica.getDocument(id);
-  };
+  type StoredDocument = {
+    value?: unknown;
+    cfc?: { labelMap?: { entries: StoredEntry[] } };
+  } | undefined;
+
+  const rawDocOf = (id: string): StoredDocument =>
+    (storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): StoredDocument;
+    }).getDocument(id);
 
   const entriesOf = (id: string): StoredEntry[] =>
     rawDocOf(id)?.cfc?.labelMap?.entries ?? [];
@@ -444,6 +443,14 @@ describe("CFC observation classes (C2 persist split)", () => {
     tx.prepareCfc();
     expect((await tx.commit()).ok).toBeDefined();
 
+    // The value/shape pair the probe must not consume is stamped on the
+    // laundered document, and the stored value pins the output document the
+    // entries below are read from.
+    expect(
+      first.entries.filter((e) => e.origin === "derived").map((e) => e.observes)
+        .sort(),
+    ).toEqual(["shape", "value"]);
+    expect(rawDocOf(outId)?.value).toEqual({ probed: true });
     expect(entriesOf(outId).filter((e) => e.origin === "derived")).toEqual([]);
   });
 });

--- a/packages/runner/test/cfc-projection.test.ts
+++ b/packages/runner/test/cfc-projection.test.ts
@@ -338,6 +338,13 @@ describe("CFC projection claims", () => {
 
       const persistedId = parseLink(cell.getAsLink()).id!;
       const entries = readPersistedEntries(storageManager, persistedId);
+      // The source struct's own declared entry stands in the same label map,
+      // so an absent `latitude` entry is a fact about a map that was written.
+      expect(
+        entries?.find((e) =>
+          e.path.length === 1 && e.path[0] === "measurement"
+        ),
+      ).toBeDefined();
       expect(
         entries?.find((e) => e.path.length === 1 && e.path[0] === "latitude"),
       ).toBeUndefined();

--- a/packages/runner/test/cfc-read-scope.test.ts
+++ b/packages/runner/test/cfc-read-scope.test.ts
@@ -16,17 +16,24 @@ type StoredEntry = {
   origin?: string;
 };
 
+type StoredDocument = {
+  value?: unknown;
+  cfc?: { labelMap?: { entries: StoredEntry[] } };
+} | undefined;
+
+const storedDocument = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  id: string,
+): StoredDocument =>
+  (storageManager.open(signer.did()).replica as unknown as {
+    getDocument(id: string): StoredDocument;
+  }).getDocument(id);
+
 const replicaEntries = (
   storageManager: ReturnType<typeof StorageManager.emulate>,
   id: string,
-): StoredEntry[] => {
-  const replica = storageManager.open(signer.did()).replica as unknown as {
-    getDocument(id: string): {
-      cfc?: { labelMap?: { entries: StoredEntry[] } };
-    } | undefined;
-  };
-  return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
-};
+): StoredEntry[] =>
+  storedDocument(storageManager, id)?.cfc?.labelMap?.entries ?? [];
 
 const newRuntime = (
   storageManager: ReturnType<typeof StorageManager.emulate>,
@@ -109,9 +116,20 @@ describe("CFC flow-join read scope", () => {
       );
       derived.set({ doubled: amount * 2 });
       const derivedId = derived.getAsNormalizedFullLink().id;
+      const sourceId = source.getAsNormalizedFullLink().id;
       tx.prepareCfc();
       expect((await tx.commit()).ok).toBeDefined();
 
+      // The sibling that was not read carries the atom the derived document
+      // must not pick up, and the stored value pins the derived document the
+      // entries below are read from.
+      expect(
+        replicaEntries(storageManager, sourceId)
+          .flatMap((e) => e.label.confidentiality ?? []),
+      ).toContainEqual("secret");
+      expect(storedDocument(storageManager, derivedId)?.value).toEqual({
+        doubled: 24,
+      });
       const flowEntry = replicaEntries(storageManager, derivedId)
         .find((e) => e.origin === "derived");
       expect(flowEntry?.label.confidentiality ?? []).not.toContainEqual(

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -461,7 +461,11 @@ describe("CFC template population (Stage A): the two under-taints", () => {
       { path: [], label: { confidentiality: ["memb-secret"] } },
     ]);
     const listId = await buildList(rt, "tp-list-i", criteriaId, ["tp-el-i"]);
-    const before = JSON.stringify(entriesOf(listId));
+    const beforeEntries = entriesOf(listId);
+    // The container metadata that must re-derive byte-identically is there to
+    // re-derive.
+    expect(beforeEntries.some((e) => e.origin === "structure")).toBe(true);
+    const before = JSON.stringify(beforeEntries);
 
     const again = rt.edit();
     again.readOrThrow(readAddress(criteriaId, []));
@@ -1173,6 +1177,13 @@ describe("CFC template population (Stage A): record-only additionalProperties wa
       ifc: { confidentiality: ["root-label"] },
     } as JSONSchema, { k: 1 });
     const stored = entriesOf(id);
+    // The root declaration is stamped, so an absent `*` entry is a fact about
+    // a label map that was written.
+    expect(stored).toContainEqual({
+      path: [],
+      label: { confidentiality: ["root-label"] },
+      origin: "declared",
+    });
     expect(stored.some((e) => e.path.includes("*"))).toBe(false);
   });
 });

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -1709,6 +1709,11 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
       const plainId = plain.getAsNormalizedFullLink().id;
       tx.prepareCfc();
       expect((await tx.commit()).ok).toBeDefined();
+      // The stored value pins the document the label map is read from, so the
+      // empty map below is that document's own.
+      expect(storedDocument(storageManager, plainId)?.value).toEqual({
+        note: "public",
+      });
       expect(replicaEntries(storageManager, plainId)).toEqual([]);
       expect(
         tx.getCfcState().diagnostics.filter((d) => d.includes("writer-fit")),
@@ -2303,6 +2308,11 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           "writer-fit confidentiality misfit",
         );
         expect(committed.error?.message).toContain(`for ${storeId} at /`);
+        // The stored value pins the store the forged marker named, so the
+        // absent declaration below is that document's own.
+        expect(storedDocument(storageManager, storeId)?.value).toEqual({
+          copied: "public",
+        });
         expect(
           replicaEntries(storageManager, storeId).some((entry) =>
             entry.origin === "declared"
@@ -3336,6 +3346,11 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
             flag.includes(`${substrateId} at /`)
           ),
         ).toBe(true);
+        // The stored value pins the flagged document, so the absent
+        // declaration below is that document's own.
+        expect(storedDocument(storageManager, substrateId)?.value).toEqual({
+          copied: "s3cr3t!",
+        });
         expect(
           replicaEntries(storageManager, substrateId)
             .filter((entry) => entry.origin === "declared"),
@@ -3461,6 +3476,11 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
         expect(committed.error?.message).toContain(
           "writer-fit confidentiality misfit",
         );
+        // The stored value pins the bystander, so the absent declaration
+        // below is that document's own.
+        expect(storedDocument(storageManager, bystanderId)?.value).toEqual({
+          note: "public",
+        });
         expect(
           replicaEntries(storageManager, bystanderId)
             .filter((entry) => entry.origin === "declared"),


### PR DESCRIPTION
PROBLEM

A test reaching the CFC label map writes a chain like

    replica.getDocument(id)?.cfc?.labelMap?.entries ?? []

Four states read as the same empty list: the replica holds no value for the document, the document carries no `cfc` metadata, that metadata carries no `labelMap`, and the label map holds no matching entry. An assertion over that list saying an entry is absent therefore also passes when the label-map machinery persisted nothing whatsoever. Eighteen such assertions, across seventeen cases in fourteen files under `packages/runner/test`, read documents no passing run stamps, so nothing a change did to that machinery could turn them red. Two of those cases never asserted the entry they are named for at all. Two snapshot equalities elsewhere compare a document's entries across a re-derivation and hold trivially when both sides are empty.

SOLUTION

Each case now pins the chain before asserting over it. A positive companion the same helper reads back from the same document closes all four states at once, and where the run labels nothing there, the case names the value the document stores, which is what says the document is there. `cfc-observation-classes` pins it once inside `flowJoinOf`, which every case in that file reads its join through. The two snapshot equalities assert the entry they compare is there to compare. `unit-test-coding-style.md` gains the hazard beside the `SpaceReplica.getDocument()` one it extends: that collapse is the first of these four states, and the chain adds three more.

DESIGN DISCUSSION

Each finding is established by breaking what the assertion is about and confirming the case fails: every persisted label-map read in the file rewritten to yield nothing, or the document read rewritten to yield `undefined`. Running that over every test file in `packages/runner/test` that reaches a persisted label map is what found them, and each fix is rechecked the same way.

A companion read from a different document is not enough on its own. It says the machinery works and says nothing about the document under assertion, which a second mutation exposes: replacing the identifier that assertion reads with one no run writes leaves such a case green while the companion goes on reading the document it did pin. Two cases stood in that position and now name their own document's value.

Two files reach the map through `readStoredCfcMetadata()`, whose chain carries no `cfc` segment, so a search keyed on that segment passes over them. Searching for `labelMap.entries` with the segment optional covers both spellings and adds ten files across the runner suite; those two are the only ones holding an absence assertion that survives the break.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

