### PR TITLE
refactor(ts-transformers): the emit-side parens strips share one documented definition

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1064,6 +1064,15 @@ narrower paths beside it. The lift is then applied to the whole object and
 re-runs for any field of it, where it could have been applied to the one field
 the body reads.
 
+The set has one deliberately narrow reader on the way out. When the rewriter
+synthesizes an `ifElse`/`when`/`unless` call, `unwrapParentheses` tidies the
+operands placed in the call, and the probe recognizing a zero-arg inline IIFE
+callee reads through the same function: parentheses alone come off. Every
+other transparent wrapper can carry a type, and schema injection still reads
+operand types at those argument positions, so `as`, `<T>x`, `satisfies`, and
+`!` stay on the operands — a ternary branch reading `state.note!` keeps a
+non-nullable operand schema because the assertion stays in the tree.
+
 Key rewrite rules:
 
 - `a && b`: lowers to `when(condition, value)` only in pattern context

--- a/packages/ts-transformers/src/transformers/builtins/ifelse.ts
+++ b/packages/ts-transformers/src/transformers/builtins/ifelse.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 import { CFHelpers } from "../../core/mod.ts";
+import { unwrapParentheses } from "../../utils/expression.ts";
 
 export interface IfElseParams {
   expression: ts.ConditionalExpression;
@@ -18,16 +19,15 @@ export interface IfElseOverrides {
 export function createIfElseCall(params: IfElseParams): ts.CallExpression {
   const { cfHelpers, overrides, expression } = params;
 
-  let predicate = overrides?.predicate ?? expression.condition;
-  let whenTrue = overrides?.whenTrue ?? expression.whenTrue;
-  let whenFalse = overrides?.whenFalse ?? expression.whenFalse;
-  while (ts.isParenthesizedExpression(predicate)) {
-    predicate = predicate.expression;
-  }
-  while (ts.isParenthesizedExpression(whenTrue)) whenTrue = whenTrue.expression;
-  while (ts.isParenthesizedExpression(whenFalse)) {
-    whenFalse = whenFalse.expression;
-  }
+  const predicate = unwrapParentheses(
+    overrides?.predicate ?? expression.condition,
+  );
+  const whenTrue = unwrapParentheses(
+    overrides?.whenTrue ?? expression.whenTrue,
+  );
+  const whenFalse = unwrapParentheses(
+    overrides?.whenFalse ?? expression.whenFalse,
+  );
 
   return cfHelpers.createHelperCall(
     "ifElse",
@@ -51,14 +51,8 @@ export interface WhenParams {
 export function createWhenCall(params: WhenParams): ts.CallExpression {
   const { cfHelpers, condition, value } = params;
 
-  let cond = condition;
-  let val = value;
-  while (ts.isParenthesizedExpression(cond)) {
-    cond = cond.expression;
-  }
-  while (ts.isParenthesizedExpression(val)) {
-    val = val.expression;
-  }
+  const cond = unwrapParentheses(condition);
+  const val = unwrapParentheses(value);
 
   return cfHelpers.createHelperCall(
     "when",
@@ -75,14 +69,8 @@ export function createWhenCall(params: WhenParams): ts.CallExpression {
 export function createUnlessCall(params: WhenParams): ts.CallExpression {
   const { cfHelpers, condition, value } = params;
 
-  let cond = condition;
-  let val = value;
-  while (ts.isParenthesizedExpression(cond)) {
-    cond = cond.expression;
-  }
-  while (ts.isParenthesizedExpression(val)) {
-    val = val.expression;
-  }
+  const cond = unwrapParentheses(condition);
+  const val = unwrapParentheses(value);
 
   return cfHelpers.createHelperCall(
     "unless",

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/call-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/call-expression.ts
@@ -8,6 +8,7 @@ import {
   isSyntheticNode,
 } from "../../../ast/mod.ts";
 import { getCellKind } from "../../cell-type.ts";
+import { unwrapParentheses } from "../../../utils/expression.ts";
 import { classifyOpaquePathTerminalCall } from "../../opaque-roots.ts";
 import { createLiftAppliedCall } from "../../builtins/lift-applied.ts";
 import { createReactiveWrapperForExpression } from "../rewrite-helpers.ts";
@@ -31,10 +32,10 @@ function getZeroArgInlineIifeCallee(
     return undefined;
   }
 
-  let callee: ts.Expression = expression.expression;
-  while (ts.isParenthesizedExpression(callee)) {
-    callee = callee.expression;
-  }
+  // Parentheses only: a callee under a type assertion is not recognized as an
+  // inline IIFE — the assertion re-types the call, and the general call
+  // lowering handles it.
+  const callee = unwrapParentheses(expression.expression);
 
   return ts.isArrowFunction(callee) || ts.isFunctionExpression(callee)
     ? callee

--- a/packages/ts-transformers/src/utils/expression.ts
+++ b/packages/ts-transformers/src/utils/expression.ts
@@ -68,6 +68,28 @@ export function unwrapExpression(expr: ts.Expression): ts.Expression {
 }
 
 /**
+ * The expression with directly nested parentheses removed and every other
+ * transparent wrapper kept.
+ *
+ * The deliberately narrow companion to {@link unwrapExpression} for a caller
+ * that rebuilds emitted code around the expression rather than classifying
+ * it. Parentheses never change the type the checker reports, so removing them
+ * removes only noise in the printed output. Every other wrapper can change it
+ * — `as` and `<T>x` assert a type, `satisfies` shapes what a literal infers
+ * as, `!` drops the nullable arms — and the schema stages read operand types
+ * at the argument positions such a caller builds, so a wrapper stripped there
+ * is a schema changed: a ternary branch reading `state.note!` keeps a
+ * non-nullable operand schema only while the assertion stays in the tree.
+ */
+export function unwrapParentheses(expr: ts.Expression): ts.Expression {
+  let current = expr;
+  while (ts.isParenthesizedExpression(current)) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/**
  * The outermost expression that still denotes the same value as `expr`: `expr`
  * itself when nothing wraps it, otherwise the last transparent wrapper stacked
  * around it.

--- a/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
+++ b/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
@@ -17,7 +17,9 @@ import ts from "typescript";
 
 import { transformFiles, transformSource, validateSource } from "./utils.ts";
 import {
+  callSchemas,
   callsMatching,
+  callsNamed,
   hasKeyPathRead,
   parseModule,
 } from "./transformed-ast.ts";
@@ -363,5 +365,88 @@ describe("transparent wrapper consistency", () => {
 
       expect(normalizeDataFlows(graphOf(a!, b!)).length).toBe(2);
     });
+  });
+
+  describe("conditional-helper operand tidying", () => {
+    // The synthesized `ifElse`/`when`/`unless` operands read a deliberately
+    // narrower set than the classifying stages: `unwrapParentheses` strips
+    // only parentheses, because the schema stages read operand types at these
+    // argument positions and every other transparent wrapper can carry a
+    // type. These pin both halves — the tidying, and the wrapper that must
+    // survive it.
+
+    const source = (ui: string) =>
+      `      import { pattern, UI } from "commonfabric";
+      interface Input {
+        flag: boolean;
+        label: string;
+        note?: string;
+      }
+      export default pattern<Input>((state) => ({
+        [UI]: ${ui},
+      }));
+    `;
+
+    const undefinedArmed = (schema: Record<string, unknown>): boolean =>
+      Array.isArray(schema.type) && schema.type.includes("undefined");
+
+    it("keeps the operand schema non-nullable for a non-null asserted branch", async () => {
+      const output = await transformSource(
+        source(`<p>{state.flag ? (state.note)! : "off"}</p>`),
+        { types: COMMONFABRIC_TYPES },
+      );
+      const schemas = callSchemas(parseModule(output), "ifElse");
+
+      expect(schemas.length).toBeGreaterThan(0);
+      expect(schemas.some(undefinedArmed)).toBe(false);
+    });
+
+    it("emits the `undefined` arm for the same branch without the assertion", async () => {
+      // The control: the `undefined` arm is present until the author asserts
+      // it away, so its absence in the asserted case is the assertion's doing.
+
+      const output = await transformSource(
+        source(`<p>{state.flag ? state.note : "off"}</p>`),
+        { types: COMMONFABRIC_TYPES },
+      );
+      const schemas = callSchemas(parseModule(output), "ifElse");
+
+      expect(schemas.some(undefinedArmed)).toBe(true);
+    });
+
+    const TIDIED: readonly {
+      helper: string;
+      ui: string;
+      operand: string;
+    }[] = [
+      {
+        helper: "ifElse",
+        ui: `<p>{state.flag ? ("on") : "off"}</p>`,
+        operand: "on",
+      },
+      { helper: "when", ui: `<p>{state.flag && ("yes")}</p>`, operand: "yes" },
+      {
+        helper: "unless",
+        ui: `<p>{state.label || ("fallback")}</p>`,
+        operand: "fallback",
+      },
+    ];
+
+    for (const { helper, ui, operand } of TIDIED) {
+      it(`strips redundant parentheses from the synthesized \`${helper}\` operands`, async () => {
+        const output = await transformSource(source(ui), {
+          types: COMMONFABRIC_TYPES,
+        });
+        const call = callsNamed(parseModule(output), helper).at(-1);
+
+        expect(call).toBeDefined();
+        expect(call!.arguments.some(ts.isParenthesizedExpression)).toBe(false);
+        expect(
+          call!.arguments.some((argument) =>
+            ts.isStringLiteral(argument) && argument.text === operand
+          ),
+        ).toBe(true);
+      });
+    }
   });
 });


### PR DESCRIPTION
The transparent-wrapper unification arc (#6274, #6463) left one catalogued
residue: eight parens-only unwrap loops on the emit side — seven in
`builtins/ifelse.ts` tidying the operands of synthesized
`ifElse`/`when`/`unless` calls, one in
`expression-rewrite/emitters/call-expression.ts` probing a zero-arg IIFE
callee. The task was a decision: (a) route them through the shared
`unwrapExpression`, proving no behavior change, or (b) keep the narrow set and
document why. This PR is (b), and the reason is stronger than "deliberately
narrow": **the narrowness is load-bearing**, which probing (a) demonstrates
directly.

## Why not (a): stripping type-bearing wrappers moves emitted schemas

Probe: minimal patterns exercising each of the eight operand positions across
wrapper spellings (bare / parens / `as` / `satisfies` / `!`), compiled through
the real pipeline via the package's `transformSource` harness, on `main`
versus an (a)-patched build (all eight loops switched to `unwrapExpression`).

The (a) patch does not just delete surviving wrapper text — it changes the
schemas the operands are served. The realistic case: with `note?: string`,

```tsx
<p>{state.flag ? state.note! : "off"}</p>
```

emits an operand schema of `{ type: "string" }` on `main`, and
`{ type: ["string", "undefined"] }` under (a) — the author's non-null
assertion is silently discarded. A branch cast (`("on") as never`) similarly
flips that operand's emitted schema from `false` (the `never` schema) to the
bare literal's schema.

Mechanism: the expression-site lowering stages run before `SchemaInjection` /
`SchemaGenerator`, and those stages read checker types at the synthesized
call's argument nodes. Today the wrapper node *is* the argument, so the type
it asserts is the type the schema derives from. `unwrapExpression` on the way
out would discard authored type intent — parentheses are the only member of
the transparent set that can never change the checker-reported type, so
parens-only is exactly the safe subset for a site that rebuilds emitted code.
This is the same reasoning `stripSyntacticWrappers` in
`pattern-body-reactive-root-lowering.ts` documents for its own narrow set.

The IIFE-callee probe is different: there the narrowness is currently inert —
`main` and the (a) patch emit byte-identical output for cast/`satisfies`/`!`
callee spellings on bodies with and without direct cell reads. It stays
narrow with its own one-line rationale (a callee under a type assertion is
not recognized as an inline IIFE; the assertion re-types the call, and the
general call lowering handles it).

## Shape of (b): one definition instead of eight undocumented copies

`src/utils/expression.ts` already states the arc's rule: *"A stripper that
reads a narrower set does so deliberately, and says why at its own
definition."* The eight loops now do exactly that — they collapse into one
named definition, `unwrapParentheses`, beside the transparent set, whose doc
comment carries the why. No behavior change: the probe corpus is
byte-identical between this branch and `main` across every case and spelling
(verified against the current base after rebasing over ~430 commits,
including the #7140/#7153 conditional-lowering changes), and
`UPDATE_GOLDENS=1` moves zero fixtures.

## Tests

`test/transparent-wrapper-consistency.test.ts` gains a
"conditional-helper operand tidying" describe pinning both halves:

- a non-null asserted branch keeps a non-nullable operand schema, with a
  control proving the `undefined` arm exists without the assertion (so the
  pin cannot pass vacuously);
- redundant parentheses are stripped from the operands of all three
  synthesized helpers.

Forced-positive matrix (each new assertion demonstrated able to fail against
the drift it guards):

| `unwrapParentheses` body      | schema pin | parens pins |
| ----------------------------- | ---------- | ----------- |
| full `unwrapExpression` strip | FAILS      | pass        |
| identity (no strip)           | passes     | FAIL ×3     |
| parens-only (shipped)         | pass       | pass        |

## Docs

Spec §7.2 (`ts_transformers_current_behavior_spec.md`) documents the narrow
emit-side reader alongside the section's existing wrapper-set prose, per the
package rule that transformer behavior descriptions live there.

## Gates

On the current base: repo-wide `deno fmt --check`, `deno lint`,
`deno task check`; full `packages/ts-transformers` suite (1165 passed /
0 failed); `UPDATE_GOLDENS=1` with zero golden movement and a clean tree;
`deno task cfcheck`; `check-docs`, `check-conflict-markers`,
`check-control-characters`, `check-no-waitfor`, `check-skill-facts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

