### PR TITLE
perf(cli): select receipts before loading linked results

### DIFF
--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -247,9 +247,14 @@ cf piece call --cell <topic> addComment '{"body":"first","agentName":"Sol"}' \
 }
 ```
 
-This shapes a result that already exists rather than deciding what travels: the
-readback has the whole receipt in hand before the selection runs. So a
-value-less verb keeps reporting no `result` at all — there is nothing for a
+A selection over a schemaless handler receipt first loads the receipt without
+following its children. If it holds an object or array, the selection reads from
+that container and can avoid fetching unselected linked content. Root links,
+instances, scalars, and receipts read through an explicit schema are materialized
+before selection, as are tool results. A root link can resolve to an absent
+value, so its stored existence alone does not establish a result.
+
+A value-less verb keeps reporting no `result` at all — there is nothing for a
 selection to be about — and `--no-wait`, which never reads the receipt back,
 refuses all three flags. `--show-links` composes with a projection, because a
 projection leaves every surviving path where it was; it does not compose with

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1217,9 +1217,8 @@ no longer say which positions they came from, and an address names a position.
 A selection over a schemaless handler receipt starts by loading the receipt
 without following its children. If it holds an object or array, the CLI selects
 from that container directly. An address-only selection can therefore return a
-stored child link without loading the child. The receipt's declared result
-schema remains available for cycle bounding; it does not replace the selection's
-source schema.
+stored child link without loading the child. The verb's declared result remains
+available for cycle bounding; it does not replace the selection's source schema.
 
 Root links, instances, scalars, and receipts read through an explicit schema are
 materialized before selection. A root link can resolve to an absent value, so
@@ -1236,7 +1235,7 @@ order; that step starts no graph or storage work. When isolating the read
 matters, shape the collect instead. Call plain (or `--no-wait`), then collect
 from the receipt with `cf cell get --cell <receipt id> --select …`.
 
-Three cases follow from that:
+Selections also follow these rules:
 
 - **A value-less verb still reports nothing.** Its receipt is the empty witness,
   and the Invocation JSON omits `result` to say so. A selection is about a

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1045,18 +1045,20 @@ constructs its first storage read from the union of predicate-observed and
 projected paths. Structurally declared properties, including local `$ref` item
 schemas, are pruned to that union: predicate-only fields can decide membership
 without appearing in the result, and omitted linked subgraphs are not hydrated.
-Schema-less or root-union sources retain a value-shape read before the transform
-because their array/object projection semantics cannot be established from the
-declaration. Ambiguous source-schema compositions remain intact and can retain a
-wider selector. The runtime's list filter/map builtins therefore handle CFC
-exactly as authored pattern expressions do: predicate observations label array
-membership, projection reads propagate labels, and filtered elements retain
-their source links. Projection map/lift nodes construct the requested shape from
-a source-schema-selected read rather than returning a widening identity alias.
-Nested non-stream Cell handles are materialized before the predicate/projection
-JavaScript runs; stream handles remain capabilities. The source cell's schema
-remains authoritative for Common Fabric metadata. A caller cannot introduce or
-override `ifc`, `asCell`, `scope`, or `default` through `--schema`.
+A schemaless source first loads its stored root without following children; an
+object or array establishes its projection shape directly. Root links and
+instances need materialization, as do ambiguous schema unions, whose schema can
+transform the stored value. Ambiguous source-schema compositions remain intact
+and can retain a wider selector. The runtime's list filter/map builtins
+therefore handle CFC exactly as authored pattern expressions do: predicate
+observations label array membership, projection reads propagate labels, and
+filtered elements retain their source links. Projection map/lift nodes construct
+the requested shape from a source-schema-selected read rather than returning a
+widening identity alias. Nested non-stream Cell handles are materialized before
+the predicate/projection JavaScript runs; stream handles remain capabilities.
+The source cell's schema remains authoritative for Common Fabric metadata. A
+caller cannot introduce or override `ifc`, `asCell`, `scope`, or `default`
+through `--schema`.
 
 #### Which keywords a `--schema` projection may contain
 
@@ -1212,25 +1214,27 @@ no longer say which positions they came from, and an address names a position.
 
 #### What a selection means for a call
 
-A selection shapes a result that already exists. It does not narrow what the
-call fetches: the readback materializes the whole receipt before the selection
-runs. (A plain result's receipt does carry a descriptive schema of what it holds
-— a receipt holding anything reactive carries none — but either way the fetch
-has happened before the selection applies.) The same holds for a tool, whose
-result is read off the cell the tool wrote. Use a selection to control what
-reaches stdout, not to control what travels.
+A selection over a schemaless handler receipt starts by loading the receipt
+without following its children. If it holds an object or array, the CLI selects
+from that container directly. An address-only selection can therefore return a
+stored child link without loading the child. The receipt's declared result
+schema remains available for cycle bounding; it does not replace the selection's
+source schema.
 
-A selection also adds a computed read after the call. The shaped readback runs
-through the same shared read step as `cf cell get`, and waits for its output
-with one `Cell.pull()`. That pull drives the output's transitive computation and
-linked-document loads through the runtime scheduler and its manager-wide
-convergence pool, so work already active in that runtime can still share the
-wait. Declared object keys are then ordered locally from the projection before
-rendering, and the keys an open projection retains beyond its declaration follow
-them in the value's own order; that step starts no graph or storage work. When
-isolating the read matters, shape the collect instead. Call plain (or
-`--no-wait`), then collect from the receipt with
-`cf cell get --cell <receipt id> --select …`.
+Root links, instances, scalars, and receipts read through an explicit schema are
+materialized before selection. A root link can resolve to an absent value, so
+its stored existence alone does not establish a result. Tool calls also
+materialize their result before selection.
+
+A shaped readback uses the same shared read step as `cf cell get`. Its
+`Cell.pull()` calls drive transitive computation and linked-document loads
+through the runtime scheduler and its manager-wide convergence pool, so work
+already active in that runtime can still share the wait. Declared object keys
+are then ordered locally from the projection before rendering, and the keys an
+open projection retains beyond its declaration follow them in the value's own
+order; that step starts no graph or storage work. When isolating the read
+matters, shape the collect instead. Call plain (or `--no-wait`), then collect
+from the receipt with `cf cell get --cell <receipt id> --select …`.
 
 Three cases follow from that:
 

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -190,13 +190,13 @@ export interface CallableExecutionDeps {
    * linked contents are fetched. Other receipts are materialized before
    * selection to establish whether a result exists. The shared step waits
    * for its computed output with `Cell.pull()`, whose scheduler and
-   * linked-document convergence pool
-   * are runtime/manager-wide; a shaped call can therefore still share a wait
-   * with active work that the plain call's transaction-local acknowledgment
-   * does not. Declared object keys are ordered locally from the projection
-   * after that readiness boundary, with an open projection's retained extras
-   * following in value order. A verb that returns nothing keeps returning
-   * nothing — there is no value for a selection to be about. */
+   * linked-document convergence pool are runtime/manager-wide; a shaped call
+   * can therefore still share a wait with active work that the plain call's
+   * transaction-local acknowledgment does not. Declared object keys are ordered
+   * locally from the projection after that readiness boundary, with an open
+   * projection's retained extras following in value order. A verb that returns
+   * nothing keeps returning nothing — there is no value for a selection to be
+   * about. */
   selection?: CellSelection;
 
   /** @internal Seam for tests, mirroring `getCellValue`'s. */
@@ -1743,17 +1743,11 @@ export async function executeResolvedCallable(
           () => stored.pull(),
         );
         raw = stored.getRaw();
-        // A stored container establishes presence without loading its children.
-        // A root link needs materialization: its target can be absent.
-        if (isStoredContainer(raw)) {
-          value = raw;
-        } else {
-          value = await timeCliPhase(
-            "executeCallable.receipt.pull",
-            () => receipt.pull(),
-          );
-          raw = receipt.getRaw();
-        }
+      }
+      // A stored container establishes presence without loading its children.
+      // A root link needs materialization: its target can be absent.
+      if (isStoredContainer(raw)) {
+        value = raw;
       } else {
         value = await timeCliPhase(
           "executeCallable.receipt.pull",

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -45,6 +45,7 @@ import {
   type CellSelection,
   CellSelectionError,
   deriveSelectedValue,
+  isStoredContainer,
   LINK_MARKER_KEY,
 } from "./cell-selection.ts";
 import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
@@ -185,12 +186,11 @@ export interface CallableExecutionDeps {
    * to arrive in. Answered by the same selection step `cf cell get` reads
    * through, so one grammar covers reads and calls.
    *
-   * It shapes a result that exists rather than deciding what is fetched: the
-   * readback has already materialized the whole receipt by the time this
-   * applies. (A plain result's receipt does carry a descriptive schema of
-   * what it holds — a reactive result's carries none — but either way the
-   * fetch has happened first.) The shared step waits for its computed output
-   * with `Cell.pull()`, whose scheduler and linked-document convergence pool
+   * A schemaless receipt holding a stored container is selected before its
+   * linked contents are fetched. Other receipts are materialized before
+   * selection to establish whether a result exists. The shared step waits
+   * for its computed output with `Cell.pull()`, whose scheduler and
+   * linked-document convergence pool
    * are runtime/manager-wide; a shaped call can therefore still share a wait
    * with active work that the plain call's transaction-local acknowledgment
    * does not. Declared object keys are ordered locally from the projection
@@ -1734,10 +1734,33 @@ export async function executeResolvedCallable(
     let links: Record<string, InvocationResultLink> | undefined;
     if (link) {
       const receipt = resolved.pieces.runtime.getCellFromLink<any>(link);
-      const value = await timeCliPhase(
-        "executeCallable.receipt.pull",
-        () => receipt.pull(),
-      );
+      let value: unknown;
+      let raw: unknown;
+      if (deps.selection !== undefined && receipt.schema === undefined) {
+        const stored = receipt.asSchema(false);
+        await timeCliPhase(
+          "executeCallable.receipt.probe",
+          () => stored.pull(),
+        );
+        raw = stored.getRaw();
+        // A stored container establishes presence without loading its children.
+        // A root link needs materialization: its target can be absent.
+        if (isStoredContainer(raw)) {
+          value = raw;
+        } else {
+          value = await timeCliPhase(
+            "executeCallable.receipt.pull",
+            () => receipt.pull(),
+          );
+          raw = receipt.getRaw();
+        }
+      } else {
+        value = await timeCliPhase(
+          "executeCallable.receipt.pull",
+          () => receipt.pull(),
+        );
+        raw = receipt.getRaw();
+      }
       // A value-less verb's receipt is an empty record — existence-only.
       // Presence is decided on the receipt's STORED value, never on the
       // materialized one: a `FabricInstance` crossing the cell read arrives
@@ -1748,7 +1771,6 @@ export async function executeResolvedCallable(
       // the plain empty record; every other stored shape — plain JSON, the
       // link a launched or chained-cell result converts to, an instance's
       // codec form, a keyless raw primitive — is a result.
-      const raw = receipt.getRaw();
       const valueLess = isObjectNotArray(raw) && !isInstance(raw) &&
         Object.keys(raw).length === 0;
       if (value !== undefined && !valueLess) {

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -6,10 +6,12 @@
  */
 
 import type { Cell } from "@commonfabric/api";
+import { ANNOTATION_KEYS } from "@commonfabric/piece/schema-compatibility";
 import {
   ContextualFlowControl,
   createBuilder,
   deepEqual,
+  isLink,
   type JSONSchema,
   KeepAsCell,
   type MemorySpace,
@@ -25,9 +27,12 @@ import {
   resolveCfcSchemaRef,
   resolveCfcSchemaRefs,
 } from "@commonfabric/runner/cfc/schema-refs";
-import { ANNOTATION_KEYS } from "@commonfabric/piece/schema-compatibility";
 import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
-import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
+import {
+  isInstance,
+  isObjectNotArray,
+  isObjectOrArray,
+} from "@commonfabric/utils/types";
 import { runtimeErrorLog } from "./callable.ts";
 import {
   declaredFieldNames,
@@ -3083,6 +3088,27 @@ export interface DeriveSelectedValueDependencies {
 }
 
 /**
+ * Whether a raw cell value establishes its container shape without following
+ * a link or materializing a Fabric instance.
+ */
+export function isStoredContainer(value: unknown): boolean {
+  return isObjectOrArray(value) && !isInstance(value) && !isLink(value);
+}
+
+/** Reads a schemaless root's array shape without traversing its children. */
+async function sourceRootIsArray(cell: Cell<unknown>): Promise<boolean> {
+  if (cell.schema === undefined) {
+    const stored = cell.asSchema(false);
+    await stored.pull();
+    const raw = stored.getRaw();
+    if (isStoredContainer(raw)) return Array.isArray(raw);
+  }
+  // A link can point at another shape, and a schema can transform the stored
+  // value. Materialization decides those cases.
+  return Array.isArray(await cell.pull());
+}
+
+/**
  * Applies `selection` to `sourceCell` through an actual runtime pattern graph,
  * returning the value the caller asked for.
  *
@@ -3143,7 +3169,7 @@ export async function deriveSelectedValue(
 
   const rootKind = schemaRootKind(sourceSchema);
   const sourceIsArray = rootKind === "unknown"
-    ? Array.isArray(await sourceValueCell.pull())
+    ? await sourceRootIsArray(sourceValueCell)
     : rootKind === "array";
   if (selection.filter !== undefined && !sourceIsArray) {
     throw new CellSelectionError(

--- a/packages/cli/test/piece-call-receipt-selection.test.ts
+++ b/packages/cli/test/piece-call-receipt-selection.test.ts
@@ -1,0 +1,371 @@
+/** Exercises receipt selections against a cold replica of a shared store. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import {
+  type Cell,
+  type IExtendedStorageTransaction,
+  type JSONSchema,
+  type MemorySpace,
+  Runtime,
+} from "@commonfabric/runner";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
+import {
+  EmulatedStorageManager,
+  newLoopbackServer,
+} from "@commonfabric/runner/storage/cache.deno";
+
+import {
+  type CallableExecutionDeps,
+  type CallableResolution,
+  executeResolvedCallable,
+} from "../lib/callable.ts";
+import {
+  parseSelectionFilter,
+  parseSelectionProjection,
+  parseSelectProjection,
+} from "../lib/cell-selection.ts";
+
+/** Cells seeded on one replica and inspected from another. */
+interface Fixture {
+  /** The durable outcome supplied by the dispatch double. */
+  receipt: Cell<unknown>;
+
+  /** Linked documents whose delivery the test observes. */
+  targets: Cell<unknown>[];
+}
+
+/** Runs production readback over stored cells; only dispatch is a double. */
+async function withReceipt(
+  seed: (
+    runtime: Runtime,
+    space: MemorySpace,
+    tx: IExtendedStorageTransaction,
+  ) => Fixture,
+  check: (
+    execute: (deps?: CallableExecutionDeps) => ReturnType<
+      typeof executeResolvedCallable
+    >,
+    received: (cell: Cell<unknown>) => boolean,
+    fixture: Fixture,
+  ) => Promise<void>,
+): Promise<void> {
+  const signer = await Identity.fromPassphrase("receipt-selection");
+  const server = newLoopbackServer({ subscriptionRefreshDelayMs: 0 });
+  const writerStorage = EmulatedStorageManager.connectTo(server, {
+    as: signer,
+  });
+  const readerStorage = EmulatedStorageManager.connectTo(server, {
+    as: signer,
+  });
+  const errors: string[] = [];
+  const writer = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager: writerStorage,
+  });
+  const reader = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager: readerStorage,
+    errorHandlers: [(error) => errors.push(error.message)],
+  });
+  try {
+    const tx = writer.edit();
+    const fixture = seed(writer, signer.did(), tx);
+    writer.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await writerStorage.synced();
+    const link = fixture.receipt.getAsNormalizedFullLink();
+    const resolution = {
+      callableCell: {
+        schema: { asCell: ["stream"] },
+        send: (_value: unknown, onCommit?: (tx: unknown) => void) => {
+          // A same-id collision reads the winner's stored outcome. No handler
+          // or derived computation runs on the reader to populate its cache.
+          onCommit?.({
+            status: () => ({
+              status: "error",
+              error: Object.assign(new Error("Receipt exists"), {
+                precondition: "receipt-exists",
+              }),
+            }),
+            handlingReceiptLink: link,
+          });
+        },
+      },
+      callableKind: "handler",
+      cellKey: "create",
+      pieces: { runtime: reader, getSpace: () => signer.did() },
+      space: signer.did(),
+    } as unknown as CallableResolution;
+    await check(
+      (deps = {}) =>
+        executeResolvedCallable(resolution, {}, {
+          invocation: { id: "inv:receipt", session: "ses:receipt" },
+          ...deps,
+        }),
+      (cell) =>
+        readerStorage.open(signer.did()).replica.getDocument(
+          cell.getAsNormalizedFullLink().id,
+        ) !== undefined,
+      fixture,
+    );
+    expect(errors).toEqual([]);
+  } finally {
+    await reader.dispose();
+    await writer.dispose();
+    await readerStorage.close();
+    await writerStorage.close();
+    await server.close();
+  }
+}
+
+/** Stores a record receipt with cold linked content beneath each field. */
+function seedRecord(
+  runtime: Runtime,
+  space: MemorySpace,
+  tx: IExtendedStorageTransaction,
+  schema: JSONSchema | undefined = {
+    type: "object",
+    properties: { topic: true, other: true },
+  },
+): Fixture {
+  const body = runtime.getCell<unknown>(space, "body", undefined, tx);
+  body.set("Unselected body");
+  const topic = runtime.getCell<unknown>(space, "topic", undefined, tx);
+  topic.set({ title: "Stored title", body: body.getAsLink() });
+  const other = runtime.getCell<unknown>(space, "other", undefined, tx);
+  other.set({ title: "Unselected sibling" });
+  const receipt = runtime.getCell<unknown>(space, "receipt", undefined, tx);
+  receipt.set({ topic: topic.getAsLink(), other: other.getAsLink() });
+  if (schema !== undefined) {
+    receipt.setMetaRaw("schema", schema, rawMetaWriteAuthorization);
+  }
+  return { receipt, targets: [topic, body, other] };
+}
+
+describe("piece call receipt selection", () => {
+  it("returns a stored child address without delivering that child or its siblings", async () => {
+    await withReceipt(seedRecord, async (execute, received, fixture) => {
+      const output = await execute({
+        selection: { projection: parseSelectProjection("topic@") },
+      });
+      const topicAddress = `/${
+        fixture.targets[0].getAsNormalizedFullLink().id
+      }`;
+      expect(output.invocation?.deduplicated).toBe(true);
+      expect(output.invocation?.result).toEqual({
+        topic: { $link: topicAddress },
+      });
+      expect(received(fixture.receipt)).toBe(true);
+      expect(fixture.targets.map(received)).toEqual([false, false, false]);
+    });
+  });
+
+  it("returns a JSON-schema address selection without delivering the target", async () => {
+    await withReceipt(seedRecord, async (execute, received, fixture) => {
+      const output = await execute({
+        selection: {
+          projection: await parseSelectionProjection(
+            '{"properties":{"topic":{"$link":true}}}',
+          ),
+        },
+      });
+      expect(output.invocation?.result).toEqual({
+        topic: { $link: `/${fixture.targets[0].getAsNormalizedFullLink().id}` },
+      });
+      expect(fixture.targets.map(received)).toEqual([false, false, false]);
+    });
+  });
+
+  it("returns a selected field from a cold receipt", async () => {
+    await withReceipt(seedRecord, async (execute) => {
+      const output = await execute({
+        selection: { projection: parseSelectProjection("topic.title") },
+      });
+      expect(output.invocation?.result).toEqual({
+        topic: { title: "Stored title" },
+      });
+    });
+  });
+
+  it("keeps a declared result bound separate from the caller's selection", async () => {
+    await withReceipt(
+      (runtime, space, tx) =>
+        seedRecord(runtime, space, tx, {
+          type: "object",
+          properties: {
+            topic: {
+              type: "object",
+              properties: { title: { type: "string" } },
+            },
+          },
+        }),
+      async (execute) => {
+        const output = await execute({
+          selection: { projection: parseSelectProjection("other.title") },
+        });
+        expect(output.invocation?.result).toEqual({
+          other: { title: "Unselected sibling" },
+        });
+      },
+    );
+  });
+
+  it("filters and projects a stored array", async () => {
+    await withReceipt(
+      (runtime, space, tx) => {
+        const fixture = seedRecord(runtime, space, tx);
+        fixture.receipt.set([
+          {
+            keep: true,
+            title: "Kept",
+            details: fixture.targets[0].getAsLink(),
+          },
+          {
+            keep: false,
+            title: "Dropped",
+            details: fixture.targets[2].getAsLink(),
+          },
+        ]);
+        fixture.receipt.setMetaRaw(
+          "schema",
+          { type: "array" },
+          rawMetaWriteAuthorization,
+        );
+        return fixture;
+      },
+      async (execute) => {
+        const output = await execute({
+          selection: {
+            filter: parseSelectionFilter(".keep == true"),
+            projection: parseSelectProjection("title"),
+          },
+        });
+        expect(output.invocation?.result).toEqual([{ title: "Kept" }]);
+      },
+    );
+  });
+
+  it("keeps an empty witness absent from the selected invocation result", async () => {
+    await withReceipt(
+      (runtime, space, tx) => {
+        const fixture = seedRecord(runtime, space, tx, {
+          type: "object",
+          properties: {},
+        });
+        fixture.receipt.set({});
+        return fixture;
+      },
+      async (execute) => {
+        const output = await execute({
+          selection: { projection: parseSelectProjection("@") },
+        });
+        expect(output.invocation?.result).toBeUndefined();
+      },
+    );
+  });
+
+  it("collects backing links from the selected result", async () => {
+    await withReceipt(seedRecord, async (execute, _received, fixture) => {
+      const output = await execute({
+        selection: { projection: parseSelectProjection("topic@") },
+        showLinks: true,
+      });
+      expect(output.invocation?.links).toEqual({
+        "/": `/${fixture.receipt.getAsNormalizedFullLink().id}`,
+        "/topic": `/${fixture.targets[0].getAsNormalizedFullLink().id}`,
+      });
+    });
+  });
+
+  it("reads a legacy receipt whose root shape has no schema", async () => {
+    await withReceipt(
+      (runtime, space, tx) => {
+        const fixture = seedRecord(runtime, space, tx);
+        fixture.receipt.setMetaRaw(
+          "schema",
+          undefined,
+          rawMetaWriteAuthorization,
+        );
+        return fixture;
+      },
+      async (execute, _received, fixture) => {
+        const output = await execute({
+          selection: { projection: parseSelectProjection("topic@") },
+        });
+        expect(output.invocation?.result).toEqual({
+          topic: {
+            $link: `/${fixture.targets[0].getAsNormalizedFullLink().id}`,
+          },
+        });
+      },
+    );
+  });
+
+  it("materializes a root link before selecting its target", async () => {
+    await withReceipt(
+      (runtime, space, tx) => {
+        const fixture = seedRecord(runtime, space, tx);
+        fixture.receipt.set(fixture.targets[0].getAsLink());
+        fixture.receipt.setMetaRaw(
+          "schema",
+          { type: "object" },
+          rawMetaWriteAuthorization,
+        );
+        return fixture;
+      },
+      async (execute, received, fixture) => {
+        const output = await execute({
+          selection: { projection: parseSelectProjection("title") },
+        });
+        expect(output.invocation?.result).toEqual({ title: "Stored title" });
+        expect(received(fixture.targets[0])).toBe(true);
+      },
+    );
+  });
+
+  it("omits a result when a root link resolves to an absent document", async () => {
+    await withReceipt(
+      (runtime, space, tx) => {
+        const fixture = seedRecord(runtime, space, tx);
+        const absent = runtime.getCell(space, "absent", undefined, tx);
+        fixture.receipt.set(absent.getAsLink());
+        fixture.receipt.setMetaRaw(
+          "schema",
+          { type: "object" },
+          rawMetaWriteAuthorization,
+        );
+        return fixture;
+      },
+      async (execute) => {
+        const output = await execute({
+          selection: { projection: parseSelectProjection("@") },
+        });
+        expect(output.invocation?.result).toBeUndefined();
+      },
+    );
+  });
+
+  it("keeps JSON null distinct from a value-less receipt", async () => {
+    await withReceipt(
+      (runtime, space, tx) => {
+        const fixture = seedRecord(runtime, space, tx);
+        fixture.receipt.set(null);
+        fixture.receipt.setMetaRaw(
+          "schema",
+          undefined,
+          rawMetaWriteAuthorization,
+        );
+        return fixture;
+      },
+      async (execute) => {
+        const output = await execute({
+          selection: { projection: await parseSelectionProjection("true") },
+        });
+        expect(output.invocation?.result).toBe(null);
+      },
+    );
+  });
+});

--- a/packages/cli/test/piece-call-receipt-selection.test.ts
+++ b/packages/cli/test/piece-call-receipt-selection.test.ts
@@ -51,6 +51,7 @@ async function withReceipt(
     received: (cell: Cell<unknown>) => boolean,
     fixture: Fixture,
   ) => Promise<void>,
+  declaredResult?: CallableResolution["declaredResult"],
 ): Promise<void> {
   const signer = await Identity.fromPassphrase("receipt-selection");
   const server = newLoopbackServer({ subscriptionRefreshDelayMs: 0 });
@@ -95,6 +96,7 @@ async function withReceipt(
         },
       },
       callableKind: "handler",
+      declaredResult,
       cellKey: "create",
       pieces: { runtime: reader, getSpace: () => signer.did() },
       space: signer.did(),
@@ -190,18 +192,9 @@ describe("piece call receipt selection", () => {
     });
   });
 
-  it("keeps a declared result bound separate from the caller's selection", async () => {
+  it("returns a caller-selected field outside the verb's declared result", async () => {
     await withReceipt(
-      (runtime, space, tx) =>
-        seedRecord(runtime, space, tx, {
-          type: "object",
-          properties: {
-            topic: {
-              type: "object",
-              properties: { title: { type: "string" } },
-            },
-          },
-        }),
+      seedRecord,
       async (execute) => {
         const output = await execute({
           selection: { projection: parseSelectProjection("other.title") },
@@ -210,6 +203,17 @@ describe("piece call receipt selection", () => {
           other: { title: "Unselected sibling" },
         });
       },
+      () =>
+        Promise.resolve({
+          type: "object",
+          properties: {
+            topic: {
+              type: "object",
+              properties: { title: { type: "string" } },
+            },
+          },
+          additionalProperties: false,
+        }),
     );
   });
 

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1720,6 +1720,7 @@ function createPieceCallableHarness(options: {
   };
 
   const defaultReceiptCell = {
+    asSchema: () => defaultReceiptCell,
     get: () => options.receiptValue,
     pull: () => Promise.resolve(options.receiptValue),
     // The stored form presence is decided on. Defaults to the materialized
@@ -3192,7 +3193,8 @@ function linkedReceiptCell(
   const resolvedRoot = root.doc
     ? build(root, root.doc, root.doc.path ?? [])
     : build(root, receiptDoc, receiptDoc.path ?? []);
-  return mockCell({
+  const receipt = mockCell({
+    asSchema: () => receipt,
     get: () => value,
     pull: () => Promise.resolve(value),
     // These receipts hold plain JSON, whose stored form is the value itself;
@@ -3202,6 +3204,7 @@ function linkedReceiptCell(
     resolveAsCell: () => resolvedRoot,
     getAsNormalizedFullLink: () => mockLink(receiptDoc),
   });
+  return receipt;
 }
 
 /**
@@ -3746,6 +3749,7 @@ describe("call selection", () => {
     // through, pointed at the cell the value was read from — so the shaped
     // answer carries the source's own links rather than a copy of a copy.
     const receiptCell = {
+      asSchema: () => receiptCell,
       get: () => topicResult,
       pull: () => Promise.resolve(topicResult),
       getRaw: () => topicResult,

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -365,16 +365,18 @@ compose as filter-then-project. Both run through runtime filter/map/lift nodes,
 which construct projected values from source-schema-selected reads. A declared
 root shape and structurally selectable properties make the initial read the
 union of predicate and projection paths, so omitted linked subgraphs are not
-hydrated; ambiguous compositions can retain a wider selector, and schema-less or
-root-union sources need a value-shape read first. CFC behavior is the same as a
-computed pattern expression. Source schema metadata is authoritative; projection
-schemas cannot supply `ifc`, `asCell`, `scope`, or `default`. A projection marks
-a position to get that position's address — one string in the canonical
-reference syntax `/[@did/]<id>[@scope][/path]`, where the space rides in front
-only when it differs from the space the command targeted and the scope follows
-the id only when it is not the default, no schema inlined — instead of what is
-behind it, or beside a projection to get both. A JSON `--schema` marks with
-`"$link": true`; a field list marks with a trailing `@`, so
+hydrated; ambiguous compositions can retain a wider selector. A schemaless
+source probes its stored root without following children; a stored object or
+array establishes the shape directly. Root links, instances, and root-union
+schemas need materialization to establish that shape. CFC behavior is the same
+as a computed pattern expression. Source schema metadata is authoritative;
+projection schemas cannot supply `ifc`, `asCell`, `scope`, or `default`. A
+projection marks a position to get that position's address — one string in the
+canonical reference syntax `/[@did/]<id>[@scope][/path]`, where the space rides
+in front only when it differs from the space the command targeted and the scope
+follows the id only when it is not the default, no schema inlined — instead of
+what is behind it, or beside a projection to get both. A JSON `--schema` marks
+with `"$link": true`; a field list marks with a trailing `@`, so
 `--select 'topic@,topic.title'` returns one `topic` carrying its address and its
 title. A path that is only `@` marks the position the read is already at, so
 `--select '@'` returns the source's own address and `--select '@,title'` returns
@@ -422,15 +424,15 @@ handler's `result` inside the Invocation JSON, or a tool's JSON on stdout:
 deno task cf piece call --cell ID addTopic '{"title":"Ship it"}' -- --select topic.title
 ```
 
-A selection shapes a result that already exists; it does not narrow what the
-call fetches — the readback materializes the whole receipt before the selection
-runs (a plain result's receipt carries a descriptive schema of what it holds; a
-reactive one carries none). A value-less verb therefore still reports no
-`result` at all rather than `{}` — but a selection that keeps nothing from a
-result that does exist is refused, so the two stay distinguishable. A shaped
-call also waits on the CLI runtime's global idle, not just its own handling's
-commit, so on a piece with heavy derived state prefer calling plain (or
-`--no-wait`) and shaping the collect:
+A selection can narrow a handler receipt's linked fetches: a schemaless receipt
+holding a stored object or array is selected before its children are loaded.
+Root links, instances, scalars, explicitly schema-constrained receipts, and tool
+results are materialized before selection. A value-less verb therefore still
+reports no `result` at all rather than `{}` — but a selection that keeps nothing
+from a result that does exist is refused, so the two stay distinguishable. A
+shaped call also waits on the CLI runtime's global idle, not just its own
+handling's commit, so on a piece with heavy derived state prefer calling plain
+(or `--no-wait`) and shaping the collect:
 `cf cell get --cell <receipt id> --select …`. `--no-wait` refuses all three
 flags, since it skips the receipt readback they are answered from.
 `--show-links` composes with a projection — links are collected after the


### PR DESCRIPTION
An address-only handler result such as `cf piece call … -- --select topic@` materializes the complete receipt before returning one link. On an existing Topics receipt, this loads 160 documents to print the topic's address.

Probe schemaless receipts with a rejecting schema first. A stored object or array establishes presence without fetching its children, so the existing selection step can run directly. Its own schemaless root-shape probe now also inspects the stored container instead of materializing the full value. Root links, instances, scalars, and explicitly constrained schemas retain materialized reads.

The original source schema, declared-result cycle bounds, value-less witness handling, commit acknowledgment, and runtime-wide convergence remain intact. In particular, a verb's compact result declaration does not become a new restriction on the caller's selection. CLI documentation and the cf skill describe the readback behavior.

Five alternating pairs against the **existing** Estuary measurement receipt, using the actual callable readback and a dispatch double that never executes the handler:

| Readback measure | Main | Patched |
| --- | ---: | ---: |
| Ordinary median, instrumentation off | 240.7 ms | 46.9 ms |
| Ordinary range | 238.7–242.7 ms | 40.4–49.7 ms |
| Instrumented median, separate five-pair series | 227.1 ms | 44.7 ms |
| Documents delivered | 160 | 1 |
| Inbound memory-protocol bytes | 154,854 | 3,833 |
| Transactions | 0 | 0 |

All outputs matched. Baseline client: `49d99e11a`; server remained `a5ed830f06827ce1b9bc0dfbe0b6a023315f3268`, `serverExecution=false`; Apple M5 Max, Deno 2.9.4. The receipt was `/of:fid1:QSQriEoJIDWA5N65LL6qrPvKHz6XjH8I6xzuOPpRWd8` in `topics-dev-476ea34f`. Connection setup is excluded from the readback timer; bytes include memory-session setup. The traced series enables phase/frame logging, without CPU sampling or idempotency checking.

**This measures receipt collection, not a complete topic creation.** The earlier 2.786-second creation readback also waited on active derivations. This experiment isolates roughly 194 ms of ordinary readback savings; it does not establish how much of that larger wait a full create recovers. The shared projection graph and `--show-links` can still fetch additional linked content.

Validation:

- New cold-replica tests cover both address-selection spellings, projected fields, arrays, existing-receipt deduplication, legacy receipts, empty witnesses, null, root links, absent targets, and link annotations. Both fetch-width regression cases fail on unmodified main.
- Existing compiled cyclic-result and cell-selection/CFC tests pass.
- Root format, lint, type check, and skill-fact checks pass.
- Full CLI package `deno task test` passes, including the compiled cyclic-result tests and serial subprocess/Git tests.

Prepared by Codex/Astra on behalf of Gideon (@mathpirate).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

