### PR TITLE
fix(piece): a default inside an allOf branch is merged into the value

### DIFF
--- a/docs/specs/json_schema.md
+++ b/docs/specs/json_schema.md
@@ -165,22 +165,42 @@ consolidated specification, and
 for the rules in the query pipeline's context, including the rollback flag
 and the cfc-relevance marking that stays independent of the combination.
 
-## Unsupported Features
+## What each operation supports
 
-We currently don't support a significant subset of JSON Schema validation
-features. While this list isn't exhaustive, here are some key limitations:
+How much of the vocabulary is implemented depends on which operation is asking.
+Two operations ask different questions of a schema, and they answer to different
+subsets of it.
 
-The `anyOf` field has limited support. Some parts of our codebase handle `anyOf`
-well, while others are restricted to matching only primitives.
+**Traversal** is a filter. It decides which linked cells a read loads and which
+properties come back, so it implements the keywords that shape a value and
+ignores the ones that only accept or reject a whole value. It follows `$ref`,
+`anyOf`, `oneOf`, `allOf`, `properties`, `additionalProperties`, `items` and
+`prefixItems`, and it checks `type` and `required`. It does not check
+`maxProperties`, `uniqueItems`, `enum` or `const`, and a value violating one of
+those reads back unchanged. It does not follow `patternProperties` either: a
+property whose only description is a pattern is neither shaped by that pattern
+nor admitted by it through a closed object.
+[Traversal](space-model/8-traversal.md) is the specification, including how
+`anyOf`, `oneOf` and `allOf` branch results are merged, which is
+runtime-specific rather than standard. Narrowing a schema across a path
+boundary can be more permissive than standard semantics, for the reason
+[Schema Narrowing](#schema-narrowing) gives below.
 
-The following operations have minimal or no support:
+**Validation** answers whether a value satisfies a schema, and it is the
+operation a verb call's payload, a pattern's structured result, and a stored
+argument are measured by. It implements nearly the whole 2020-12 vocabulary:
+`allOf`, `anyOf`, `oneOf`, `not`, `if`, `then`, `else`, `enum`, `const`,
+`contains`, `maxContains`, `propertyNames`, `dependentSchemas`,
+`dependentRequired`, `maxProperties`, `uniqueItems` and `patternProperties` are
+each enforced. Two keywords are not: `unevaluatedProperties` and
+`unevaluatedItems` are accepted and never applied, so a schema relying on one
+of them constrains nothing. `contentSchema` is refused rather than ignored —
+validating it reports that content validation is not supported.
 
-- Core logic: `allOf`, `anyOf`, `oneOf`, `not`
-- Core conditionals: `if`, `then`, `else`
-- Validation: `enum`
-
-Generally, these limitations make our system more permissive than standard JSON
-Schema implementations.
+The gap between the two matters where a value crosses from one to the other. A
+value that reads back through traversal is not thereby a value validation
+accepts, and a schema whose only constraint is one traversal ignores enforces
+nothing until something validates against it.
 
 ## TypeScript Type Mappings
 

--- a/docs/specs/json_schema.md
+++ b/docs/specs/json_schema.md
@@ -199,8 +199,8 @@ validating it reports that content validation is not supported.
 
 The gap between the two matters where a value crosses from one to the other. A
 value that reads back through traversal is not thereby a value validation
-accepts, and a schema whose only constraint is one traversal ignores enforces
-nothing until something validates against it.
+accepts. Traversal ignores some keywords entirely, so a schema built only from
+those rejects nothing until something validates against it.
 
 ## TypeScript Type Mappings
 

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -23,7 +23,10 @@ import {
   UNUSED_SINGLE_SUBSCHEMA_KEYS,
 } from "@commonfabric/runner/schema-walk";
 import { internSchema } from "@commonfabric/data-model-schema";
-import { fabricAwareEqual } from "@commonfabric/data-model";
+import {
+  fabricAwareEqual,
+  isKeyableObjectOrArray,
+} from "@commonfabric/data-model";
 
 type SchemaObject = Exclude<JSONSchema, boolean>;
 type SchemaRole = "argument" | "result";
@@ -214,6 +217,39 @@ const SUBSCHEMA_MAP_KEYS: ReadonlySet<string> = new Set<string>([
 const holdsSubschemas = (key: string): boolean =>
   SUBSCHEMA_KEYS.has(key) || SUBSCHEMA_LIST_KEYS.has(key) ||
   SUBSCHEMA_MAP_KEYS.has(key);
+
+/**
+ * Every schema written directly inside `value`, reached by following each
+ * keyword of the vocabulary above that `skip` does not name.
+ *
+ * A keyword can hold something other than the array or the record its shape
+ * calls for. Such a value describes no nested schema, and nothing is returned
+ * for it. Otherwise the keyword's contents come back as they were written. A
+ * schema that arrived from a space can carry anything in a subschema position,
+ * so a caller that needs schemas narrows each child itself.
+ */
+function subschemaChildren(
+  value: object,
+  skip?: ReadonlySet<string>,
+): unknown[] {
+  const record = value as Record<string, unknown>;
+  const children: unknown[] = [];
+  for (const key of SUBSCHEMA_KEYS) {
+    const nested = record[key];
+    if (!skip?.has(key) && nested !== undefined) children.push(nested);
+  }
+  for (const key of SUBSCHEMA_LIST_KEYS) {
+    const nested = record[key];
+    if (!skip?.has(key) && Array.isArray(nested)) children.push(...nested);
+  }
+  for (const key of SUBSCHEMA_MAP_KEYS) {
+    const nested = record[key];
+    if (!skip?.has(key) && isKeyableObjectOrArray(nested)) {
+      children.push(...Object.values(nested));
+    }
+  }
+  return children;
+}
 
 /**
  * The keys inside a `writeAuthorizedBy` writer claim's `__ctWriterIdentityOf`
@@ -1687,6 +1723,64 @@ type ActiveSchemasByStability = WeakMap<
   { stable: WeakSet<object>; unstable: WeakSet<object> }
 >;
 
+/**
+ * The keywords {@link schemaHasUnsafeMaterializedDefault} does not follow. A
+ * `default` written under one of these is never merged into a value, so no
+ * constraint written above it can be broken by merging it.
+ *
+ * Every other keyword of the vocabulary above is followed. `allOf` is one of
+ * those. Reading a value through a schema that has an `allOf` reads it through
+ * each branch merged with the rest of the schema, so a `default` inside a
+ * branch is merged into the value the read returns.
+ *
+ * Five of the keywords below are left out because of what the keyword means,
+ * and the comment on each says which. The other seven do describe the value or
+ * part of it. They are left out for a narrower reason: no code that fills a
+ * value from a schema descends them. That is a fact about
+ * `SchemaObjectTraverser` (`packages/runner/src/traverse.ts`),
+ * `extractDefaultValues` (`packages/runner/src/runner-utils.ts`) and
+ * `processDefaultValue` (`packages/runner/src/schema.ts`) rather than about the
+ * keywords. Nothing here would fail if one of those changed, so a test carries
+ * the claim instead of this sentence.
+ * `schema-compatibility-default-reach.test.ts` reads a value through a schema
+ * carrying a default under each keyword named below, and fails naming the
+ * keyword if one of those defaults is merged in.
+ *
+ * A keyword this set does not name is followed whether or not a default under
+ * it can reach a value. `patternProperties` is such a keyword, and the same
+ * test measures it. Following a keyword a default cannot reach refuses an
+ * update that was safe. Stopping at a keyword a default can reach accepts one
+ * that was not. Refusing a safe update is the failure to prefer.
+ *
+ * @internal Exported for testing only.
+ */
+export const DEFAULT_INERT_SUBSCHEMA_KEYS: ReadonlySet<string> = new Set([
+  // Describes the values the schema rejects. A default written under it names
+  // a value the schema refuses, so nothing merges that value in.
+  "not",
+  // Constrains the names of an object's members. A default supplies a value,
+  // and a name is not a value.
+  "propertyNames",
+  // Describes what the string decodes to. That is not part of the value tree,
+  // so there is nowhere under it for a default to be merged.
+  "contentSchema",
+  // Hold definitions nothing reads directly. A definition a value takes is
+  // reached through the `$ref` that names it, and `resolveSchema` follows every
+  // `$ref` this walk passes.
+  ...DEFS_KEYS,
+  "definitions",
+  // Apply to the value once their condition holds.
+  "if",
+  "then",
+  "else",
+  "dependentSchemas",
+  // Applies to one element of an array, without saying which one.
+  "contains",
+  // Apply to the members and elements no other keyword accounted for.
+  "unevaluatedProperties",
+  "unevaluatedItems",
+]);
+
 /** Whether target default merging can violate an ancestor constraint. */
 function schemaHasUnsafeMaterializedDefault(
   input: JSONSchema,
@@ -1726,36 +1820,14 @@ function schemaHasUnsafeMaterializedDefault(
       return true;
     }
 
-    const children: JSONSchema[] = [];
-    for (
-      const collection of [
-        schema.properties,
-        schema.patternProperties,
-      ]
-    ) {
-      if (collection !== undefined) {
-        children.push(...Object.values(collection));
-      }
-    }
-    for (const child of [schema.additionalProperties, schema.items]) {
-      if (child !== undefined) children.push(child);
-    }
-    for (
-      const collection of [
-        schema.prefixItems,
-        schema.anyOf,
-        schema.oneOf,
-      ]
-    ) {
-      if (collection !== undefined) children.push(...collection);
-    }
-    return children.some((child) =>
-      schemaHasUnsafeMaterializedDefault(
-        child,
-        resolution.root,
-        unstable,
-        activeByRoot,
-      )
+    return subschemaChildren(schema, DEFAULT_INERT_SUBSCHEMA_KEYS).some(
+      (child) =>
+        schemaHasUnsafeMaterializedDefault(
+          child as JSONSchema,
+          resolution.root,
+          unstable,
+          activeByRoot,
+        ),
     );
   } finally {
     activeForPath.delete(schema);
@@ -1772,24 +1844,8 @@ function collectSchemaReferences(
   const record = value as Record<string, unknown>;
   if (typeof record.$ref === "string") refs.add(record.$ref);
 
-  for (const key of SUBSCHEMA_KEYS) {
-    collectSchemaReferences(record[key], refs, seen);
-  }
-  for (const key of SUBSCHEMA_LIST_KEYS) {
-    const children = record[key];
-    if (Array.isArray(children)) {
-      for (const child of children) {
-        collectSchemaReferences(child, refs, seen);
-      }
-    }
-  }
-  for (const key of SUBSCHEMA_MAP_KEYS) {
-    const children = record[key];
-    if (children !== null && typeof children === "object") {
-      for (const child of Object.values(children)) {
-        collectSchemaReferences(child, refs, seen);
-      }
-    }
+  for (const child of subschemaChildren(value)) {
+    collectSchemaReferences(child, refs, seen);
   }
 }
 

--- a/packages/piece/test/schema-compatibility-default-reach.test.ts
+++ b/packages/piece/test/schema-compatibility-default-reach.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Which `default` values written inside a schema are merged into a value read
+ * through that schema.
+ *
+ * Reading a value through a destination schema merges that schema's defaults
+ * into it, so `assertSchemaSubset` walks a destination for every `default` that
+ * sits below a constraint merging it could break.
+ * `DEFAULT_INERT_SUBSCHEMA_KEYS` says which keywords that walk stops at, and a
+ * keyword is named there because no default under it is ever merged in.
+ *
+ * These tests boot a runtime and read a value through each such schema, so the
+ * decision recorded in `packages/piece` rests on measured `packages/runner`
+ * behavior rather than on an assumption about it.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  extractDefaultValues,
+  type IExtendedStorageTransaction,
+  type JSONSchema,
+  Runtime,
+} from "@commonfabric/runner";
+import { validateSchemaValue } from "@commonfabric/runner/cfc";
+import type { JSONSchemaObj } from "@commonfabric/api";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Identity } from "@commonfabric/identity";
+import {
+  assertSchemaSubset,
+  DEFAULT_INERT_SUBSCHEMA_KEYS,
+} from "../src/schema-compatibility.ts";
+
+const signer = await Identity.fromPassphrase("schema compatibility reach");
+const space = signer.did();
+
+/**
+ * An object schema naming a member `a` with a default beside a member `b`
+ * without one. Written under a keyword a read descends, the default on `a` is
+ * merged into the value.
+ */
+const defaultedMember: JSONSchema = {
+  type: "object",
+  properties: {
+    b: { type: "number" },
+    a: { type: "number", default: 0 },
+  },
+};
+
+/**
+ * One case per keyword {@link DEFAULT_INERT_SUBSCHEMA_KEYS} names. Each case
+ * gives a schema carrying a default under that keyword, a value to read through
+ * it, and what `validateSchemaValue` says about the pair.
+ *
+ * Each schema is shaped so that the default would be merged in if anything read
+ * the keyword at all. `then` and `else` come with the `if` that selects them,
+ * and the array keywords come with an array.
+ *
+ * Most cases carry {@link defaultedMember}. Two cannot. `not` describes the
+ * values the schema rejects, so its case carries a schema `{ b: 2 }` does not
+ * match. `propertyNames` constrains names rather than values, so its case
+ * carries a string default.
+ */
+const DEFAULT_UNDER_INERT_KEYWORD: Record<
+  string,
+  { schema: JSONSchemaObj; stored: unknown; validationIssue?: string }
+> = {
+  not: {
+    schema: { type: "object", not: { type: "number", default: 5 } },
+    stored: { b: 2 },
+  },
+  propertyNames: {
+    schema: {
+      type: "object",
+      propertyNames: { type: "string", default: "a" },
+    },
+    stored: { b: 2 },
+  },
+  contentSchema: {
+    schema: { type: "string", contentSchema: defaultedMember },
+    stored: "b",
+    validationIssue: "content validation is not supported",
+  },
+  $defs: {
+    schema: {
+      type: "object",
+      $defs: { Dormant: defaultedMember },
+      properties: { b: { type: "number" } },
+    },
+    stored: { b: 2 },
+  },
+  definitions: {
+    schema: {
+      type: "object",
+      definitions: { Dormant: defaultedMember },
+      properties: { b: { type: "number" } },
+    },
+    stored: { b: 2 },
+  },
+  if: {
+    schema: { type: "object", if: defaultedMember },
+    stored: { b: 2 },
+  },
+  then: {
+    schema: { type: "object", if: { type: "object" }, then: defaultedMember },
+    stored: { b: 2 },
+  },
+  else: {
+    schema: { type: "object", if: { type: "string" }, else: defaultedMember },
+    stored: { b: 2 },
+  },
+  dependentSchemas: {
+    schema: { type: "object", dependentSchemas: { b: defaultedMember } },
+    stored: { b: 2 },
+  },
+  contains: {
+    schema: { type: "array", contains: defaultedMember },
+    stored: [{ b: 2 }],
+  },
+  unevaluatedProperties: {
+    schema: { type: "object", unevaluatedProperties: defaultedMember },
+    stored: { b: { b: 2 } },
+  },
+  unevaluatedItems: {
+    schema: { type: "array", unevaluatedItems: defaultedMember },
+    stored: [{ b: 2 }],
+  },
+};
+
+/** Whether `value` or anything nested inside it carries a `default`. */
+function carriesDefault(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  return Object.hasOwn(value, "default") ||
+    Object.values(value).some(carriesDefault);
+}
+
+/**
+ * An `allOf` branch naming a member with a default. The constraint on the
+ * whole object outside the branch is one that a second member breaks.
+ */
+const boundedObjectWithDefaultUnderAllOf: JSONSchema = {
+  type: "object",
+  maxProperties: 1,
+  allOf: [defaultedMember],
+};
+
+describe("schema-compatibility-default-reach", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let cellCount = 0;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /** What `stored` reads back as when it is read through `schema`. */
+  function readThrough(schema: JSONSchema, stored: unknown): unknown {
+    const cell = runtime.getCell<unknown>(
+      space,
+      `default reach ${cellCount++}`,
+      undefined,
+      tx,
+    );
+    cell.set(stored);
+    return cell.asSchema(schema).get();
+  }
+
+  it("merges a default written under `allOf` into the value read", () => {
+    // This is why the walk follows `allOf`. `{ b: 2 }` satisfies the schema,
+    // and reading `{ b: 2 }` through that same schema returns a value the
+    // schema rejects.
+
+    expect(validateSchemaValue(boundedObjectWithDefaultUnderAllOf, { b: 2 }))
+      .toBeUndefined();
+
+    const read = readThrough(boundedObjectWithDefaultUnderAllOf, { b: 2 });
+    expect(read).toEqual({ b: 2, a: 0 });
+    expect(validateSchemaValue(boundedObjectWithDefaultUnderAllOf, read))
+      .toBe("object has more than maxProperties 1");
+  });
+
+  it("refuses a link whose target carries that default", () => {
+    expect(() =>
+      assertSchemaSubset(
+        boundedObjectWithDefaultUnderAllOf,
+        boundedObjectWithDefaultUnderAllOf,
+      )
+    ).toThrow(/not stable under default insertion/);
+  });
+
+  it("leaves a default written under `patternProperties` out of the value read", () => {
+    // The walk follows `patternProperties` even though no default under it is
+    // ever merged into a value. The comment on
+    // `DEFAULT_INERT_SUBSCHEMA_KEYS` gives that as the side to err on, and
+    // this case is the part of that claim a test can hold.
+
+    const schema: JSONSchemaObj = {
+      type: "object",
+      patternProperties: { "^i": defaultedMember },
+    };
+    expect(readThrough(schema, { i: { b: 2 } })).toEqual({ i: { b: 2 } });
+    expect(extractDefaultValues(schema, schema)).toBeUndefined();
+  });
+
+  it("has a case carrying a default for every keyword named as default-inert", () => {
+    // Both halves matter. Without the first, a keyword added to the set is
+    // never measured. Without the second, a case that forgot its `default`
+    // passes below for a reason that has nothing to do with the keyword.
+
+    expect(Object.keys(DEFAULT_UNDER_INERT_KEYWORD).sort())
+      .toEqual([...DEFAULT_INERT_SUBSCHEMA_KEYS].sort());
+
+    for (
+      const [keyword, { schema }] of Object.entries(DEFAULT_UNDER_INERT_KEYWORD)
+    ) {
+      const under = (schema as Record<string, unknown>)[keyword];
+      expect(carriesDefault(under), keyword).toBe(true);
+    }
+  });
+
+  it("leaves a default written under a default-inert keyword out of the value read", () => {
+    for (
+      const [keyword, { schema, stored, validationIssue }] of Object.entries(
+        DEFAULT_UNDER_INERT_KEYWORD,
+      )
+    ) {
+      expect(validateSchemaValue(schema, stored), keyword).toBe(
+        validationIssue,
+      );
+      expect(readThrough(schema, stored), keyword).toEqual(stored);
+      expect(extractDefaultValues(schema, schema), keyword).toBeUndefined();
+    }
+  });
+});

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -6,6 +6,7 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import {
   assertPatternSchemasBackwardCompatible,
   assertSchemaSubset,
+  DEFAULT_INERT_SUBSCHEMA_KEYS,
   schemasHaveSameContract,
 } from "../src/schema-compatibility.ts";
 
@@ -40,6 +41,16 @@ const oldPattern = pattern(
     required: ["doubled"],
   },
 );
+
+/** An object whose `maxProperties` a second merged member would break. */
+const boundedObject: JSONSchema = {
+  type: "object",
+  maxProperties: 1,
+  properties: {
+    a: { type: "number", default: 0 },
+    b: { type: "number" },
+  },
+};
 
 describe("piece schema compatibility", () => {
   describe("schemasHaveSameContract()", () => {
@@ -1602,6 +1613,123 @@ describe("piece schema compatibility", () => {
     expect(() => assertSchemaSubset(source, target)).toThrow(
       /not stable under default insertion/,
     );
+  });
+
+  it("refuses a target default written under `allOf`", () => {
+    // Reading a value through an `allOf` reads it through each branch merged
+    // with the rest of the schema. A default inside a branch is therefore
+    // merged into the value the read returns. The reads themselves are in
+    // `schema-compatibility-default-reach.test.ts`.
+
+    const branchHoldsBoth: JSONSchema = { allOf: [boundedObject] };
+    expect(() => assertSchemaSubset(branchHoldsBoth, branchHoldsBoth))
+      .toThrow(/not stable under default insertion/);
+
+    const branchBelowAProperty: JSONSchema = {
+      type: "object",
+      properties: { item: { allOf: [boundedObject] } },
+    };
+    expect(() => assertSchemaSubset(branchBelowAProperty, branchBelowAProperty))
+      .toThrow(/not stable under default insertion/);
+
+    const constraintAboveTheBranch: JSONSchema = {
+      type: "object",
+      maxProperties: 1,
+      allOf: [{
+        type: "object",
+        properties: {
+          a: { type: "number", default: 0 },
+          b: { type: "number" },
+        },
+      }],
+    };
+    expect(() =>
+      assertSchemaSubset(constraintAboveTheBranch, constraintAboveTheBranch)
+    ).toThrow(/not stable under default insertion/);
+  });
+
+  it("refuses a default under `allOf` that no constraint above it can break", () => {
+    // What the case above costs. `allOf` is not one of the keywords the walk
+    // treats as stable under default insertion, so reaching an `allOf` marks
+    // everything below it unstable and refuses every default there. Nothing in
+    // this target is unsafe. Its only constraint is an element count, and
+    // merging a member into an element leaves that count as it was. The same
+    // schema written without the `allOf` wrapper is accepted.
+
+    const elements: JSONSchema = {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { a: { type: "number", default: 0 } },
+      },
+    };
+    const wrapped: JSONSchema = {
+      type: "array",
+      maxItems: 1,
+      allOf: [elements],
+    };
+    expect(() => assertSchemaSubset(wrapped, wrapped))
+      .toThrow(/not stable under default insertion/);
+
+    const unwrapped: JSONSchema = { ...elements, maxItems: 1 };
+    expect(() => assertSchemaSubset(unwrapped, unwrapped)).not.toThrow();
+  });
+
+  it("accepts a target default under a default-inert keyword", () => {
+    // Where the walk above stops. Each case writes a default under one of the
+    // keywords the walk does not follow, below the same constraint on the whole
+    // value. No default under any of them is ever merged into a value, so the
+    // link proof stands. Two cases carry a default the others do not: `not`
+    // describes the values the schema rejects, and `propertyNames` constrains
+    // names rather than values.
+
+    const inertKeywordTargets: Record<string, JSONSchema> = {
+      not: { not: { type: "number", default: 5 } },
+      propertyNames: {
+        type: "object",
+        propertyNames: { type: "string", default: "a" },
+      },
+      contentSchema: { type: "string", contentSchema: boundedObject },
+      $defs: { $defs: { Unreferenced: boundedObject }, type: "object" },
+      definitions: {
+        definitions: { Unreferenced: boundedObject },
+        type: "object",
+      },
+      if: { if: boundedObject, type: "object" },
+      then: { if: { type: "object" }, then: boundedObject },
+      else: { if: { type: "string" }, else: boundedObject },
+      dependentSchemas: {
+        type: "object",
+        dependentSchemas: { b: boundedObject },
+      },
+      contains: { type: "array", contains: boundedObject },
+      unevaluatedProperties: {
+        type: "object",
+        unevaluatedProperties: boundedObject,
+      },
+      unevaluatedItems: { type: "array", unevaluatedItems: boundedObject },
+    };
+    expect(Object.keys(inertKeywordTargets).sort())
+      .toEqual([...DEFAULT_INERT_SUBSCHEMA_KEYS].sort());
+
+    for (const [keyword, inert] of Object.entries(inertKeywordTargets)) {
+      const target: JSONSchema = {
+        type: "object",
+        properties: { item: inert },
+      };
+      expect(() => assertSchemaSubset(target, target), keyword).not.toThrow();
+    }
+
+    // A `$defs` body a `$ref` names is one a value can take. The walk resolves
+    // every `$ref` it passes, so the same definition is refused once something
+    // references it.
+    const namedDefinition: JSONSchema = {
+      type: "object",
+      $defs: { Referenced: boundedObject },
+      properties: { item: { $ref: "#/$defs/Referenced" } },
+    };
+    expect(() => assertSchemaSubset(namedDefinition, namedDefinition))
+      .toThrow(/not stable under default insertion/);
   });
 
   it("rejects changed migration defaults below default-unstable constraints", () => {


### PR DESCRIPTION
Two pieces can be joined by a durable link. Proving that link safe means showing that every value the source can hold is a value the destination accepts, and `assertSchemaSubset` is that proof. It has to account for the destination's `default` values. Reading a value through the destination schema merges those defaults into the value before anything validates it, so the value that gets validated is not the value the source held.

Merging a default can break a constraint written above the place the default sits. `maxProperties: 1` on an object is such a constraint: merging a second member into that object leaves it with two. So is `uniqueItems` on an array, and so is a `dependentRequired` pair. The proof therefore walks the whole destination schema looking for a `default` that sits below one of those constraints, and refuses the link when it finds one.

That walk needs to know which keywords hold a nested schema. It carried its own list of them, naming `properties`, `patternProperties`, `additionalProperties`, `items`, `prefixItems`, `anyOf` and `oneOf`, and no others. The rest of this file takes that list from `@commonfabric/runner/schema-walk` instead. That module exists because several hand-written copies of the list had each drifted from it.

The list this walk carried left out `allOf`, and a default inside an `allOf` branch does reach the value. Reading a value through a schema that has an `allOf` reads it through each branch merged with the rest of the schema, in `SchemaObjectTraverser` (runner `traverse.ts`). A `default` inside a branch is therefore merged into the value the read returns, the same way one written beside the `allOf` would be. So the proof accepted this schema as a link destination:

    {
      type: "object",
      maxProperties: 1,
      allOf: [{
        type: "object",
        properties: {
          a: { type: "number", default: 0 },
          b: { type: "number" },
        },
      }],
    }

`{ b: 2 }` satisfies that schema. Reading `{ b: 2 }` through the same schema returns `{ b: 2, a: 0 }`, which has two members and does not satisfy it. The walk now follows `allOf` and refuses the destination.

Eleven keywords are still left out, and the reason for each is now written beside it. Five are left out because of what the keyword means. `not` describes the values the schema rejects. `propertyNames` constrains the names of an object's members rather than their values. `contentSchema` describes what the string decodes to, which is not part of the value tree. `$defs` and `definitions` hold definitions nothing reads directly, because a definition a value takes is reached through the `$ref` that names it, and the walk resolves every `$ref` it passes. A default written under any of those five is never merged into a value.

The other six, and `if`, do describe the value or part of it. They are left out for a narrower reason: no code that fills a value from a schema descends them. That is a fact about `SchemaObjectTraverser`, `extractDefaultValues` and `processDefaultValue` rather than about the keywords, so nothing in this package would fail if one of those three changed. A test carries the claim instead. It reads a value through a schema carrying a default under each of the eleven keywords, asserts that the default is not merged in, and names the keyword when it fails.

The same test measures `patternProperties`, which the walk does follow even though a default under it is never merged in either. That is deliberate. Following a keyword a default cannot reach refuses an update that was safe. Stopping at a keyword a default can reach accepts one that was not. Refusing a safe update is the failure to prefer.

Widening the walk refuses more links than before. A search of `packages/patterns/baselines` finds none of these keywords in any pattern baseline, and a search of `packages/schema-generator` finds `allOf` named only in prose. It follows from those two searches that no generated schema is affected.

`allOf` is also not one of the keywords the walk treats as stable under default insertion. Reaching an `allOf` therefore marks everything below it unstable, and a default below it is refused whether or not any constraint above it could have been broken. A test records that. It pairs such a destination with the same schema written without the `allOf` wrapper, which the proof accepts, so a reader can see that the `allOf` alone is what makes the difference.

The two walks over the keyword list in this file now share one helper, so the reference collector and the default walk can no longer disagree about what a schema's children are. The helper asks whether a value is a container with `isKeyableObjectOrArray`. A fabric special object keeps its state in private fields and has no own properties at all, and that predicate returns `false` for one rather than handing back an empty record to iterate.

`json_schema.md` said the opposite of what this change rests on, and it is corrected here rather than left to mislead the next reader. It listed `allOf`, `anyOf`, `oneOf`, `not`, `if`, `then`, `else` and `enum` under "minimal or no support", and said the limitations make the system more permissive than a standard implementation. That was one answer for two operations that differ.

Traversal is a filter deciding what a read loads and what comes back. It follows `$ref`, `anyOf`, `oneOf`, `allOf`, `properties`, `additionalProperties`, `items` and `prefixItems`, and checks `type` and `required`. It checks none of `maxProperties`, `uniqueItems`, `enum` or `const`, so a value violating one of those reads back unchanged. It does not follow `patternProperties` either: a member matching a pattern that declares the wrong type reads back unshaped, where the same mismatch written under `properties` drops the member.

Validation answers whether a value satisfies a schema, and it is what a verb call's payload, a pattern's structured result and a stored argument are measured by. It enforces every keyword the old list named, along with `contains`, `maxContains`, `propertyNames`, `dependentSchemas`, `dependentRequired`, `maxProperties`, `uniqueItems` and `patternProperties`. Three it does not: `unevaluatedProperties` and `unevaluatedItems` are accepted and never applied, and `contentSchema` is refused outright rather than ignored.

Both lists come from reading a value through each schema against a live runtime and from calling `validateSchemaValue` on each pair. The traversal list agrees with `space-model/8-traversal.md`, which already specified `allOf` branch-result merging and names a conformance test for it. That spec and this one disagreed, and this one was the stale half.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

