### PR TITLE
fix(piece): changeSource verdicts come from commit receipts

### DIFF
--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -528,6 +528,20 @@ export interface PatternUpdateReceipt extends PieceSourceSetResult {
     | { status: "failed"; warning: string };
 }
 
+/**
+ * The verdict {@link PieceController.changeSource} returns: `applied` when
+ * storage accepted the transaction carrying the source transition, and
+ * `incompatible` when the candidate cannot run over the piece's retained
+ * state, with the prepared change a caller may confirm to apply anyway.
+ *
+ * `applied` is the transaction's own outcome, never a read of the piece
+ * beside the call — a read answers what the piece points at now, which a
+ * concurrent later change may have moved, and it resolves from local cache
+ * over a provider failure. `executionWarning` reports a failure in the work
+ * that refreshes the running piece after its transition committed; such a
+ * failure does not undo the accepted transition, the same split
+ * {@link PatternUpdateReceipt}'s `refresh` arm reports for a direct edit.
+ */
 export type PieceSourceActionResult =
   | { status: "applied"; executionWarning?: string }
   | {
@@ -4180,6 +4194,11 @@ export class PieceController<T = unknown> {
         baseline,
       );
       const mutationVersion = ++this.#mutationVersion;
+      // The transaction's own verdict: `editWithRetry` reports a rejected
+      // commit in its result, so past that check the transition is written.
+      // What can still fail is the schema refresh `#runMutation` runs after
+      // the operation, which does not undo the accepted detach.
+      let committed = false;
       try {
         await this.#runMutation(mutationVersion, async () => {
           const result = await this.#pieces.runtime.editWithRetry((tx) => {
@@ -4193,11 +4212,12 @@ export class PieceController<T = unknown> {
             return true;
           });
           if (result.error !== undefined) throw result.error;
+          committed = true;
           return this.#cell;
         });
         return { status: "applied" };
       } catch (error) {
-        if (await this.#sourceTransitionCommitted(transition.revisionId)) {
+        if (committed) {
           return {
             status: "applied",
             executionWarning: pieceSourceErrorMessage(error),
@@ -4420,48 +4440,61 @@ export class PieceController<T = unknown> {
       { selectedRevisionId: prepared.selectedRevisionId },
     );
     const mutationVersion = ++this.#mutationVersion;
+    // The accepted setup transaction's receipt, held exactly when storage
+    // accepted this change's transaction: from the resolved update, or from
+    // the post-commit error that carries it. It is what lets the catch below
+    // tell a transition that landed from one that did not.
+    let commit: PatternSetupCommitReceipt | undefined;
     try {
       await this.#runMutation(mutationVersion, async () => {
-        return await execute(
-          this.#pieces,
-          this.id,
-          candidate,
-          undefined,
-          {
-            start: true,
-            expectedPatternIdentity: previousRef,
-            validateCurrentArgument: acceptedReview === undefined
-              ? undefined
-              : (argumentCell) => {
-                const evidence = pieceSourceArgumentEvidence(
-                  argumentCell,
-                  this.#pieces,
-                );
-                if (evidence !== acceptedReview.argumentEvidence) {
-                  throw new Error(
-                    "the retained piece input changed after compatibility was checked",
+        try {
+          const result = await executePatternUpdate(
+            this.#pieces,
+            this.id,
+            candidate,
+            undefined,
+            {
+              expectedPatternIdentity: previousRef,
+              validateCurrentArgument: acceptedReview === undefined
+                ? undefined
+                : (argumentCell) => {
+                  const evidence = pieceSourceArgumentEvidence(
+                    argumentCell,
+                    this.#pieces,
                   );
+                  if (evidence !== acceptedReview.argumentEvidence) {
+                    throw new Error(
+                      "the retained piece input changed after compatibility was checked",
+                    );
+                  }
+                },
+              validateArgumentLinks: (argumentCell, argumentSchema) => {
+                try {
+                  assertPieceSourceRetainedLinksCompatible(
+                    argumentCell,
+                    argumentSchema,
+                    this.#pieces,
+                    previousPattern.argumentSchema,
+                  );
+                } catch (error) {
+                  const message = error instanceof Error
+                    ? error.message
+                    : String(error);
+                  if (acceptedReview?.issues.retainedLinks === message) return;
+                  throw error;
                 }
               },
-            validateArgumentLinks: (argumentCell, argumentSchema) => {
-              try {
-                assertPieceSourceRetainedLinksCompatible(
-                  argumentCell,
-                  argumentSchema,
-                  this.#pieces,
-                  previousPattern.argumentSchema,
-                );
-              } catch (error) {
-                const message = error instanceof Error
-                  ? error.message
-                  : String(error);
-                if (acceptedReview?.issues.retainedLinks === message) return;
-                throw error;
-              }
+              sourceTransition: transition,
             },
-            sourceTransition: transition,
-          },
-        ) as Cell<T>;
+          );
+          commit = result.commit;
+          return result.cell as Cell<T>;
+        } catch (error) {
+          if (error instanceof PatternSetupPostCommitError) {
+            commit = error.commit;
+          }
+          throw error;
+        }
       });
       // The transition cleared whatever the last reconciliation concluded,
       // and this is the fresh answer: the piece now runs what this origin
@@ -4487,15 +4520,20 @@ export class PieceController<T = unknown> {
       }
       return { status: "applied" };
     } catch (error) {
-      if (await this.#sourceTransitionCommitted(transition.revisionId)) {
+      if (commit !== undefined) {
         // The transition committed and running its source then failed, so
         // neither outcome is true: the piece did not decline this source, and
         // it is not demonstrably running it either. The warning below says
         // what happened, and the next reconciliation settles what the piece
-        // is doing rather than this guessing now.
+        // is doing rather than this guessing now. The wrapper's own message
+        // only restates that split, so the warning carries the cause — the
+        // failure itself — as `setPattern`'s refresh arm does.
+        const cause = error instanceof PatternSetupPostCommitError
+          ? error.cause
+          : error;
         return {
           status: "applied",
-          executionWarning: pieceSourceErrorMessage(error),
+          executionWarning: pieceSourceErrorMessage(cause),
         };
       }
       if (isOverridableArgumentCompatibilityError(error)) {
@@ -4839,24 +4877,6 @@ export class PieceController<T = unknown> {
         this.#cell = cell.asSchema(pattern.resultSchema);
       }
       return;
-    }
-  }
-
-  async #sourceTransitionCommitted(revisionId: string): Promise<boolean> {
-    try {
-      if (
-        getPieceSourceRevisions(this.#cell).some((revision) =>
-          revision.revisionId === revisionId
-        )
-      ) {
-        return true;
-      }
-      await this.#cell.sync();
-      return getPieceSourceRevisions(this.#cell).some((revision) =>
-        revision.revisionId === revisionId
-      );
-    } catch {
-      return false;
     }
   }
 
@@ -5228,6 +5248,12 @@ function pieceSourceTransition(
   };
 }
 
+/**
+ * Helper for `setInput()`, which re-runs the piece's current pattern over a
+ * caller-supplied argument. A source change goes through
+ * `executePatternUpdate` below instead, which carries the transition and
+ * returns the accepted transaction's receipt.
+ */
 async function execute(
   pieces: PiecesController,
   pieceId: string,
@@ -5236,15 +5262,6 @@ async function execute(
   options?: {
     start?: boolean;
     expectedPatternIdentity?: { identity: string; symbol: string };
-    validateCurrentArgument?: (
-      argumentCell: Cell<unknown>,
-    ) => void;
-    validateArgumentLinks?: (
-      argumentCell: Cell<unknown>,
-      argumentSchema: JSONSchema,
-    ) => void;
-    repository?: string;
-    sourceTransition?: PieceSourceTransition;
   },
 ): Promise<Cell<unknown>> {
   return await pieces.runWithPattern(pattern, pieceId, input, options);

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -532,12 +532,14 @@ export interface PatternUpdateReceipt extends PieceSourceSetResult {
  * The verdict {@link PieceController.changeSource} returns: `applied` when
  * storage accepted the transaction carrying the source transition, and
  * `incompatible` when the candidate cannot run over the piece's retained
- * state, with the prepared change a caller may confirm to apply anyway.
+ * state, with the prepared change a caller may confirm to apply anyway. An
+ * update that finds its active origin already current makes no transition;
+ * it reports `applied` after recording that finding.
  *
- * `applied` is the transaction's own outcome, never a read of the piece
- * beside the call — a read answers what the piece points at now, which a
- * concurrent later change may have moved, and it resolves from local cache
- * over a provider failure. `executionWarning` reports a failure in the work
+ * A transition's `applied` is its transaction's own outcome, never a read of
+ * the piece beside the call — a read answers what the piece points at now,
+ * which a concurrent later change may have moved, and it resolves from local
+ * cache over a provider failure. `executionWarning` reports a failure in the work
  * that refreshes the running piece after its transition committed; such a
  * failure does not undo the accepted transition, the same split
  * {@link PatternUpdateReceipt}'s `refresh` arm reports for a direct edit.

--- a/packages/piece/test/piece-source-lifecycle.test.ts
+++ b/packages/piece/test/piece-source-lifecycle.test.ts
@@ -1762,6 +1762,80 @@ describe("piece source lifecycle", () => {
     ).toHaveLength(1);
   });
 
+  it("reports a restore's refresh failure without rereading source history after its receipt", async () => {
+    // What the receipt replaces: confirming the transition by synchronizing
+    // the piece and re-reading its revision list. Such a read answers a
+    // different question — which revisions the piece holds now, after any
+    // concurrent change — and `syncCell` resolves normally over a provider
+    // error, so a cache hit reads as durable truth. The guard is armed the
+    // moment the setup transaction issues its receipt and fails every source
+    // history read from then on, so a read-back added beside the receipt
+    // fails this case rather than quietly agreeing with it.
+
+    const piece = await pieces.create(versionProgram("v1"), { input: {} });
+    await stampOrigin(piece, "system:receipt-guard.tsx");
+    await piece.changeSource({ kind: "detach" });
+    const baseline = (await readPieceSourceState(runtime, piece.getCell()))
+      .history[0];
+    await piece.setPattern(versionProgram("v2"));
+
+    const mutablePieces = pieces as unknown as {
+      syncPattern: typeof pieces.syncPattern;
+    };
+    const syncPattern = pieces.syncPattern;
+    const runSyncedWithCommit = runtime.runSyncedWithCommit.bind(runtime);
+    const cellPrototype = Object.getPrototypeOf(piece.getCell()) as {
+      getMetaRaw: (field: string, options?: unknown) => unknown;
+    };
+    const getMetaRaw = cellPrototype.getMetaRaw;
+    let receiptIssued = false;
+    let sourceHistoryReadsAfterReceipt = 0;
+    mutablePieces.syncPattern = () => {
+      if (!receiptIssued) {
+        throw new Error("post-commit refresh started before the receipt");
+      }
+      throw new Error("injected post-commit refresh failure");
+    };
+    runtime.runSyncedWithCommit = (async (...args) => {
+      const result = await runSyncedWithCommit(...args);
+      receiptIssued = true;
+      return result;
+    }) as typeof runtime.runSyncedWithCommit;
+    cellPrototype.getMetaRaw = function (field, options) {
+      if (receiptIssued && field === "pieceSourceHistory") {
+        sourceHistoryReadsAfterReceipt++;
+        throw new Error(
+          "the commit receipt must not be verified by rereading source history",
+        );
+      }
+      return getMetaRaw.call(this, field, options);
+    };
+    try {
+      const result = await piece.changeSource({
+        kind: "restore",
+        revisionId: baseline.revisionId,
+      });
+
+      expect(receiptIssued).toBe(true);
+      expect(sourceHistoryReadsAfterReceipt).toBe(0);
+      expect(result).toEqual({
+        status: "applied",
+        executionWarning: "injected post-commit refresh failure",
+      });
+    } finally {
+      mutablePieces.syncPattern = syncPattern;
+      runtime.runSyncedWithCommit = runSyncedWithCommit;
+      cellPrototype.getMetaRaw = getMetaRaw;
+    }
+
+    // Read after the guard has proved the restore itself did not.
+    expect(getPatternIdentityRef(piece.getCell())).toEqual(baseline.pattern);
+    expect(
+      (await readPieceSourceState(runtime, piece.getCell())).history.at(-1)
+        ?.operation,
+    ).toBe("revert");
+  });
+
   it("reports a committed detach after a concurrent refresh fails", async () => {
     const piece = await pieces.create(versionProgram("v1"), { input: {} });
     await stampOrigin(piece, "system:detach-refresh.tsx");
@@ -1775,6 +1849,23 @@ describe("piece source lifecycle", () => {
     // Only awaited, never read: this test is about what the newer edit does
     // to the detach beside it, not about what it returns.
     let newerEdit: Promise<unknown> | undefined;
+    const cellPrototype = Object.getPrototypeOf(cell) as {
+      getMetaRaw: (field: string, options?: unknown) => unknown;
+    };
+    const getMetaRaw = cellPrototype.getMetaRaw;
+    // Armed at the refresh failure: from there to the verdict is exactly
+    // where a read-back would run.
+    let refreshFailed = false;
+    let sourceHistoryReadsAfterFailure = 0;
+    cellPrototype.getMetaRaw = function (field, options) {
+      if (refreshFailed && field === "pieceSourceHistory") {
+        sourceHistoryReadsAfterFailure++;
+        throw new Error(
+          "a committed detach must not be verified by rereading source history",
+        );
+      }
+      return getMetaRaw.call(this, field, options);
+    };
 
     runtime.editWithRetry = (async (action, maxRetries) => {
       const result = await originalEditWithRetry(action, maxRetries);
@@ -1787,6 +1878,7 @@ describe("piece source lifecycle", () => {
           heldSyncEntered.resolve();
           return releaseHeldSync.promise.then(() => originalSync());
         }
+        refreshFailed = true;
         return Promise.reject(
           new Error("detach post-commit refresh failed"),
         );
@@ -1801,9 +1893,12 @@ describe("piece source lifecycle", () => {
         status: "applied",
         executionWarning: "detach post-commit refresh failed",
       });
+      expect(sourceHistoryReadsAfterFailure).toBe(0);
     } finally {
       mutableCell.sync = originalSync;
       runtime.editWithRetry = originalEditWithRetry;
+      refreshFailed = false;
+      cellPrototype.getMetaRaw = getMetaRaw;
       releaseHeldSync.resolve();
     }
     await newerEdit;

--- a/packages/piece/test/piece-source-lifecycle.test.ts
+++ b/packages/piece/test/piece-source-lifecycle.test.ts
@@ -1537,15 +1537,15 @@ describe("piece source lifecycle", () => {
     }
 
     const mutablePieces = pieces as unknown as {
-      runWithPattern: typeof pieces.runWithPattern;
+      runPatternUpdate: typeof pieces.runPatternUpdate;
     };
-    const runWithPattern = pieces.runWithPattern.bind(pieces);
-    mutablePieces.runWithPattern = async (...args) => {
+    const runPatternUpdate = pieces.runPatternUpdate.bind(pieces);
+    mutablePieces.runPatternUpdate = async (...args) => {
       await seedLegacyModeLink(
         piece,
         (await secondSource.result.getCell()).key("value"),
       );
-      return await runWithPattern(...args);
+      return await runPatternUpdate(...args);
     };
     try {
       await expect(
@@ -1556,7 +1556,7 @@ describe("piece source lifecycle", () => {
         "retained piece input changed after compatibility was checked",
       );
     } finally {
-      mutablePieces.runWithPattern = runWithPattern;
+      mutablePieces.runPatternUpdate = runPatternUpdate;
     }
   });
 
@@ -1587,10 +1587,10 @@ describe("piece source lifecycle", () => {
     }
 
     const mutablePieces = pieces as unknown as {
-      runWithPattern: typeof pieces.runWithPattern;
+      runPatternUpdate: typeof pieces.runPatternUpdate;
     };
-    const runWithPattern = pieces.runWithPattern.bind(pieces);
-    mutablePieces.runWithPattern = async (...args) => {
+    const runPatternUpdate = pieces.runPatternUpdate.bind(pieces);
+    mutablePieces.runPatternUpdate = async (...args) => {
       const tx = runtime.edit();
       piece.getCell().withTx(tx).setMetaRaw(
         "argument",
@@ -1598,7 +1598,7 @@ describe("piece source lifecycle", () => {
         rawMetaWriteAuthorization,
       );
       await tx.commit();
-      return await runWithPattern(...args);
+      return await runPatternUpdate(...args);
     };
     try {
       await expect(
@@ -1607,7 +1607,7 @@ describe("piece source lifecycle", () => {
         }),
       ).rejects.toThrow("piece missing its current argument");
     } finally {
-      mutablePieces.runWithPattern = runWithPattern;
+      mutablePieces.runPatternUpdate = runPatternUpdate;
     }
   });
 
@@ -1626,15 +1626,15 @@ describe("piece source lifecycle", () => {
     webSources["/api/patterns/new-link-race.tsx"] = optionalModeProgram(2);
 
     const mutablePieces = pieces as unknown as {
-      runWithPattern: typeof pieces.runWithPattern;
+      runPatternUpdate: typeof pieces.runPatternUpdate;
     };
-    const runWithPattern = pieces.runWithPattern.bind(pieces);
-    mutablePieces.runWithPattern = async (...args) => {
+    const runPatternUpdate = pieces.runPatternUpdate.bind(pieces);
+    mutablePieces.runPatternUpdate = async (...args) => {
       await seedLegacyModeLink(
         piece,
         (await source.result.getCell()).key("value"),
       );
-      return await runWithPattern(...args);
+      return await runPatternUpdate(...args);
     };
     try {
       const result = await piece.changeSource({
@@ -1648,7 +1648,7 @@ describe("piece source lifecycle", () => {
         );
       }
     } finally {
-      mutablePieces.runWithPattern = runWithPattern;
+      mutablePieces.runPatternUpdate = runPatternUpdate;
     }
   });
 
@@ -1666,10 +1666,10 @@ describe("piece source lifecycle", () => {
     );
 
     const mutablePieces = pieces as unknown as {
-      runWithPattern: typeof pieces.runWithPattern;
+      runPatternUpdate: typeof pieces.runPatternUpdate;
     };
-    const runWithPattern = pieces.runWithPattern;
-    mutablePieces.runWithPattern = () => {
+    const runPatternUpdate = pieces.runPatternUpdate;
+    mutablePieces.runPatternUpdate = () => {
       throw new Error(
         "piece source is incompatible with retained input: synthetic",
       );
@@ -1682,7 +1682,7 @@ describe("piece source lifecycle", () => {
         }),
       ).rejects.toThrow("retained input: synthetic");
     } finally {
-      mutablePieces.runWithPattern = runWithPattern;
+      mutablePieces.runPatternUpdate = runPatternUpdate;
     }
   });
 
@@ -1698,12 +1698,12 @@ describe("piece source lifecycle", () => {
     webSources["/api/patterns/non-error.tsx"] = versionProgram("candidate");
 
     const mutablePieces = pieces as unknown as {
-      runWithPattern: typeof pieces.runWithPattern;
+      runPatternUpdate: typeof pieces.runPatternUpdate;
     };
-    const runWithPattern = pieces.runWithPattern;
-    mutablePieces.runWithPattern =
+    const runPatternUpdate = pieces.runPatternUpdate;
+    mutablePieces.runPatternUpdate =
       (() =>
-        Promise.reject("raw execution rejection")) as typeof runWithPattern;
+        Promise.reject("raw execution rejection")) as typeof runPatternUpdate;
     let reason: unknown;
     try {
       await piece.changeSource({
@@ -1713,12 +1713,18 @@ describe("piece source lifecycle", () => {
     } catch (error) {
       reason = error;
     } finally {
-      mutablePieces.runWithPattern = runWithPattern;
+      mutablePieces.runPatternUpdate = runPatternUpdate;
     }
     expect(reason).toBe("raw execution rejection");
   });
 
   it("reports a saved transition separately from a later refresh failure", async () => {
+    // Injected at the post-commit work the update path actually performs:
+    // `runPatternUpdate` synchronizes the pattern AFTER its setup transaction
+    // is accepted, so a failure there is the refresh failing over a committed
+    // transition, and the verdict below has to say so from that transaction's
+    // receipt rather than report the transition unsaved.
+
     const piece = await pieces.create(versionProgram("v1"), { input: {} });
     const origin = "system:post-commit.tsx";
     await stampOrigin(piece, origin);
@@ -1728,11 +1734,11 @@ describe("piece source lifecycle", () => {
     await piece.setPattern(versionProgram("v2"));
 
     const mutablePieces = pieces as unknown as {
-      runWithPattern: typeof pieces.runWithPattern;
+      syncPattern: typeof pieces.syncPattern;
     };
-    const runWithPattern = pieces.runWithPattern.bind(pieces);
-    mutablePieces.runWithPattern = async (...args) => {
-      await runWithPattern(...args);
+    const syncPattern = pieces.syncPattern.bind(pieces);
+    mutablePieces.syncPattern = async (...args) => {
+      await syncPattern(...args);
       throw new Error("post-commit refresh failed");
     };
     try {
@@ -1746,7 +1752,7 @@ describe("piece source lifecycle", () => {
         executionWarning: "post-commit refresh failed",
       });
     } finally {
-      mutablePieces.runWithPattern = runWithPattern;
+      mutablePieces.syncPattern = syncPattern;
     }
 
     const state = await readPieceSourceState(runtime, piece.getCell());
@@ -1845,6 +1851,11 @@ describe("piece source lifecycle", () => {
   });
 
   it("recognizes a saved transition even after a newer source change", async () => {
+    // The newer edit lands between this restore's accepted setup transaction
+    // and its failed refresh, so by the time the verdict is classified the
+    // piece is no longer on the restored revision. The transaction's own
+    // receipt is what keeps that verdict `applied`.
+
     const piece = await pieces.create(versionProgram("v1"), { input: {} });
     const origin = "system:concurrent-post-commit.tsx";
     await stampOrigin(piece, origin);
@@ -1854,15 +1865,15 @@ describe("piece source lifecycle", () => {
     await piece.setPattern(versionProgram("v2"));
 
     const mutablePieces = pieces as unknown as {
-      runWithPattern: typeof pieces.runWithPattern;
+      syncPattern: typeof pieces.syncPattern;
     };
-    const runWithPattern = pieces.runWithPattern.bind(pieces);
+    const syncPattern = pieces.syncPattern.bind(pieces);
     let changedAgain = false;
-    mutablePieces.runWithPattern = async (...args) => {
-      await runWithPattern(...args);
+    mutablePieces.syncPattern = async (...args) => {
+      await syncPattern(...args);
       if (!changedAgain) {
         changedAgain = true;
-        mutablePieces.runWithPattern = runWithPattern;
+        mutablePieces.syncPattern = syncPattern;
         await piece.setPattern(versionProgram("v3"));
       }
       throw new Error("older post-commit refresh failed");
@@ -1878,7 +1889,7 @@ describe("piece source lifecycle", () => {
         executionWarning: "older post-commit refresh failed",
       });
     } finally {
-      mutablePieces.runWithPattern = runWithPattern;
+      mutablePieces.syncPattern = syncPattern;
     }
 
     const state = await readPieceSourceState(runtime, piece.getCell());


### PR DESCRIPTION
## What

`PieceController.changeSource` — restore, follow, repoint, adopt, and detach — decided whether its source transition had committed by synchronizing the piece and re-reading its revision list (`#sourceTransitionCommitted`). #6234 established why that is unsound and replaced it for `setPattern` with commit receipts: `syncCell` logs a failed provider pull as `sync-load-failure` and resolves normally, so a read-back proves local cache state, not a commit; and a concurrent later transition can make a committed one look unsaved. This is the follow-up #6234 named.

## How

- Restore, follow, repoint, and adopt apply their transition through `runPatternUpdate`, the path `setPattern` takes. An `applied` verdict is the accepted setup transaction's `PatternSetupCommitReceipt`, held from the resolved update or from the `PatternSetupPostCommitError` that carries it. A post-commit refresh failure still surfaces as `applied` with `executionWarning`, which now carries the failure itself rather than the wrapper's message — the same split `PatternUpdateReceipt.refresh` reports for a direct edit.
- Detach keeps its bare transition write — the spec has it clear the origin "without rerunning setup" (`docs/specs/piece-source-lifecycle.md`) — and reads its verdict off that transaction's own `editWithRetry` result, the same acceptance the receipt path mints from.
- `#sourceTransitionCommitted` is deleted; the now single-caller `execute()` helper drops the transition and validator options that only the receipt path carries.
- `PieceSourceActionResult` keeps its shape (it crosses the shell RPC; `cf-piece-menu` and `runtime-processor` consume it) and gains a doc comment stating the transaction-derived contract. `docs/features/host-embedding.md` already states that contract for hosts.

Since #7201 the runner refuses any transition-carrying setup on a sealing runtime, so moving these actions onto the receipt path changes nothing about when they refuse — only which refusal message they raise (`SEALING_RECEIPT_REFUSAL`), and nothing pins that through `changeSource`.

## Tests

`piece-source-lifecycle.test.ts`: five stubs move from `runWithPattern` to `runPatternUpdate`; the two post-commit cases inject at `syncPattern`, the post-commit work the update path performs, so the real receipt wrap is what classifies them. The detach-concurrency and unreadable-history cases pass unchanged.

Each classification arm was mutation-tested: disabling the receipt arm fails exactly the two post-commit cases; forcing it fails exactly the five rejection and incompatibility cases; the detach arm's two mutations fail the concurrent-refresh case and the two transaction-failure cases respectively.

Local: piece 61 files / 927 steps, runtime-client 30 / 650, runner 1341 / 8114 (runner is untouched), repo-wide fmt, lint, `deno task check`, package-cycle, conflict-marker, and control-character gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

