### PR TITLE
test(runner): the served-intent wait wakes on the client's delivery, not a deadline

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -901,11 +901,13 @@ boundary the test can await without adding one to production code.
   before its first check so an arrival cannot slip between the two; the engine
   holds any such state before delivering it, which is what makes an engine
   predicate safe to re-check on the client's wake. Its deadline is the same
-  kind of stuck-condition net, sized far past any healthy arrival so machine
-  load cannot carry a passing run across it — the failure mode a deadline
-  close to the healthy latency has under contention. The bounded poll stays
-  for the rest: the watermark, the stats counters, and engine rows nothing
-  delivers.
+  kind of stuck-condition net, and crossing it proves only that the predicate
+  did not come true within the window — no fixed bound can tell a stuck wait
+  from one delayed past it. Its width, generous headroom over any healthy
+  arrival observed, is what keeps a crossing pointing at a stuck wait rather
+  than at contention stretching a passing run — the reading a deadline close
+  to the healthy latency cannot support. The bounded poll stays for the rest:
+  the watermark, the stats counters, and engine rows nothing delivers.
 
 ### A pull that drives its own loading
 

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -892,6 +892,21 @@ boundary the test can await without adding one to production code.
   elapsed milliseconds and the poll count, which is what separates a predicate
   that never came true from one the test never got to evaluate.
 
+  One class of that state does have a reporter after all: an engine row the
+  serving loop writes that also fans out to a flag-ON client — the served
+  intent landing in the firing session's effects instance is the canonical
+  case — reaches that client's storage-notification relay, the same relay the
+  effects channel consumes. `wait-on-delivery.ts` beside `wait-until.ts` wakes
+  on those deliveries and re-reads an engine predicate on each, subscribing
+  before its first check so an arrival cannot slip between the two; the engine
+  holds any such state before delivering it, which is what makes an engine
+  predicate safe to re-check on the client's wake. Its deadline is the same
+  kind of stuck-condition net, sized far past any healthy arrival so machine
+  load cannot carry a passing run across it — the failure mode a deadline
+  close to the healthy latency has under contention. The bounded poll stays
+  for the rest: the watermark, the stats counters, and engine rows nothing
+  delivers.
+
 ### A pull that drives its own loading
 
 `packages/generated-patterns/integration/pattern-harness.ts` compares a runtime

--- a/packages/runner/test/executor-effect-channel.test.ts
+++ b/packages/runner/test/executor-effect-channel.test.ts
@@ -65,6 +65,7 @@ import type { MemorySpace } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { WaveAccumulator, waveRunContextOf } from "../src/executor/wave.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitOnDelivery } from "./support/wait-on-delivery.ts";
 import { waitUntil } from "./support/wait-until.ts";
 
 /** The settle-gate seam (see executor-events-down.test.ts): holds the
@@ -406,10 +407,17 @@ describe("Phase 4 client-effect channel", () => {
     await clientRuntime.storageManager.synced();
 
     const sessionId = clientManager.id;
-    await waitUntil(
-      () => intentsOf(engine, aliceSigner.did(), sessionId).length === 1,
-      "the intent to land in alice's session instance",
-    );
+    // The wait wakes on the client's own delivery of the effects doc —
+    // the intent write fans out to the firing session — and reads the
+    // ENGINE, which holds the entry before any delivery of it.
+    await waitOnDelivery({
+      manager: clientManager,
+      wants: (_space, id, scope) =>
+        id === SERVER_EXECUTION_EFFECTS_DOC_ID && scope === "session",
+      predicate: () =>
+        intentsOf(engine, aliceSigner.did(), sessionId).length === 1,
+      label: "the intent to land in alice's session instance",
+    });
     const [intent] = intentsOf(engine, aliceSigner.did(), sessionId);
 
     // T2.Q2: the §5 shape — nonce, kind navigate, a target link,
@@ -423,16 +431,16 @@ describe("Phase 4 client-effect channel", () => {
     ).get({ seq: intent.issuedIn }) as { class: string } | undefined;
     expect(issuedRow?.class).toBe("derived");
 
-    // The handler's own consequence landed too (same wave family).
-    await waitUntil(
-      () => {
-        const doc = Engine.read(engine, {
-          id: argument.getAsNormalizedFullLink().id,
-        });
-        return ((doc?.value as { value?: number })?.value ?? 0) === 1;
-      },
-      "the handler consequence to land",
-    );
+    // The handler's consequence is visible whenever the entry is: the
+    // handler contribution seals before the intent tx it feeds, a wave
+    // batch applies in one store transaction (commitWave's contract),
+    // and the per-event fold withdraws the intent tx with a withdrawn
+    // handler contribution (the requeue tests pin both directions) —
+    // so the entry's visibility carries the consequence's.
+    const argumentDoc = Engine.read(engine, {
+      id: argument.getAsNormalizedFullLink().id,
+    });
+    expect((argumentDoc?.value as { value?: number })?.value).toBe(1);
 
     // T2.Q1 + protocol §1: the intent write's annotation carries the
     // ADDRESSING (alice's session scope key) AND the acting identity

--- a/packages/runner/test/support/wait-on-delivery.ts
+++ b/packages/runner/test/support/wait-on-delivery.ts
@@ -4,9 +4,9 @@ import type {
   MemorySpace,
 } from "../../src/storage/interface.ts";
 
-/** The stuck-condition net (two minutes): sized far past any healthy
- * delivery in these suites, so machine load cannot carry a passing run
- * across it. */
+/** The stuck-condition net (two minutes): generous headroom over any
+ * healthy delivery observed in these suites, so that a crossing points
+ * at a stuck wait rather than a slow one. */
 const STUCK_NET_MS = 120_000;
 
 /**
@@ -29,10 +29,12 @@ const STUCK_NET_MS = 120_000;
  * awaited work may take: the serving loop holds the event loop open
  * through its lease-renew interval, so a wait with no net would wedge
  * the run instead of failing it (see "Where the polling `waitFor`
- * stays" in `docs/development/waiting-in-tests.md`). Crossing it says
- * the delivery never came, never that it came slowly. Under the
- * package's fake clock the net freezes with every other test-armed
- * timer and the wait is purely event-driven.
+ * stays" in `docs/development/waiting-in-tests.md`). Crossing it
+ * proves only that no delivery satisfied the predicate within the
+ * window — a fixed bound cannot tell a stuck wait from one delayed
+ * past it; the width just makes the stuck reading the likely one.
+ * Under the package's fake clock the net freezes with every other
+ * test-armed timer and the wait is purely event-driven.
  */
 export const waitOnDelivery = async (options: {
   /** The client storage manager whose notification relay carries the

--- a/packages/runner/test/support/wait-on-delivery.ts
+++ b/packages/runner/test/support/wait-on-delivery.ts
@@ -1,0 +1,89 @@
+import { CoalescedDocListener } from "../../src/speculation/doc-notification-listener.ts";
+import type {
+  IStorageNotificationCapability,
+  MemorySpace,
+} from "../../src/storage/interface.ts";
+
+/** The stuck-condition net (two minutes): sized far past any healthy
+ * delivery in these suites, so machine load cannot carry a passing run
+ * across it. */
+const STUCK_NET_MS = 120_000;
+
+/**
+ * Resolves once `predicate` holds, waking on each client-side delivery
+ * of the docs `wants` selects — a test-owned tap of the storage
+ * manager's notification relay, the same relay the effects channel
+ * consumes — with the predicate checked once up front and then once per
+ * delivery burst.
+ *
+ * Soundness rests on one ordering: the predicate must read state that
+ * is true no later than the moment a wanted delivery reaches this
+ * client. An engine read qualifies — the server commits before it fans
+ * out — so a predicate false at the up-front check has its delivery
+ * still ahead of the already-subscribed listener, and the wake cannot
+ * be missed. State nothing delivers to this client (a watermark, a
+ * stats counter) never wakes this wait; that state waits through
+ * `waitUntil` (wait-until.ts).
+ *
+ * The deadline is a stuck-condition net, not a bound on how long the
+ * awaited work may take: the serving loop holds the event loop open
+ * through its lease-renew interval, so a wait with no net would wedge
+ * the run instead of failing it (see "Where the polling `waitFor`
+ * stays" in `docs/development/waiting-in-tests.md`). Crossing it says
+ * the delivery never came, never that it came slowly. Under the
+ * package's fake clock the net freezes with every other test-armed
+ * timer and the wait is purely event-driven.
+ */
+export const waitOnDelivery = async (options: {
+  /** The client storage manager whose notification relay carries the
+   * wanted deliveries. */
+  manager: IStorageNotificationCapability;
+
+  /** Which delivered docs wake the predicate re-check. A space reset
+   * wakes it regardless. */
+  wants: (
+    space: MemorySpace,
+    id: string,
+    scope: string | undefined,
+  ) => boolean;
+
+  /** The state being awaited, read fresh on every wake. */
+  predicate: () => boolean;
+
+  /** Names the awaited state when the stuck net fires. */
+  label: string;
+}): Promise<void> => {
+  const { manager, wants, predicate, label } = options;
+  const settled = Promise.withResolvers<void>();
+  const listener = new CoalescedDocListener(manager, {
+    wants,
+    onNotify: () => {
+      try {
+        if (predicate()) settled.resolve();
+      } catch (error) {
+        settled.reject(error);
+      }
+    },
+  });
+  // Subscribe BEFORE the first check: a delivery that lands between the
+  // two still dispatches a re-check instead of slipping past.
+  listener.ensure();
+  try {
+    if (predicate()) return;
+    const net = setTimeout(() => {
+      settled.reject(
+        new Error(
+          `timed out waiting for ${label} — no satisfying delivery ` +
+            `within ${STUCK_NET_MS} ms`,
+        ),
+      );
+    }, STUCK_NET_MS);
+    try {
+      await settled.promise;
+    } finally {
+      clearTimeout(net);
+    }
+  } finally {
+    listener.release();
+  }
+};


### PR DESCRIPTION
## The flake

The T2 hops 1–4 step of `executor-effect-channel.test.ts` waited for the §5
intent entry by polling the engine under `waitUntil`'s 20-second deadline. That
deadline sits within a loaded machine's reach: the step's latency is
compile-dominated (~11 s idle in the sessions that hit it), so CPU contention —
parallel suites, a coverage run — carried healthy runs across it. It produced
three false alarms during the #6234 sessions (2026-08-27 and 09-01). #6587
removed the dominant cause (the test's enacting client raced retirement; it is
headless now) and unified the shared `waitUntil`; what remained is the
structural one this PR closes — a deadline converts a slow pass into a failure,
and no fixed bound is out of load's reach when it sits 2× above the healthy
latency.

## The fix: wake on the real event

The entry has a reporter the family's documentation entry overlooked: the
intent write fans out to the firing session, headless clients included — the
effects channel subscribes whether or not a `navigateCallback` exists; only
enactment is gated on one. So the client's storage-notification relay reports
the arrival.

The new `packages/runner/test/support/wait-on-delivery.ts` taps that relay
through the production channel's own `CoalescedDocListener`, re-reading an
engine predicate once up front and once per delivery burst. Subscribing before
the first check closes the missed-arrival race, and the engine holding state
before delivering it is what makes an engine predicate sound on a client wake.
Its two-minute deadline is a stuck-condition net, not a bound on the work: the
serving loop holds the event loop open through lease renew, so a netless wait
would wedge the run instead of failing it (the same fact
`waiting-in-tests.md` records for `waitUntil`) — crossing it proves only that
nothing satisfied the predicate within the window; its generous width over
observed healthy latency keeps a crossing pointing at a stuck wait rather
than a slow one.

The step's second wait — the handler consequence — needed no wait at all: the
handler contribution seals before the intent tx it feeds, a wave batch applies
in one store transaction (`commitWave`'s contract), and the per-event fold
withdraws the intent with a withdrawn handler contribution (the M2 and
seal-failure tests pin both directions). The entry's visibility therefore
carries the consequence's. It is a plain read now, which also pins that
carriage.

`waiting-in-tests.md`'s entry for the `waitUntil` family gains the delivery
carve-out in the same change. The file's other `waitUntil` call sites stay:
they watch state nothing delivers to a client (watermarks, stats counters,
sidecar rows). `check-no-waitfor` is unaffected — it scans `integration/`
imports of the shared `waitFor`, and the runner's `test/support` helpers sit
outside its scan by that document's stated design.

## Verification

- A probe run confirmed the wait resolves through a delivery dispatch, not the
  up-front check.
- A mutation run (unsatisfiable predicate under a shrunk net) failed cleanly
  naming the label, with teardown intact — the net path works.
- The file passed repeatedly, including three runs under a deliberately
  concurrent full-suite load.
- Full runner suite green on the rebased tree; repo-wide `deno fmt --check`,
  `deno lint`, `deno task check`, `deno task check-docs`, and
  `deno task check-no-waitfor` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
