### PR TITLE
fix(runner): preserve scoped defaults in child inputs

### DIFF
--- a/docs/specs/scoped-cell-instances.md
+++ b/docs/specs/scoped-cell-instances.md
@@ -348,6 +348,20 @@ the target cell's declared/effective scope controls which scoped storage
 instance is written. A write does not widen or narrow the target cell just
 because the value being written was read from another scope.
 
+A writable handle created for an absent defaulted property uses the scope on
+its `asCell` entry, whether the property is read through the containing object
+or projected with `key()`. A stored value or reference retains its own scope;
+a reference to a missing target is still an existing reference. An unresolved
+or scope-blocked ancestor cannot authorize creation of a scoped default.
+
+Pattern argument setup materializes missing declared scoped properties even
+when the caller supplies the argument object through a Cell reference. The
+redirect stays at the input slot so existing child bindings follow subsequent
+explicit rebinding. Existing values and references remain authoritative,
+including a reference to the same input field at a narrower scope. The reads
+that authorize initialization remain commit dependencies, so a concurrent
+explicit write cannot be overwritten silently.
+
 ## TypeScript Authoring
 
 Scope wrappers are type-level annotations:

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -2638,15 +2638,25 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   narrowed requests, without reopening fixed SQLite cases or counting the
   compile regression twice.
 
-  A separate child-input residual remains: passing an uninitialized
-  `PerUser<Writable<Default<0>>>` value into a child can give both users the
-  same space-scoped writable handle. It also occurs with an ordinary nested
-  child without `compileAndRun`. Explicitly initializing each user's input
-  through the parent's schema produces separate user-scoped handles. The
-  served compile handler regression initializes those inputs; it establishes
-  program selection, not correct scope creation for an uninitialized default.
-  Owed: preserve the declared scope when that default writable handle is
-  materialized, with a two-user child-handler regression.
+  Child-input default creation is covered separately from builtin instance
+  identity. `executor-compile-and-run.test.ts` passes uninitialized
+  `PerUser<Writable<number | Default<0>>>` and `PerSession` inputs to static
+  and compiled children, then dispatches their handlers under separate users
+  or two sessions of the initializing user. Argument setup creates missing
+  declared scope redirects through whole-object input references.
+  `scoped-input-initialization.test.ts` preserves explicit values and
+  references, including references to missing targets, and rejects
+  initialization that races with an explicit write.
+  `scoped-default-writable.test.ts` covers direct projection of an absent
+  defaulted slot, its write destination, and its dependency behavior.
+
+  A separate session-initialization gap remains: after one user initializes
+  a `PerSession` input, a later user's intermediate user instance can lack
+  its session redirect. Completing that hop must preserve an explicitly
+  supplied reference to the same field in user scope; pointer shape alone
+  cannot distinguish that reference from an automatically created redirect.
+  Owed: durable initialization ownership and a later-user, two-session
+  handler regression, including explicit-reference and reload controls.
 - OW29 — space-root demanders + demand-arrival re-runs (the reverted
   Phase-7 extension recorded under OW17): a client whose only watch is
   the space-scoped piece root supplies NO identity to the run supply,

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -460,6 +460,97 @@ export function diffAndUpdate(
   return changes.length > 0;
 }
 
+/** Materialize absent scoped input slots behind a pattern's argument reference. */
+export function initializeScopedArgumentSlots(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  argumentLink: NormalizedFullLink,
+  schema: JSONSchema | undefined,
+): void {
+  const resolvedSchema = resolveSchema(schema);
+  if (
+    !isObjectOrArray(resolvedSchema) ||
+    !isObjectOrArray(resolvedSchema.properties)
+  ) return;
+  let blocked = false;
+  const container = resolveLink(runtime, tx, argumentLink, "value", {
+    onScopeBlocked: () => blocked = true,
+  });
+  if (blocked || container.pendingHopDoc || isFabricDataUri(container.id)) {
+    return;
+  }
+  const options = {
+    nonRecursive: true,
+    meta: { ...markReadAsAttemptedWrite, ...allowMutableTransactionRead },
+  };
+  const value = tx.readValueOrThrow(container, options);
+  if (!isKeyableObjectNotArray(value) || isPrimitiveCellLink(value)) return;
+  const changes: ChangeSet = [];
+  for (const key of Object.keys(resolvedSchema.properties)) {
+    const childSchema = ContextualFlowControl.getSchemaAtPath(schema, [key]);
+    const scope = declaredCellScope(childSchema);
+    if (scope === undefined || scopeRank(scope) <= scopeRank(container.scope)) {
+      continue;
+    }
+    if (Object.hasOwn(value, key)) continue;
+    const childLink: NormalizedFullLink = {
+      ...container,
+      path: [...container.path, key],
+      schema: childSchema,
+    };
+    changes.push(...scopedRedirectChanges(
+      runtime,
+      tx,
+      childLink,
+      scope,
+      argumentLink,
+      options,
+      { seen: new Map() },
+      undefined,
+    ));
+  }
+  applyChangeSet(tx, changes);
+}
+
+/** Build the redirect chain for a declared narrower slot without writing its content. */
+function scopedRedirectChanges(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  link: NormalizedFullLink,
+  scope: CellScope,
+  context: unknown,
+  options: DiffAndUpdateOptions | undefined,
+  state: DiffWalkState,
+  currentValue: unknown,
+): ChangeSet {
+  const scopedLink: NormalizedFullLink = { ...link, scope };
+  const viaUser = getServerExecutionConfig() && scope === "session" &&
+    scopeRank(link.scope) < scopeRank("user");
+  const target = viaUser ? { ...link, scope: "user" as const } : scopedLink;
+  const changes = viaUser
+    ? normalizeAndDiff(
+      runtime,
+      tx,
+      target,
+      createSigilLinkFromParsedLink(scopedLink, { base: target }),
+      context,
+      options,
+      state,
+    )
+    : [];
+  changes.push(...normalizeAndDiff(
+    runtime,
+    tx,
+    link,
+    createSigilLinkFromParsedLink(target, { base: link }),
+    context,
+    options,
+    state,
+    currentValue,
+  ));
+  return changes;
+}
+
 export type ChangeSet = {
   location: NormalizedFullLink;
   value: FabricValue;
@@ -1718,64 +1809,16 @@ export function normalizeAndDiff(
           path: [...link.path, key],
           schema: childSchema,
         };
-        const scopedLink: NormalizedFullLink = {
-          ...childLink,
-          scope: childScope,
-        };
-        // The eager via-user hop (scopes.md §2's MUST, flag-gated): an
-        // eager space→session redirect chains via user like every other
-        // narrowing write, so the chain shape stays uniform.
-        if (
-          getServerExecutionConfig() &&
-          childScope === "session" &&
-          scopeRank(link.scope) < scopeRank("user")
-        ) {
-          const userLink: NormalizedFullLink = {
-            ...childLink,
-            scope: "user",
-          };
-          changes.push(
-            ...normalizeAndDiff(
-              runtime,
-              tx,
-              userLink,
-              createSigilLinkFromParsedLink(scopedLink, {
-                base: userLink,
-              }) as unknown,
-              context,
-              options,
-              state,
-            ),
-            ...normalizeAndDiff(
-              runtime,
-              tx,
-              childLink,
-              createSigilLinkFromParsedLink(userLink, {
-                base: childLink,
-              }) as unknown,
-              context,
-              options,
-              state,
-              currentRecord[key],
-            ),
-          );
-          eagerScopedKeys.add(key);
-          continue;
-        }
-        changes.push(
-          ...normalizeAndDiff(
-            runtime,
-            tx,
-            childLink,
-            createSigilLinkFromParsedLink(scopedLink, {
-              base: childLink,
-            }) as unknown,
-            context,
-            options,
-            state,
-            currentRecord[key],
-          ),
-        );
+        changes.push(...scopedRedirectChanges(
+          runtime,
+          tx,
+          childLink,
+          childScope,
+          context,
+          options,
+          state,
+          currentRecord[key],
+        ));
         eagerScopedKeys.add(key);
       }
     }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -201,7 +201,10 @@ import {
   readVerifiedSourceClosure,
 } from "./compilation-cache/cell-cache.ts";
 import { createRef } from "./create-ref.ts";
-import { diffAndUpdate } from "./data-updating.ts";
+import {
+  diffAndUpdate,
+  initializeScopedArgumentSlots,
+} from "./data-updating.ts";
 import { getVerifiedProvenance } from "./harness/verified-provenance.ts";
 import { setResultCell } from "./result-utils.ts";
 import {
@@ -2692,6 +2695,12 @@ export class Runner {
       argumentLink,
       storable,
       argumentLink,
+    );
+    initializeScopedArgumentSlots(
+      this.#runtime,
+      tx,
+      argumentLink,
+      argumentSchema,
     );
   }
 

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -70,7 +70,11 @@ import type { CfcAddress } from "./cfc/types.ts";
 import { ignoreReadForScheduling } from "./scheduler.ts";
 import { arrayMatchesPositionally } from "./schema-match.ts";
 import { canFollowScopedLink, isCellScope } from "./scope.ts";
-import { internalVerifierRead } from "./storage/reactivity-log.ts";
+import {
+  excludeReadFromConflict,
+  internalVerifierRead,
+  linkResolutionProbe,
+} from "./storage/reactivity-log.ts";
 import {
   canBranchMatch,
   combineOptionalSchema,
@@ -94,10 +98,9 @@ const cfcAddressFromLink = (link: NormalizedFullLink): CfcAddress => ({
   path: [...link.path],
 });
 
-// Creation-only: stamp the asCell entry's declared scope onto a newly created
-// cell's link. Never use this on a link that was followed/resolved during a
-// read — there the link's own storage-resolved scope is authoritative and
-// schema scope acts only as a follow cap (see link-resolution.ts).
+// The `asCell` declaration chooses the scope of a new slot. Existing values
+// and references keep their storage-resolved scope; their schema scope only
+// constrains which links a read may follow.
 const linkWithAsCellScope = (
   link: NormalizedFullLink,
   entry:
@@ -1219,6 +1222,37 @@ export function validateAndTransform(
       link.schema = SchemaObjectTraverser.hasAsCell(combined)
         ? combined
         : effectiveSchema!;
+    }
+    const handleSchema = resolveSchema(link.schema);
+    const handleEntry = ContextualFlowControl.getAsCellValues(handleSchema)[0];
+    if (
+      isObjectOrArray(handleSchema) && handleSchema.default !== undefined &&
+      isCellScope(ContextualFlowControl.getAsCellScope(handleEntry))
+    ) {
+      // Inspect the addressed slot before following its leaf reference: an
+      // existing reference retains its target even when that target is absent.
+      // This handle-only probe remains reactive to the slot's arrival.
+      const absentSlot = tx.runWithAmbientReadMeta(
+        excludeReadFromConflict,
+        () => {
+          let blocked = false;
+          const sourceLink = isCellViewRef(sourceRef)
+            ? sourceRef.link
+            : sourceRef;
+          const slot = resolveLink(runtime, tx, sourceLink, "top", {
+            onScopeBlocked: () => {
+              blocked = true;
+            },
+          });
+          return !blocked && !slot.pendingHopDoc &&
+            !slot.id.startsWith("data:") &&
+            tx.readValueOrThrow(slot, {
+                nonRecursive: true,
+                meta: linkResolutionProbe,
+              }) === undefined;
+        },
+      );
+      if (absentSlot) link = linkWithAsCellScope(link, handleEntry);
     }
     objectCreator.setBase(link, cfcLabelView);
     return objectCreator.createObject(link, undefined);

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1244,12 +1244,20 @@ export function validateAndTransform(
               blocked = true;
             },
           });
-          return !blocked && !slot.pendingHopDoc &&
-            !slot.id.startsWith("data:") &&
+          if (
+            blocked || slot.pendingHopDoc || slot.id.startsWith("data:") ||
             tx.readValueOrThrow(slot, {
                 nonRecursive: true,
                 meta: linkResolutionProbe,
-              }) === undefined;
+              }) !== undefined
+          ) return false;
+          const address = toMemorySpaceAddress(slot);
+          const parent = tx.readOrThrow({
+            ...address,
+            path: address.path.slice(0, -1),
+          }, { nonRecursive: true, meta: linkResolutionProbe });
+          return !isObjectOrArray(parent) ||
+            !Object.hasOwn(parent, address.path.at(-1)!);
         },
       );
       if (absentSlot) link = linkWithAsCellScope(link, handleEntry);

--- a/packages/runner/test/executor-compile-and-run.test.ts
+++ b/packages/runner/test/executor-compile-and-run.test.ts
@@ -50,6 +50,20 @@ export default pattern<{ code?: PerUser<Draft>; count?: PerUser<Writable<number 
 
 const PER_SESSION_PARENT = PER_USER_PARENT.replaceAll("PerUser", "PerSession");
 
+const STATIC_CHILD_PARENT = `
+import { action, computed, Default, pattern, PerUser, Stream, Writable } from "commonfabric";
+const Child = pattern<{ count: Writable<number> }, { answer: number; bump: Stream<unknown>; isHidden: boolean }>(
+  ({ count }) => ({
+    answer: computed(() => count.get()),
+    bump: action(() => count.set(count.get() + 1)),
+    isHidden: true,
+  }),
+);
+export default pattern<{ code?: PerUser<Writable<string | Default<"">>>; count?: PerUser<Writable<number | Default<0>>> }>(
+  ({ count }) => ({ compiled: { pending: false, result: Child({ count: count! }) } }),
+);
+`;
+
 const CLEARABLE_PER_USER_PARENT = `
 import { compileAndRun, computed, Default, pattern, PerUser, Writable } from "commonfabric";
 type Draft = Writable<string | Default<"">>;
@@ -851,6 +865,72 @@ export default pattern<{ code: string; count: number }, { compiled: any }>(({ co
       piece.cancelDemand();
     }
   });
+
+  for (const scope of ["user", "session"] as const) {
+    for (const compiled of [false, true]) {
+      it(`isolates uninitialized ${scope} defaults in ${compiled ? "compiled" : "static"} child handlers`, async () => {
+        const parentSource = compiled ? PER_USER_PARENT : STATIC_CHILD_PARENT;
+        const code = handlerChildProgram(1);
+        const piece = await createParent(
+          code,
+          scope === "session"
+            ? parentSource.replaceAll("PerUser", "PerSession")
+            : parentSource,
+          true,
+        );
+        let other: Awaited<ReturnType<typeof joinParent>> | undefined;
+        try {
+          await childValue(piece.result, 0);
+          other = await joinParent(
+            piece,
+            scope === "session" ? aliceSigner : bobSigner,
+            code,
+          );
+          await childValue(other.result, 0, other.runtime);
+
+          expect(
+            piece.argument.key("count").resolveAsCell()
+              .getAsNormalizedFullLink().scope,
+          ).toBe(scope);
+          expect(
+            other.argument.key("count").resolveAsCell()
+              .getAsNormalizedFullLink().scope,
+          ).toBe(scope);
+
+          const firstDelivered = Promise.withResolvers<string>();
+          piece.result.key("compiled").key("result").key("bump").send(
+            {},
+            (tx) => {
+              firstDelivered.resolve(tx.status().status);
+            },
+          );
+          expect(await firstDelivered.promise).not.toBe("error");
+          await childValue(piece.result, 1);
+          await covered();
+          await other.runtime.idle();
+          expect(other.result.key("compiled").get()?.result?.answer).toBe(0);
+
+          const secondDelivered = Promise.withResolvers<string>();
+          other.result.key("compiled").key("result").key("bump").send(
+            {},
+            (tx) => {
+              secondDelivered.resolve(tx.status().status);
+            },
+          );
+          expect(await secondDelivered.promise).not.toBe("error");
+          await childValue(other.result, 1, other.runtime);
+          await covered();
+          await client.idle();
+          expect(piece.result.key("compiled").get()?.result?.answer).toBe(1);
+          expect(host.stats().unstampedSealRefusals).toBe(0);
+          expect(servingErrors).toEqual([]);
+        } finally {
+          await other?.dispose();
+          piece.cancelDemand();
+        }
+      });
+    }
+  }
 
   it("dispatches each user's child handler to that user's selected program", async () => {
     const a = handlerChildProgram(1);

--- a/packages/runner/test/executor-dprime-w0.test.ts
+++ b/packages/runner/test/executor-dprime-w0.test.ts
@@ -865,7 +865,10 @@ describe("W1 (d′): demand = the tracked-ids closure, the walk deleted", () => 
       "both pieces' labels to land and bob's solo demand to register",
     );
     await servingRuntime!.idle();
-    await new Promise((resolve) => setTimeout(resolve, 400));
+    await waitUntil(
+      () => servingRuntime!.scheduler.demandedWriterCount >= 4,
+      "both pieces' writers to enter the demand root set",
+    );
     const writersBefore = servingRuntime!.scheduler.demandedWriterCount;
     const leavesBefore = host!.stats().demand.demandRootLeaves;
     expect(writersBefore).toBeGreaterThanOrEqual(4);
@@ -876,7 +879,6 @@ describe("W1 (d′): demand = the tracked-ids closure, the walk deleted", () => 
     await bobClient.manager.close();
     runtimes.splice(runtimes.indexOf(bob), 1);
     managers.splice(managers.indexOf(bobClient.manager), 1);
-    await new Promise((resolve) => setTimeout(resolve, 800));
     await waitUntil(
       () => {
         host!.spaceServer(space)!.noteDemandChanged();
@@ -886,7 +888,12 @@ describe("W1 (d′): demand = the tracked-ids closure, the walk deleted", () => 
       },
       "bob's rows to leave the demand set",
     );
-    await new Promise((resolve) => setTimeout(resolve, 600));
+    await waitUntil(
+      () =>
+        servingRuntime!.scheduler.demandedWriterCount < writersBefore &&
+        host!.stats().demand.demandRootLeaves > leavesBefore,
+      "the departing session's writers to release their demand roots",
+    );
     const writersAfter = servingRuntime!.scheduler.demandedWriterCount;
     const leavesAfter = host!.stats().demand.demandRootLeaves;
     console.log(

--- a/packages/runner/test/executor-fan-out.test.ts
+++ b/packages/runner/test/executor-fan-out.test.ts
@@ -266,6 +266,7 @@ describe("fan-out stage B: the per-demander run supply (E2E)", () => {
   const standUp = async (options: {
     names: { arg: string; result: string };
     pattern?: string;
+    userScopedNote?: boolean;
     clients: Identity[];
   }) => {
     host = newHost();
@@ -292,7 +293,20 @@ describe("fan-out stage B: the per-demander run supply (E2E)", () => {
     await aliceResult.sync();
     {
       const seed = alice.edit();
-      aliceArg.withTx(seed).set({ n: 1 });
+      aliceArg.withTx(seed).set({
+        n: 1,
+        ...(options.userScopedNote
+          ? {
+            note: alice.getCell(
+              space,
+              options.names.arg,
+              undefined,
+              undefined,
+              "user",
+            ).key("note"),
+          }
+          : {}),
+      });
       expect((await seed.commit()).error).toBeUndefined();
     }
     {
@@ -387,6 +401,10 @@ describe("fan-out stage B: the per-demander run supply (E2E)", () => {
   it("(a) two users watching ONLY the space root of a piece with a per-user derivation get TWO server-side instances with their OWN values, attributed to the user alone; the service identity ran no demanded work (the arbitration)", async () => {
     const setup = await standUp({
       names: { arg: "fo-a-arg", result: "fo-a-result" },
+      pattern: FAN_OUT_PATTERN.replace(
+        "note?: PerSession<Draft>",
+        "note?: PerUser<Draft>",
+      ),
       clients: [aliceSigner, bobSigner],
     });
     const { engine, clients } = setup;
@@ -511,6 +529,7 @@ describe("fan-out stage B: the per-demander run supply (E2E)", () => {
   it("(c) RAGGED: a node user-scoped for Alice and session-scoped for Bob — Bob's instance per session, Alice's per user, both correct, no session-keyed rows for Alice (S4)", async () => {
     const setup = await standUp({
       names: { arg: "fo-c-arg", result: "fo-c-result" },
+      userScopedNote: true,
       clients: [aliceSigner, bobSigner],
     });
     const { engine, clients } = setup;
@@ -518,18 +537,22 @@ describe("fan-out stage B: the per-demander run supply (E2E)", () => {
     const bob = clients.get(bobSigner.did())!;
     const aliceKey = setup.userKey(aliceSigner);
     const bobKey = setup.userKey(bobSigner);
-    // Alice writes a per-user draft; Bob writes a per-SESSION note. The
-    // `noteEcho` node then reads session state for Bob (his note is a
-    // session doc) and — through the never-written note slot's redirect
-    // chain — for Alice too once Bob's write narrowed the slot: the
-    // slot's space redirect points via user to session (the eager
-    // via-user hop), so Alice's read of it discovers `session` as well.
-    // The RAGGED shape lives on the `echo` node: Alice's draft narrows
-    // it to user; Bob's session note does not touch it. Bob's session
-    // instances of `noteEcho` hold his note; Alice's session instances
-    // hold nothing.
+    // The supplied note reference starts at user scope, so Alice's absent
+    // note stays at user scope under the PerSession follow cap. Bob's typed
+    // note write installs his own session hop. The same noteEcho node then
+    // reads user state for Alice and session state for Bob.
+    const noteScope = (runtime: Runtime) =>
+      runtime.getCellFromLink({
+        space,
+        id: setup.argId,
+        path: ["note"],
+        scope: "space",
+      }).resolveAsCell().getAsNormalizedFullLink().scope;
+    expect(noteScope(alice)).toBe("user");
     await setup.writeDraft(alice, "A");
     await setup.writeNote(bob, "N");
+    expect(noteScope(alice)).toBe("user");
+    expect(noteScope(bob)).toBe("session");
     await waitUntil(
       () => instanceHolds(engine, aliceKey, '"echo:A"'),
       "alice's user instance of echo",

--- a/packages/runner/test/scoped-default-writable.test.ts
+++ b/packages/runner/test/scoped-default-writable.test.ts
@@ -1,0 +1,268 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+
+import type { CellScope, JSONSchema } from "../src/builder/types.ts";
+import type { Cell } from "../src/cell.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { SpaceReplica } from "../src/storage/v2.ts";
+
+const signer = await Identity.fromPassphrase("scoped default writable");
+const space = signer.did();
+
+const countSchema = (scope: CellScope) =>
+  ({
+    type: "object",
+    properties: {
+      count: {
+        type: "number",
+        default: 0,
+        asCell: [{ kind: "cell", scope }],
+      },
+    },
+  }) as const satisfies JSONSchema;
+
+describe("scoped-default-writable", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await storageManager.synced();
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  for (const scope of ["user", "session"] as const) {
+    it(`reads and writes an absent default through its declared ${scope} instance`, async () => {
+      const raw = runtime.getCell<Record<string, unknown>>(
+        space,
+        `default-${scope}`,
+      );
+      const seed = runtime.edit();
+      raw.withTx(seed).set({});
+      expect((await seed.commit()).error).toBeUndefined();
+
+      const shaped = raw.asSchema(countSchema(scope));
+      const whole = shaped.get().count!;
+      const projected = shaped.key("count").get()!;
+      const address = {
+        id: raw.getAsNormalizedFullLink().id,
+        path: ["count"],
+        space,
+        scope,
+      };
+      expect(whole.getAsNormalizedFullLink()).toMatchObject(address);
+      expect(projected.getAsNormalizedFullLink()).toMatchObject(address);
+      expect(whole.get()).toBe(0);
+      expect(projected.get()).toBe(0);
+
+      const write = runtime.edit();
+      projected.withTx(write).set(7);
+      expect((await write.commit()).error).toBeUndefined();
+      expect(runtime.getCellFromLink(address).get()).toBe(7);
+      expect(shaped.key("count").get()!.get()).toBe(7);
+      expect(raw.key("count").getRaw()).toBeUndefined();
+    });
+
+    it(`preserves an inline space value under a ${scope} handle declaration`, async () => {
+      const raw = runtime.getCell<Record<string, unknown>>(
+        space,
+        `inline-${scope}`,
+      );
+      const seed = runtime.edit();
+      raw.withTx(seed).set({ count: 4 });
+      expect((await seed.commit()).error).toBeUndefined();
+
+      const shaped = raw.asSchema(countSchema(scope));
+      const projected = shaped.key("count").get()!;
+      expect(shaped.get().count!.getAsNormalizedFullLink().scope).toBe("space");
+      expect(projected.getAsNormalizedFullLink()).toMatchObject({
+        id: raw.getAsNormalizedFullLink().id,
+        path: ["count"],
+        scope: "space",
+      });
+      expect(projected.get()).toBe(4);
+      const write = runtime.edit();
+      projected.withTx(write).set(8);
+      expect((await write.commit()).error).toBeUndefined();
+      expect(raw.key("count").get()).toBe(8);
+      expect(
+        runtime.getCellFromLink({
+          ...projected.getAsNormalizedFullLink(),
+          schema: undefined,
+          scope,
+        }).getRaw(),
+      ).toBeUndefined();
+    });
+
+    for (const overwrite of ["this", "redirect"] as const) {
+      it(`preserves a ${overwrite} link to an absent space referent under a ${scope} declaration`, async () => {
+        const raw = runtime.getCell<Record<string, unknown>>(
+          space,
+          `linked-${scope}-${overwrite}`,
+        );
+        const target = runtime.getCell<number>(
+          space,
+          `absent-target-${scope}-${overwrite}`,
+        );
+        const seed = runtime.edit();
+        raw.withTx(seed).set({
+          count: overwrite === "redirect"
+            ? target.getAsWriteRedirectLink()
+            : target.getAsLink(),
+        });
+        expect((await seed.commit()).error).toBeUndefined();
+
+        const projected = raw.asSchema(countSchema(scope)).key("count").get()!;
+        expect(projected.getAsNormalizedFullLink()).toMatchObject({
+          id: target.getAsNormalizedFullLink().id,
+          path: [],
+          scope: "space",
+        });
+        const write = runtime.edit();
+        projected.withTx(write).set(9);
+        expect((await write.commit()).error).toBeUndefined();
+        expect(target.get()).toBe(9);
+        expect(parseLink(raw.key("count").getRaw(), raw.key("count")))
+          .toMatchObject({
+            id: target.getAsNormalizedFullLink().id,
+            scope: "space",
+          });
+        expect(
+          runtime.getCellFromLink({
+            ...target.getAsNormalizedFullLink(),
+            scope,
+          }).getRaw(),
+        ).toBeUndefined();
+      });
+    }
+
+    it(`creates a ${scope} default at an absent slot reached through an ancestor link`, async () => {
+      const target = runtime.getCell<Record<string, unknown>>(
+        space,
+        `ancestor-target-${scope}`,
+      );
+      const raw = runtime.getCell<Record<string, unknown>>(
+        space,
+        `ancestor-${scope}`,
+      );
+      const seed = runtime.edit();
+      target.withTx(seed).set({});
+      raw.withTx(seed).set(target);
+      expect((await seed.commit()).error).toBeUndefined();
+
+      const projected = raw.asSchema(countSchema(scope)).key("count").get()!;
+      expect(projected.getAsNormalizedFullLink()).toMatchObject({
+        id: target.getAsNormalizedFullLink().id,
+        path: ["count"],
+        scope,
+      });
+      const write = runtime.edit();
+      projected.withTx(write).set(6);
+      expect((await write.commit()).error).toBeUndefined();
+      expect(
+        runtime.getCellFromLink({
+          ...target.getAsNormalizedFullLink(),
+          path: ["count"],
+          scope,
+        }).get(),
+      ).toBe(6);
+      expect(target.key("count").getRaw()).toBeUndefined();
+    });
+  }
+
+  it("preserves an unresolved ancestor target until its document arrives", async () => {
+    const target = runtime.getCell<Record<string, unknown>>(space, "pending");
+    const raw = runtime.getCell<Record<string, unknown>>(space, "pending-link");
+    const seed = runtime.edit();
+    raw.withTx(seed).set(target);
+    expect((await seed.commit()).error).toBeUndefined();
+
+    const projected = raw.asSchema(countSchema("user")).key("count").get()!;
+    expect(projected.getAsNormalizedFullLink()).toMatchObject({
+      id: target.getAsNormalizedFullLink().id,
+      scope: "space",
+      pendingHopDoc: true,
+    });
+  });
+
+  it("keeps a blocked ancestor unavailable under the declared follow cap", async () => {
+    const target = runtime.getCellFromLink<Record<string, unknown>>({
+      ...runtime.getCell(space, "blocked-target").getAsNormalizedFullLink(),
+      scope: "session",
+    });
+    const raw = runtime.getCell<Record<string, unknown>>(space, "blocked-link");
+    const seed = runtime.edit();
+    target.withTx(seed).set({});
+    raw.withTx(seed).set(target);
+    expect((await seed.commit()).error).toBeUndefined();
+
+    const projected = raw.asSchema(countSchema("user")).key("count").get()!;
+    expect(projected.getAsNormalizedFullLink().id.startsWith("data:")).toBe(
+      true,
+    );
+    expect(projected.getAsNormalizedFullLink().scope).toBe("space");
+    expect(target.key("count").getRaw()).toBeUndefined();
+  });
+
+  it("reprojects a default handle when a space value arrives at its slot", async () => {
+    const raw = runtime.getCell<Record<string, unknown>>(space, "arriving");
+    const seed = runtime.edit();
+    raw.withTx(seed).set({});
+    expect((await seed.commit()).error).toBeUndefined();
+
+    const scopes: CellScope[] = [];
+    const cancel = raw.asSchema(countSchema("user")).key("count").sink(
+      (handle) => {
+        scopes.push(handle!.getAsNormalizedFullLink().scope);
+      },
+    );
+    try {
+      await runtime.idle();
+      expect(scopes.at(-1)).toBe("user");
+      const write = runtime.edit();
+      raw.withTx(write).key("count").set(3);
+      expect((await write.commit()).error).toBeUndefined();
+      await runtime.idle();
+      expect(scopes.at(-1)).toBe("space");
+    } finally {
+      cancel();
+    }
+  });
+
+  for (const readThrough of [false, true]) {
+    it(`${readThrough ? "records" : "excludes"} a value dependency after ${readThrough ? "reading through" : "only projecting"} a handle`, async () => {
+      const raw = runtime.getCell<Record<string, unknown>>(space, "concurrent");
+      const seed = runtime.edit();
+      raw.withTx(seed).set({ count: 4 });
+      expect((await seed.commit()).error).toBeUndefined();
+
+      const holder = runtime.edit();
+      const projected: Cell<number> = raw.withTx(holder)
+        .asSchema(countSchema("user")).key("count").get()!;
+      expect(projected.getAsNormalizedFullLink().scope).toBe("space");
+      if (readThrough) expect(projected.get()).toBe(4);
+      const replica = storageManager.open(space).replica as SpaceReplica;
+      const reads = replica.accessForTestingOnly.buildReads(holder.tx, 1)
+        .confirmed;
+      expect(
+        reads.some((read) =>
+          read.id === raw.getAsNormalizedFullLink().id &&
+          read.path.join("/") === "value/count"
+        ),
+      ).toBe(readThrough);
+      holder.abort();
+    });
+  }
+});

--- a/packages/runner/test/scoped-default-writable.test.ts
+++ b/packages/runner/test/scoped-default-writable.test.ts
@@ -1,7 +1,9 @@
 import { expect } from "@std/expect";
+import { toFileUrl } from "@std/path";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { Identity } from "@commonfabric/identity";
+import * as Engine from "@commonfabric/memory/v2/engine";
 
 import type { CellScope, JSONSchema } from "../src/builder/types.ts";
 import type { Cell } from "../src/cell.ts";
@@ -104,6 +106,109 @@ describe("scoped-default-writable", () => {
           scope,
         }).getRaw(),
       ).toBeUndefined();
+    });
+
+    it(`preserves an explicitly undefined space slot under a ${scope} declaration`, async () => {
+      const raw = runtime.getCell<Record<string, unknown>>(
+        space,
+        `undefined-${scope}`,
+      );
+      const seed = runtime.edit();
+      raw.withTx(seed).set({ count: undefined });
+      expect((await seed.commit()).error).toBeUndefined();
+      expect(Object.hasOwn(raw.get(), "count")).toBe(true);
+
+      const shaped = raw.asSchema(countSchema(scope));
+      const projected = shaped.key("count").get()!;
+      expect(shaped.get().count!.getAsNormalizedFullLink().scope).toBe("space");
+      expect(projected.getAsNormalizedFullLink().scope).toBe("space");
+      expect(projected.get()).toBe(0);
+      const write = runtime.edit();
+      projected.withTx(write).set(8);
+      expect((await write.commit()).error).toBeUndefined();
+      expect(raw.key("count").get()).toBe(8);
+      expect(
+        runtime.getCell(
+          space,
+          `undefined-${scope}`,
+          undefined,
+          undefined,
+          scope,
+        )
+          .key("count").getRaw(),
+      ).toBeUndefined();
+    });
+
+    it(`rejects a ${scope} default write when a concurrent writer fills the space slot`, async () => {
+      const raw = runtime.getCell<Record<string, unknown>>(
+        space,
+        `inferred-target-${scope}`,
+      );
+      const seed = runtime.edit();
+      raw.withTx(seed).set({});
+      expect((await seed.commit()).error).toBeUndefined();
+      const holder = runtime.edit();
+      const projected = raw.withTx(holder).asSchema(countSchema(scope))
+        .key("count").get()!;
+      expect(projected.getAsNormalizedFullLink().scope).toBe(scope);
+      projected.set(7);
+      const replica = storageManager.open(space).replica as SpaceReplica;
+      const reads = replica.accessForTestingOnly.buildReads(holder.tx, 1);
+      const id = raw.getAsNormalizedFullLink().id;
+      holder.abort();
+
+      // Validate the captured wire reads at the engine, independently of the
+      // originating replica's local snapshot-conflict check.
+      for (const fill of [false, true]) {
+        const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+        const engine = await Engine.open({ url: toFileUrl(path) });
+        try {
+          Engine.applyCommit(engine, {
+            sessionId: "writer",
+            principal: signer.did(),
+            commit: {
+              localSeq: 1,
+              reads: { confirmed: [], pending: [] },
+              operations: [{ op: "set", id, value: { value: {} } }],
+            },
+          });
+          if (fill) {
+            Engine.applyCommit(engine, {
+              sessionId: "writer",
+              principal: signer.did(),
+              commit: {
+                localSeq: 2,
+                reads: { confirmed: [], pending: [] },
+                operations: [{
+                  op: "patch",
+                  id,
+                  patches: [{ op: "add", path: "/value/count", value: 3 }],
+                }],
+              },
+            });
+          }
+          const commit = () =>
+            Engine.applyCommit(engine, {
+              sessionId: "holder",
+              principal: signer.did(),
+              commit: {
+                localSeq: 1,
+                reads,
+                operations: [{
+                  op: "set",
+                  id,
+                  scope,
+                  value: { value: { count: 7 } },
+                }],
+              },
+            });
+          if (fill) expect(commit).toThrow(Engine.ConflictError);
+          else expect(commit).not.toThrow();
+        } finally {
+          Engine.close(engine);
+          await Deno.remove(path);
+        }
+      }
     });
 
     for (const overwrite of ["this", "redirect"] as const) {

--- a/packages/runner/test/scoped-input-initialization.test.ts
+++ b/packages/runner/test/scoped-input-initialization.test.ts
@@ -1,0 +1,202 @@
+/** Scoped input initialization preserves authored references and existing values. */
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { Identity } from "@commonfabric/identity";
+import {
+  resetServerExecutionConfig,
+  setServerExecutionConfig,
+} from "@commonfabric/memory/v2";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { initializeScopedArgumentSlots } from "../src/data-updating.ts";
+import { createSigilLinkFromParsedLink, parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("scoped input initialization");
+const space = signer.did();
+const argumentSchema = (scope: "user" | "session"): JSONSchema => ({
+  type: "object",
+  properties: {
+    count: { type: "number", default: 0, asCell: [{ kind: "cell", scope }] },
+  },
+});
+
+describe("scoped-input-initialization", () => {
+  let manager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    manager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+    });
+    setServerExecutionConfig(true);
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await manager.close();
+    resetServerExecutionConfig();
+  });
+
+  for (const scope of ["user", "session"] as const) {
+    it(`initializes an absent ${scope} input through a whole-object reference`, async () => {
+      const raw = runtime.getCell<Record<string, unknown>>(space, "inputs");
+      const argument = runtime.getCell(space, "argument");
+      await Promise.all([raw.sync(), argument.sync()]);
+      const tx = runtime.edit();
+      raw.withTx(tx).set({ unrelated: 7 });
+      argument.withTx(tx).set(raw);
+      initializeScopedArgumentSlots(
+        runtime,
+        tx,
+        argument.getAsNormalizedFullLink(),
+        argumentSchema(scope),
+      );
+      expect((await tx.commit()).error).toBeUndefined();
+      const shaped = raw.asSchema(argumentSchema(scope));
+      expect(
+        shaped.key("count").resolveAsCell().getAsNormalizedFullLink().scope,
+      ).toBe(scope);
+      expect(raw.key("unrelated").get()).toBe(7);
+      const write = runtime.edit();
+      raw.withTx(write).key("count").set(3);
+      expect((await write.commit()).error).toBeUndefined();
+      expect(
+        runtime.getCell(space, "inputs", undefined, undefined, scope).key(
+          "count",
+        ).get(),
+      ).toBe(3);
+    });
+  }
+
+  for (const value of [7, undefined]) {
+    it(`preserves an explicitly present ${String(value)} input`, async () => {
+      const raw = runtime.getCell<Record<string, unknown>>(space, "present");
+      await raw.sync();
+      const tx = runtime.edit();
+      raw.withTx(tx).set({ count: value });
+      initializeScopedArgumentSlots(
+        runtime,
+        tx,
+        raw.getAsNormalizedFullLink(),
+        argumentSchema("user"),
+      );
+      expect(raw.withTx(tx).key("count").getRaw({ lastNode: "top" })).toBe(
+        value,
+      );
+      expect((await tx.commit()).error).toBeUndefined();
+    });
+  }
+
+  for (const value of [7, undefined, "link"] as const) {
+    it(`preserves a present ${String(value)} at an intermediate user slot`, async () => {
+      const raw = runtime.getCell<Record<string, unknown>>(
+        space,
+        "intermediate",
+      );
+      const user = runtime.getCell<Record<string, unknown>>(
+        space,
+        "intermediate",
+        undefined,
+        undefined,
+        "user",
+      );
+      const target = runtime.getCell<number>(space, "explicit-target");
+      await Promise.all([raw.sync(), user.sync(), target.sync()]);
+      const tx = runtime.edit();
+      const input = raw.key("count").getAsNormalizedFullLink();
+      raw.withTx(tx).set({
+        count: createSigilLinkFromParsedLink({ ...input, scope: "user" }),
+      });
+      user.withTx(tx).set({ count: value === "link" ? target : value });
+      const before = user.withTx(tx).key("count").getRaw({ lastNode: "top" });
+      initializeScopedArgumentSlots(
+        runtime,
+        tx,
+        raw.getAsNormalizedFullLink(),
+        argumentSchema("session"),
+      );
+      expect(user.withTx(tx).key("count").getRaw({ lastNode: "top" })).toEqual(
+        before,
+      );
+      expect((await tx.commit()).error).toBeUndefined();
+    });
+  }
+
+  for (const overwrite of [undefined, "redirect"] as const) {
+    for (const present of [false, true]) {
+      it(`preserves a ${overwrite ?? "value"} link to a ${present ? "present" : "missing"} target`, async () => {
+        const raw = runtime.getCell<Record<string, unknown>>(space, "linked");
+        const target = runtime.getCell<number>(space, "target");
+        await Promise.all([raw.sync(), target.sync()]);
+        const tx = runtime.edit();
+        if (present) target.withTx(tx).set(9);
+        const link = createSigilLinkFromParsedLink({
+          ...target.getAsNormalizedFullLink(),
+          overwrite,
+        });
+        raw.withTx(tx).set({ count: link });
+        const before = raw.withTx(tx).key("count").getRaw({ lastNode: "top" });
+        initializeScopedArgumentSlots(
+          runtime,
+          tx,
+          raw.getAsNormalizedFullLink(),
+          argumentSchema("user"),
+        );
+        const after = raw.withTx(tx).key("count").getRaw({ lastNode: "top" });
+        expect(after).toEqual(before);
+        expect(parseLink(after, raw)?.scope).toBe("space");
+        expect((await tx.commit()).error).toBeUndefined();
+      });
+    }
+  }
+
+  it("preserves an explicit reference to the same slot in user scope", async () => {
+    const raw = runtime.getCell<Record<string, unknown>>(space, "self-input");
+    const user = runtime.getCell(
+      space,
+      "self-input",
+      undefined,
+      undefined,
+      "user",
+    )
+      .key("count");
+    await Promise.all([raw.sync(), user.sync()]);
+    const tx = runtime.edit();
+    raw.withTx(tx).set({ count: user });
+    initializeScopedArgumentSlots(
+      runtime,
+      tx,
+      raw.getAsNormalizedFullLink(),
+      argumentSchema("session"),
+    );
+    expect((await tx.commit()).error).toBeUndefined();
+    expect(raw.key("count").resolveAsCell().getAsNormalizedFullLink().scope)
+      .toBe("user");
+  });
+
+  it("rejects initialization that raced with an explicit input write", async () => {
+    const raw = runtime.getCell<Record<string, unknown>>(space, "racing");
+    await raw.sync();
+    const seed = runtime.edit();
+    raw.withTx(seed).set({});
+    expect((await seed.commit()).error).toBeUndefined();
+    const initialize = runtime.edit();
+    initializeScopedArgumentSlots(
+      runtime,
+      initialize,
+      raw.getAsNormalizedFullLink(),
+      argumentSchema("user"),
+    );
+    const rebind = runtime.edit();
+    raw.withTx(rebind).key("count").set(11);
+    expect((await rebind.commit()).error).toBeUndefined();
+    expect((await initialize.commit()).error?.name).toBe(
+      "StorageTransactionInconsistent",
+    );
+    expect(raw.key("count").get()).toBe(11);
+  });
+});

--- a/packages/runner/test/scoped-input-initialization.test.ts
+++ b/packages/runner/test/scoped-input-initialization.test.ts
@@ -178,6 +178,52 @@ describe("scoped-input-initialization", () => {
       .toBe("user");
   });
 
+  it("preserves a whole-object reference blocked by its follow cap", async () => {
+    const raw = runtime.getCell(space, "capped-argument");
+    const target = runtime.getCell<Record<string, unknown>>(
+      space,
+      "capped-target",
+      undefined,
+      undefined,
+      "user",
+    );
+    await Promise.all([raw.sync(), target.sync()]);
+    const seed = runtime.edit();
+    target.withTx(seed).set({});
+    raw.withTx(seed).set(target);
+    expect((await seed.commit()).error).toBeUndefined();
+    const authoredLink = raw.getRaw({ lastNode: "top" });
+
+    const blocked = runtime.edit();
+    initializeScopedArgumentSlots(
+      runtime,
+      blocked,
+      raw.asSchema({ type: "object", scope: "space" })
+        .getAsNormalizedFullLink(),
+      argumentSchema("session"),
+    );
+    expect((await blocked.commit()).error).toBeUndefined();
+    expect(raw.getRaw({ lastNode: "top" })).toEqual(authoredLink);
+    expect(target.getRaw()).toEqual({});
+
+    const allowed = runtime.edit();
+    initializeScopedArgumentSlots(
+      runtime,
+      allowed,
+      raw.asSchema({ type: "object", scope: "user" })
+        .getAsNormalizedFullLink(),
+      argumentSchema("session"),
+    );
+    expect((await allowed.commit()).error).toBeUndefined();
+    expect(raw.getRaw({ lastNode: "top" })).toEqual(authoredLink);
+    expect(parseLink(target.key("count").getRaw({ lastNode: "top" }), target))
+      .toMatchObject({
+        id: target.getAsNormalizedFullLink().id,
+        path: ["count"],
+        scope: "session",
+      });
+  });
+
   it("rejects initialization that raced with an explicit input write", async () => {
     const raw = runtime.getCell<Record<string, unknown>>(space, "racing");
     await raw.sync();


### PR DESCRIPTION
Passing an uninitialized `PerUser<Writable<number | Default<0>>>` input into a static or compiled child can give both users the same space-scoped handle. Pattern setup now creates omitted scoped input redirects through whole-object Cell arguments using the existing redirect construction. Projecting an absent defaulted property with `key()` also creates its handle at the declared scope.

Existing values and references remain authoritative, including explicitly stored `undefined`, references to missing targets, and an explicit same-slot user reference. Initialization keeps its absence checks in commit dependencies; handle-only projection remains reactive without adding a content-value conflict dependency.

Validation covers real serving-host child handlers for two users and two sessions of the initializing user, direct read/write destinations, pending and blocked ancestors, reference preservation, and a concurrent input write. Focused regression and adjacent suites: 48 tests / 173 steps passed. The full runner package passed 1,417 tests / 8,854 steps with no failures and one ignored step. The follow-up presence correction passed 12 suites / 170 steps, including real-engine concurrent-fill rejection and unchanged-slot controls; its two explicit-undefined regressions fail on the preceding head. Repository formatting, lint, and type checking passed again after that correction. All 598 documentation code-block checks passed.

Fan-out fixtures explicitly select the user-only or mixed user/session input scopes their assertions require. The session-departure regression waits for demand-root transitions instead of fixed delays.

The coverage document records a separate, reproduced baseline gap: a later user's `PerSession` intermediate may lack its session redirect even when the first user's input was explicitly initialized. Completing that hop needs durable initialization ownership so it cannot retarget an explicit user reference; this PR preserves that boundary.
