### PR TITLE
perf(memory): deduplicate result-schema metadata in sync frames

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1043,9 +1043,13 @@ the per-epic implementation notes).
 - **Interaction with `contentAddressedSchemas`.** The two mechanisms
   compose (see that flag's entry): the table encoder skips
   reference-only positions, so it compresses exactly the stored links
-  that still carry inline schemas and approaches a no-op as
-  reference-bearing links take over. Runtime construction leaves the
-  table's negotiation untouched.
+  that still carry inline schemas. Its link-position work approaches a no-op
+  as reference-bearing links take over. Document-root result-schema metadata
+  remains inline at rest; peers additionally advertising the build capability
+  `syncDocumentSchemasV1` can share repeated metadata through the same table.
+  This use remains after links migrate to `cid:`. Runtime construction leaves
+  the table's negotiation untouched. Disabling `syncSchemaTableV2` disables
+  both uses.
 - **Current default and planned end state.** On by default, everywhere;
   negotiated, so it degrades safely against older peers. The end state is
   to retire the negotiation and the expanded form once every peer AND the

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -146,6 +146,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Investigations, journals, and working notes
 
+- [Topics startup schema metadata](development/performance/2026-09-topics-startup-schema-metadata.md) — 2026-09-10: a 249-topic startup capture, fresh-piece confirmation of inline result-schema metadata despite content-addressed links, and a negotiated extension of the existing schema table reducing the largest compressed response by 40.6% in exact offline replay; deployed latency remains unmeasured.
+
 - [Pattern read accounting: first-batch baseline](development/performance/2026-09-pattern-read-accounting.md) — 2026-09-10: transaction-scoped read counters, generic reduction update costs, headless lunch-poll attribution, and instrumentation overhead measurements.
 - [Incremental aggregate comparison](development/performance/2026-09-incremental-aggregates.md) — 2026-09-10: compiled aggregate initialization costs, paired update timings, read-work scaling, and coordinator rescan findings.
 

--- a/docs/history/development/performance/2026-09-topics-startup-schema-metadata.md
+++ b/docs/history/development/performance/2026-09-topics-startup-schema-metadata.md
@@ -1,0 +1,119 @@
+---
+status: historical
+created: 2026-09-10
+archived: 2026-09-10
+reason: "Point-in-time Topics startup capture and offline validation of negotiated result-schema metadata deduplication."
+---
+
+# Topics startup: repeated result-schema metadata
+
+A September 10 capture of the deployed Topics board identified repeated
+document-root result schemas as a substantial part of its startup transfer.
+Extending the existing sync schema table to those fields reduced the largest
+response's compressed size by **40.6%**, with exact reconstruction of the entire
+response. This is an offline transport result, not a measured reduction in
+deployed startup latency.
+
+## Capture and scope
+
+- Client base: `74705eea1`, Apple M5 Max, macOS arm64, Deno 2.9.4.
+- Estuary server: `a5ed830f06827ce1b9bc0dfbe0b6a023315f3268`.
+- Board: 249 Topics. The command started the board and read its index using
+  `cell get … index --step --select @`, avoiding the separate CLI mapped
+  projection cost.
+- Both ends used `serverExecution=false`, `modernCellRep=false`,
+  `contentAddressedSchemas=true`, `readerSchemaPrecedence=true`,
+  `commitPreconditions=true`, `computedCellIds=true`,
+  `plainResultReceipts=true`, and `lazyMaterialization=true`.
+- Existing CLI phase timers, memory frame logging, and the in-process CPU
+  profiler were enabled. A diagnostic WebSocket observer additionally recorded
+  actual message lengths; a transport receiver wrapper retained the large
+  sync locally for offline replay. It changed no requested reads.
+
+The command returned 249 addresses. Its incoming messages totaled 18,874,603
+bytes after decompression and 4,416,796 bytes at the WebSocket message boundary.
+The largest response carried 4,843 upserts: 18,202,576 uncompressed bytes and
+4,275,563 received compressed bytes. The offline compressor reproduced a
+4,275,513-byte envelope for the same text. The comparisons below use that same
+local compressor for both arms rather than comparing different encoders.
+
+The board startup phase took 4.588 seconds in this instrumented invocation.
+It included fresh compilation work on this client base, so it is not a matched
+comparison with earlier startup timings. The largest watch request spanned
+about 2.13 seconds; about 0.35 seconds went into decompression, decoding,
+schema expansion, and replica application, with additional diagnostic logging
+overhead. Other clients and host load were
+uncontrolled. These timings locate work; they are not benchmark samples.
+
+## Why the existing `cid:` work does not remove these copies
+
+Content-addressed schemas cover link schemas, pattern bindings, and selectors.
+The runtime's `Runner.#updateResultSchemaMeta` separately stores the complete
+result schema at the document root, beside `value`, `argument`, and `internal`.
+The existing transport schema table also targets link schemas rather than this
+metadata field.
+
+A local control compiled and instantiated a new, two-field pattern with
+`contentAddressedSchemas=true`. Its projected title link carried a
+`{ "$ref": "cid:…" }` schema, while `getMetaRaw("schema")` returned the
+complete object schema, structurally equal to the compiled result schema.
+The duplication therefore also occurs on freshly created pieces; it is not
+solely legacy stored links awaiting migration.
+
+The captured response contained 499 result-schema metadata fields but only
+four distinct schemas, repeated 249, 138, 111, and one times. Their serialized
+JSON field sizes totaled 4,537,456 bytes. Other substantial fields were
+`internal` (4,335,902 bytes) and `value` (6,895,238 bytes). These field sizes
+describe the decoded capture and are not additive estimates of compressed
+network traffic.
+
+## Change and offline comparison
+
+The patch extends the existing hash-verified, frame-local schema table. With
+both `syncSchemaTableV2` and the additional `syncDocumentSchemasV1` capability
+negotiated, repeated large `doc.schema` values travel once in `schemaTable`.
+Each affected upsert carries `documentSchemaRef` outside its document. The
+client restores the metadata before ordinary schema expansion and cache
+application. The stored documents, versions, query roots, and startup
+synchronization are unchanged. Older peers continue using inline metadata.
+
+The replay expanded the captured response once, then sent that identical
+input through both encoder modes, the real memory boundary codec, and the
+actual gzip envelope helpers. Every output was decoded and expanded and
+compared structurally with the complete original response. One warmup pair
+was retained separately; seven measured pairs alternated arm order. No live
+server or network was involved in the replay.
+
+| Largest response | Existing encoding | Metadata table |
+| --- | ---: | ---: |
+| Uncompressed protocol bytes | 18,202,576 | 13,731,755 |
+| Compressed envelope bytes | 4,275,513 | 2,540,960 |
+| Complete reconstructed response | Identical | Identical |
+| Local codec pipeline median | 400 ms | 381 ms |
+| Local codec pipeline range | 396–408 ms | 335–579 ms |
+
+The byte reduction is exact for this capture. The local processing result is
+variable: patched decoding had larger outliers, and the warmup pair took
+447 ms for existing encoding and 516 ms with metadata deduplication. This
+does not establish a robust CPU or startup-latency improvement. The expected
+benefit is less transfer work; a deployment must be measured before assigning
+an end-to-end saving. The replay excludes server query evaluation, network
+waiting, and client replica application.
+
+## Validation and remaining work
+
+The memory tests cover exact wire round trips, metadata-only responses and
+effects, modern links, Fabric values in schema defaults, ordinary application
+fields, small/unique/already-content-addressed schemas, and malformed or
+forged table references. A real loopback server/client matrix covers absent,
+false, and true client capabilities against enabled and disabled servers and
+checks the restored documents in the watch view.
+
+Repository formatting, lint, and type checks passed. The complete memory
+package suite passed with 616 tests and 587 test steps.
+
+Raw captures, the fresh-piece control, the replay harness, and both prototype
+and final replay records remain in the local investigation artifacts; no Topic
+content or private identity was included in this changeset. Extending `cid:`
+storage to result-schema metadata remains a separate opportunity requiring
+its own persistence, schema-closure delivery, and reader-compatibility work.

--- a/docs/specs/content-addressed-schemas.md
+++ b/docs/specs/content-addressed-schemas.md
@@ -541,6 +541,15 @@ table (`schema-ref@2:`) skips reference-only schema positions. Schema
 document bodies travel once, as ordinary document upserts, and benefit from
 any document-level caching.
 
+Result-schema metadata at a piece document's root (`doc.schema`) remains
+inline at rest. It is separate from link and binding schemas, so enabling
+`contentAddressedSchemas` does not deduplicate that field, even on newly
+instantiated pieces. When peers also negotiate `syncDocumentSchemasV1`, the
+existing frame-local schema table can deduplicate repeated result metadata
+during delivery; the client restores the inline field before applying the
+sync. See [the protocol](memory-v2/04-protocol.md#negotiated-schema-table-encoding).
+Retiring the table's link-position use does not retire this metadata use.
+
 ### What this does not change
 
 - **Link identity**: `areNormalizedLinksSame` and `addressKey` exclude

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -221,6 +221,12 @@ when absent. The server sends compact sync payloads only when both peers
 advertise the capability; otherwise it sends the historical fully expanded
 shape.
 
+`syncDocumentSchemasV1` additionally permits repeated document-root `schema`
+metadata to use that table. It defaults to `false` when absent. The server
+requires both peers to advertise both capabilities before emitting document
+schema references; a peer supporting only `syncSchemaTableV2` receives inline
+document metadata and may still receive compact link schemas.
+
 `entityIdListing` advertises support for `entity-id.list`. It defaults to
 `false` when absent. A client must not send the request unless the server
 advertises the capability.
@@ -406,6 +412,7 @@ interface HelloMessage {
     stableExpressionResultIds?: boolean;
     messageCompressionV1?: boolean;
     syncSchemaTableV2?: boolean;
+    syncDocumentSchemasV1?: boolean;
     entityIdListing?: boolean;
     entityIdPagination?: boolean;
     entityIdLookup?: boolean;
@@ -608,6 +615,25 @@ recognized schema position after expansion — a reference the client does not
 interpret must fail the frame rather than reach the session cache as data.
 After expansion, downstream consumers observe the historical `SessionSync`
 shape with inline schemas and no `schemaTable` field.
+
+When both peers also advertise `syncDocumentSchemasV1`, a sync upsert MAY omit
+its document's root `schema` field and instead carry
+`documentSchemaRef: "<tagged-hash>"` alongside `id`, `seq`, and `doc`. The hash
+names an entry in the same `schemaTable`. This reference belongs to the upsert
+envelope; fields with that name inside a stored document are ordinary data.
+The encoder moves only repeated schemas with an inline memory-wire representation
+of at least 256 characters into the table. Small, unique, and reference-only
+`{ "$ref": "cid:…" }` metadata stays inline.
+
+The client MUST verify the referenced entry's hash, restore `doc.schema`, and
+remove `documentSchemaRef` before applying the upsert. It MUST reject a missing
+table entry, a non-string or empty reference, a missing document, or an upsert
+carrying both `documentSchemaRef` and an own `doc.schema` field. Document schemas
+are restored before link-schema expansion, so link positions inside the restored
+metadata receive the same processing as inline metadata. Table and envelope
+references are frame-local and MUST NOT enter stored documents or the session
+cache. Document versions, watch coverage, and the stored representation are
+unchanged.
 
 Earlier revisions of this encoding also interned the `schema` field of
 `$alias` records. Those records are Pattern-binding vocabulary, not links —

--- a/packages/memory/test/v2.test.ts
+++ b/packages/memory/test/v2.test.ts
@@ -152,6 +152,7 @@ describe("memory v2 flags", () => {
       entityIdLookup: true,
       sessionHoldings: true,
       syncSchemaTableV2: false,
+      syncDocumentSchemasV1: true,
     });
 
     setModernCellRepConfig(true);
@@ -174,6 +175,7 @@ describe("memory v2 flags", () => {
       entityIdLookup: true,
       sessionHoldings: true,
       syncSchemaTableV2: true,
+      syncDocumentSchemasV1: true,
     });
 
     resetModernCellRepConfig();
@@ -190,6 +192,7 @@ describe("memory v2 flags", () => {
         commitPreconditions: true,
         applyOp: true,
         syncSchemaTableV2: true,
+        syncDocumentSchemasV1: true,
         messageCompressionV1: true,
         sqliteCommitRowLabelEval: true,
         pendingReadStacks: true,
@@ -205,6 +208,7 @@ describe("memory v2 flags", () => {
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
+        syncDocumentSchemasV1: false,
         messageCompressionV1: false,
         // A peer without commit-time sqlite row-label evaluation stays
         // compatible — the capability only gates the runner's write-gate
@@ -229,6 +233,7 @@ describe("parseMemoryProtocolFlags", () => {
       commitPreconditions: false,
       applyOp: false,
       syncSchemaTableV2: false,
+      syncDocumentSchemasV1: false,
       messageCompressionV1: false,
       sqliteCommitRowLabelEval: false,
       pendingReadStacks: false,
@@ -244,6 +249,7 @@ describe("parseMemoryProtocolFlags", () => {
       commitPreconditions: false,
       applyOp: false,
       syncSchemaTableV2: false,
+      syncDocumentSchemasV1: false,
       messageCompressionV1: false,
       sqliteCommitRowLabelEval: false,
       pendingReadStacks: false,
@@ -266,6 +272,7 @@ describe("parseMemoryProtocolFlags", () => {
         commitPreconditions: true,
         applyOp: false,
         syncSchemaTableV2: false,
+        syncDocumentSchemasV1: false,
         messageCompressionV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
@@ -307,6 +314,7 @@ describe("parseMemoryProtocolFlags", () => {
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: true,
+        syncDocumentSchemasV1: false,
         messageCompressionV1: false,
         sessionHoldings: false,
         sqliteCommitRowLabelEval: false,
@@ -328,6 +336,7 @@ describe("parseMemoryProtocolFlags", () => {
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
+        syncDocumentSchemasV1: false,
         messageCompressionV1: true,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
@@ -351,6 +360,7 @@ describe("parseMemoryProtocolFlags", () => {
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
+        syncDocumentSchemasV1: false,
         messageCompressionV1: false,
         sqliteCommitRowLabelEval: true,
         pendingReadStacks: false,
@@ -382,6 +392,7 @@ describe("parseMemoryProtocolFlags", () => {
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
+        syncDocumentSchemasV1: false,
         messageCompressionV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
@@ -406,6 +417,7 @@ describe("parseMemoryProtocolFlags", () => {
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
+        syncDocumentSchemasV1: false,
         messageCompressionV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: true,
@@ -427,6 +439,7 @@ describe("parseMemoryProtocolFlags", () => {
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
+        syncDocumentSchemasV1: false,
         messageCompressionV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
@@ -452,6 +465,7 @@ describe("parseMemoryProtocolFlags", () => {
         commitPreconditions: false,
         applyOp: false,
         syncSchemaTableV2: false,
+        syncDocumentSchemasV1: false,
         messageCompressionV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,

--- a/packages/memory/test/v2/sync-document-schemas.test.ts
+++ b/packages/memory/test/v2/sync-document-schemas.test.ts
@@ -1,0 +1,310 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { JSONSchema } from "@commonfabric/api";
+import {
+  getModernCellRepConfig,
+  linkRefFrom,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
+
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  type HelloMessage,
+  parseMemoryProtocolFlags,
+  type ServerMessage,
+  type SessionSync,
+} from "../../v2.ts";
+import { connect, loopback, type Transport } from "../../v2/client.ts";
+import { Server } from "../../v2/server.ts";
+import {
+  compressServerMessageSchemas,
+  compressSessionSyncSchemas,
+  expandServerMessageSchemas,
+  expandSessionSyncSchemas,
+  hasDocumentSchemaReferences,
+  type SchemaTableSessionSync,
+} from "../../v2/sync-schema-table.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "../v2-auth-test-helpers.ts";
+
+/** Returns a schema large enough to make per-document repetition costly. */
+function resultSchema(): JSONSchema {
+  return {
+    type: "object",
+    properties: Object.fromEntries(Array.from({ length: 40 }, (_, index) => [
+      `field${index}`,
+      { type: "string", description: `Description of field ${index}` },
+    ])),
+    required: ["field1", "field0"],
+    additionalProperties: false,
+  };
+}
+
+/** Returns independently allocated metadata, as decoded storage rows hold it. */
+function resultSync(count = 20): SessionSync {
+  return {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: Array.from({ length: count }, (_, index) => ({
+      id: `of:result-${index}`,
+      branch: "",
+      seq: 1,
+      doc: { value: { field0: `row ${index}` }, schema: resultSchema() },
+    })),
+    removes: [],
+  };
+}
+
+describe("sync-document-schemas", () => {
+  it("reduces repeated metadata and reconstructs the complete sync after encoding", () => {
+    const sync = resultSync();
+    const before = encodeMemoryBoundary(sync);
+    const compressed = compressSessionSyncSchemas(
+      sync,
+      undefined,
+      true,
+    ) as SchemaTableSessionSync;
+    const wire = encodeMemoryBoundary(compressed);
+    expect(wire.length).toBeLessThan(before.length / 4);
+    expect(Object.keys(compressed.schemaTable!)).toHaveLength(1);
+    expect(
+      compressed.upserts.every((u) =>
+        u.documentSchemaRef !== undefined && !Object.hasOwn(u.doc!, "schema")
+      ),
+    ).toBe(true);
+    expect(expandSessionSyncSchemas(decodeMemoryBoundary(wire))).toEqual(sync);
+    expect(encodeMemoryBoundary(sync)).toBe(before);
+  });
+
+  it("leaves unique, small, and content-addressed metadata inline", () => {
+    const one = resultSync(1);
+    expect(compressSessionSyncSchemas(one, undefined, true)).toBe(one);
+    for (const schema of [true, false, {}, { $ref: "cid:fid1:existing" }]) {
+      const sync = resultSync(2);
+      for (const upsert of sync.upserts) upsert.doc = { value: 1, schema };
+      expect(compressSessionSyncSchemas(sync, undefined, true)).toBe(sync);
+    }
+  });
+
+  it("keeps metadata inline unless its additional capability is enabled", () => {
+    const sync = resultSync();
+    expect(compressSessionSyncSchemas(sync)).toBe(sync);
+  });
+
+  it("preserves nested application schemas and composes with link-schema tables", () => {
+    const sync = resultSync(2);
+    const application = {
+      schema: resultSchema(),
+      documentSchemaRef: "ordinary application data",
+      ...Object.fromEntries([["__proto__", { safe: true }]]),
+      nested: linkRefFrom({
+        id: "of:target",
+        path: [],
+        schema: resultSchema(),
+      }),
+    };
+    for (const upsert of sync.upserts) {
+      upsert.doc = {
+        value: application,
+        schema: {
+          ...resultSchema() as object,
+          default: linkRefFrom({ id: "of:default", path: [], schema: true }),
+        },
+      };
+    }
+    const compressed = compressSessionSyncSchemas(sync, undefined, true);
+    expect(expandSessionSyncSchemas(compressed)).toEqual(sync);
+    expect(hasDocumentSchemaReferences({
+      type: "response",
+      ok: { sync },
+    })).toBe(false);
+  });
+
+  it("expands metadata-only references in response and effect envelopes", () => {
+    const sync = resultSync(2);
+    const messages: ServerMessage[] = [
+      { type: "response", requestId: "watch", ok: { sync } },
+      {
+        type: "session/effect",
+        sessionId: "test-session",
+        space: "did:key:test-space",
+        effect: sync,
+      },
+    ];
+    for (const message of messages) {
+      const compressed = compressServerMessageSchemas(message, undefined, true);
+      expect(hasDocumentSchemaReferences(compressed)).toBe(true);
+      expect(encodeMemoryBoundary(compressed).includes("schema-ref@2:")).toBe(
+        false,
+      );
+      expect(expandServerMessageSchemas(compressed)).toEqual(message);
+    }
+  });
+
+  it("preserves Fabric values in schema defaults through the wire codec", () => {
+    const sync = resultSync(2);
+    for (const upsert of sync.upserts) {
+      upsert.doc = {
+        value: 1,
+        schema: { ...resultSchema() as object, default: 1n },
+      };
+    }
+    const compressed = compressSessionSyncSchemas(sync, undefined, true);
+    expect(
+      expandSessionSyncSchemas(
+        decodeMemoryBoundary(encodeMemoryBoundary(compressed)),
+      ),
+    )
+      .toEqual(sync);
+  });
+
+  it("restores metadata alongside modern links", () => {
+    const previous = getModernCellRepConfig();
+    setModernCellRepConfig(true);
+    try {
+      const sync = resultSync(2);
+      for (const upsert of sync.upserts) {
+        upsert.doc = {
+          schema: resultSchema(),
+          value: linkRefFrom({
+            id: "of:target",
+            path: [],
+            schema: resultSchema(),
+          }),
+        };
+      }
+      const compressed = compressSessionSyncSchemas(sync, undefined, true);
+      expect(
+        expandSessionSyncSchemas(
+          decodeMemoryBoundary(encodeMemoryBoundary(compressed)),
+        ),
+      )
+        .toEqual(sync);
+    } finally {
+      setModernCellRepConfig(previous);
+    }
+  });
+
+  it("rejects missing, forged, or ambiguous document-schema references", () => {
+    const sync = compressSessionSyncSchemas(
+      resultSync(2),
+      undefined,
+      true,
+    ) as SchemaTableSessionSync;
+    const hash = sync.upserts[0].documentSchemaRef!;
+    for (
+      const schemaTable of [undefined, {}, {
+        [hash]: { type: "number" as const },
+      }]
+    ) {
+      expect(() => expandSessionSyncSchemas({ ...sync, schemaTable }))
+        .toThrow();
+    }
+    for (
+      const upsert of [
+        { ...sync.upserts[0], documentSchemaRef: "" },
+        { ...sync.upserts[0], documentSchemaRef: undefined },
+        { ...sync.upserts[0], doc: undefined },
+        { ...sync.upserts[0], doc: { value: 1, schema: true } },
+      ]
+    ) {
+      expect(() => expandSessionSyncSchemas({ ...sync, upserts: [upsert] }))
+        .toThrow();
+    }
+  });
+
+  it("defaults absent capabilities to false and rejects malformed flags", () => {
+    const flags = getMemoryProtocolFlags();
+    const { syncDocumentSchemasV1: _capability, ...oldFlags } = flags;
+    expect(parseMemoryProtocolFlags(oldFlags)?.syncDocumentSchemasV1).toBe(
+      false,
+    );
+    expect(parseMemoryProtocolFlags({ ...flags, syncDocumentSchemasV1: "yes" }))
+      .toBeNull();
+  });
+
+  for (const clientCapability of [undefined, false, true]) {
+    for (const serverCapability of [false, true]) {
+      it(`restores cold metadata with client capability ${clientCapability} and server capability ${serverCapability}`, async () => {
+        /** Server with an explicit peer capability for the negotiation matrix. */
+        class TestServer extends Server {
+          /** @inheritDoc */
+          override memoryProtocolFlags() {
+            return {
+              ...super.memoryProtocolFlags(),
+              syncDocumentSchemasV1: serverCapability,
+            };
+          }
+        }
+        const server = new TestServer({
+          ...testSessionOpenServerOptions,
+          store: new URL("memory://document-schema-negotiation"),
+          subscriptionRefreshDelayMs: 0,
+        });
+        const underlying = loopback(server);
+        const received: unknown[] = [];
+        const transport: Transport = {
+          ...underlying,
+          send(payload) {
+            const message = decodeMemoryBoundary(payload) as HelloMessage;
+            if (message.type === "hello") {
+              const flags = { ...message.flags };
+              if (clientCapability === undefined) {
+                delete flags.syncDocumentSchemasV1;
+              } else flags.syncDocumentSchemasV1 = clientCapability;
+              payload = encodeMemoryBoundary({ ...message, flags });
+            }
+            return underlying.send(payload);
+          },
+          setReceiver(receiver) {
+            underlying.setReceiver((payload) => {
+              received.push(decodeMemoryBoundary(payload));
+              receiver(payload);
+            });
+          },
+        };
+        const client = await connect({ transport });
+        try {
+          const session = await client.mount(
+            "did:key:document-schemas",
+            {},
+            testSessionOpenAuthFactory,
+          );
+          const sync = resultSync(2);
+          await session.transact({
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            operations: sync.upserts.map((u) => ({
+              op: "set",
+              id: u.id,
+              value: u.doc!,
+            })),
+          });
+          const view = await session.watchAdd([{
+            id: "results",
+            kind: "graph",
+            query: {
+              roots: sync.upserts.map((u) => ({
+                id: u.id,
+                selector: { path: [], schema: false },
+              })),
+            },
+          }]);
+          expect(received.some(hasDocumentSchemaReferences))
+            .toBe(clientCapability === true && serverCapability);
+          expect(view.entities.map((e) => e.document))
+            .toEqual(sync.upserts.map((u) => u.doc));
+        } finally {
+          await client.close();
+          await server.close();
+        }
+      });
+    }
+  }
+});

--- a/packages/memory/test/v2/sync-document-schemas.test.ts
+++ b/packages/memory/test/v2/sync-document-schemas.test.ts
@@ -97,6 +97,22 @@ describe("sync-document-schemas", () => {
     expect(compressSessionSyncSchemas(sync)).toBe(sync);
   });
 
+  it("returns false for values outside a sync message envelope", () => {
+    for (
+      const message of [
+        undefined,
+        null,
+        false,
+        1,
+        "documentSchemaRef",
+        [{ documentSchemaRef: "outside an envelope" }],
+        { documentSchemaRef: "outside an envelope" },
+      ]
+    ) {
+      expect(hasDocumentSchemaReferences(message)).toBe(false);
+    }
+  });
+
   it("preserves nested application schemas and composes with link-schema tables", () => {
     const sync = resultSync(2);
     const application = {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1098,6 +1098,9 @@ export type MemoryProtocolFlags = {
   /** Hash-keyed per-frame schema table. */
   syncSchemaTableV2: boolean;
 
+  /** Document-root schema metadata can share the frame-local schema table. */
+  syncDocumentSchemasV1: boolean;
+
   /** The peer can exchange versioned binary gzip message envelopes. */
   messageCompressionV1: boolean;
 
@@ -1181,6 +1184,8 @@ export type WireMemoryProtocolFlags = {
   applyOp?: boolean;
   operationCodecs?: readonly string[];
   syncSchemaTableV2?: boolean;
+  /** Additional opt-in for document-root schemas in the sync schema table. */
+  syncDocumentSchemasV1?: boolean;
   messageCompressionV1?: boolean;
   sqliteCommitRowLabelEval?: boolean;
   pendingReadStacks?: boolean;
@@ -1995,6 +2000,7 @@ export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   // as the delivery diff base wherever they are sent.
   sessionHoldings: true,
   syncSchemaTableV2: getSyncSchemaTableConfig(),
+  syncDocumentSchemasV1: true,
 });
 
 /**
@@ -2061,6 +2067,14 @@ export const parseMemoryProtocolFlags = (
   if (
     syncSchemaTableV2 !== undefined &&
     typeof syncSchemaTableV2 !== "boolean"
+  ) {
+    return null;
+  }
+
+  const syncDocumentSchemasV1 = value.syncDocumentSchemasV1;
+  if (
+    syncDocumentSchemasV1 !== undefined &&
+    typeof syncDocumentSchemasV1 !== "boolean"
   ) {
     return null;
   }
@@ -2138,6 +2152,7 @@ export const parseMemoryProtocolFlags = (
       ? {}
       : { operationCodecs: [...operationCodecs].sort() as string[] }),
     syncSchemaTableV2: syncSchemaTableV2 === true,
+    syncDocumentSchemasV1: syncDocumentSchemasV1 === true,
     messageCompressionV1: messageCompressionV1 === true,
     // Absent (an older peer) parses to false: the capability must be
     // POSITIVELY advertised for the runner to relax its write gate.
@@ -2173,6 +2188,7 @@ export const wireMemoryProtocolFlags = (
     ? {}
     : { operationCodecs: flags.operationCodecs }),
   syncSchemaTableV2: flags.syncSchemaTableV2,
+  syncDocumentSchemasV1: flags.syncDocumentSchemasV1,
   messageCompressionV1: flags.messageCompressionV1,
   sqliteCommitRowLabelEval: flags.sqliteCommitRowLabelEval,
   pendingReadStacks: flags.pendingReadStacks,

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -44,7 +44,10 @@ import {
 import type { AppliedCommit } from "./engine.ts";
 import type { Server } from "./server.ts";
 import { containsReservedSchemaRefSubstring } from "./sync-schema-ref.ts";
-import { expandServerMessageSchemas } from "./sync-schema-table.ts";
+import {
+  expandServerMessageSchemas,
+  hasDocumentSchemaReferences,
+} from "./sync-schema-table.ts";
 import { logIncomingFrame, logOutgoingFrame } from "./frame-log.ts";
 import { memoryMessageFrameBytes } from "./message-compression.ts";
 import { type ArmedTurn, armTurn } from "./turn.ts";
@@ -513,10 +516,13 @@ export class Client {
       logger.time(decodeStart, "receive", "decodeBoundary");
       logIncomingFrame(message, memoryMessageFrameBytes(payload));
       // A frame whose raw text lacks every reserved reference prefix cannot
-      // carry a schema reference (strings serialize verbatim — see the note
-      // on encodeMemoryBoundary), so the expansion walk over its upserts is
-      // skipped entirely.
-      if (containsReservedSchemaRefSubstring(payload)) {
+      // carry a link-schema reference (strings serialize verbatim — see the
+      // note on encodeMemoryBoundary). Document-schema references occupy the
+      // upsert envelope instead, so check those before skipping expansion.
+      if (
+        containsReservedSchemaRefSubstring(payload) ||
+        hasDocumentSchemaReferences(message)
+      ) {
         const schemaExpansionStart = performance.now();
         message = expandServerMessageSchemas(message);
         logger.time(schemaExpansionStart, "receive", "schemaExpansion");

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -780,6 +780,7 @@ class Connection {
   #ready = false;
   #closed = false;
   #syncSchemaTable = false;
+  #syncDocumentSchemas = false;
   #stableExpressionResultIds = false;
   #sessions = new Map<string, SessionHandle>();
   #sessionOpenChallenge: SessionOpenChallengeState | null = null;
@@ -802,7 +803,11 @@ class Connection {
   #send(message: ServerMessage): void {
     const schemaStart = performance.now();
     const prepared = this.#syncSchemaTable
-      ? compressServerMessageSchemas(message)
+      ? compressServerMessageSchemas(
+        message,
+        undefined,
+        this.#syncDocumentSchemas,
+      )
       : message;
     timing.time(schemaStart, "memory", "response", "prepareSchemas");
     const sendStart = performance.now();
@@ -1064,6 +1069,8 @@ class Connection {
         clientFlags?.stableExpressionResultIds === true;
       this.#syncSchemaTable = clientFlags?.syncSchemaTableV2 === true &&
         serverFlags?.syncSchemaTableV2 === true;
+      this.#syncDocumentSchemas = clientFlags?.syncDocumentSchemasV1 === true &&
+        serverFlags?.syncDocumentSchemasV1 === true;
       this.#ready = true;
       return;
     }

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -8,6 +8,7 @@ import type {
   SessionEffectMessage,
   SessionSync,
 } from "../v2.ts";
+import { encodeMemoryBoundary } from "../v2.ts";
 import { mapLinkSchemas } from "./schema-table-links.ts";
 import {
   findSyncSchemaRef,
@@ -16,8 +17,18 @@ import {
 
 type SchemaTable = Record<string, JSONSchema>;
 
-export type SchemaTableSessionSync = SessionSync & {
+/** A wire upsert whose document-root schema is held in the sync's table. */
+export type SchemaTableUpsert = SessionSync["upserts"][number] & {
+  /** Tagged table hash, removed before the upsert reaches the session cache. */
+  documentSchemaRef?: string;
+};
+
+/** Wire sync carrying schema bodies shared by its link and metadata references. */
+export type SchemaTableSessionSync = Omit<SessionSync, "upserts"> & {
+  /** Schema bodies verified against their tagged hashes during expansion. */
   schemaTable?: SchemaTable;
+  /** Document updates with optional frame-local metadata references. */
+  upserts: SchemaTableUpsert[];
 };
 
 type RewriteState = {
@@ -116,16 +127,99 @@ const expandValue = (
     (schema) => expandSchemaValue(schema, schemas, onSchema),
   );
 
+/**
+ * Moves repeated document-root schemas into the existing frame-local table.
+ * References live on the upsert envelope, so schema-shaped application data
+ * never acquires another interpreted position. Small and unique schemas stay
+ * inline to keep the table from increasing their encoded size.
+ */
+const compressDocumentSchemas = (
+  upserts: SessionSync["upserts"],
+  state: RewriteState,
+): SchemaTableUpsert[] => {
+  const hashes = new Map<number, string>();
+  const counts = new Map<string, number>();
+  const schemas = new Map<string, JSONSchema>();
+  for (let index = 0; index < upserts.length; index++) {
+    const schema = upserts[index].doc?.schema;
+    if (!isCompressibleSchema(schema) || typeof schema === "boolean") {
+      continue;
+    }
+    const hash = internSchema(schema, true).taggedHashString;
+    hashes.set(index, hash);
+    counts.set(hash, (counts.get(hash) ?? 0) + 1);
+    schemas.set(hash, schema);
+  }
+  const repeated = new Set(
+    [...schemas].filter(([hash, schema]) =>
+      counts.get(hash)! >= 2 && encodeMemoryBoundary(schema).length >= 256
+    ).map(([hash]) => hash),
+  );
+  return upserts.map((upsert, index) => {
+    const hash = hashes.get(index);
+    if (hash === undefined || !repeated.has(hash)) return upsert;
+    const { schema, ...doc } = upsert.doc!;
+    schemaRefFor(schema as JSONSchema, state);
+    state.changed = true;
+    return { ...upsert, doc, documentSchemaRef: hash };
+  });
+};
+
+/**
+ * Restores document metadata before link-schema expansion sees its contents.
+ * A malformed envelope must fail before any partial document reaches a cache.
+ */
+const expandDocumentSchema = (
+  upsert: SchemaTableUpsert,
+  schemas: SchemaTable | undefined,
+  onSchema?: (schema: JSONSchema) => void,
+): SessionSync["upserts"][number] => {
+  if (!Object.hasOwn(upsert, "documentSchemaRef")) return upsert;
+  if (
+    typeof upsert.documentSchemaRef !== "string" ||
+    !isPlainObject(upsert.doc) || Object.hasOwn(upsert.doc, "schema")
+  ) {
+    throw new Error("Invalid document schema table reference");
+  }
+  const schema = expandSchemaRef(
+    `${SYNC_SCHEMA_REF_PREFIX}${upsert.documentSchemaRef}`,
+    schemas,
+    onSchema,
+  );
+  const { documentSchemaRef: _reference, ...rest } = upsert;
+  return { ...rest, doc: { ...upsert.doc, schema } };
+};
+
+/** Finds document-schema references only on sync upsert envelopes. */
+export const hasDocumentSchemaReferences = (message: unknown): boolean => {
+  if (!isPlainObject(message)) return false;
+  const sync = message.type === "session/effect"
+    ? message.effect
+    : message.type === "response" && isPlainObject(message.ok)
+    ? message.ok.sync
+    : undefined;
+  return isPlainObject(sync) && sync.type === "sync" &&
+    Array.isArray(sync.upserts) &&
+    sync.upserts.some((upsert) =>
+      isPlainObject(upsert) && Object.hasOwn(upsert, "documentSchemaRef")
+    );
+};
+
+/**
+ * Packs link schemas and, when additionally negotiated, repeated document
+ * metadata into a frame-local table. Schema interning may freeze its inputs.
+ */
 export const compressSessionSyncSchemas = (
   sync: SessionSync,
   onSchema?: (schema: JSONSchema) => void,
+  includeDocumentSchemas = false,
 ): SessionSync | SchemaTableSessionSync => {
   const state: RewriteState = {
     schemas: new Map(),
     changed: false,
     onSchema,
   };
-  const upserts = sync.upserts.map((upsert) => {
+  let upserts = sync.upserts.map((upsert) => {
     if (upsert.doc === undefined) {
       return upsert;
     }
@@ -135,6 +229,10 @@ export const compressSessionSyncSchemas = (
       doc: doc as typeof upsert.doc,
     };
   });
+
+  if (includeDocumentSchemas) {
+    upserts = compressDocumentSchemas(upserts, state);
+  }
 
   if (!state.changed) {
     return sync;
@@ -147,6 +245,7 @@ export const compressSessionSyncSchemas = (
   };
 };
 
+/** Restores verified inline schemas before a sync reaches the session cache. */
 export const expandSessionSyncSchemas = (
   sync: SessionSync | SchemaTableSessionSync,
   onSchema?: (schema: JSONSchema) => void,
@@ -154,6 +253,7 @@ export const expandSessionSyncSchemas = (
   const schemas = (sync as SchemaTableSessionSync).schemaTable;
   if (schemas === undefined || Object.keys(schemas).length === 0) {
     for (const upsert of sync.upserts) {
+      expandDocumentSchema(upsert, schemas, onSchema);
       const ref = findSyncSchemaRef(upsert.doc);
       if (ref !== undefined) {
         expandSchemaRef(ref, schemas, onSchema);
@@ -162,7 +262,8 @@ export const expandSessionSyncSchemas = (
     return sync;
   }
 
-  const upserts = sync.upserts.map((upsert) => {
+  const upserts = sync.upserts.map((wireUpsert) => {
+    const upsert = expandDocumentSchema(wireUpsert, schemas, onSchema);
     if (upsert.doc === undefined) {
       return upsert;
     }
@@ -192,6 +293,7 @@ export const expandSessionSyncSchemas = (
 const compressResponseSync = (
   message: ServerMessage,
   onSchema?: (schema: JSONSchema) => void,
+  includeDocumentSchemas = false,
 ): ServerMessage => {
   if (message.type !== "response" || message.ok === undefined) {
     return message;
@@ -211,6 +313,7 @@ const compressResponseSync = (
       sync: compressSessionSyncSchemas(
         sync as unknown as SessionSync,
         onSchema,
+        includeDocumentSchemas,
       ),
     },
   };
@@ -243,17 +346,23 @@ const expandResponseSync = (
   };
 };
 
+/** Compacts syncs in response and effect envelopes using negotiated capabilities. */
 export const compressServerMessageSchemas = (
   message: ServerMessage,
   onSchema?: (schema: JSONSchema) => void,
+  includeDocumentSchemas = false,
 ): ServerMessage => {
   if (message.type === "session/effect") {
     return {
       ...message,
-      effect: compressSessionSyncSchemas(message.effect, onSchema),
+      effect: compressSessionSyncSchemas(
+        message.effect,
+        onSchema,
+        includeDocumentSchemas,
+      ),
     } as SessionEffectMessage;
   }
-  return compressResponseSync(message, onSchema);
+  return compressResponseSync(message, onSchema, includeDocumentSchemas);
 };
 
 export const expandServerMessageSchemas = (


### PR DESCRIPTION
Cold Topics startup receives hundreds of copies of the same result-schema metadata. Content-addressed schemas already deduplicate link and binding schemas, but `doc.schema` remains inline, including on freshly instantiated pieces. A 249-Topic Estuary capture contained 499 metadata schemas with only four distinct values.

Extend the existing hash-verified sync schema table to repeated document-root schemas when both peers negotiate `syncDocumentSchemasV1` alongside `syncSchemaTableV2`. References live on the upsert envelope and are expanded before cache application. Older peers keep receiving inline metadata. Small, unique, and already-content-addressed metadata stays inline. Stored documents, query coverage, versions, and cold-start synchronization are unchanged.

Replaying the largest captured response through the real codecs reconstructs the entire original message exactly:

| Response size | Existing | Patched |
| --- | ---: | ---: |
| Uncompressed protocol bytes | 18,202,576 | 13,731,755 |
| Compressed envelope bytes | 4,275,513 | 2,540,960 |

The compressed response is **40.6% smaller**. This is an offline byte reduction, not a deployed startup-speed claim. Seven alternating replay pairs gave local codec medians of 400 ms and 381 ms, with wider patched variance; no robust CPU improvement is claimed. The report records ranges, warmup results, capture boundaries, and the remaining `cid` metadata opportunity.

Validation:

- Repository `deno fmt --check`, `deno lint`, and `deno task check` pass.
- Full memory package `deno task test`: 616 tests and 587 steps pass.
- Protocol documentation: all 62 code blocks pass; history index validation passes.
- Regression coverage includes exact encoding/decoding, response and effect envelopes, a real loopback client/server capability matrix, modern links, Fabric defaults, ordinary schema-shaped data, and malformed or forged references.
- Reviewed with the repository's `cf-review` skill; no outstanding findings.

Measurement server: `a5ed830f06827ce1b9bc0dfbe0b6a023315f3268`, server execution disabled. Client base: `74705eea1`. No server deployment or production data migration performed.

Prepared by Codex/Astra on behalf of Gideon (@mathpirate).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

