### PR TITLE
fix(runner): an LLM dialog's result carries its inputs' confidentiality

### DIFF
--- a/docs/specs/cfc-render-boundary-composition.md
+++ b/docs/specs/cfc-render-boundary-composition.md
@@ -66,12 +66,31 @@ The labels a sub-pattern's result document carries are the ones its own fields
 earned. A field aliasing an argument cell carries that cell's label through the
 link machinery. A field fed by a lift or a handler carries the join that
 module makes onto its own result (`applyArgumentIfcToResult`, called from
-`packages/runner/src/builder/module.ts`), except where a built-in sets
-`propagateInputIfc: false` because it resolves label views at run time
-instead — `llmDialog` is the one that does. And under
+`packages/runner/src/builder/module.ts`), and every module's output cells carry
+the join of its input cells' labels (`connectInputAndOutputs`, defined in
+`packages/runner/src/builder/node-utils.ts` and called from `module.ts` and
+`pattern.ts`), which covers a built-in whose result is written at run time
+rather than declared. And under
 `cfcFlowLabels: "persist"` the per-transaction join is written as a `derived`
 component on each value write target; at `observe` it only reaches a
 diagnostic, and at `off` nothing derives it.
+
+No module is excused that input join. A module labeling its outputs below the
+join of its inputs makes §8.9.1's flow-precision claim, which that section
+holds to trust in the executing implementation for `flow-taint-precision` under
+the acting user, and a graph is assembled before there is one. What the join
+states is not §8.9.2's measurement: the build transaction reads nothing, so
+§8.9.2 applied there yields the empty label, which is the argument the next
+paragraph makes for a pattern's own root. It is a static over-approximation of
+what any future attempt could consume, and it is the floor rather than a first
+guess — it mints a `declared` entry, and a path's effective label is the join of
+all its components, so the `derived` component above adds to it and never
+narrows it. A label narrower than the join is therefore available only through
+§8.9.1's trust gate, and nothing in the runtime evaluates that concept.
+
+The join reaches output cells, so a handler is covered by the result join above
+instead: a handler node is built with no outputs, and what its writes carry is
+the join its module makes onto its own result.
 
 The declared result schema adds none of its own: `factoryFromPattern` stores
 the schema the author declared, so a pattern that accepts a confidential
@@ -99,5 +118,7 @@ grant — the direction that refuses rather than admits.
 
 `packages/runner/test/cfc-argument-ifc-propagation.test.ts` holds each builder
 against its own schema, and `packages/runner/test/pattern.test.ts` measures
-where the label reaches the result instead. The `cfc-render-policy-demo`
+where the label reaches the result instead.
+`packages/runner/test/cfc-builtin-output-ifc.test.ts` holds each LLM built-in
+to the input join, at both dial settings. The `cfc-render-policy-demo`
 integration test drives the composed case under the ceiling.

--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -119,7 +119,6 @@ export const llmDialog = createNodeFactory({
   type: "ref",
   implementation: "llmDialog",
   resultSchema: LLMDialogResultSchema,
-  propagateInputIfc: false,
 }) as (
   params: FactoryInput<BuiltInLLMParams>,
 ) => Reactive<BuiltInLLMDialogState>;

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -50,13 +50,16 @@ export function connectInputAndOutputs(node: NodeRef) {
   node.inputs = traverseValue(node.inputs, connect);
   node.outputs = traverseValue(node.outputs, connect);
 
-  // We will also apply ifc tags from inputs to outputs, unless the module has
-  // precise built-in flow handling for its result.
-  if (
-    !isObjectOrArray(node.module) || node.module.propagateInputIfc !== false
-  ) {
-    applyInputIfcToOutput(node.inputs, node.outputs);
-  }
+  // Every module's outputs carry the join of its inputs' ifc tags. The graph is
+  // assembled before anything is read, so the join over-approximates what any
+  // one attempt goes on to consume, and it stays the floor: it mints a
+  // `declared` entry, and a path's effective label is the join of all its
+  // components, so no later measurement narrows it. Labeling an output below
+  // the join is the flow-precision claim of CFC §8.9.1, which that section
+  // holds to trust in the executing implementation for `flow-taint-precision`
+  // under the acting user, and this seam names no user.
+  // `docs/specs/cfc-render-boundary-composition.md` states the rest.
+  applyInputIfcToOutput(node.inputs, node.outputs);
 }
 
 export function applyArgumentIfcToResult(

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -176,7 +176,6 @@ declare module "@commonfabric/api" {
     wrapper?: "handler";
     argumentSchema?: JSONSchema;
     resultSchema?: JSONSchema;
-    propagateInputIfc?: boolean;
 
     /** If true, this module is an effect (side-effectful) rather than a computation */
     isEffect?: boolean;

--- a/packages/runner/test/cfc-builtin-output-ifc.test.ts
+++ b/packages/runner/test/cfc-builtin-output-ifc.test.ts
@@ -1,0 +1,332 @@
+/**
+ * What a reader of an LLM built-in's output sees when a confidential cell was
+ * handed to that built-in as a parameter.
+ *
+ * Two mechanisms put the label there, and the cases below separate them.
+ * `connectInputAndOutputs` joins every input cell's `ifc` onto the output
+ * cell's schema while the graph is assembled, which is the conservative
+ * default of CFC §8.9.2 over-approximated before anything is read. The
+ * `cfcFlowLabels` dial at `"persist"` measures each transaction's own reads
+ * and writes the join as the `derived` component. The dial is off in the
+ * default posture, so the first mechanism is what a deployment has, and
+ * §8.9.1 holds a label less restrictive than the conservative default to
+ * trust in the executing implementation for `flow-taint-precision`. Both dial
+ * settings are exercised because a label present only under `"persist"` is a
+ * label the default posture does not carry.
+ *
+ * `cfc-argument-ifc-propagation.test.ts` holds the other seam, where a
+ * confidential argument reaches a module's declared result schema.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { BuiltInLLMMessage } from "@commonfabric/api";
+import { findInternedSchema } from "@commonfabric/data-model-schema";
+import { Identity } from "@commonfabric/identity";
+import {
+  addMockResponse,
+  clearMockResponses,
+  enableMockMode,
+  resetMockMode,
+} from "@commonfabric/llm/client";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import type {
+  JSONSchema,
+  JSONSchemaObj,
+  NodeRef,
+} from "../src/builder/types.ts";
+import { cfcLabelViewForResolvedCellWithStatus } from "../src/cfc/label-view.ts";
+import type { CfcFlowLabelsMode } from "../src/cfc/types.ts";
+import { LLMDialogResultSchema } from "../src/builtins/llm-schemas.ts";
+import { Runtime } from "../src/runtime.ts";
+import { parseExternalSchemaRef } from "../src/schema-decompose.ts";
+import { waitForLlmMessages } from "./support/llm-result.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-builtin-output-ifc");
+const space = signer.did();
+
+const BRIEFING_ATOM = {
+  type: "https://commonfabric.org/cfc/atom/Resource",
+  class: "SensitiveBriefing",
+  subject: "did:example:subject",
+} as const;
+
+// One confidential field, the shape a `Confidential<...>` argument compiles to.
+const ARGUMENT_SCHEMA = {
+  type: "object",
+  properties: {
+    briefing: { type: "string", ifc: { confidentiality: [BRIEFING_ATOM] } },
+  },
+} as const satisfies JSONSchema;
+
+// The label the turn's cases put on the dialog's `messages` input, which is the
+// pattern's own cell rather than its argument.
+const LABELED_MESSAGES_SCHEMA = {
+  type: "array",
+  ifc: { confidentiality: [BRIEFING_ATOM] },
+} as const satisfies JSONSchema;
+
+const RESULT_SCHEMA = {
+  type: "object",
+  properties: {
+    addMessage: { asCell: ["stream"] },
+    pending: { type: "boolean" },
+    messages: { type: "array" },
+    answer: {},
+  },
+} as const satisfies JSONSchema;
+
+type Builder = ReturnType<typeof createBuilder>["commonfabric"];
+
+const createRuntime = (cfcFlowLabels: CfcFlowLabelsMode) => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+    cfcEnforcementMode: "enforce-explicit",
+    cfcFlowLabels,
+  });
+  return { runtime, storageManager };
+};
+
+/**
+ * The schema of the cell a node writes its output to.
+ *
+ * The node holds that schema interned behind an external reference, so the
+ * reference is resolved rather than read.
+ */
+const outputSchema = (node: NodeRef): JSONSchema | undefined => {
+  const alias = (node.outputs as {
+    $alias?: { schema?: JSONSchema | { $ref?: string } };
+  })?.$alias;
+  const ref = (alias?.schema as { $ref?: string } | undefined)?.$ref;
+  const taggedHash = typeof ref === "string"
+    ? parseExternalSchemaRef(ref)?.taggedHash
+    : undefined;
+  return taggedHash !== undefined
+    ? findInternedSchema(taggedHash)?.schema
+    : alias?.schema as JSONSchema | undefined;
+};
+
+/**
+ * The `ifc` on that schema.
+ *
+ * Five states report `undefined` together: a node with no output binding, a
+ * binding naming no schema, a reference that does not parse, a reference naming
+ * no interned schema, and the one a reader means — a schema carrying no `ifc`.
+ * A case asserting the last pins {@link outputSchema} as well.
+ */
+const outputIfc = (node: NodeRef): JSONSchemaObj["ifc"] =>
+  (outputSchema(node) as JSONSchemaObj | undefined)?.ifc;
+
+/**
+ * The confidentiality clauses a reader of `cell` sees, flattened across the
+ * entries of its label view.
+ *
+ * The resolved view is the one an inspection surface uses: it follows the link
+ * the selected path lands on, which a pattern result's field into a built-in's
+ * output document always is.
+ */
+const confidentialityOf = (cell: unknown): unknown[] => {
+  const { view } = cfcLabelViewForResolvedCellWithStatus(cell);
+  return (view?.entries ?? []).flatMap((entry) =>
+    entry.label.confidentiality ?? []
+  );
+};
+
+/**
+ * Builds a one-node pattern whose single built-in is handed the confidential
+ * argument as its `system` parameter, and returns that node.
+ *
+ * The body drops what the built-in returns. `pattern()` takes the same join
+ * over the cells a body returns, and the built-in's output cell is one of
+ * them, so returning that cell itself labels its schema whatever this seam
+ * did. Returning a path into it — `dialog.result`, say — escapes that, because
+ * the join then reaches the alias rather than the output cell.
+ */
+const nodeForBuiltin = (
+  runtime: Runtime,
+  build: (builder: Builder, briefing: unknown) => unknown,
+): NodeRef => {
+  const { commonfabric } = createTrustedBuilder(runtime);
+  const factory = commonfabric.pattern(
+    (input: { briefing: string }) => {
+      build(commonfabric, input.briefing);
+      return { answer: "unrelated to the built-in" };
+    },
+    ARGUMENT_SCHEMA,
+    { type: "object", properties: { answer: { type: "string" } } } as const,
+  );
+  const nodes = factory.nodes ?? [];
+  expect(nodes.length).toBe(1);
+  return nodes[0] as NodeRef;
+};
+
+describe("cfc-builtin-output-ifc", () => {
+  describe("the build-time join", () => {
+    // Each case names the built-in whose node it measures, because the join is
+    // attached per node and an exemption would be per built-in.
+
+    const measure = async (
+      build: (builder: Builder, briefing: unknown) => unknown,
+    ) => {
+      const { runtime, storageManager } = createRuntime("off");
+      try {
+        return outputIfc(nodeForBuiltin(runtime, build));
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    };
+
+    it("puts the argument's label on `llm`'s output schema", async () => {
+      expect(
+        await measure((builder, briefing) =>
+          builder.llm({ system: briefing } as never)
+        ),
+      ).toEqual({ confidentiality: [BRIEFING_ATOM] });
+    });
+
+    it("puts the argument's label on `generateText`'s output schema", async () => {
+      expect(
+        await measure((builder, briefing) =>
+          builder.generateText({ system: briefing } as never)
+        ),
+      ).toEqual({ confidentiality: [BRIEFING_ATOM] });
+    });
+
+    it("puts the argument's label on `generateObject`'s output schema", async () => {
+      expect(
+        await measure((builder, briefing) =>
+          builder.generateObject({ system: briefing } as never)
+        ),
+      ).toEqual({ confidentiality: [BRIEFING_ATOM] });
+    });
+
+    it("puts the argument's label on `llmDialog`'s output schema", async () => {
+      expect(
+        await measure((builder, briefing) =>
+          builder.llmDialog({ system: briefing } as never)
+        ),
+      ).toEqual({ confidentiality: [BRIEFING_ATOM] });
+    });
+
+    it("leaves an output schema unlabeled when no input carries a label", async () => {
+      const { runtime, storageManager } = createRuntime("off");
+      try {
+        const { commonfabric } = createTrustedBuilder(runtime);
+        const factory = commonfabric.pattern(
+          () => {
+            commonfabric.llmDialog({ system: "plain" } as never);
+            return { answer: "unrelated to the built-in" };
+          },
+          false,
+          {
+            type: "object",
+            properties: { answer: { type: "string" } },
+          } as const,
+        );
+        const node = (factory.nodes ?? [])[0] as NodeRef;
+
+        // The schema the node names is the one `llmDialog` declares, by
+        // identity, because interning hands back the object it was given. That
+        // says the binding, the reference and the lookup all resolved, so the
+        // absent `ifc` below is the schema carrying none.
+        expect(outputSchema(node)).toBe(LLMDialogResultSchema);
+        expect(outputIfc(node)).toBeUndefined();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
+  // A whole turn, because the label these cases read is minted by the write the
+  // turn performs rather than by the schema the graph declares. The pattern
+  // declares no argument and labels the messages cell it hands the dialog, so
+  // the join `pattern()` takes over a pattern's own argument and result
+  // contributes nothing and this seam is the only candidate.
+  for (const dial of ["persist", "off"] as const) {
+    describe(`a completed dialog turn under cfcFlowLabels: "${dial}"`, () => {
+      const runTurn = async () => {
+        enableMockMode();
+        clearMockResponses();
+        addMockResponse(() => true, {
+          role: "assistant",
+          content: "a reply shaped by the briefing",
+          id: "cfc-builtin-output-ifc",
+        });
+        const { runtime, storageManager } = createRuntime(dial);
+        const tx = runtime.edit();
+        const { commonfabric } = createTrustedBuilder(runtime);
+        const { pattern, llmDialog, Cell } = commonfabric;
+        const factory = pattern(
+          () => {
+            const messages = Cell.of<BuiltInLLMMessage[]>(
+              [],
+              LABELED_MESSAGES_SCHEMA,
+            );
+            const dialog = llmDialog({ messages } as never);
+            return {
+              addMessage: dialog.addMessage,
+              pending: dialog.pending,
+              messages,
+              answer: dialog.result,
+            };
+          },
+          false,
+          RESULT_SCHEMA,
+        );
+        const resultCell = runtime.getCell(
+          space,
+          `dialog-result-${dial}`,
+          RESULT_SCHEMA,
+          tx,
+        );
+        const result = runtime.run(tx, factory, {}, resultCell);
+        await tx.commit();
+        const addMessage = await result.key("addMessage").pull();
+        addMessage!.send({ role: "user", content: "what does it say?" });
+        const settled = await waitForLlmMessages(runtime, result, 2);
+        return { runtime, storageManager, result, settled };
+      };
+
+      const withTurn = async (
+        body: (turn: Awaited<ReturnType<typeof runTurn>>) => void,
+      ) => {
+        const turn = await runTurn();
+        try {
+          body(turn);
+        } finally {
+          resetMockMode();
+          await turn.runtime.dispose();
+          await turn.storageManager.close();
+        }
+      };
+
+      it("appends the model's reply to the dialog's messages", () =>
+        withTurn(({ settled }) => {
+          // Without this the cases below would pass on a turn that never ran:
+          // an absent label and an absent request look alike from the outside.
+          expect(settled.messages?.length).toBe(2);
+          expect((settled.messages?.[1] as BuiltInLLMMessage).content).toBe(
+            "a reply shaped by the briefing",
+          );
+        }));
+
+      it("labels the dialog state with the labeled input's atom", () =>
+        withTurn(({ result }) => {
+          expect(confidentialityOf(result.key("answer"))).toContainEqual(
+            BRIEFING_ATOM,
+          );
+          expect(confidentialityOf(result.key("pending"))).toContainEqual(
+            BRIEFING_ATOM,
+          );
+        }));
+    });
+  }
+});


### PR DESCRIPTION
PROBLEM

`llmDialog` set `propagateInputIfc: false`, excusing its output cell from the join of its input cells' `ifc` labels that every other module takes. A pattern handing the built-in a confidential cell got an unlabeled dialog state:

    const dialog = llmDialog({ messages, system: input.briefing });
    return { pending: dialog.pending, answer: dialog.result };

With `cfcFlowLabels` at `"persist"` the measured per-transaction join covered that. The dial is off in the default posture, where nothing did. CFC §8.9.1 holds a label less restrictive than the conservative default to trust in the executing implementation for `flow-taint-precision`; no such check stood behind the flag.

SOLUTION

Remove the flag, its `Module` field, and the branch at `connectInputAndOutputs` that read it. The join is unconditional, so `llmDialog` carries its inputs' labels exactly as `llm`, `generateText` and `generateObject` do, at every dial setting.

`cfc-builtin-output-ifc.test.ts` holds all four built-ins to the join on their node's output schema, and drives a whole dialog turn at `cfcFlowLabels` `"persist"` and `"off"`, reading the label off the dialog state the pattern exposes. Its turn arms declare no pattern argument and label the messages cell they hand the dialog, so the join `pattern()` takes over a pattern's own argument and result cannot reach the dialog's output document and this seam is the only candidate. Against the flag, the `"off"` arm and the `llmDialog` schema case fail while the other built-ins' cases pass.

DESIGN DISCUSSION

The justification recorded at the seam was the built-in's run-time flow handling. That handling fits each observation against the sink ceiling before a request goes out, records per message the confidentiality that request observed, and stamps model output with `LlmDerived` integrity. It computes no output confidentiality, so it did not cover what the flag was excusing.

§8.9.1 offers two routes for a label below the conservative join: trust in the implementation for `flow-taint-precision` under the acting user, or precision that is a structural fact of the journal. Neither is reachable here. A graph is assembled before there is an acting user, so the trust gate cannot be evaluated at this seam. And the journal route does not return precision to it either: a path's effective label is the join of all its components, so the `declared` entry the join mints is a floor that the `derived` component adds to and never narrows. That leaves the conservative join as what this seam can state, and the flag as a claim with nothing behind it. Removing it deletes a decision point rather than adding one.

What the join states is not §8.9.2's measurement. A build transaction reads nothing, so §8.9.2 applied there yields the empty label — the argument #7220 made for a pattern's own result root. It is a static over-approximation of what any future attempt could consume.

Dropping the join from one module also broke a premise #7220 rests on. That change stopped joining a pattern's argument confidentiality onto its result root on the ground that a field fed by a lift or a handler carries the join its module makes onto its own result; `propagateInputIfc: false` made `llmDialog` the single module for which that was false.

The join only does anything where an input cell's schema carries `ifc`, so the cost falls on patterns passing a labeled cell to the built-in. One pattern in the tree combines a labeled cell with an LLM built-in, `cfc-agent-prompt-injection-demo`, and it hands that cell to `generateObject`, which has always taken the join. The price where it does land is breadth: the join covers the dialog's output document root, so `pending` carries it along with `result`. `llm` already pays that, and §8.9.2 counts write timing as a channel.

Two gaps this does not close, each filed as a Topic. The dialog writes model replies into the caller's `messages` cell, which no output join reaches, so a reply document carries no confidentiality of its own below `"persist"`. And the built-in already computes the confidentiality each request observed, but writes it as no label — the precision that would need no trust gate, being a record of what the runtime sent rather than a claim by executed code.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

