### PR TITLE
test(memory): derive valid content IDs for identity-commit fixtures

### DIFF
--- a/packages/memory/test/v2-engine-identity-commit.test.ts
+++ b/packages/memory/test/v2-engine-identity-commit.test.ts
@@ -1,3 +1,4 @@
+import { taggedHashStringOf } from "@commonfabric/data-model";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { toFileUrl } from "@std/path";
@@ -990,10 +991,12 @@ describe("applyCommit() with an identity commit", () => {
 
   it("accepts an identical content-addressed re-set beside an identical set over a stale read", () => {
     const installSeq = installThenRewrite();
+    const content = { type: "string" };
+    const contentId = `cid:${taggedHashStringOf(content)}`;
     applyCommit(engine, {
       sessionId: "s:a",
       commit: commit(2, {
-        operations: [setOp("cid:fid1:closure", { type: "string" })],
+        operations: [setOp(contentId, content)],
       }),
     });
 
@@ -1005,7 +1008,7 @@ describe("applyCommit() with an identity commit", () => {
           pending: [],
         },
         operations: [
-          setOp("cid:fid1:closure", { type: "string" }),
+          setOp(contentId, content),
           setOp("of:doc", { n: 2 }),
         ],
       }),
@@ -1017,6 +1020,8 @@ describe("applyCommit() with an identity commit", () => {
 
   it("refuses a content-addressed set of new content over a stale read", () => {
     const installSeq = installThenRewrite();
+    const content = { type: "number" };
+    const contentId = `cid:${taggedHashStringOf(content)}`;
 
     expect(() =>
       applyCommit(engine, {
@@ -1027,7 +1032,7 @@ describe("applyCommit() with an identity commit", () => {
             pending: [],
           },
           operations: [
-            setOp("cid:fid1:fresh", { type: "number" }),
+            setOp(contentId, content),
             setOp("of:doc", { n: 2 }),
           ],
         }),


### PR DESCRIPTION
## Why

Two identity-commit tests install content under invented `cid:` identifiers. Content verification from #7197 correctly rejects those fixtures before either test reaches the stale-read behavior it intends to check, leaving the shared memory CI shard failing.

## What Changed

Derive each test document's identifier with the canonical `taggedHashStringOf` helper. Preserve the existing assertions: an identical re-set is elided, and new content cannot pass a stale read.

## Test plan

- Both cases fail on current main before this change; all 31 identity-commit steps pass afterward.
- Full memory package: 618 tests / 603 steps passed.
- All 46 type-check groups, repository format and lint passed.
- Antagonistic cf-review confirmed the fixtures now reach the intended identity/conflict checks and runtime validation remains unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

