### PR TITLE
feat: enforce one import statement per module and import kind

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -152,6 +152,7 @@
     "plugins": [
       "./tasks/lint-access-for-testing-only.ts",
       "./tasks/lint-bench-console.ts",
+      "./tasks/lint-import-list.ts",
       "./tasks/lint-inline-imports.ts",
       "./tasks/lint-self-import.ts"
     ]

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -72,7 +72,11 @@ about one aspect of the runtime, are indexed in
   evaluates the module, side effects included: drop it, and put what it was
   there for in a comment on the surviving statement. Against nothing but an
   `import type`, it stays — a type-only import is erased and evaluates nothing,
-  so the bare import is the only thing producing the effect.
+  so the bare import is the only thing producing the effect. A statement whose
+  every name is marked `type` inline is erased the same way, so it belongs to
+  that second case rather than the first: the bare import stays, and that
+  statement is written `import type` to say what it is, which leaves the pair
+  one statement of each kind.
 - Import a given module in exactly one or two statements. Two shapes are
   allowed:
   - One unified statement, marking any type-only names inline:
@@ -84,8 +88,25 @@ about one aspect of the runtime, are indexed in
   allows is a second statement of the same kind — two value imports from one
   module, or two `import type`s from it. Those represent one dependency as
   though it were two, and the second is easy to miss when the first is being
-  edited or removed, so merge their specifier lists. A bare `import "x";` counts
-  toward the total.
+  edited or removed, so merge their specifier lists. Where one of the two takes
+  the module as a namespace, `import * as name from "x";`, no other name may
+  sit beside it in that statement, and the merge is to reach through the
+  namespace for what the other statement named. Where that reads worse than
+  the pair — a namespace imported only so its `typeof` names the whole module,
+  against a list of names the file uses throughout — the two statements stay,
+  with a `deno-lint-ignore` saying which case it is.
+  `packages/runner/src/builder/types.ts` is the one file in that position
+  today. A bare `import "x";` counts toward the total.
+
+  The `cf-import-list/one-statement-per-kind` lint rule
+  (`tasks/lint-import-list.ts`, registered in the root `deno.jsonc`) holds this
+  bullet, and this one alone. The grouping, collation, sorting and `@/` rules
+  around it are left to review, since several of them have exceptions that a
+  checker reading a file from top to bottom would call correct code wrong. The
+  rule reads a specifier as written, so `@/thing.ts` and `../thing.ts` are two
+  modules to it. Where it reports, the statement that survives the merge goes
+  where the earliest of the ones it replaces sat, which keeps the module's
+  evaluation at the point in the list it was already reached from.
 - Within a package that defines the `@/` import alias, address the aliased tree
   as `@/...` rather than by a `../` path that climbs out of the current
   directory to reach it. The alias exists so that a module's address does not
@@ -100,7 +121,7 @@ about one aspect of the runtime, are indexed in
 - These rules govern the declaration list. What may not be written outside it
   at all — a type spelled `import("./mod.ts").Thing`, and a module loaded by an
   `import("./mod.ts")` expression under some function — is
-  [`imports.md`](imports.md), which two lint rules enforce.
+  [`imports.md`](imports.md), which two further lint rules enforce.
 
 ### Classes
 

--- a/docs/development/imports.md
+++ b/docs/development/imports.md
@@ -9,8 +9,11 @@ function. Both are called an inline import here.
 
 How the declarations at the top are then grouped, collated and sorted, and how
 many statements one module may take, is the `Imports` section of
-[`DEVELOPMENT.md`](DEVELOPMENT.md). This document is about what may not be
-written outside that list at all.
+[`DEVELOPMENT.md`](DEVELOPMENT.md). One rule of that section is enforced too,
+by `cf-import-list/one-statement-per-kind` in
+[`tasks/lint-import-list.ts`](../../tasks/lint-import-list.ts): a module is
+imported in one statement of each kind, never two. That section documents it.
+This document is about what may not be written outside the list at all.
 
 Two lint rules keep them out. They live in
 [`tasks/lint-inline-imports.ts`](../../tasks/lint-inline-imports.ts) and are

--- a/packages/cf-harness/audit/test/seeded-violations.test.ts
+++ b/packages/cf-harness/audit/test/seeded-violations.test.ts
@@ -34,7 +34,10 @@ import type { PromptSlotBinding } from "../../src/contracts/prompt-slot.ts";
 import type { HarnessRunReport } from "../../src/contracts/run-report.ts";
 import { createToolOutputId } from "../../src/contracts/tool-result.ts";
 import type { HarnessTranscriptMessage } from "../../src/contracts/transcript.ts";
-import type { HarnessRunState } from "../../src/run-state.ts";
+import type {
+  HarnessFabricSessionCfcPosture,
+  HarnessRunState,
+} from "../../src/run-state.ts";
 import { BUILTIN_TOOL_REGISTRY } from "../../src/tools/registry.ts";
 import { RUN_CHECKS } from "../checks/registry.ts";
 import {
@@ -42,7 +45,6 @@ import {
   HOST_AUTHORED_OUTPUT_WRITERS,
 } from "../checks/structural.ts";
 import { harnessFabricSessionPosture } from "../../src/cfc-posture.ts";
-import type { HarnessFabricSessionCfcPosture } from "../../src/run-state.ts";
 import {
   loadRunFamily,
   type RunEvidence,

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -31,6 +31,7 @@ import {
   HARNESS_BROWSER_ACCESS_LEASE_TYPE,
   HARNESS_BROWSER_ACCESS_PROFILE_MODES,
   type HarnessBrowserAccessLease,
+  normalizeCdpOrigin,
   parseBrowserAccessExpiresAt,
 } from "./contracts/browser-access.ts";
 import {
@@ -116,7 +117,6 @@ import {
   validateStructuredResultValue,
 } from "./structured-result.ts";
 import { BUILTIN_TOOLS } from "./tools/registry.ts";
-import { normalizeCdpOrigin } from "./contracts/browser-access.ts";
 import {
   defaultHarnessCredentialStorePath,
   FileHarnessCredentialStore,

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -20,6 +20,7 @@ import {
   type HarnessPromptSlotBindingSource,
 } from "./contracts/cfc-policy-snapshot.ts";
 import {
+  ADDRESS_HANDLE_TOKEN_PREFIX,
   HANDLE_TOKEN_PATTERN,
   type HarnessHandleEntry,
   type HarnessHandleTable,
@@ -124,7 +125,6 @@ import {
   type CreateHarnessEngineOptions,
 } from "./engine.ts";
 import { OpenAICompatibleGatewayClient } from "./gateway/openai-client.ts";
-import { ADDRESS_HANDLE_TOKEN_PREFIX } from "./contracts/handle-table.ts";
 import {
   createHarnessHandleTable,
   defineOwnEntry,

--- a/packages/cf-harness/src/tools/run-skill-script.ts
+++ b/packages/cf-harness/src/tools/run-skill-script.ts
@@ -4,6 +4,7 @@ import type { JSONSchema } from "@commonfabric/api";
 import type { CfcLabelView, CfcSandboxResult } from "@commonfabric/runner/cfc";
 
 import {
+  normalizeCdpOrigin,
   redactCdpEndpoint,
   validateBrowserAccessLeaseFreshness,
 } from "../contracts/browser-access.ts";
@@ -21,7 +22,6 @@ import {
   isSkillScriptAllowlisted,
   normalizeSkillScriptPath,
 } from "../skills/scripts.ts";
-import { normalizeCdpOrigin } from "../contracts/browser-access.ts";
 import { createClearedHostProcessEnv } from "./host-process-env.ts";
 import type { HarnessToolDefinition } from "./types.ts";
 

--- a/packages/cf-harness/test/cfc-properties/support/episode.ts
+++ b/packages/cf-harness/test/cfc-properties/support/episode.ts
@@ -19,7 +19,10 @@ import { PiecesController } from "@commonfabric/piece/ops";
 import { Runtime } from "@commonfabric/runner";
 import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type {
+  CfcEnforcementMode,
+  CfcSandboxResult,
+} from "@commonfabric/runner/cfc";
 
 import {
   SEED_ENVELOPE_SCHEMA_HASH,
@@ -32,7 +35,6 @@ import { auditRunFamily } from "../../../audit/checks/structural.ts";
 import { discoverRunFamilies } from "../../../audit/evidence.ts";
 import type { CheckResult, CheckVerdict } from "../../../audit/report.ts";
 import { type PromptSlotBinding } from "../../../src/contracts/prompt-slot.ts";
-import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 
 import { CAPABILITY_PROBE_SENTINEL } from "../../../src/diagnostics.ts";
 import type {

--- a/packages/cf-harness/test/measure-runs.test.ts
+++ b/packages/cf-harness/test/measure-runs.test.ts
@@ -9,6 +9,7 @@ import {
   familyIdOf,
   foldTotals,
   importedPatternIdsOf,
+  main,
   measureArtifactRoot,
   type MeasurementTotals,
   measureTranscript,
@@ -23,7 +24,6 @@ import {
   toolOutcomeOf,
   totalsOf,
 } from "../scripts/measure-runs.ts";
-import { main } from "../scripts/measure-runs.ts";
 import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
 
 const FIXTURE_ROOT = fromFileUrl(

--- a/packages/cf-harness/test/run-measurement-batch.test.ts
+++ b/packages/cf-harness/test/run-measurement-batch.test.ts
@@ -10,6 +10,7 @@ import {
   indexChangeOf,
   type IndexPreflight,
   type IndexSnapshot,
+  main,
   parseMeasurementSuite,
   preflightCellSpec,
   preflightPosture,
@@ -21,7 +22,6 @@ import {
   resolveImportedPatternOrigins,
   runTask,
 } from "../scripts/run-measurement-batch.ts";
-import { main } from "../scripts/run-measurement-batch.ts";
 import { emptyTotals as emptyMeasurementTotals } from "../scripts/measure-runs.ts";
 import observedStatus from "./support/measurement-console-status.json" with {
   type: "json",

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1,6 +1,6 @@
 import { Command, ValidationError } from "@cliffy/command";
 import { Table } from "@cliffy/table";
-import type { CellScope } from "@commonfabric/api";
+import type { CellScope, FabricValue } from "@commonfabric/api";
 import {
   type ApplyReport,
   type ApplyRow,
@@ -63,7 +63,6 @@ import {
   commandSpellingNotice,
   noCommandSpellingNotice,
 } from "../lib/deprecated-spelling.ts";
-import type { FabricValue } from "@commonfabric/api";
 import { toCompactDebugString } from "@commonfabric/data-model";
 import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 

--- a/packages/cli/lib/shuttle/verbs.ts
+++ b/packages/cli/lib/shuttle/verbs.ts
@@ -79,8 +79,7 @@ import { type Announce } from "./announce.ts";
 import { connectionEntries, type HeldConnection } from "./connection.ts";
 import { resolveHandle } from "./handles.ts";
 import { renderVerbList, renderVerbPage, type VerbHelp } from "./help.ts";
-import { splitLine } from "./line.ts";
-import { quoteToken } from "./line.ts";
+import { quoteToken, splitLine } from "./line.ts";
 import {
   type ListingHandles,
   listingLines,

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { dirname, join } from "@std/path";
 import type { JSONSchema } from "@commonfabric/api";
-import { undeclaredVerbFieldError } from "../lib/callable.ts";
+import {
+  CF_RUNTIME_ERROR_LOG,
+  undeclaredVerbFieldError,
+} from "../lib/callable.ts";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import {
   type ExecCommandSpec,
@@ -19,7 +22,6 @@ import {
   resolveMountedCallableFile,
 } from "../lib/exec.ts";
 import { writeMountState } from "../lib/fuse.ts";
-import { CF_RUNTIME_ERROR_LOG } from "../lib/callable.ts";
 import type { SpaceConfig } from "../lib/piece.ts";
 import { cf, relevantStderr } from "./utils.ts";
 

--- a/packages/connectors/agents/connector/test/fabric-target_test.ts
+++ b/packages/connectors/agents/connector/test/fabric-target_test.ts
@@ -29,8 +29,6 @@ import {
   agentOwnerSchema,
   agentPrincipalSchema,
   cellHasOwnerProtection,
-} from "../src/fabric-graph.ts";
-import {
   pushStableCellGraph,
   readStableCellGraphValue,
 } from "../src/fabric-graph.ts";

--- a/packages/connectors/github/host/test/host.test.ts
+++ b/packages/connectors/github/host/test/host.test.ts
@@ -1,7 +1,9 @@
 import type { GithubClient } from "@commonfabric/github-connector/client";
 import type { GithubFabricTarget } from "@commonfabric/github-connector/fabric";
-import type { GithubPullRequestCollection } from "@commonfabric/github-connector/types";
-import type { GithubPullRequest } from "@commonfabric/github-connector/types";
+import type {
+  GithubPullRequest,
+  GithubPullRequestCollection,
+} from "@commonfabric/github-connector/types";
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { GithubHost } from "../src/host.ts";

--- a/packages/patterns/factory-outputs/lot-watch/main.test.tsx
+++ b/packages/patterns/factory-outputs/lot-watch/main.test.tsx
@@ -23,9 +23,8 @@
  * NOTE: Uses .filter(() => true).length for array lengths per reactivity tracking note.
  */
 import { action, assert, pattern, TESTS, Writable } from "commonfabric";
-import LotWatch from "./main.tsx";
+import LotWatch, { classifyPlate, plateKey } from "./main.tsx";
 import type { KnownVehicle, PlateGroup, Sighting } from "./main.tsx";
-import { classifyPlate, plateKey } from "./main.tsx";
 
 // groupSightingsByPlate is not exported; inline the same logic here so we can
 // test the grouping contract without modifying main.tsx.

--- a/packages/patterns/gideon-tests/test-30-fetchjson-dynamic-instantiation.tsx
+++ b/packages/patterns/gideon-tests/test-30-fetchjson-dynamic-instantiation.tsx
@@ -14,8 +14,7 @@
  * 1. Static fetchJson at top level (control - should work)
  * 2. fetchJson inside .map() with expression callback (claimed to fail)
  */
-import { computed, Default, NAME, pattern, UI } from "commonfabric";
-import { fetchJson } from "commonfabric";
+import { computed, Default, fetchJson, NAME, pattern, UI } from "commonfabric";
 
 interface Repo {
   id: string;

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -8,8 +8,14 @@
  * composer wrappers, whose silent guards are correct behavior (an empty draft
  * is a non-event in a composer, not a headless mutation).
  */
-import { action, assert, type Default, TESTS, Writable } from "commonfabric";
-import { pattern } from "commonfabric";
+import {
+  action,
+  assert,
+  type Default,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import Topics, { type TopicDemand } from "./main.tsx";
 import Topic, { type TopicComment, type TopicLink } from "./topic.tsx";
 

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -15,12 +15,12 @@ import {
   Default,
   equals,
   NAME,
+  pattern,
   Stream,
   TESTS,
   UI,
   Writable,
 } from "commonfabric";
-import { pattern } from "commonfabric";
 import {
   type MentionableRow,
   mentionableRowsOf,

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
-import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
+import {
+  createBuilder,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { createBuilder } from "@commonfabric/runner";
 
 import type { Cell as BuilderCell } from "../../../runner/src/builder/types.ts";
 import { hashStringOf } from "@commonfabric/data-model";

--- a/packages/piece/test/ops/piece-controller.test.ts
+++ b/packages/piece/test/ops/piece-controller.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
-import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
+import {
+  PIECE_SOURCE_MOVED,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import {
@@ -9,7 +13,6 @@ import {
   PieceSourceChangedError,
   pinnedSourceMoved,
 } from "../../src/ops/piece-controller.ts";
-import { PIECE_SOURCE_MOVED } from "@commonfabric/runner";
 import { PiecesController } from "../../src/ops/pieces-controller.ts";
 
 const signer = await Identity.fromPassphrase("piece controller edit");

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -14,6 +14,12 @@ import type {
   schema as schemaFunction,
   SELF as SELFSymbol,
 } from "@commonfabric/api";
+// The declared surface this file checks against is `typeof` this whole
+// module, which only a namespace import can name, and a namespace import
+// takes no other name beside it. So this statement and the one above it
+// cannot become one, and reaching through the namespace instead would
+// prefix every use of the types above.
+// deno-lint-ignore cf-import-list/one-statement-per-kind
 import type * as DeclaredApi from "@commonfabric/api";
 import type { Schema } from "@commonfabric/api/schema";
 import {

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -49,7 +49,11 @@ import {
   recordRelevantSchemaWritePolicyInput,
 } from "../cell.ts";
 import { ContextualFlowControl } from "../cfc.ts";
-import { cfcSchemaChildRoot } from "../cfc/schema-refs.ts";
+import {
+  cfcSchemaChildRoot,
+  cfcSchemaToObject,
+  resolveCfcSchemaRefs,
+} from "../cfc/schema-refs.ts";
 import { isExternalSchemaRef } from "../schema-decompose.ts";
 import type { CfcConfClause } from "../cfc/clause.ts";
 import {
@@ -67,7 +71,6 @@ import {
   uniqueCfcAtoms,
 } from "../cfc/observation.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
-import { cfcSchemaToObject, resolveCfcSchemaRefs } from "../cfc/schema-refs.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
 import { settleAbandonedRequest } from "./abandoned-request.ts";
 import { markEffectCompletion } from "../executor/effect-completion.ts";

--- a/packages/runner/src/builtins/navigate-to.ts
+++ b/packages/runner/src/builtins/navigate-to.ts
@@ -3,7 +3,7 @@ import {
   SERVER_EXECUTION_EFFECTS_DOC_ID,
 } from "@commonfabric/memory/v2";
 import { type Cell, createCell } from "../cell.ts";
-import { type Action } from "../scheduler.ts";
+import { type Action, ignoreReadForScheduling } from "../scheduler.ts";
 import { type RawBuiltinResult } from "../module.ts";
 import { type Runtime } from "../runtime.ts";
 import type {
@@ -11,7 +11,6 @@ import type {
   MemorySpace,
 } from "../storage/interface.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
-import { ignoreReadForScheduling } from "../scheduler.ts";
 import { mergeableOpRead } from "../storage/reactivity-log.ts";
 import { waveRunContextOf } from "../executor/wave.ts";
 import { speculationRunContextOf } from "../speculation/overlay-destination.ts";

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -42,11 +42,18 @@ import {
 } from "@commonfabric/memory/v2/server";
 import * as Engine from "@commonfabric/memory/v2/engine";
 import {
+  type CellScope,
   type DeliveryAttention,
   type DeliveryDeferral,
   eventAttentionEntryKey,
   eventAttentionIndexKey,
+  identityOfScopeKey,
+  resolveScopeKey,
+  type ScopeKeyIdentity,
+  scopeOfScopeKey,
   SERVER_EXECUTION_ATTENTION_DOC_ID,
+  SERVER_EXECUTION_EFFECTS_DOC_ID,
+  SERVER_EXECUTION_WATERMARK_DOC_ID,
   type StreamEventEntry,
   type StreamEventsDocValue,
   toDirtyKey,
@@ -85,6 +92,7 @@ import {
 import { getLogger } from "@commonfabric/utils/logger";
 import type { Runtime, ServerRunInfo } from "../runtime.ts";
 import type {
+  CommitError,
   IExtendedStorageTransaction,
   IStorageTransaction,
   ITransactionSealSink,
@@ -96,7 +104,6 @@ import type {
   TransactionSealDestination,
   Unit,
 } from "../storage/interface.ts";
-import type { CommitError } from "../storage/interface.ts";
 import {
   ensurePieceRunningVerdict,
   type EnsurePieceVerdict,
@@ -122,15 +129,6 @@ import { effectCompletionKeyOf } from "./effect-completion.ts";
 import { markRendererTrustedEvent } from "../cfc/ui-contract.ts";
 import { EVENT_DEFERRAL_DROP_THRESHOLD } from "../scheduler/constants.ts";
 import { LT1_LATE_SEAL_REFUSED } from "../scheduler/types.ts";
-import {
-  type CellScope,
-  identityOfScopeKey,
-  resolveScopeKey,
-  type ScopeKeyIdentity,
-  scopeOfScopeKey,
-  SERVER_EXECUTION_EFFECTS_DOC_ID,
-  SERVER_EXECUTION_WATERMARK_DOC_ID,
-} from "@commonfabric/memory/v2";
 import type { PostCommitSideEffect } from "../cfc/types.ts";
 import {
   attentionForExpiredDeliveryFailure,

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -142,11 +142,11 @@ import {
   sinkCeilingsOf,
   type SinkGovernanceRegistry,
   type SinkMaxConfidentiality,
+  STANDARD_PROMPT_CAVEAT_POLICY,
   type TrustSnapshot,
   ungatedSink,
 } from "./cfc/mod.ts";
 import { parseFlagValue } from "./experimental-posture.ts";
-import { STANDARD_PROMPT_CAVEAT_POLICY } from "./cfc/mod.ts";
 import type { CommitBackpressurePolicy } from "./scheduler/backpressure.ts";
 import type { PatternCoverageCollector } from "./pattern-coverage.ts";
 import type { IStorageManager } from "./storage/interface.ts";

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -79,7 +79,7 @@ import {
 import { EffectsChannel } from "./speculation/effects-channel.ts";
 import { waveRunContextOf } from "./executor/wave.ts";
 import { Action, Scheduler } from "./scheduler.ts";
-import { entityKey } from "./scheduler/keys.ts";
+import { entityKey, entityNameKey } from "./scheduler/keys.ts";
 import {
   type CommitBackpressurePolicy,
   resolveCommitBackpressure,
@@ -156,7 +156,6 @@ import {
 } from "./storage/reactivity-log.ts";
 import { isRetryableCommitRejection } from "./storage/rejection.ts";
 import { isCellScope, normalizeCellScope, scopeRank } from "./scope.ts";
-import { entityNameKey } from "./scheduler/keys.ts";
 import { toURI } from "./uri-utils.ts";
 import { normalizeSpaceHost, SpaceHostValidationError } from "./space-host.ts";
 import { flattenBuilderArtifacts } from "./storage-preflight.ts";

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -6,8 +6,8 @@ import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
   MediaType,
+  ReplicaLoadFailure,
 } from "../storage/interface.ts";
-import type { ReplicaLoadFailure } from "../storage/interface.ts";
 import type {
   SchedulerEventPreflightActionSummary,
   SchedulerEventPreflightStats,

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -85,6 +85,7 @@ import {
 } from "@commonfabric/memory/v2";
 import type { Runtime, ServerRunInfo } from "../runtime.ts";
 import type {
+  CommitError,
   IExtendedStorageTransaction,
   IStorageTransaction,
   ITransactionSealSink,
@@ -96,7 +97,6 @@ import type {
   Unit,
   URI,
 } from "../storage/interface.ts";
-import type { CommitError } from "../storage/interface.ts";
 import type { PostCommitSideEffect } from "../cfc/types.ts";
 import { CoalescedDocListener } from "./doc-notification-listener.ts";
 

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -9,6 +9,7 @@ import type {
   ClientCommit,
   CommitClass,
   CommitPrecondition,
+  DeliveryFailureClass,
   EntityDocument,
   EntityIdListOptions,
   EntityIdListResult,
@@ -25,7 +26,6 @@ import type {
   SqliteQueryResult,
   SqliteRegisterDiskSourceResult,
 } from "@commonfabric/memory/v2";
-import type { DeliveryFailureClass } from "@commonfabric/memory/v2";
 import type { OutboxAppendRow } from "@commonfabric/memory/v2/execution-outbox";
 import type { Cancel } from "../cancel.ts";
 import type { EntityId } from "../create-ref.ts";

--- a/packages/runner/src/storage/v2-watch.ts
+++ b/packages/runner/src/storage/v2-watch.ts
@@ -1,4 +1,4 @@
-import type { SchemaPathSelector } from "@commonfabric/api";
+import type { JSONSchemaObj, SchemaPathSelector } from "@commonfabric/api";
 import {
   hashSchema,
   internPathSelector,
@@ -11,8 +11,6 @@ import type {
   ScopeKey,
   ScopeKeyIdentity,
 } from "@commonfabric/memory/v2";
-
-import type { JSONSchemaObj } from "@commonfabric/api";
 
 import { pruneCfcSchemaDefinitions } from "../cfc/schema-refs.ts";
 import {

--- a/packages/runner/test/cfc-prepare-crash-surfacing.test.ts
+++ b/packages/runner/test/cfc-prepare-crash-surfacing.test.ts
@@ -45,7 +45,6 @@ import {
 import { RetryImmediately } from "../src/scheduler/retry-immediately.ts";
 import { resolveLink } from "../src/link-resolution.ts";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
-import { SessionRegistry } from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
@@ -310,7 +309,7 @@ describe("wish commit-prep failure surfacing (OW50 seat S-J)", () => {
 
     const makeServer = () =>
       new MemoryV2Server.Server({
-        sessions: new SessionRegistry({ ttlMs: 600_000 }),
+        sessions: new MemoryV2Server.SessionRegistry({ ttlMs: 600_000 }),
         subscriptionRefreshDelayMs: 0,
         authorizeSessionOpen(message) {
           const principal = (message.authorization as { principal?: unknown })

--- a/packages/runner/test/engine-evaluate-record-graph.test.ts
+++ b/packages/runner/test/engine-evaluate-record-graph.test.ts
@@ -1,16 +1,14 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  compileWithEntryBody,
   Engine,
+  evaluateWithEntryBody,
   getVerifiedProvenance,
   joinedBodies,
   Runtime,
   signer,
   StorageManager,
-} from "./engine-test-support.ts";
-import {
-  compileWithEntryBody,
-  evaluateWithEntryBody,
 } from "./engine-test-support.ts";
 import type { RuntimeProgram } from "./engine-test-support.ts";
 import { validateCfcPolicyArtifactManifest } from "../src/cfc/policy.ts";

--- a/packages/runner/test/engine-ses.test.ts
+++ b/packages/runner/test/engine-ses.test.ts
@@ -2,13 +2,13 @@ import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  compileWithEntryBody,
   Engine,
   joinedBodies,
   Runtime,
   signer,
   StorageManager,
 } from "./engine-test-support.ts";
-import { compileWithEntryBody } from "./engine-test-support.ts";
 import type { RuntimeProgram } from "./engine-test-support.ts";
 describe("Engine in SES mode", () => {
   let runtime: Runtime;

--- a/packages/runner/test/executor-cooperative-yield.test.ts
+++ b/packages/runner/test/executor-cooperative-yield.test.ts
@@ -32,7 +32,6 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import * as Engine from "@commonfabric/memory/v2/engine";
 import { liveExecutionLeaseHolder } from "@commonfabric/memory/v2/execution-lease";
-import { SessionRegistry } from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { Runtime } from "../src/runtime.ts";
 import type {
@@ -46,7 +45,7 @@ import { waitUntil } from "./support/wait-until.ts";
 
 const newSharedServer = () =>
   new MemoryV2Server.Server({
-    sessions: new SessionRegistry({ ttlMs: 600_000 }),
+    sessions: new MemoryV2Server.SessionRegistry({ ttlMs: 600_000 }),
     subscriptionRefreshDelayMs: 0,
     authorizeSessionOpen(message) {
       const principal = (message.authorization as { principal?: unknown })

--- a/packages/runner/test/executor-serving-loop.test.ts
+++ b/packages/runner/test/executor-serving-loop.test.ts
@@ -32,7 +32,6 @@ import {
 import { stampWaveRunContext } from "../src/executor/wave.ts";
 import { markEffectCompletion } from "../src/executor/effect-completion.ts";
 import { decodeMemoryBoundary, resolveScopeKey } from "@commonfabric/memory/v2";
-import { SessionRegistry } from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -80,9 +79,11 @@ const newSharedServer = (
   options: { sessionTtlMs?: number; subscriptionRefreshDelayMs?: number } = {},
 ) =>
   new MemoryV2Server.Server({
-    ...(options.sessionTtlMs === undefined
-      ? {}
-      : { sessions: new SessionRegistry({ ttlMs: options.sessionTtlMs }) }),
+    ...(options.sessionTtlMs === undefined ? {} : {
+      sessions: new MemoryV2Server.SessionRegistry({
+        ttlMs: options.sessionTtlMs,
+      }),
+    }),
     subscriptionRefreshDelayMs: options.subscriptionRefreshDelayMs ?? 0,
     authorizeSessionOpen(message) {
       const principal = (message.authorization as { principal?: unknown })

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -19,7 +19,9 @@ import {
   type EntityDocument,
   getMemoryProtocolFlags,
   type PatchOp,
+  resetServerExecutionConfig,
   type SessionSync,
+  setServerExecutionConfig,
   type SqliteOperation,
   toDocumentPath,
 } from "@commonfabric/memory/v2";
@@ -37,10 +39,6 @@ import {
 } from "@commonfabric/utils/logger";
 
 import { applyPatch } from "../../memory/v2/patch.ts";
-import {
-  resetServerExecutionConfig,
-  setServerExecutionConfig,
-} from "@commonfabric/memory/v2";
 import {
   parentPath,
   parsePointer,

--- a/packages/runner/test/schema-to-ts.test.ts
+++ b/packages/runner/test/schema-to-ts.test.ts
@@ -8,13 +8,12 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 // LiftFunction. The lift materialization test below is compile-time only and
 // declares a locally-typed `lift` (the facade `lift` is `declare const`, no
 // runtime value). (handler still materializes via its module.ts overloads.)
-import type { LiftFunction } from "@commonfabric/api";
+import type { AsCellType, LiftFunction, ReadonlyCell } from "@commonfabric/api";
 
 import { handler } from "../src/builder/module.ts";
 
 import "@commonfabric/api/schema";
 
-import type { AsCellType, ReadonlyCell } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import { type Cell, Runtime, type Stream } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -55,6 +55,7 @@ import {
   entityIdFrom,
   type EventIntentOutcome,
   getCellOrThrow,
+  getMetaLink,
   getPatternIdentityRef,
   hasOperationStorageCapability,
   type IExtendedStorageTransaction,
@@ -62,8 +63,11 @@ import {
   isCell,
   isCellResult,
   isLoopbackHostname,
+  KeepAsCell,
   markDurableReadTx,
+  type NormalizedFullLink,
   normalizeSpaceHost,
+  parseLink,
   PatternCoverageCollector,
   popFrame,
   pushFrame,
@@ -104,12 +108,6 @@ import {
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject } from "@commonfabric/utils/types";
 
-import {
-  getMetaLink,
-  KeepAsCell,
-  type NormalizedFullLink,
-  parseLink,
-} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
 import {
   type ActionRunTraceResponse,

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -35,7 +35,9 @@ import { siteTableCause, siteTableSchema } from "@commonfabric/home-schemas";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import {
   type Cell,
+  CompilerStackLoadError,
   entityIdFrom,
+  parseLink,
   popFrame,
   pushFrame,
   Runtime,
@@ -53,9 +55,7 @@ import {
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { StorageManager as WorkerStorageManager } from "@commonfabric/runner/storage/cache";
 
-import { parseLink } from "@commonfabric/runner";
 import * as V2Storage from "@commonfabric/runner/storage/v2";
-import { CompilerStackLoadError } from "@commonfabric/runner";
 import {
   type CellRef,
   type CfcLabelView,

--- a/packages/runtime-client/test/client/transport-web-worker.test.ts
+++ b/packages/runtime-client/test/client/transport-web-worker.test.ts
@@ -1,11 +1,16 @@
 import { describe, it } from "@std/testing/bdd";
-import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
-import { type ErrorNotification, NotificationType } from "@/protocol/mod.ts";
+import {
+  fabricFromRealmValue,
+  realmFromFabricValue,
+} from "@commonfabric/data-model/codecs";
+import {
+  ClientTransportNotificationType,
+  type ErrorNotification,
+  NotificationType,
+  TransportNotificationType,
+} from "@/protocol/mod.ts";
 import { expect } from "@std/expect";
-import { TransportNotificationType } from "@/protocol/mod.ts";
 import { WebWorkerRuntimeTransport } from "@/client/transports/web-worker/transport-web-worker.ts";
-import { ClientTransportNotificationType } from "@/protocol/mod.ts";
-import { fabricFromRealmValue } from "@commonfabric/data-model/codecs";
 
 // Exercises the transport's handling of forwarded worker console output
 // without a real worker: a fake Worker class lets us construct the transport,

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -27,7 +27,7 @@ import {
   iconStar,
   iconThemeToggle,
 } from "../components/icons.ts";
-import { type PieceItem } from "../components/PieceList.ts";
+import type { PieceItem } from "../components/PieceList.ts";
 import { getEffectiveTheme, toggleTheme } from "../lib/theme-preference.ts";
 
 type ConnectionStatus =

--- a/packages/shell/src/views/SchedulerGraphView.ts
+++ b/packages/shell/src/views/SchedulerGraphView.ts
@@ -7,9 +7,9 @@ import { property, query, state } from "lit/decorators.js";
 
 import type { DebuggerController } from "../lib/debugger-controller.ts";
 
-import "./SchedulerSourceView.ts";
-
 import { entityUriFromActionId } from "../lib/scheduler-graph-identity.ts";
+// Loading this module defines the `x-scheduler-source` element that this
+// view renders.
 import {
   parseActionLocation,
   type SourceViewNode,

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -1,23 +1,21 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  clearTimingMeasures,
+  detailOfMeasure,
   getGlobalLogFloor,
   getLogger,
   getLoggerCountsBreakdown,
+  getTimingMeasuresState,
   getTimingStatsBreakdown,
   getTotalLoggerCounts,
   log,
   LOG_COLORS,
+  parseTimingMeasureCap,
   resetAllLoggerCounts,
   resetAllTimingStats,
-  setGlobalLogFloor,
-} from "../src/logger.ts";
-import {
-  clearTimingMeasures,
-  detailOfMeasure,
-  getTimingMeasuresState,
-  parseTimingMeasureCap,
   resetTimingMeasureBudget,
+  setGlobalLogFloor,
   setTimingMeasuresEnabled,
   TIMING_MEASURE_PREFIX,
 } from "../src/logger.ts";

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -6,7 +6,7 @@ import {
   type TestRecord,
 } from "@commonfabric/test-support/records";
 import type { CapabilityId } from "./ci-capabilities.ts";
-import { loadTopology } from "./test-topology.ts";
+import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
 
 import {
   batchesOf,
@@ -23,7 +23,6 @@ import {
   runLane,
   spoolRecords,
 } from "./ci-lane.ts";
-import { capabilitiesBySuite } from "./test-topology.ts";
 import { census } from "./test-selection/census.ts";
 import type { Suite } from "./test-topology/suite.ts";
 import {

--- a/tasks/lint-import-list.test.ts
+++ b/tasks/lint-import-list.test.ts
@@ -146,6 +146,53 @@ describe("lint-import-list", () => {
       expect(diagnose(source)).toEqual([MERGE_THROUGH_NAMESPACE]);
     });
 
+    it("reports merging through the namespace only where one of the pair takes it", () => {
+      // Each statement merges into the first of its kind, so the namespace
+      // written third blocks its own merge and not the one above it.
+      const source = `
+        import { a } from "./mod.ts";
+        import { b } from "./mod.ts";
+        import * as mod from "./mod.ts";
+        export const all = [a, b, mod];
+      `;
+      expect(diagnose(source)).toEqual([MERGE, MERGE_THROUGH_NAMESPACE]);
+      expect(statements(source)).toEqual([
+        `import { b } from "./mod.ts";`,
+        `import * as mod from "./mod.ts";`,
+      ]);
+    });
+
+    it("reports a second `import type` of one module with an empty clause", () => {
+      const source = `
+        import type {} from "./mod.ts";
+        import type {} from "./mod.ts";
+      `;
+      expect(diagnose(source)).toEqual([MERGE]);
+      expect(statements(source)).toEqual([`import type {} from "./mod.ts";`]);
+    });
+
+    it("counts an empty `import type` clause against a named one", () => {
+      const source = `
+        import type {} from "./mod.ts";
+        import type { A } from "./mod.ts";
+        export type Alias = A;
+      `;
+      expect(diagnose(source)).toEqual([MERGE]);
+      expect(statements(source)).toEqual([
+        `import type { A } from "./mod.ts";`,
+      ]);
+    });
+
+    it("passes an empty `import type` clause beside a bare import", () => {
+      // The bare statement is what evaluates the module, and the `import type`
+      // is a statement of the other kind, so the pair is one of each.
+      const source = `
+        import "./mod.ts";
+        import type {} from "./mod.ts";
+      `;
+      expect(diagnose(source)).toEqual([]);
+    });
+
     it("reports each statement after the first, one report each", () => {
       const source = `
         import { a } from "./mod.ts";

--- a/tasks/lint-import-list.test.ts
+++ b/tasks/lint-import-list.test.ts
@@ -1,0 +1,280 @@
+/// <reference lib="deno.unstable" />
+
+/**
+ * Runs `cf-import-list/one-statement-per-kind` over short files, and checks
+ * which statement it reports and which of its five messages it gives.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import plugin from "./lint-import-list.ts";
+
+const RULE = "cf-import-list/one-statement-per-kind";
+
+/** The five shapes the rule reports, told apart by a phrase of each message. */
+const MERGE = "merge";
+const BARE_BESIDE_VALUE = "bare-beside-value";
+const REPEATED_BARE = "repeated-bare";
+const TYPES_BESIDE_BARE = "types-beside-bare";
+const MERGE_THROUGH_NAMESPACE = "merge-through-namespace";
+
+const PHRASES: readonly (readonly [string, string])[] = [
+  ["merge the two lists of names", MERGE],
+  ["reach through the namespace", MERGE_THROUGH_NAMESPACE],
+  ["This bare statement adds nothing beside it", BARE_BESIDE_VALUE],
+  ["A module is evaluated once however many times", REPEATED_BARE],
+  ["This statement names nothing but types", TYPES_BESIDE_BARE],
+];
+
+/** Which shape each diagnostic reports, in the order reported. */
+function diagnose(source: string): string[] {
+  return run(source).map((diagnostic) => {
+    expect(diagnostic.id).toEqual(RULE);
+    const match = PHRASES.find(([phrase]) =>
+      diagnostic.message.includes(phrase)
+    );
+    if (match === undefined) {
+      throw new Error(`Unrecognized message: ${diagnostic.message}`);
+    }
+    return match[1];
+  });
+}
+
+/** The statement each diagnostic is reported against, in the order reported. */
+function statements(source: string): string[] {
+  return run(source).map(({ range }) => source.slice(range[0], range[1]));
+}
+
+/** What the rule reports over one file, in the order it reports it. */
+function run(source: string): Deno.lint.Diagnostic[] {
+  return Deno.lint.runPlugin(plugin, "sample.ts", source);
+}
+
+describe("lint-import-list", () => {
+  describe("one-statement-per-kind", () => {
+    it("passes one statement marking its type-only names inline", () => {
+      const source = `
+        import { type Thing, make } from "./mod.ts";
+        export const thing: Thing = make();
+      `;
+      expect(diagnose(source)).toEqual([]);
+    });
+
+    it("passes an `import type` above a value import of one module", () => {
+      const source = `
+        import type { Thing } from "./mod.ts";
+        import { make } from "./mod.ts";
+        export const thing: Thing = make();
+      `;
+      expect(diagnose(source)).toEqual([]);
+    });
+
+    it("passes one statement each from two modules", () => {
+      const source = `
+        import { a } from "./a.ts";
+        import { b } from "./b.ts";
+        export const both = [a, b];
+      `;
+      expect(diagnose(source)).toEqual([]);
+    });
+
+    it("passes two spellings of one module, which it reads as two", () => {
+      const source = `
+        import { a } from "@/mod.ts";
+        import { b } from "../src/mod.ts";
+        export const both = [a, b];
+      `;
+      expect(diagnose(source)).toEqual([]);
+    });
+
+    it("passes a re-export beside an import of the same module", () => {
+      const source = `
+        import { a } from "./mod.ts";
+        export { b } from "./mod.ts";
+        export const one = a;
+      `;
+      expect(diagnose(source)).toEqual([]);
+    });
+
+    it("reports a second value import of one module", () => {
+      const source = `
+        import { a } from "./mod.ts";
+        import { b } from "./mod.ts";
+        export const both = [a, b];
+      `;
+      expect(diagnose(source)).toEqual([MERGE]);
+      expect(statements(source)).toEqual([`import { b } from "./mod.ts";`]);
+    });
+
+    it("reports a second `import type` of one module", () => {
+      const source = `
+        import type { A } from "./mod.ts";
+        import type { B } from "./mod.ts";
+        export type Both = [A, B];
+      `;
+      expect(diagnose(source)).toEqual([MERGE]);
+      expect(statements(source)).toEqual([
+        `import type { B } from "./mod.ts";`,
+      ]);
+    });
+
+    it("reports a value import beside a default import of one module", () => {
+      const source = `
+        import mod from "./mod.ts";
+        import { a } from "./mod.ts";
+        export const both = [mod, a];
+      `;
+      expect(diagnose(source)).toEqual([MERGE]);
+    });
+
+    it("reports a namespace import beside a named import of one module", () => {
+      const source = `
+        import * as mod from "./mod.ts";
+        import { a } from "./mod.ts";
+        export const both = [mod, a];
+      `;
+      expect(diagnose(source)).toEqual([MERGE_THROUGH_NAMESPACE]);
+      expect(statements(source)).toEqual([`import { a } from "./mod.ts";`]);
+    });
+
+    it("reports two `import type`s the same way when one is a namespace", () => {
+      const source = `
+        import type { A } from "./mod.ts";
+        import type * as mod from "./mod.ts";
+        export type Both = [A, typeof mod];
+      `;
+      expect(diagnose(source)).toEqual([MERGE_THROUGH_NAMESPACE]);
+    });
+
+    it("reports each statement after the first, one report each", () => {
+      const source = `
+        import { a } from "./mod.ts";
+        import { b } from "./mod.ts";
+        import { c } from "./mod.ts";
+        export const all = [a, b, c];
+      `;
+      expect(diagnose(source)).toEqual([MERGE, MERGE]);
+      expect(statements(source)).toEqual([
+        `import { b } from "./mod.ts";`,
+        `import { c } from "./mod.ts";`,
+      ]);
+    });
+
+    it("passes a bare import of a module nothing else imports", () => {
+      const source = `
+        import "./polyfill.ts";
+        export const ready = true;
+      `;
+      expect(diagnose(source)).toEqual([]);
+    });
+
+    it("passes a bare import beside nothing but an `import type`", () => {
+      const source = `
+        import "./mod.ts";
+        import type { Thing } from "./mod.ts";
+        export type Alias = Thing;
+      `;
+      expect(diagnose(source)).toEqual([]);
+    });
+
+    it("reports the bare import when a value import also names the module", () => {
+      const source = `
+        import "./mod.ts";
+        import { a } from "./mod.ts";
+        export const one = a;
+      `;
+      expect(diagnose(source)).toEqual([BARE_BESIDE_VALUE]);
+      expect(statements(source)).toEqual([`import "./mod.ts";`]);
+    });
+
+    it("reports the bare import written below the value import as well", () => {
+      const source = `
+        import { a } from "./mod.ts";
+        import "./mod.ts";
+        export const one = a;
+      `;
+      expect(diagnose(source)).toEqual([BARE_BESIDE_VALUE]);
+      expect(statements(source)).toEqual([`import "./mod.ts";`]);
+    });
+
+    it("passes a statement naming nothing but types on its own", () => {
+      const source = `
+        import { type Thing } from "./mod.ts";
+        export type Alias = Thing;
+      `;
+      expect(diagnose(source)).toEqual([]);
+    });
+
+    it("reports the statement naming nothing but types, not the bare import", () => {
+      const source = `
+        import "./mod.ts";
+        import { type Thing } from "./mod.ts";
+        export type Alias = Thing;
+      `;
+      expect(diagnose(source)).toEqual([TYPES_BESIDE_BARE]);
+      expect(statements(source)).toEqual([
+        `import { type Thing } from "./mod.ts";`,
+      ]);
+    });
+
+    it("reports it the same way with the bare import written below", () => {
+      const source = `
+        import { type Thing } from "./mod.ts";
+        import "./mod.ts";
+        export type Alias = Thing;
+      `;
+      expect(diagnose(source)).toEqual([TYPES_BESIDE_BARE]);
+      expect(statements(source)).toEqual([
+        `import { type Thing } from "./mod.ts";`,
+      ]);
+    });
+
+    it("reports the bare import beside a namespace import of one module", () => {
+      const source = `
+        import "./mod.ts";
+        import * as mod from "./mod.ts";
+        export const one = mod;
+      `;
+      expect(diagnose(source)).toEqual([BARE_BESIDE_VALUE]);
+      expect(statements(source)).toEqual([`import "./mod.ts";`]);
+    });
+
+    it("reports a bare import repeated with nothing else naming the module", () => {
+      const source = `
+        import "./polyfill.ts";
+        import "./polyfill.ts";
+        export const ready = true;
+      `;
+      expect(diagnose(source)).toEqual([REPEATED_BARE]);
+    });
+
+    it("reports the value pair and the bare statement of one module apart", () => {
+      const source = `
+        import "./mod.ts";
+        import { a } from "./mod.ts";
+        import { b } from "./mod.ts";
+        export const both = [a, b];
+      `;
+      expect(diagnose(source)).toEqual([MERGE, BARE_BESIDE_VALUE]);
+      expect(statements(source)).toEqual([
+        `import { b } from "./mod.ts";`,
+        `import "./mod.ts";`,
+      ]);
+    });
+
+    it("reports the same module under each kind separately", () => {
+      const source = `
+        import type { A } from "./mod.ts";
+        import type { B } from "./mod.ts";
+        import { c } from "./mod.ts";
+        import { d } from "./mod.ts";
+        export const both: [A, B] = [c, d];
+      `;
+      expect(diagnose(source)).toEqual([MERGE, MERGE]);
+      expect(statements(source)).toEqual([
+        `import type { B } from "./mod.ts";`,
+        `import { d } from "./mod.ts";`,
+      ]);
+    });
+  });
+});

--- a/tasks/lint-import-list.ts
+++ b/tasks/lint-import-list.ts
@@ -1,0 +1,208 @@
+/// <reference lib="deno.unstable" />
+
+/**
+ * A lint rule that holds one module's entry in a file's import list to one
+ * statement of each kind.
+ *
+ * A module is imported in one statement, marking any type-only names inline,
+ * or in two when one of them is an `import type` and the other is a value
+ * import. What this rule reports is a second statement of the same kind for
+ * one module: two value imports of it, or two `import type`s of it. Written
+ * that way, one dependency reads as two, and the second is easy to miss when
+ * the first is being edited or removed.
+ *
+ * A bare `import "x";` is a value statement, so it counts toward that module's
+ * total, and what it counts against decides what happens to it. Beside a value
+ * import that binds something, it adds nothing, since that import evaluates
+ * the module, side effects included: the rule reports the bare statement.
+ * Beside nothing but an `import type`, it is the only statement that evaluates
+ * the module at all, and the rule leaves the pair alone as two statements of
+ * different kinds.
+ *
+ * Between those sits a statement that names nothing but types, `import { type
+ * Thing } from "x";`. It is a value statement to the grammar, and TypeScript
+ * erases it as it erases an `import type`, so it evaluates nothing either.
+ * Beside a bare import of the same module, the rule reports that statement
+ * rather than the bare one, because writing it `import type` is what makes the
+ * pair legal and leaves the module evaluated.
+ *
+ * Whichever statement survives a merge goes where the earliest of the
+ * statements it replaces sat. That is what keeps the module's evaluation at
+ * the point in the list it was already reached from, which matters when the
+ * module installs something that an import below it reads as that one loads.
+ *
+ * One pair has no merge at all: a namespace import takes no other name beside
+ * it, so `import * as name from "x"` and a named import of `x` of the same
+ * kind cannot become one statement. Usually the fix is to reach through the
+ * namespace for what the named statement took. Where that reads worse — a
+ * namespace imported only so its `typeof` names the whole module, against a
+ * list of names the file uses throughout — the pair stays, and takes a
+ * `deno-lint-ignore` saying which case it is.
+ *
+ * The rule reads a specifier as written, so two spellings of one module —
+ * `@/thing.ts` and `../thing.ts` — are two modules to it. Which spelling to
+ * use is a separate rule of the same section, and one for review.
+ *
+ * See the `Imports` section of docs/development/DEVELOPMENT.md.
+ */
+
+/** Which of the two kinds of statement a declaration is. */
+type Kind = Deno.lint.ImportDeclaration["importKind"];
+
+const REFERENCE =
+  "See the `Imports` section of docs/development/DEVELOPMENT.md.";
+
+/** What a message calls a statement of one kind. */
+function kindWord(kind: Kind): string {
+  return kind === "type" ? "`import type`" : "value import";
+}
+
+/** Reports a second statement of one kind naming a module. */
+function mergeMessage(kind: Kind, specifier: string): string {
+  return `This file already imports \`${specifier}\` in another ` +
+    `${kindWord(kind)} above. A module takes one statement of each kind, so ` +
+    "merge the two lists of names into one statement, marking a type-only " +
+    "name inline with `type` where that is what the merge needs. The " +
+    "statement that stays goes where the earlier of the two sat. Written as " +
+    "two, one dependency reads as two, and the second is easy to miss when " +
+    `the first is being edited or removed. ${REFERENCE}`;
+}
+
+/** Reports a second statement of one kind where one takes a namespace. */
+function mergeThroughNamespaceMessage(kind: Kind, specifier: string): string {
+  return `This file already imports \`${specifier}\` in another ` +
+    `${kindWord(kind)} above, and one of the two takes the module as a ` +
+    "namespace, which no other name may sit beside. So these two cannot " +
+    "become one statement: reach through the namespace for what the other " +
+    "one named, and drop that statement. Where that reads worse than the " +
+    "pair — a namespace imported only so its `typeof` names the whole " +
+    "module, against a list of names the file uses throughout — keep both " +
+    "and say so with `// deno-lint-ignore " +
+    `cf-import-list/one-statement-per-kind\`. ${REFERENCE}`;
+}
+
+/** Reports a bare import beside a statement that binds something. */
+function bareBesideValueMessage(specifier: string): string {
+  return `This file also imports \`${specifier}\` in a value import that ` +
+    "names what it takes, and a value import evaluates the module, side " +
+    "effects included. This bare statement adds nothing beside it: drop it, " +
+    "and say in a comment on the statement that stays what the bare one was " +
+    "there for. That statement goes where the earlier of the two sat, so the " +
+    `module is still evaluated at the same point in the list. ${REFERENCE}`;
+}
+
+/**
+ * Reports a statement naming nothing but types beside a bare import of the
+ * same module.
+ */
+function typesBesideBareMessage(specifier: string): string {
+  return `This file also imports \`${specifier}\` for its side effect, in a ` +
+    "bare `import` statement. This statement names nothing but types, so " +
+    "TypeScript erases the whole of it and the bare statement is what " +
+    "evaluates the module. Write this one as `import type`: the two are then " +
+    "one statement of each kind, which is the second of the two shapes the " +
+    `section allows. ${REFERENCE}`;
+}
+
+/** Reports a bare import beside another bare import of the same module. */
+function repeatedBareMessage(specifier: string): string {
+  return `This file already imports \`${specifier}\` for its side effect ` +
+    "above. A module is evaluated once however many times it is imported, " +
+    `so this statement does nothing: drop it. ${REFERENCE}`;
+}
+
+/** The statements of one kind naming one module, in the order written. */
+interface Run {
+  readonly kind: Kind;
+  readonly specifier: string;
+  /** The statements that name what they take. */
+  readonly named: Deno.lint.ImportDeclaration[];
+  /** The bare statements, which name nothing and run the module. */
+  readonly bare: Deno.lint.ImportDeclaration[];
+}
+
+/**
+ * Whether a statement binds anything the program can reach at run time. A
+ * statement whose every name is marked `type` inline binds nothing, and
+ * TypeScript erases it along with those names, so it does not evaluate the
+ * module it names.
+ */
+function bindsValue(node: Deno.lint.ImportDeclaration): boolean {
+  return node.specifiers.some((specifier) =>
+    specifier.type !== "ImportSpecifier" || specifier.importKind !== "type"
+  );
+}
+
+/** Whether a statement takes the whole module under one name. */
+function takesNamespace(node: Deno.lint.ImportDeclaration): boolean {
+  return node.specifiers.some((specifier) =>
+    specifier.type === "ImportNamespaceSpecifier"
+  );
+}
+
+export default {
+  name: "cf-import-list",
+  rules: {
+    "one-statement-per-kind": {
+      create(context) {
+        const runs = new Map<string, Run>();
+
+        return {
+          ImportDeclaration(node) {
+            const kind = node.importKind;
+            const specifier = node.source.value;
+            const key = `${kind} ${specifier}`;
+            let run = runs.get(key);
+            if (run === undefined) {
+              run = { kind, specifier, named: [], bare: [] };
+              runs.set(key, run);
+            }
+            const statements = node.specifiers.length > 0
+              ? run.named
+              : run.bare;
+            statements.push(node);
+          },
+
+          "Program:exit"() {
+            for (const { kind, specifier, named, bare } of runs.values()) {
+              const namespaced = named.some(takesNamespace);
+              for (const node of named.slice(1)) {
+                context.report({
+                  node,
+                  message: namespaced
+                    ? mergeThroughNamespaceMessage(kind, specifier)
+                    : mergeMessage(kind, specifier),
+                });
+              }
+              if (kind === "type" || bare.length === 0) continue;
+              if (named.some(bindsValue)) {
+                for (const node of bare) {
+                  context.report({
+                    node,
+                    message: bareBesideValueMessage(specifier),
+                  });
+                }
+                continue;
+              }
+              // Nothing here evaluates the module but the bare statements, so
+              // the first of those stays and the rest repeat it. A statement
+              // naming nothing but types is spelled to say so.
+              if (named.length > 0) {
+                context.report({
+                  node: named[0],
+                  message: typesBesideBareMessage(specifier),
+                });
+              }
+              for (const node of bare.slice(1)) {
+                context.report({
+                  node,
+                  message: repeatedBareMessage(specifier),
+                });
+              }
+            }
+          },
+        };
+      },
+    },
+  },
+} satisfies Deno.lint.Plugin;

--- a/tasks/lint-import-list.ts
+++ b/tasks/lint-import-list.ts
@@ -26,6 +26,12 @@
  * rather than the bare one, because writing it `import type` is what makes the
  * pair legal and leaves the module evaluated.
  *
+ * An `import type` with an empty clause, `import type {} from "x";`, binds
+ * nothing and evaluates nothing. The split above is about which statements
+ * evaluate the module, and an `import type` answers that the same way whatever
+ * its clause holds, so an empty one counts toward the module's `import type`
+ * total like any other rather than standing apart as a bare statement does.
+ *
  * Whichever statement survives a merge goes where the earliest of the
  * statements it replaces sat. That is what keeps the module's evaluation at
  * the point in the list it was already reached from, which matters when the
@@ -157,7 +163,11 @@ export default {
               run = { kind, specifier, named: [], bare: [] };
               runs.set(key, run);
             }
-            const statements = node.specifiers.length > 0
+            // The split is about which statements evaluate the module, which
+            // is a question only a value statement raises: an `import type`
+            // evaluates nothing whatever its clause holds, so an empty one
+            // counts toward its kind rather than standing apart as bare.
+            const statements = kind === "type" || node.specifiers.length > 0
               ? run.named
               : run.bare;
             statements.push(node);
@@ -165,11 +175,16 @@ export default {
 
           "Program:exit"() {
             for (const { kind, specifier, named, bare } of runs.values()) {
-              const namespaced = named.some(takesNamespace);
+              // A statement merges into the first of its kind, so what
+              // decides which message it takes is whether either of those two
+              // takes a namespace, rather than whether any statement in the
+              // run does.
               for (const node of named.slice(1)) {
+                const throughNamespace = takesNamespace(named[0]) ||
+                  takesNamespace(node);
                 context.report({
                   node,
-                  message: namespaced
+                  message: throughNamespace
                     ? mergeThroughNamespaceMessage(kind, specifier)
                     : mergeMessage(kind, specifier),
                 });

--- a/tasks/test-selection/policy.test.ts
+++ b/tasks/test-selection/policy.test.ts
@@ -2,11 +2,10 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import * as policy from "./policy.ts";
-import { DIALS } from "./policy.ts";
 
 // A dial nobody documented is a number that decides what runs and cannot
 // be found, so the two halves of this module are held to each other.
-const NAMED_IN_TABLE = new Set(DIALS.map((dial) => dial.name));
+const NAMED_IN_TABLE = new Set(policy.DIALS.map((dial) => dial.name));
 const EXPORTED_DIALS = Object.keys(policy).filter((name) =>
   /^[A-Z][A-Z0-9_]*$/.test(name) && name !== "DIALS"
 );
@@ -78,21 +77,21 @@ describe("policy", () => {
 
     it("names nothing this module does not export", () => {
       const exported = new Set(EXPORTED_DIALS);
-      const strays = DIALS.map((dial) => dial.name).filter((name) =>
+      const strays = policy.DIALS.map((dial) => dial.name).filter((name) =>
         !exported.has(name)
       );
       expect(strays).toEqual([]);
     });
 
     it("gives every dial a unit and a reason to move it", () => {
-      for (const dial of DIALS) {
+      for (const dial of policy.DIALS) {
         expect(dial.unit.length).toBeGreaterThan(0);
         expect(dial.why.length).toBeGreaterThan(0);
       }
     });
 
     it("lists each dial once", () => {
-      expect(NAMED_IN_TABLE.size).toBe(DIALS.length);
+      expect(NAMED_IN_TABLE.size).toBe(policy.DIALS.length);
     });
   });
 
@@ -104,13 +103,13 @@ describe("policy", () => {
 
     it("holds one row per dial and no row without one", () => {
       expect(dialTable().map((row) => unquoted(row[0]!)))
-        .toEqual(DIALS.map((dial) => dial.name));
+        .toEqual(policy.DIALS.map((dial) => dial.name));
     });
 
     it("gives every dial the value, unit, source, and reason `policy.ts` gives it", () => {
       const rows = dialTable();
       const disagreements: string[] = [];
-      for (const dial of DIALS) {
+      for (const dial of policy.DIALS) {
         const row = rows.find((cells) => unquoted(cells[0]!) === dial.name);
         if (row === undefined) {
           disagreements.push(


### PR DESCRIPTION
PROBLEM

The `Imports` section of the Development Guide gives a module one import statement of each kind: one unified statement marking any type-only names inline, or an `import type` and a value import kept adjacent. A second statement of the same kind writes one dependency as though it were two, and the second is easy to miss when the first is edited:

    import { splitLine } from "./line.ts";
    import { quoteToken } from "./line.ts";

Nothing checked this, so the pairs an earlier sweep merged by hand (#5854 through #5860) came back one at a time. Forty-seven of them stand across forty-three files, which is what the rule below reports over `upstream/main`.

SOLUTION

The rule is `cf-import-list/one-statement-per-kind`, in `tasks/lint-import-list.ts` and registered under `lint.plugins` in the root `deno.jsonc`, so a plain `deno lint` reports it. It collects the import declarations by kind and by specifier as written, and reports every statement after the first of a kind. It enforces that one rule and no other: the grouping, collation, sorting and `@/` rules of the same section have exceptions the prose spells out, and a checker reading a file from top to bottom would call correct code wrong.

Every site it reports is merged here, except one that has no merge at all. The `Imports` section gains a paragraph naming the rule and its boundaries, the namespace case below, and the case of a statement that names nothing but types beside a bare import. `imports.md`, which covers the two rules about what may not be written outside the import list, points at this third one for the list itself.

DESIGN DISCUSSION

Three things decide what the rule reports, and none is visible from a statement read on its own.

A bare `import "x";` counts toward the module's total, and it is a value statement. Beside a value import that binds something, it adds nothing, because that import evaluates the module, side effects included, so the rule reports the bare statement. Beside nothing but an `import type`, the bare statement is the only thing that evaluates the module at all, and the two are statements of different kinds, so the rule leaves them alone.

Between those sits `import { type Thing } from "x";`. It is a value statement to the grammar, which is what the syntax tree reports, but every name it binds is marked `type`, so TypeScript erases the whole statement and it evaluates nothing. Deno does the same: a module imported that way and no other way is never loaded. Beside a bare import of the same module the rule reports that statement rather than the bare one, because writing it `import type` is what makes the pair legal while leaving the module evaluated. Dropping the bare statement instead would stop the module loading, which for the shell's header view means a custom element that is never defined.

A namespace import takes no other name beside it, so `import * as name` and a named import of the same module and kind have no single-statement form at all. That pair gets a message of its own, saying to reach through the namespace for what the other statement named. Where that reads worse than the pair, the two stay and take a `deno-lint-ignore`. `packages/runner/src/builder/types.ts` is the one file in that position: its namespace import exists so that `typeof` can name the whole declared API surface, and reaching through it would prefix every use of the fourteen types the file also imports by name.

Most of the merged sites are two lists of names becoming one. Four turned on something:

- `packages/shell/src/views/SchedulerGraphView.ts` imported `./SchedulerSourceView.ts` twice: bare, to define the `x-scheduler-source` element, and again for `parseActionLocation`. The second evaluates the module, so the bare statement is dropped and a comment on the survivor says what it was there for.
- `packages/shell/src/views/HeaderView.ts` looked like that one and is not: its second statement names nothing but types, so the bare import is the only thing defining `x-piece-list`. That statement is written `import type` instead.
- `packages/runner/test/schema-to-ts.test.ts` took two sets of types from `@commonfabric/api` either side of a bare `import "@commonfabric/api/schema";`. A bare import is there for its side effect, so where it sits is part of what it does — but an `import type` is erased and evaluates nothing, so merging these two above the bare import changes nothing about what runs.
- `packages/patterns/factory-outputs/lot-watch/main.test.tsx` imported its pattern by default import and its helpers by named import, with the `import type` between them. The two value statements become one, and the type statement stays beside it as the second half of the allowed pair.

The tests drive the plugin over short files with `Deno.lint.runPlugin`, one test per shape the rule has to accept or reject, and each asserts both which message came back and which statement it was reported against. Each was made to fail before being trusted, against six deliberate breaks of the rule: ignoring bare statements, reporting the first statement of a run instead of the later ones, dropping the kind from the grouping key, always sparing one bare statement, taking every statement to bind a value or none to, and taking no statement to carry a namespace.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

