### PR TITLE
test(memory): hash the identity-commit test's content-addressed fixtures

### DIFF
--- a/packages/memory/test/v2-engine-identity-commit.test.ts
+++ b/packages/memory/test/v2-engine-identity-commit.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { toFileUrl } from "@std/path";
 
+import { taggedHashStringOf } from "@commonfabric/data-model";
+
 import {
   applyCommit,
   close,
@@ -17,6 +19,11 @@ const setOp = (id: string, value: unknown) =>
 
 const patchOp = (id: string, patches: unknown[]) =>
   ({ op: "patch", id, patches }) as never;
+
+// A content-addressed document is the content its id names, so the fixture
+// derives the id from the content the way the engine verifies it.
+const cidSetOp = (content: unknown) =>
+  setOp(`cid:${taggedHashStringOf(content)}`, content);
 
 const commit = (localSeq: number, extra: Record<string, unknown>) =>
   ({
@@ -993,7 +1000,7 @@ describe("applyCommit() with an identity commit", () => {
     applyCommit(engine, {
       sessionId: "s:a",
       commit: commit(2, {
-        operations: [setOp("cid:fid1:closure", { type: "string" })],
+        operations: [cidSetOp("export const closure = 1;")],
       }),
     });
 
@@ -1005,7 +1012,7 @@ describe("applyCommit() with an identity commit", () => {
           pending: [],
         },
         operations: [
-          setOp("cid:fid1:closure", { type: "string" }),
+          cidSetOp("export const closure = 1;"),
           setOp("of:doc", { n: 2 }),
         ],
       }),
@@ -1027,7 +1034,7 @@ describe("applyCommit() with an identity commit", () => {
             pending: [],
           },
           operations: [
-            setOp("cid:fid1:fresh", { type: "number" }),
+            cidSetOp("export const fresh = 2;"),
             setOp("of:doc", { n: 2 }),
           ],
         }),


### PR DESCRIPTION
## Summary

Main's CI has been red since a77cae396e (#7197). The failing test is `packages/memory/test/v2-engine-identity-commit.test.ts`, whose two content-addressed steps fail with:

```
ProtocolError: memory v2 commit installs content-addressed document cid:fid1:closure whose content does not hash to its id
```

## Cause

The fixtures in #7233 predate the hash verification #7197 added to `applyCommitTransaction` in `packages/memory/v2/engine.ts`. They named their documents `cid:fid1:closure` and `cid:fid1:fresh`, ids that are not the hash of any content. Since #7197 the engine refuses a `cid:` set whose content does not hash to its id, so both steps failed on that refusal before reaching the elision and the conflict they assert. The second step expected a `ConflictError` and got the `ProtocolError` instead.

## Fix

The test now derives each `cid:` id from its content with `taggedHashStringOf()` from `@commonfabric/data-model`, the helper the engine verifies with (a small `cidSetOp(content)` fixture builder). The engine check is unchanged.

Both steps now exercise what they guard:

- The identical re-set beside an identical set over a stale read elides both operations (`elidedOpIndexes` is `[0, 1]`, no revisions).
- The install of new content over a stale read reaches the `ConflictError` the step asserts. A scratch probe confirms the conflict is the stale read (`stale confirmed read: of:doc at seq 1 conflicted with seq 2`), and that the same operations on a current basis are accepted and install the `cid:` document.

## Verification

- `deno test --no-check -A test/v2-engine-identity-commit.test.ts`: 1 passed (31 steps), 0 failed
- `deno task test` in `packages/memory`: 618 passed (603 steps), 0 failed
- `deno fmt --check` and `deno lint` on the file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

