### PR TITLE
fix(runner): a compilation-cache document is outside writer-fit

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -312,9 +312,10 @@ The strict-only delta is:
   entries document refuses every mark a served run writes to record that it
   handled an event, and every entry a same-space served emission carries into
   the document on its own transaction. Both are ordinary operation rather
-  than edge cases. One predicate covers those two classes and the meta seam
-  above (`isDeclarablePolicyPath` in `prepare.ts`), because all three answer
-  one question: could a schema have declared a policy here.
+  than edge cases. One predicate covers those two classes, the marked class
+  below, and the meta seam above (`isDeclarablePolicyPath` in `prepare.ts`),
+  because all of them answer one question: could a schema have declared a
+  policy here.
 
   Two id classes is what this is, rather than a rule about documents the
   runtime mints. The runtime mints many more and route 2 below is what most
@@ -341,6 +342,91 @@ The strict-only delta is:
   express one, so pattern-authored traffic arrives `authored` whatever id it
   names.
 
+  A third class is outside the check for the same reason and reaches it by a
+  different route, because its ids say nothing at all. It is also the one the
+  spec already names: §18.6.2's read exclusions list "program/source text
+  loaded to execute the handler" beside the `cid:` schema documents and the
+  `/cfc/...` label metadata this runtime already excludes, and calls all three
+  public infrastructure. A compilation-cache record holds one module for the
+  compiler — the `cid:` document its bytes live in, the identities of its
+  imports, and the predecessor identities its writer authority descends from
+  ([`module-loading.md`](./module-loading.md), and the write side in
+  [`cell-cache.ts`](../../packages/runner/src/compilation-cache/cell-cache.ts)).
+  The cache addresses it by the cause `pattern:<identity>`, or
+  `compileCache:<runtimeVersion>/<identity>` for the compiled set, whose
+  `<identity>` is the module's content-derived Merkle identity. The entity id
+  that cause mints is an ordinary `of:fid1:<hash>`, indistinguishable from a
+  piece's argument document, so there is nothing for a predicate over id
+  strings to recognize, and giving the class an id of its own would re-address
+  every cached module in every space that holds one. The write side names the
+  document instead: the cache records an authorized whole-document
+  `runtime.undeclarable-store` marker beside each of its writes, and the
+  measurement asks the transaction. No pattern names one of these documents.
+  The schemas that describe their fields are the cache's own write schemas,
+  which declare integrity and no confidentiality, so the ceiling that resolves
+  there is the empty one, and a measured cache write carrying any clause
+  misfits. A piece's source transition stages the
+  successor module's delegation union on the same transaction that moves the
+  piece's source pointer, so that the authority and the pointer land together,
+  and that transaction also reads the piece's argument — which is why the
+  measurement reaches a cache document during an ordinary pattern update
+  rather than only in an unusual flow.
+
+  Three things bound the marker, and the first is what the other two rest on.
+  The recording method is the same public one route 2's marker uses, so the
+  runtime's authorization is what separates a claim it made from one pattern-
+  authored code wrote; a marker without it counts for nothing. The marker
+  names a whole document, because whether a schema could have declared a
+  policy is a question about the document rather than about a path inside one;
+  `anchorValueAsEntity` carries the claim down to a document anchored out of a
+  marked value, which holds part of that value at an id derived from it, the
+  same way it carries a runtime-owned store's. A cache record is written raw,
+  with its import edges inline, so the cache itself anchors nothing. And it
+  lasts for the transaction that recorded it, with no enrollment beside it:
+  the measurement runs over documents the asking transaction wrote, so a
+  marker recorded beside the write always covers the question. That is the one
+  respect in which it is narrower than route 2's marker, which answers for
+  stores a later transaction writes.
+
+  One thing this class does NOT take from §18.6.2 is its write-side mirror.
+  That section states its read exclusion as mirroring "the write-side rule
+  that the same addresses are not value-write targets", which would leave the
+  record unstamped as well as unmeasured, the way a `cid:` document is. This
+  runtime keeps it a stamp target and skips the ceiling alone, as it does for
+  the two id classes above, and safety invariant 9 is what decides that rather
+  than a preference. The delegation metadata holds module identities, and
+  §17.7 says holding one grants no access to the artifact it names, so the
+  content written there is public. Which identity appears is the other
+  question: a transaction that read a labeled value and chose a successor by
+  it writes that choice into the record, and §8.11.3 puts a decision's label
+  on every downstream output whatever the output's own content is — the router
+  attack at one bit per update. Unstamping the record would drop exactly that.
+  The module's bytes are unaffected either way, living in a `cid:` document of
+  their own, so the divergence covers the compiler's bookkeeping and nothing
+  else. Its cost is that a later reader of the delegation field consumes the
+  clause. For a join the target's own space produced the two shapes differ
+  only in what is labeled: neither refuses. They part on a join that drew a
+  clause from elsewhere, which the skip is scoped away from, so the
+  implemented shape measures the cache write and can refuse it at strict where
+  §18.6.2's shape, having no write target there at all, would not. That is the
+  direction the residency half of the ceiling was written for, so the
+  divergence keeps a refusal rather than giving one up. §18.6.4's checklist
+  obligation to document "the excluded address patterns" is discharged by this
+  section.
+
+  A cache document is off route 2 on the same keying ground an entries
+  document is. Route 2 declares one piece's flow join as the store's policy,
+  so it wants a store keyed on that piece's own nodes; a cache document is
+  keyed on module content, every piece in the space running that module
+  addresses it, and it outlives all of them. What route 2 leaves behind is
+  also permanent, and that is the second reason. It writes a `declared` entry
+  per measured path, which §8.12.1 does not let back, on a document nothing
+  collects; the flow stamp the skip keeps instead is a per-value component
+  §8.12.8 replaces on overwrite. The two routes agree on what a later reader
+  carries — reading a cache document is how a pattern's code is loaded, and
+  under either route the clause reaches whoever loads that module next — so
+  that consequence is not what separates them.
+
   An entries document takes this route rather than §8.12.5's route 2 below,
   and the ownership route 2 asks for is the reason. Route 2 declares a policy
   out of one piece's flow join, so it reaches stores keyed on that piece's
@@ -362,18 +448,21 @@ The strict-only delta is:
   label map would grow by one entry per event the stream ever carried, on a
   durable log that outlives the pieces that wrote to it.
 
-  The skip is scoped to a join the target's own space produced. Every clause
-  the join carries comes from a document some read resolved, and the join
-  records which space each of those lived in; where any of them lived
-  elsewhere, the target is measured like any other document. So the residency
-  half of the ceiling still holds for the direction it was written for — a
-  derivation cannot carry another space's labeled value into a local document
-  by materializing it, and an emission cannot carry one into a local stream's
-  entries document — while work over the space's own data proceeds. A
-  computed cell shares a replica set with the source it derives from, and an
-  entries document shares one with the document holding the stream it belongs
-  to, so in both cases the value reaches no reader it had not reached
-  already, and what follows it is the stamp.
+  The skip is scoped to a join the target's own space produced, for the marked
+  class as much as for the two id classes. Every clause the join carries comes
+  from a document some read resolved, and the join records which space each of
+  those lived in; where any of them lived elsewhere, the target is measured
+  like any other document. So the residency half of the ceiling still holds
+  for the direction it was written for — a derivation cannot carry another
+  space's labeled value into a local document by materializing it, an emission
+  cannot carry one into a local stream's entries document, and a source
+  transition cannot carry one into a local cache document — while work over
+  the space's own data proceeds. A computed cell shares a replica set with the
+  source it derives from, an entries document shares one with the document
+  holding the stream it belongs to, and a cache document shares one with every
+  piece in that space running the module it holds, so in each case the value
+  reaches no reader it had not reached already, and what follows it is the
+  stamp.
 
   A declared entry can still reach one of these documents, from a
   schema-carrying write to it, and the skip is unconditional over that route
@@ -644,9 +733,9 @@ The strict-only delta is:
   ordinary document measures against its own ceiling whichever transaction
   makes it: a bystander written by a later transaction of the same piece is
   refused exactly as one written by the setup transaction is. A `computed:`
-  document and a stream's entries document are outside the route for a
-  different reason — the measurement skips them altogether, per the
-  exemption above.
+  document, a stream's entries document and a compilation-cache document are
+  outside the route for a different reason — the measurement skips them
+  altogether, per the exemption above.
 
   It DOES reach further than the setup-time route in two ways worth stating,
   because neither follows from "the same rule, later". The piece's result

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -346,7 +346,8 @@ logical path past what that field declares. That is over-taint, so reads stay
 protected, and giving the envelope seam its own path space is the fix. Shares
 the meta-seam predicate with the schema write-policy requirement (#6077).
 
-A second narrowing follows the same rule over a document rather than a path.
+A second narrowing follows the same rule over a document rather than a path,
+and covers two id classes.
 A computed cell is the derived internal cell the runtime materializes to hold
 a derivation's result, addressed under its own URI scheme
 (`computed:fid1:<hash>`). No author declares a store policy on one — a
@@ -367,7 +368,51 @@ it: that route declares out of one piece's flow join and is keyed on that
 piece's own nodes, while an entries document is keyed on the stream, is
 written by every party that can reach the stream, and outlives all of them.
 
-Both id classes are outside the check at every rung, through the same
+A third narrowing covers the program-text half of the §18.6.2 exclusion the
+paragraph above names, and it is the one place where the shape the spec
+states and the shape the runtime implements come apart. A compilation-cache
+record holds one module for the compiler — the `cid:` document its bytes
+live in, its import identities, and the predecessor identities its writer
+authority descends from. The cache addresses it by the cause
+`pattern:<identity>`, or `compileCache:<runtimeVersion>/<identity>` for the
+compiled set, whose `<identity>` is the module's content-derived Merkle
+identity; the entity id that cause mints is an ordinary `of:fid1:<hash>`. No
+pattern names the record and the only schemas describing its fields are the
+cache's own, which declare integrity alone. Because the id is that ordinary
+shape, no predicate over id strings can recognize the class: the write side
+names each document instead, under an authorized whole-document marker the
+measurement reads off the transaction.
+
+Where the two come apart is the write side. §18.6.2 mirrors its read
+exclusion to "the write-side rule that the same addresses are not value-
+write targets", which would leave a cache document unstamped as well as
+unmeasured. The runtime keeps it as a stamp target and skips the ceiling
+alone, which is what the two narrowings above do and what §4 of the
+enforcement matrix states at length. Safety invariant 9 is what keeps the
+stamp rather than a preference. The delegation metadata holds module
+identities, and §17.7 says holding one grants no access to the artifact it
+names, so the content written there is public. Which identity appears is the
+other question: a transaction that read a labeled value and chose a
+successor by it writes that choice into the record, and §8.11.3 puts a
+decision's label on every downstream output whatever the output's own
+content is. Unstamping the record would drop exactly that. The bytes are
+unaffected either way, being in a `cid:` document that already takes
+§18.6.2's route on both sides, so the divergence covers the compiler's
+bookkeeping and nothing else. Its cost is that a later reader of that field
+consumes the clause, which is a recorded residual rather than a claim that
+the two shapes agree. For a join the target's own space produced the two
+differ only in what is labeled: neither refuses. They part on a join that
+drew a clause from elsewhere, which the skip is scoped away from, so the
+implemented shape measures the cache write and can refuse it at strict where
+§18.6.2's shape, having no write target there at all, would not.
+
+Route 2 is not open to this class, on the keying ground an entries document
+is off it for — a cache document is keyed on module content, every piece in
+the space running that module addresses it, and it outlives all of them —
+and on a second: route 2 leaves a `declared` entry per measured path, which
+§8.12.1 does not let back, on a document nothing collects.
+
+All three are outside the check at every rung, through the same
 predicate the meta seam uses, and the skip is scoped to a join the target's
 own space produced: the join records the space each contributing document
 lived in, and a target whose join drew a clause from elsewhere is measured
@@ -376,9 +421,14 @@ holds for the direction it was written for, while work over its own space's
 data proceeds — within one space a computed cell shares a replica set with
 its source, and an entries document with the document holding its stream.
 
-Two id classes is what this is, rather than a rule about documents the
-runtime mints: the document anchoring splits out of a value has an id derived
-from its parent's, which no author named either, and it is measured.
+An enumeration is what this is, rather than a rule about documents the
+runtime mints. The document anchoring splits out of a value has an id
+derived from its parent's, which no author named either, and it is measured
+— except where its parent is itself outside the check by the marker, which
+carries down to it, because it holds part of the value the marker names. The
+compilation cache reaches that carry today only through the general rule:
+its own records are written raw, with their import edges inline, so the
+cache itself anchors nothing.
 
 Nothing is laundered here either. The join still lands on the exempt
 document as its `derived` component, so a later read of it is tainted and a
@@ -402,7 +452,7 @@ refuses a clause a policy evaluation would have discharged. A residual stands wh
 computed document, from a schema-carrying write: it stops being a write
 ceiling there, and stays a read floor.
 
-A third narrowing does not skip the measurement but answers it. The runtime
+A fourth narrowing does not skip the measurement but answers it. The runtime
 materializes documents to hold a piece's MACHINERY rather than data an author
 named: a piece's argument, result and internal documents, minted by the runner
 from the piece's result cause; the state documents a builtin mints from its own

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -746,6 +746,26 @@ cell's contents. The cache is designed around this:
   The compiled document therefore carries a **CFC integrity label**, written with
   the entry (`addIntegrity`) and **required on read** (`requiredIntegrity`). The
   label — not the SES verifier — is the security boundary for cache hits.
+- **A cache document declares no confidentiality policy, and says so.** Both
+  sets are addressed by causes built from the module's content-derived
+  identity, so no pattern names one of these records, and the schemas
+  describing their fields are the two write schemas in `cell-cache.ts`, which
+  declare integrity alone. So the ceiling the §8.12.4 writer-fit check
+  resolves at a cache write is the empty one, and at `enforce-strict` a write
+  carrying any confidentiality clause is a refused commit — which any
+  transaction that both reads labeled data and reaches a cache write takes, a
+  piece's source transition among them. Each cache write therefore records a
+  `runtime.undeclarable-store` marker naming its document
+  (`recordUndeclarablePolicyStore`), and the check skips the ceiling there.
+  The skip is scoped to a join the target's own space produced: where a clause
+  reached the join from another space, the cache write is measured like any
+  other, so a compile cannot carry a foreign space's labeled value into a
+  local record. The write stays a flow-stamp target, so the transaction's join
+  still lands on the record and a later read of a stamped path carries that
+  clause. The module's bytes are unaffected: they live in a `cid:` document,
+  which CFC leaves out of the flow join on both sides, so what a stamp can
+  reach is the compiler's bookkeeping beside them. `cfc-enforcement-matrix.md`
+  §4 carries the reasoning, including where this stops short of spec §18.6.2.
 - **Fail-closed, not fail-hard.** A compiled document with a missing or invalid
   integrity label is treated as a **cache miss** and recompiled from the
   (self-verifying) source set, which re-runs the SES verifier. So the verifier

--- a/packages/piece/test/setsrc-module-delegation.test.ts
+++ b/packages/piece/test/setsrc-module-delegation.test.ts
@@ -8,10 +8,12 @@ import {
   type RuntimeProgram,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { readStoredCfcMetadata } from "@commonfabric/runner/cfc";
 import {
   loadCompiledClosure,
   loadVerifiedSourceClosure,
   setCompileCacheRuntimeVersionForTesting,
+  sourceDocKey,
 } from "../../runner/src/compilation-cache/cell-cache.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 
@@ -54,6 +56,35 @@ export const revision = ${JSON.stringify(version)};
 `,
       },
     ],
+  };
+}
+
+/**
+ * The same contract in two revisions, with a confidential argument. The label
+ * is what makes the piece's argument document CFC-relevant, so a transaction
+ * reading it carries that clause in its flow join; the two revisions declare
+ * the same label, so nothing about the swap itself weakens anything.
+ */
+function confidentialArgumentProgram(version: string): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: `/// <cts-enable />
+import { Confidential, NAME, pattern } from "commonfabric";
+const ATOM = {
+  type: "https://commonfabric.org/cfc/atom/Resource",
+  class: "SetsrcDelegationCheck",
+  subject: "did:example:owner",
+} as const;
+type Label = readonly [typeof ATOM];
+interface Args { seed: Confidential<string, Label>; }
+export default pattern<Args, { label: string }>(({ seed }) => ({
+  [NAME]: "Delegation check",
+  label: ${JSON.stringify(version)} + ":" + seed,
+}));
+`,
+    }],
   };
 }
 
@@ -545,6 +576,87 @@ export default pattern<{seed?: ${seedType}}>(() => {
       for (const freshRuntime of freshRuntimes.reverse()) {
         await freshRuntime.dispose();
       }
+    }
+  });
+
+  it("updates a piece whose argument carries a confidentiality label", async () => {
+    // The source transition stages the successor's delegation union on the
+    // same transaction that moves the piece's source pointer, so that the
+    // authority and the pointer land together. That transaction also reads the
+    // piece's argument. Where the argument carries a label, the join reaches
+    // the cache document the union is staged on, and measuring that write
+    // against the ceiling a content-addressed cache document declares — none —
+    // refuses the commit. At the strict rung that is a refused pattern update
+    // for exactly the pieces a confidentiality label is written for.
+    const strictStorage = StorageManager.emulate({ as: signer });
+    const strictRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager: strictStorage,
+      cfcEnforcementMode: "enforce-strict",
+      cfcFlowLabels: "persist",
+    });
+    try {
+      const strictPieces = new PiecesController(
+        await createSession({
+          identity: signer,
+          spaceName: "setsrc-delegation-strict-" + crypto.randomUUID(),
+        }),
+        strictRuntime,
+      );
+      await strictPieces.synced();
+      const piece = await strictPieces.create(
+        confidentialArgumentProgram("v1"),
+        { input: { seed: "hello" } },
+      );
+      await strictRuntime.idle();
+      const previous = getPatternIdentityRef(piece.getCell())!;
+
+      await piece.setPattern(confidentialArgumentProgram("v2"));
+      await strictRuntime.idle();
+
+      // The swap happened, the argument survived it, and the successor
+      // inherited the predecessor's writer authority.
+      expect(await piece.result.get(["label"])).toBe("v2:hello");
+      const successor = getPatternIdentityRef(piece.getCell())!;
+      expect(successor.identity).not.toBe(previous.identity);
+      const tx = strictRuntime.edit();
+      try {
+        const closure = await loadVerifiedSourceClosure(
+          strictRuntime,
+          strictPieces.getSpace(),
+          successor.identity,
+          tx,
+        );
+        expect(closure?.get(successor.identity)?.delegatedModuleIdentities)
+          .toContain(previous.identity);
+        // The skip decides which store the value may land in, not whether the
+        // join follows it: the successor's record carries the argument's
+        // clause. Without this the case would pass equally if the label had
+        // stopped reaching the write at all, which is what the refusal was
+        // about.
+        const recordId = strictRuntime.getCell(
+          strictPieces.getSpace(),
+          sourceDocKey(successor.identity),
+          undefined,
+          tx,
+        ).getAsNormalizedFullLink().id;
+        const stamped = readStoredCfcMetadata(tx, {
+          space: strictPieces.getSpace(),
+          id: recordId,
+        })?.labelMap.entries ?? [];
+        expect(
+          stamped.flatMap((entry) => entry.label.confidentiality ?? []),
+        ).toContainEqual({
+          type: "https://commonfabric.org/cfc/atom/Resource",
+          class: "SetsrcDelegationCheck",
+          subject: "did:example:owner",
+        });
+      } finally {
+        tx.abort();
+      }
+    } finally {
+      await strictRuntime.dispose();
+      await strictStorage.close();
     }
   });
 });

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1972,6 +1972,12 @@ const isMetaSeamPath = (
  * id derived from its parent's, which no author named either, and it is
  * measured. Adding a class here means arguing that case on its own.
  *
+ * A class is enumerable here only while its ids say which class they are. A
+ * document at a plain `of:fid1:<hash>` id looks like every other document, so
+ * a third class of that shape is named by the runtime as it writes it instead
+ * — `CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE`, which the compilation
+ * cache records for its own documents.
+ *
  * The entries document's half is a prefix inside the `of:` scheme rather than
  * a scheme of its own, so the id shape alone does not say who wrote it. Two
  * gates compose over one instead: this one skips the ceiling, and the memory
@@ -1987,12 +1993,14 @@ const isUndeclarableIdClass = (id: string): boolean =>
  * Whether a schema could have declared a store policy for a write at `path`
  * on `id` — the surfaces the §8.12.4 writer-fit measurement quantifies over.
  *
- * Two things are outside it. The raw meta seam is one, per {@link
+ * Three things are outside it. The raw meta seam is one, per {@link
  * isMetaSeamPath}: no value schema describes the document-root siblings of
- * `value`. The two id classes of {@link isUndeclarableIdClass} are the other.
- * A pattern declares policy on the data it names, and it names none of them.
+ * `value`. The two id classes of {@link isUndeclarableIdClass} are the second.
+ * The third is `markedUndeclarable`, a document the runtime named as it wrote
+ * it, for a class whose ids carry no shape of their own. A pattern declares
+ * policy on the data it names, and it names none of the three.
  *
- * Both stay flow stamp targets: the join lands on them as the `derived`
+ * All three stay flow stamp targets: the join lands on them as the `derived`
  * component, so a later read of one is tainted and a later egress of one is
  * gated on that label. The residency clause is part of the ceiling this
  * skips, so a derivation's result may land in a space whose name none of the
@@ -2003,10 +2011,11 @@ const isUndeclarableIdClass = (id: string): boolean =>
 const isDeclarablePolicyPath = (
   id: string,
   joinIsLocal: boolean,
+  markedUndeclarable: boolean,
   metaOnlyByPath: ReadonlyMap<string, boolean> | undefined,
   path: readonly string[],
 ): boolean =>
-  (!isUndeclarableIdClass(id) || !joinIsLocal) &&
+  ((!isUndeclarableIdClass(id) && !markedUndeclarable) || !joinIsLocal) &&
   !isMetaSeamPath(metaOnlyByPath, path);
 
 // S16 flow labels (default transition): one conservative confidentiality join
@@ -7287,10 +7296,11 @@ export const prepareBoundaryCommit = (
         }
       }
       // Writer-fit measures the surfaces a schema could have declared a
-      // policy at, which leaves out the raw meta seam and two id classes
-      // alike (`isDeclarablePolicyPath`). The measurement is skipped on both
-      // at every rung, so neither raises a strict reject nor a
-      // persist-and-flag diagnostic.
+      // policy at, which leaves out the raw meta seam, two id classes, and a
+      // document the runtime marked as undeclarable alike
+      // (`isDeclarablePolicyPath`). The measurement is skipped on all three at
+      // every rung, so none raises a strict reject nor a persist-and-flag
+      // diagnostic.
       //
       // A ceiling can still resolve at a meta path, from a document-root
       // declared entry by longest prefix. The skip is unconditional anyway:
@@ -7304,10 +7314,20 @@ export const prepareBoundaryCommit = (
       // what that field declares — over-taint, which leaves the declared
       // entry untouched and reads protected.
       if (flowConfidentiality.length > 0) {
+        // The third arm of the declarability question, asked per target the
+        // way the id classes are: whether the runtime named this document as
+        // one no schema declares a policy on. Marked as the write was made,
+        // on this transaction, which is the only one that measures it.
+        const markedUndeclarable = tx.isUndeclarablePolicyStore(
+          target.space,
+          id,
+          runtimeWritePolicyAuthorization,
+        );
         const measuredPaths = derivedStampPaths.filter((path) =>
           isDeclarablePolicyPath(
             id,
             flowJoinIsLocal,
+            markedUndeclarable,
             flowTarget?.metaOnlyByPath,
             path,
           )

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -55,6 +55,40 @@ export const CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION =
 export const CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE =
   "runtime.owned-store";
 
+// A store no pattern declares a policy on: a document the runtime mints to hold
+// its own bookkeeping, at an id whose shape says nothing about who mints it.
+// The compilation cache's source and compiled records carry it, along with any
+// document anchoring splits out of a marked value. Their ids are minted from
+// causes built on a module's content-derived identity, or derived from such an
+// id; no pattern names one, and their fields are the cache's own record of a
+// module. `target` is that
+// document, named whole; `sources` names the document it was derived from where
+// there is one, and is empty where the claim stands on the document alone.
+//
+// The prepare gate reads it for the §8.12.4 writer-fit measurement, which
+// quantifies over the paths a schema could have declared a policy at, and takes
+// it only where `target` names a whole document AND the input was recorded
+// under {@link runtimeWritePolicyAuthorization}.
+//
+// The runtime's OWN schemas do describe some of those fields — the cache's
+// write schemas carry an `addIntegrity` declaration on the delegation metadata.
+// The skip is unconditional over that route, as it is for the two id classes,
+// so a confidentiality declaration added to one of those schemas would be a
+// read floor and not a write ceiling.
+//
+// The marker names the store for one transaction, and that is the whole of what
+// this claim needs: the measurement runs over documents the transaction taking
+// it wrote, so the transaction that asks is the transaction that recorded it.
+// {@link CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE} carries an enrollment
+// beside it because route 2 answers for stores a later transaction writes.
+//
+// Skipping the ceiling is not releasing the value. The write stays a flow stamp
+// target, so the join lands on it as the `derived` component, a later read of
+// the document carries that clause, and the egress gates are unchanged.
+// `docs/specs/cfc-enforcement-matrix.md` §4 carries the reasoning.
+export const CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE =
+  "runtime.undeclarable-store";
+
 /**
  * Marks a write-policy input as one the runtime itself recorded.
  *

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -14,6 +14,10 @@ import type { JSONSchema } from "../builder/types.ts";
 import { type Cell, isCell } from "../cell.ts";
 import { readStoredCfcMetadata } from "../cfc/metadata.ts";
 import { validateCfcPolicyArtifactManifest } from "../cfc/policy.ts";
+import {
+  CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE,
+  runtimeWritePolicyAuthorization,
+} from "../cfc/types.ts";
 import { ensureCompilerStack } from "../harness/deferred-compiler-stack.ts";
 import { computeModuleHashes } from "../harness/module-identity.ts";
 import type { CacheableModule } from "../harness/types.ts";
@@ -820,6 +824,83 @@ export function codeFieldVerifies(
   return parseLink(stored, cell)?.id === `cid:${taggedHashStringOf(code)}`;
 }
 
+/**
+ * Name `doc` to the §8.12.4 writer-fit measurement as a store no pattern
+ * declares a policy on.
+ *
+ * A cache document holds the compiler's own record of a module: the `cid:`
+ * document its bytes live in, its filename, the identities of its imports, and
+ * the predecessor identities its writer authority descends from. No pattern
+ * names it and no pattern-authored schema describes a field on it — the
+ * schemas that do are the cache's own, further down this file, and they
+ * declare integrity alone. That, not the content addressing, is what leaves
+ * the ceiling empty: §17.1 makes content-addressing under the causal path an
+ * implementation detail that does not change IFC semantics. What the content
+ * address does decide is the id shape, which is why the class is named here
+ * rather than enumerated in `isUndeclarableIdClass` (`cfc/prepare.ts`): the id
+ * the cache's cause mints is an ordinary `of:fid1:<hash>`, so there is nothing
+ * for a predicate over id strings to recognize.
+ *
+ * Spec §18.6.2 names the class — "program/source text
+ * loaded to execute the handler", beside the `cid:` schema documents — and
+ * calls both public infrastructure. The bytes themselves already take that
+ * route: a `cid:` document is outside the flow join on both sides, so what
+ * remains on the record is the compiler's bookkeeping.
+ *
+ * Without the marker, any transaction that both reads labeled data and reaches
+ * a cache write is refused at `enforce-strict` — which a piece's source
+ * transition does by construction, because it stages a module's delegation
+ * union on the same transaction that moves the piece's source pointer.
+ *
+ * A cache document is not on §8.12.5's route 2, whose declaration would be the
+ * other answer. Route 2 declares one piece's flow join as the store's policy,
+ * so it wants a store keyed on that piece's own nodes. A cache document is
+ * keyed on module content: every piece in the space running that module
+ * addresses it, and it outlives all of them. What route 2 leaves behind is
+ * also permanent — a `declared` entry per measured path, which §8.12.1 does
+ * not let back, on a document nothing collects — where the flow stamp this
+ * keeps is a per-value component §8.12.8 replaces on overwrite.
+ *
+ * The write stays a flow stamp target, which is where this stops short of
+ * §18.6.2's write-side mirror — that section says the same addresses are not
+ * value-write targets at all, which would leave the record unstamped too.
+ * Safety invariant 9 is why it does not go that far. The delegation metadata
+ * holds module identities, and §17.7 says holding one grants no access to the
+ * artifact it names, so the content written here is public. WHICH identity
+ * appears is the other question: a transaction that read a labeled value and
+ * chose a successor by it writes that choice here, and §8.11.3 puts a
+ * decision's label on every downstream output whatever the output's own
+ * content is. That is the router attack at one bit per update, so the stamp
+ * stays and the ceiling is what the marker skips. The module's bytes are
+ * unaffected either way, being in a `cid:` document of their own.
+ *
+ * Every write to a cache record goes through here, whichever field it touches.
+ * The claim is about the document, so a write site that skipped it would leave
+ * the same refusal waiting for whichever transaction first reaches that site
+ * carrying a join. `anchorValueAsEntity` carries the claim down the same way
+ * it carries a runtime-owned store's, because a document anchored out of a
+ * marked value holds part of that value at an id derived from it; the cache's
+ * own records are written raw, with their import edges inline, so nothing
+ * here anchors.
+ */
+export function recordUndeclarablePolicyStore(
+  tx: IExtendedStorageTransaction,
+  doc: Cell<unknown>,
+): void {
+  const link = doc.getAsNormalizedFullLink();
+  tx.recordCfcWritePolicyInput({
+    kind: "structural-provenance",
+    target: {
+      space: link.space,
+      id: link.id,
+      scope: link.scope,
+      path: [...link.path],
+    },
+    claim: CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE,
+    sources: [],
+  }, runtimeWritePolicyAuthorization);
+}
+
 /** Attribute cache-document writes to the trusted compiler builtin. */
 function withCompileCacheBuiltin<T>(
   tx: IExtendedStorageTransaction,
@@ -876,6 +957,7 @@ export function writeSourceDocs(
         undefined,
         tx,
       );
+      recordUndeclarablePolicyStore(tx, baseCell);
       // Preserve product annotations on the entry doc only. Annotations are
       // only written there; reading every dependency doc here turns unrelated
       // stale cache cells into writeback conflict preconditions.
@@ -1465,6 +1547,7 @@ export function stageModuleDelegations(
       if (source.get()?.identity !== identity) {
         throw new Error(`source update artifact ${identity} is unavailable`);
       }
+      recordUndeclarablePolicyStore(tx, source);
       source.asSchema(sourceDocWriteSchema()).key("delegatedModuleIdentities")
         .set([...predecessors]);
       if (runtimeVersion !== undefined) {
@@ -1482,6 +1565,7 @@ export function stageModuleDelegations(
               `compiled source update artifact ${identity} is untrusted`,
             );
           }
+          recordUndeclarablePolicyStore(tx, compiled);
           compiled.asSchema(compiledDocWriteSchema()).key(
             "delegatedModuleIdentities",
           )
@@ -1536,6 +1620,7 @@ export function writeCompiledDocs(
         schema,
         tx,
       );
+      recordUndeclarablePolicyStore(tx, cell);
       // Fix B: derive the record surface from the compiled body once, here, so
       // the boot-time record build reads it instead of re-parsing per load. A
       // data entry has no record surface and its bytes are not JavaScript, so

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -48,6 +48,7 @@ import {
 import {
   CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
+  CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE,
   type CfcAddress,
   runtimeWritePolicyAuthorization,
 } from "./cfc/types.ts";
@@ -667,6 +668,38 @@ function anchorValueAsEntity(
         path: [],
       },
       claim: CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
+      sources: [{
+        space: link.space,
+        id: link.id,
+        scope: link.scope,
+        path: [...path],
+      }],
+    }, runtimeWritePolicyAuthorization);
+  }
+
+  // The same carry for the other class of parent, on the same reasoning. A
+  // document no schema declares a policy on splits its value the same way: a
+  // cache document's `imports` array holds one document per edge, and what
+  // each holds is a piece of the parent's own record at an id derived here.
+  // Without the carry the parent is exempt and its children are measured, so
+  // a transaction carrying a join that rewrites a cache document is refused
+  // at the child.
+  if (
+    tx.isUndeclarablePolicyStore(
+      link.space,
+      link.id,
+      runtimeWritePolicyAuthorization,
+    )
+  ) {
+    tx.recordCfcWritePolicyInput({
+      kind: "structural-provenance",
+      target: {
+        space: newEntryLink.space,
+        id: newEntryLink.id,
+        scope: newEntryLink.scope,
+        path: [],
+      },
+      claim: CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE,
       sources: [{
         space: link.space,
         id: link.id,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -31,6 +31,7 @@ import {
   type ModuleDelegationMap,
   moduleDelegationsFromDocs,
   planCompileCacheWriteChunks,
+  recordUndeclarablePolicyStore,
   ROOT_LINK_SPECIFIER,
   type SourceDoc,
   sourceDocKey,
@@ -3563,6 +3564,7 @@ export class PatternManager {
         undefined,
         tx,
       );
+      recordUndeclarablePolicyStore(tx, cell);
       const current = cell.get();
       const annotations = {
         ...(isObjectOrArray(current?.annotations) ? current!.annotations : {}),

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -120,6 +120,7 @@ import {
 } from "../cfc/runtime-owned-stores.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
+  CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE,
   runtimeWritePolicyAuthorized,
 } from "../cfc/types.ts";
 import { CFC_POLICY_MANIFEST_ID_PREFIX } from "../cfc/policy.ts";
@@ -536,6 +537,14 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
    * needs no more than this.
    */
   #markedOwnedStores = new Set<string>();
+
+  /**
+   * The stores no schema declares a policy on that a marker named on this
+   * transaction, keyed the same way {@link runtimeOwnedStoreKey} keys a
+   * document. No enrollment stands beside it: the measurement that reads it
+   * runs over documents the asking transaction wrote.
+   */
+  #markedUndeclarableStores = new Set<string>();
 
   /**
    * The stores the runtime owns that outlive the transaction that minted them,
@@ -1782,6 +1791,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
           runtimeOwnedStoreKey(frozen.target.space, frozen.target.id),
         );
       }
+      // The same whole-document test, for the same reason: whether a schema
+      // could have declared a policy is a question about the document. There
+      // is no owner to compare a space against — the claim says what the
+      // document is, not which piece it was minted for.
+      if (
+        frozen.kind === "structural-provenance" &&
+        frozen.claim === CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE &&
+        canonicalizeLogicalPath(frozen.target.path).length === 0
+      ) {
+        this.#markedUndeclarableStores.add(
+          runtimeOwnedStoreKey(frozen.target.space, frozen.target.id),
+        );
+      }
     }
     if (this.#cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-policy-input-added");
@@ -1856,6 +1878,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     const key = runtimeOwnedStoreKey(space, id);
     return this.#markedOwnedStores.has(key) ||
       (this.#runtimeOwnedStores?.has(key) ?? false);
+  }
+
+  isUndeclarablePolicyStore(
+    space: string,
+    id: string,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): boolean {
+    // Acted on rather than measured, so it takes the runtime's mark like the
+    // recorders do.
+    if (!runtimeWritePolicyAuthorized(authorization)) return false;
+    return this.#markedUndeclarableStores.has(
+      runtimeOwnedStoreKey(space, id),
+    );
   }
 
   recordCfcConsultedGrant(consulted: ConsultedGrant): void {
@@ -3800,6 +3835,14 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     authorization?: RuntimeWritePolicyAuthorization,
   ): boolean {
     return this.#wrapped.isRuntimeOwnedStore(space, id, authorization);
+  }
+
+  isUndeclarablePolicyStore(
+    space: string,
+    id: string,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): boolean {
+    return this.#wrapped.isUndeclarablePolicyStore(space, id, authorization);
   }
 
   recordCfcConsultedGrant(consulted: ConsultedGrant): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -2105,6 +2105,29 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   ): boolean;
 
   /**
+   * Whether the store at `id` in `space` is one no schema declares a policy
+   * on — named by an authorized whole-document
+   * `CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE` marker on this transaction.
+   *
+   * The §8.12.4 writer-fit measurement quantifies over the paths a schema
+   * could have declared a policy at, and skips the ones it cannot ask about.
+   * Two of those it reads off the id alone; this is the answer for a document
+   * whose id says nothing, which the runtime names as it writes it.
+   *
+   * This transaction alone, with no enrollment beside it: the measurement runs
+   * over documents the asking transaction wrote, so a marker recorded beside
+   * the write always covers the question.
+   *
+   * Takes the runtime's mark for the same reason {@link isRuntimeOwnedStore}
+   * does: the gate acts on the claim rather than measuring it.
+   */
+  isUndeclarablePolicyStore(
+    space: string,
+    id: string,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): boolean;
+
+  /**
    * Records a grant document consulted by policyState-guarded boundary
    * evaluation (§8.12.7 route 2a) — address plus resolution-time content
    * digest — for the prepared-digest binding (`PreparedDigestInput.

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -18,6 +18,7 @@ import { CFC_LABEL_READ_FAILED_ATOM } from "../src/cfc/observation.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
+  CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE,
   runtimeWritePolicyAuthorization,
 } from "../src/cfc/types.ts";
 import type { JSONSchema, Pattern } from "../src/builder/types.ts";
@@ -1325,6 +1326,361 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           "writer-fit confidentiality misfit",
         );
         expect(result.error?.message).toContain(`for ${entriesId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
+  describe("marked-undeclarable-store exemption", () => {
+    // The third arm of the same question the two id classes answer. A document
+    // whose id is a plain content hash looks like every other document, so the
+    // class it belongs to cannot be read off the id — the runtime names it as
+    // it writes it instead, under
+    // `CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE`. The compilation cache is
+    // what records it today: a cache document holds the compiler's record of a
+    // module at a content address of that module's bytes, so no pattern names
+    // it and no value schema describes a field on it.
+    //
+    // The marker is acted on rather than measured, so these cases pin what
+    // bounds it: who recorded it, and that it names a whole document.
+
+    /**
+     * Name `doc` as a store no schema declares a policy on, the way the
+     * compilation cache does for the documents it writes. `authorized` stands
+     * for who recorded it — the runtime passes its authorization, and code
+     * that merely holds a transaction cannot. `path` stands for how much of
+     * the document the marker names.
+     */
+    const markUndeclarable = (
+      tx: ReturnType<Runtime["edit"]>,
+      doc: { getAsNormalizedFullLink(): NormalizedFullLink },
+      { authorized = true, path = [] as readonly string[] } = {},
+    ): void => {
+      const link = doc.getAsNormalizedFullLink();
+      tx.recordCfcWritePolicyInput({
+        kind: "structural-provenance",
+        target: {
+          space: link.space,
+          scope: link.scope,
+          id: link.id,
+          path: [...path],
+        },
+        claim: CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE,
+        sources: [],
+      }, authorized ? runtimeWritePolicyAuthorization : undefined);
+    };
+
+    /**
+     * Read the seeded source and write what it carries onto `targetName`, at
+     * the path a delegation union lands on. `mark` decides whether the target
+     * is named, and how.
+     */
+    const writeTaintedRecord = async (
+      runtime: Runtime,
+      sourceName: string,
+      targetName: string,
+      mark?: (
+        tx: ReturnType<Runtime["edit"]>,
+        doc: { getAsNormalizedFullLink(): NormalizedFullLink },
+      ) => void,
+    ) => {
+      const tx = runtime.edit();
+      const source = runtime.getCell(signer.did(), sourceName, undefined, tx);
+      const raw = source.getRaw() as { secret?: string };
+      expect(raw.secret).toBe("s3cr3t");
+      const target = runtime.getCell<{ delegatedModuleIdentities?: string[] }>(
+        signer.did(),
+        targetName,
+        undefined,
+        tx,
+      );
+      mark?.(tx, target);
+      target.set({ delegatedModuleIdentities: [`predecessor/${raw.secret}`] });
+      const targetId = target.getAsNormalizedFullLink().id;
+      tx.prepareCfc();
+      return { targetId, result: await tx.commit() };
+    };
+
+    it("records no writer-fit reason for a write to a marked document", async () => {
+      // The defect this closes: a piece's source transition stages a module's
+      // delegation union on the same transaction that moves the piece's source
+      // pointer, and that transaction read the piece's argument. Measuring the
+      // cache write refuses the commit, so a pattern update is refused for
+      // exactly the pieces holding a confidential argument.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-cache-source");
+        const { targetId, result } = await writeTaintedRecord(
+          runtime,
+          "wf-cache-source",
+          "wf-cache-doc",
+          (tx, doc) => markUndeclarable(tx, doc),
+        );
+
+        expect(result.error).toBeUndefined();
+        // The exemption decides which store the value may land in, not
+        // whether the join follows it: the document holds the write and
+        // carries the clause.
+        expect(storedDocument(storageManager, targetId)?.value).toEqual({
+          delegatedModuleIdentities: ["predecessor/s3cr3t"],
+        });
+        expect(
+          replicaEntries(storageManager, targetId)
+            .filter((entry) => entry.origin === "derived")
+            .flatMap((entry) => entry.label.confidentiality ?? []),
+        ).toContain("secret");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("measures the same write into a document nothing marked", async () => {
+      // The control: the exemption keys on the marker, not on the path the
+      // value lands at or the join this transaction carries.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-cache-plain-source");
+        const { targetId, result } = await writeTaintedRecord(
+          runtime,
+          "wf-cache-plain-source",
+          "wf-cache-plain-doc",
+        );
+
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(`for ${targetId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("counts a marker recorded without the runtime's mark for nothing", async () => {
+      // The gate ACTS on this claim, and the recording method is on the public
+      // transaction interface, so pattern-authored code reaching `cell.tx` can
+      // name whatever document it likes. What separates the two is the
+      // authorization the runtime passes alongside.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-cache-forged-source");
+        const { targetId, result } = await writeTaintedRecord(
+          runtime,
+          "wf-cache-forged-source",
+          "wf-cache-forged-doc",
+          (tx, doc) => markUndeclarable(tx, doc, { authorized: false }),
+        );
+
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(`for ${targetId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("counts a marker naming a path inside the document for nothing", async () => {
+      // Whether a schema could have declared a policy is a question about the
+      // document, so the marker answers for the whole of one. A marker
+      // carrying a path names a part, and a part is not what it can claim.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-cache-partial-source");
+        const { targetId, result } = await writeTaintedRecord(
+          runtime,
+          "wf-cache-partial-source",
+          "wf-cache-partial-doc",
+          (tx, doc) =>
+            markUndeclarable(tx, doc, {
+              path: ["delegatedModuleIdentities"],
+            }),
+        );
+
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(`for ${targetId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("measures a document the marker did not name", async () => {
+      // The marker names a document, not the transaction. A transaction that
+      // marked one store and wrote another has said nothing about the second,
+      // and a gate keyed on the transaction rather than the document would let
+      // that second write through.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-cache-other-source");
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-cache-other-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        expect(raw.secret).toBe("s3cr3t");
+        const marked = runtime.getCell(
+          signer.did(),
+          "wf-cache-marked-doc",
+          undefined,
+          tx,
+        );
+        markUndeclarable(tx, marked);
+        const bystander = runtime.getCell<{ copied?: string }>(
+          signer.did(),
+          "wf-cache-bystander-doc",
+          undefined,
+          tx,
+        );
+        bystander.set({ copied: `${raw.secret}!` });
+        const bystanderId = bystander.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+
+        const result = await tx.commit();
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(`for ${bystanderId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("carries the claim to a document the marked value splits into", async () => {
+      // Anchoring puts part of a marked document's value in a document of its
+      // own — a cache document's `imports` array holds one per edge. The child
+      // is the same kind of store as its parent, and without the carry a
+      // transaction that rewrites a marked document while carrying a join is
+      // refused at the child rather than at the document it named.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-cache-anchor-source");
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-cache-anchor-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        expect(raw.secret).toBe("s3cr3t");
+        const parent = runtime.getCell<{ note: string }[]>(
+          signer.did(),
+          "wf-cache-anchor-parent",
+          anchoringList(),
+          tx,
+        );
+        markUndeclarable(tx, parent);
+        parent.set([{ note: `${raw.secret}!` }]);
+        const parentId = parent.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+
+        const result = await tx.commit();
+        expect(result.error).toBeUndefined();
+        expect(writerFitDiagnostics(tx)).toEqual([]);
+        // The parent's own write is all links after the anchor, so the
+        // content landed in the child, which is the document the claim had
+        // to reach. Its stored value pins it, and its stamp says the skip
+        // decided which store the value may land in rather than whether the
+        // join follows it.
+        const stored = storedDocument(storageManager, parentId)?.value;
+        const childId = parseLink((stored as unknown[])[0])!.id!;
+        expect(childId).not.toBe(parentId);
+        expect(storedDocument(storageManager, childId)?.value).toEqual({
+          note: "s3cr3t!",
+        });
+        expect(
+          replicaEntries(storageManager, childId)
+            .flatMap((entry) => entry.label.confidentiality ?? []),
+        ).toContain("secret");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("keeps measuring a marked document whose join came from another space", async () => {
+      // Scoped to a join the target's own space produced, the same as the two
+      // id classes: a cache write cannot carry a foreign space's labeled value
+      // into a local document.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      const foreign = (await Identity.fromPassphrase("wf-cache-foreign")).did();
+      try {
+        const seed = runtime.edit();
+        const foreignCell = runtime.getCell(
+          foreign,
+          "wf-cache-foreign-source",
+          { type: "object", properties: { secret: { type: "string" } } },
+          seed,
+        );
+        const foreignId = foreignCell.getAsNormalizedFullLink().id;
+        writeSeedEnvelopeDoc(seed, foreign);
+        seed.writeOrThrow({
+          space: foreign,
+          scope: "space",
+          id: foreignId,
+          path: [],
+        }, {
+          value: { secret: "s3cr3t" },
+          cfc: {
+            version: 1,
+            schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: ["secret"],
+                label: { confidentiality: ["secret"] },
+              }],
+            },
+          },
+        });
+        expect((await seed.commit()).ok).toBeDefined();
+
+        const tx = runtime.edit();
+        const source = runtime.getCellFromLink(
+          { id: foreignId, path: [], space: foreign, scope: "space" },
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        expect(raw.secret).toBe("s3cr3t");
+        const target = runtime.getCell<
+          { delegatedModuleIdentities?: string[] }
+        >(
+          signer.did(),
+          "wf-cache-foreign-doc",
+          undefined,
+          tx,
+        );
+        markUndeclarable(tx, target);
+        target.set({
+          delegatedModuleIdentities: [`predecessor/${raw.secret}`],
+        });
+        const targetId = target.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+
+        const result = await tx.commit();
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(`for ${targetId} at /`);
       } finally {
         await runtime.dispose();
         await storageManager.close();

--- a/packages/runner/test/extended-storage-transaction.test.ts
+++ b/packages/runner/test/extended-storage-transaction.test.ts
@@ -20,6 +20,7 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { RuntimeOwnedStores } from "../src/cfc/runtime-owned-stores.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_RUNTIME_OWNED_STORE,
+  CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE,
   runtimeWritePolicyAuthorization,
 } from "../src/cfc/types.ts";
 import { type JSONSchema } from "../src/builder/types.ts";
@@ -609,6 +610,156 @@ describe("extended-storage-transaction", () => {
           .toThrow("already configured");
       } finally {
         await tx.commit();
+      }
+    });
+  });
+
+  describe("the marking of a store no schema declares a policy on", () => {
+    // The §8.12.4 writer-fit measurement quantifies over the paths a schema
+    // could have declared a policy at. Two id classes it reads off the id;
+    // this is the answer for a document whose id says nothing, which the
+    // runtime names as it writes it. The marker lasts for the transaction
+    // that recorded it, with no enrollment beside it, because the
+    // measurement only ever runs over documents that transaction wrote.
+
+    const mark = (
+      tx: ReturnType<Runtime["edit"]>,
+      id: string,
+      { authorized = true, path = [] as readonly string[] } = {},
+    ) =>
+      tx.recordCfcWritePolicyInput({
+        kind: "structural-provenance",
+        target: { space, id, scope: "space", path: [...path] },
+        claim: CFC_STRUCTURAL_PROVENANCE_UNDECLARABLE_STORE,
+        sources: [],
+      }, authorized ? runtimeWritePolicyAuthorization : undefined);
+
+    it("answers for a document this transaction marked", async () => {
+      const tx = runtime.edit();
+      try {
+        expect(
+          tx.isUndeclarablePolicyStore(
+            space,
+            "of:marked",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(false);
+        mark(tx, "of:marked");
+        expect(
+          tx.isUndeclarablePolicyStore(
+            space,
+            "of:marked",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(true);
+        // The marker names a document, not the transaction.
+        expect(
+          tx.isUndeclarablePolicyStore(
+            space,
+            "of:not-marked",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(false);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("answers `false` to a caller without the runtime's mark", async () => {
+      const tx = runtime.edit();
+      try {
+        mark(tx, "of:unmarked-reader");
+        expect(tx.isUndeclarablePolicyStore(space, "of:unmarked-reader"))
+          .toBe(false);
+        expect(
+          tx.isUndeclarablePolicyStore(
+            space,
+            "of:unmarked-reader",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(true);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("counts a marker recorded without the runtime's mark for nothing", async () => {
+      // The gate ACTS on this claim, and the recording method is public, so
+      // an input's own fields say only what its recorder wrote.
+      const tx = runtime.edit();
+      try {
+        mark(tx, "of:forged", { authorized: false });
+        expect(
+          tx.isUndeclarablePolicyStore(
+            space,
+            "of:forged",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(false);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("counts a marker naming a path inside the document for nothing", async () => {
+      // Whether a schema could have declared a policy is a question about the
+      // document, so the marker answers for the whole of one.
+      const tx = runtime.edit();
+      try {
+        mark(tx, "of:partly-marked", { path: ["delegatedModuleIdentities"] });
+        expect(
+          tx.isUndeclarablePolicyStore(
+            space,
+            "of:partly-marked",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(false);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("is answered through a wrapper as through what it wraps", async () => {
+      const tx = runtime.edit();
+      const wrapper = createNonReactiveTransaction(tx);
+      try {
+        mark(tx, "of:marked-through-a-wrapper");
+        expect(
+          wrapper.isUndeclarablePolicyStore(
+            space,
+            "of:marked-through-a-wrapper",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(true);
+        expect(
+          wrapper.isUndeclarablePolicyStore(
+            space,
+            "of:marked-through-a-wrapper",
+          ),
+        ).toBe(false);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("does not answer for a store a previous transaction marked", async () => {
+      // The other half of "no enrollment beside it": a marker dies with its
+      // transaction, and nothing carries it forward.
+      const first = runtime.edit();
+      mark(first, "of:marked-earlier");
+      await first.commit();
+
+      const later = runtime.edit();
+      try {
+        expect(
+          later.isUndeclarablePolicyStore(
+            space,
+            "of:marked-earlier",
+            runtimeWritePolicyAuthorization,
+          ),
+        ).toBe(false);
+      } finally {
+        await later.commit();
       }
     });
   });

--- a/packages/runner/test/module-delegation.test.ts
+++ b/packages/runner/test/module-delegation.test.ts
@@ -4,6 +4,10 @@ import { stub } from "@std/testing/mock";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "./cfc-seed-envelope.ts";
 import type { PreparedSourceUpdate } from "../src/pattern-manager.ts";
 import type { JSONSchema, Pattern } from "../src/builder/types.ts";
 import type { Cell } from "../src/cell.ts";
@@ -50,6 +54,54 @@ function moduleFor(program: RuntimeProgram): CacheableModule {
     imports: [],
   };
 }
+
+/**
+ * Seed a document whose `secret` field carries a confidentiality clause, so a
+ * transaction reading it takes that clause into its flow join. This stands for
+ * the piece argument a source transition reads on the same transaction that
+ * stages the successor's delegation union.
+ */
+const seedLabeledSource = async (
+  runtime: Runtime,
+  name: string,
+): Promise<void> => {
+  const seed = runtime.edit();
+  const id = runtime.getCell(space, name, {
+    type: "object",
+    properties: { secret: { type: "string" } },
+  }).getAsNormalizedFullLink().id;
+  writeSeedEnvelopeDoc(seed, space);
+  seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+    value: { secret: "s3cr3t" },
+    cfc: {
+      version: 1,
+      schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+      labelMap: {
+        version: 1,
+        entries: [{
+          path: ["secret"],
+          label: { confidentiality: ["secret"] },
+        }],
+      },
+    },
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+};
+
+/** The persisted label-map entries on `id`, for pinning that a join landed. */
+const replicaEntries = (
+  storage: ReturnType<typeof StorageManager.emulate>,
+  id: string,
+): { label: { confidentiality?: string[] } }[] => {
+  const replica = storage.open(space).replica as unknown as {
+    getDocument(id: string): {
+      cfc?: {
+        labelMap?: { entries: { label: { confidentiality?: string[] } }[] };
+      };
+    } | undefined;
+  };
+  return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+};
 
 const protectedSchema = {
   type: "object",
@@ -968,4 +1020,145 @@ describe("module identity delegation", () => {
       expect(await setName(observer, observed, "after")).toBe("v1:after");
     });
   });
+
+  for (
+    const stage of [
+      {
+        name: "writes the closure",
+        write: (
+          runtime: Runtime,
+          tx: ReturnType<Runtime["edit"]>,
+          modules: readonly CacheableModule[],
+          entryIdentity: string,
+          predecessor: string,
+          version: string,
+        ) => {
+          const delegations = new Map([
+            [entryIdentity, new Set([predecessor])],
+          ]);
+          writeSourceDocs(
+            runtime,
+            space,
+            modules,
+            entryIdentity,
+            tx,
+            delegations,
+          );
+          writeCompiledDocs(runtime, space, modules, entryIdentity, {
+            runtimeVersion: version,
+            moduleDelegations: delegations,
+          }, tx);
+        },
+      },
+      {
+        name: "stages a delegation union",
+        write: (
+          runtime: Runtime,
+          tx: ReturnType<Runtime["edit"]>,
+          _modules: readonly CacheableModule[],
+          entryIdentity: string,
+          predecessor: string,
+          version: string,
+        ) => {
+          stageModuleDelegations(
+            runtime,
+            space,
+            new Map([[entryIdentity, new Set([predecessor])]]),
+            version,
+            tx,
+          );
+        },
+      },
+    ]
+  ) {
+    it(`commits a cache write carrying a flow join when it ${stage.name}`, async () => {
+      // A cache document is a store no pattern declares a policy on: its id is
+      // a content address of module bytes. Measuring it refuses any
+      // transaction that both reads labeled data and reaches a cache write,
+      // which a piece's source transition does by construction. The assertion
+      // is the COMMIT rather than the marker, so a write target the marker
+      // does not reach fails this: the import edge below is stored in a
+      // document of its own, which `anchorValueAsEntity` has to carry the
+      // claim down to.
+      const strict = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-strict",
+        cfcFlowLabels: "persist",
+      });
+      try {
+        const dependency = moduleFor(moduleProgram("dependency"));
+        const previous = moduleFor(moduleProgram("old"));
+        const entry = {
+          ...moduleFor(moduleProgram("new")),
+          imports: [{
+            specifier: "./dependency.ts",
+            targetIdentity: dependency.identity,
+          }],
+        };
+        const modules = [entry, dependency];
+        const version = "delegation-undeclarable-marker";
+        // Staging reads the artifacts back, so both sets have to be there.
+        expect(
+          (await strict.editWithRetry((tx) => {
+            writeSourceDocs(strict, space, modules, entry.identity, tx);
+            writeCompiledDocs(strict, space, modules, entry.identity, {
+              runtimeVersion: version,
+            }, tx);
+          })).error,
+        ).toBeUndefined();
+        await seedLabeledSource(strict, "module-delegation-secret");
+
+        const tx = strict.edit();
+        try {
+          // The read that puts a confidentiality clause in the flow join,
+          // standing for the piece argument a source transition reads.
+          const secret = strict.getCell(
+            space,
+            "module-delegation-secret",
+            undefined,
+            tx,
+          );
+          expect((secret.getRaw() as { secret?: string }).secret)
+            .toBe("s3cr3t");
+          stage.write(
+            strict,
+            tx,
+            modules,
+            entry.identity,
+            previous.identity,
+            version,
+          );
+          tx.prepareCfc();
+          const result = await tx.commit();
+          expect(result.error?.message).toBeUndefined();
+          // The commit is the assertion, and on its own it passes whether or
+          // not the transaction ever carried a clause — so pin both halves.
+          // The stamp on the record says the join reached this write, which
+          // is the thing the old refusal was about; the stored value says the
+          // write itself landed.
+          const stamped = replicaEntries(
+            storageManager,
+            strict.getCell(space, sourceDocKey(entry.identity), undefined, tx)
+              .getAsNormalizedFullLink().id,
+          ).flatMap((label) => label.label.confidentiality ?? []);
+          expect(stamped).toContain("secret");
+          const readTx = strict.edit();
+          try {
+            const stored = strict.getCell<
+              { delegatedModuleIdentities?: string[] }
+            >(space, sourceDocKey(entry.identity), undefined, readTx).get();
+            expect(stored?.delegatedModuleIdentities)
+              .toContain(previous.identity);
+          } finally {
+            readTx.abort();
+          }
+        } finally {
+          if (tx.status().status === "ready") tx.abort();
+        }
+      } finally {
+        await strict.dispose();
+      }
+    });
+  }
 });


### PR DESCRIPTION
PROBLEM

At the strictest CFC dial row, updating a piece whose argument carries a confidentiality label is refused at commit. The setup transaction reads the argument, so its flow join carries that label, and it also stages the successor module's `delegatedModuleIdentities` on the compilation cache's source document, so that the writer authority and the source pointer land together. That document is content-addressed and declares no store policy, so the section 8.12.4 writer-fit check measures the join against the empty ceiling and refuses:

    CFC enforcement rejected commit: relevant transaction was not
    prepared: writer-fit confidentiality misfit for
    of:fid1:PbGE-QEtitjFs5VtX4hRDbXDHqx1AfNzBPbEa2nJISg at
    /delegatedModuleIdentities/0 (canWrite, section 8.12.4):
    {"class":"PrivateNote","subject":"did:example:owner", ...}

A pattern update is refused for exactly the pieces a confidentiality label is written for.

SOLUTION

The measurement quantifies over the paths a schema could have declared a policy at. A cache document is not one: no pattern names it, and the only schemas describing its fields are the cache's own, which declare integrity alone. The two classes already outside the measurement are recognized from the id string, and a cache document's id is a plain `of:fid1:<hash>`, so the write side names the document instead. Each cache write records an authorized whole-document
`runtime.undeclarable-store` marker, `anchorValueAsEntity` carries the claim to the documents a cache value splits into, and the measurement asks the transaction rather than the id. The write stays a flow stamp target, so the transaction's join still lands on the document as its `derived` component and a later read of it carries that clause.

DESIGN DISCUSSION

Section 8.12.5's route 2 was the other answer, and two things rule it out. Route 2 declares one piece's flow join as the store's policy, so it wants a store keyed on that piece's own nodes; a cache document is keyed on module content, every piece in the space running that module addresses it, and it outlives all of them. And what route 2 leaves behind is permanent: a `declared` entry per measured path, which section 8.12.1 does not let back, on a document nothing collects. The flow stamp kept here is a per-value component that section 8.12.8 replaces on overwrite. The two routes agree on what a later reader of the document carries, so that consequence is not what separates them.

Three things bound the marker. It is recorded through the same public method route 2's marker uses, so the runtime's authorization is what separates a claim the runtime made from one pattern-authored code wrote. It names a whole document, because whether a schema could have declared a policy is a question about the document rather than about a path inside one. And it lasts for the transaction that recorded it, with no enrollment beside it: the measurement runs over documents the asking transaction wrote, so a marker recorded beside the write always covers the question.

The skip is scoped to a join the target's own space produced, the same as the two id classes, so a source transition cannot carry another space's labeled value into a local cache document.

This stops short of section 18.6.2's write-side mirror, which says the same addresses are not value-write targets at all and would leave a cache document unstamped as well as unmeasured. The delegation metadata is the reason: it is not program text, it decides which predecessor identities a module inherits writer authority from, and what influenced a write to it is worth recording. Neither shape refuses the write, so the difference is in what is labeled and never in what is admitted. `docs/specs/cfc-spec-changes.md` carries the divergence beside the narrowing, since SC-18 already records the whole section 18.6.2 set as owed to the writer-fit rule.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

