### PR TITLE
fix(compiler): preserve generic Cell alias payloads

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -385,6 +385,10 @@ pre-cleanup schemas.
 
 ### 6.3 Node/type interplay
 
+- A generic alias whose resolved type is a Cell uses that resolved wrapper's
+  payload. The alias's own first argument need not be the payload; source
+  type arguments supply an inner node only when the source node resolves to
+  the matching wrapper kind.
 - Capability re-wrap fidelity: when a **synthetic** node narrows a capability
   brand (the transformer re-wraps `Cell<T>` as `ReadonlyCell<T>`) and the
   node's own inner degrades to `any`, the resolved type's inner supplies the

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -387,8 +387,9 @@ pre-cleanup schemas.
 
 - A generic alias whose resolved type is a Cell uses that resolved wrapper's
   payload. The alias's own first argument need not be the payload; source
-  type arguments supply an inner node only when the source node resolves to
-  the matching wrapper kind.
+  type arguments supply an inner node only for direct Cell wrapper syntax.
+  Non-generic aliases retain their resolved declaration node so payload
+  defaults remain available to schema generation.
 - Capability re-wrap fidelity: when a **synthetic** node narrows a capability
   brand (the transformer re-wraps `Cell<T>` as `ReadonlyCell<T>`) and the
   node's own inner degrades to `any`, the resolved type's inner supplies the

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1392,6 +1392,9 @@ builder call it rebuilds carries the replaced call's source-map range (§11.5).
 - `_param` convention implies `never` schema for that parameter
 - failed inference falls back to `unknown`
 - `typeRegistry` is consulted first for synthetic nodes/types
+- Common Fabric generic aliases retain their authored type arguments when
+  qualified through `__cfHelpers`; argument pairing uses the alias arguments,
+  which can differ from the arguments of its underlying reference type.
 
 ### 10.2 `pattern(...)`
 

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -899,14 +899,12 @@ export class CommonFabricFormatter implements TypeFormatter {
       | undefined,
     targetKind: WrapperKind,
   ): ts.TypeReferenceNode | undefined {
+    // Alias declaration arguments can be unbound or describe a different
+    // parameter list. Only direct wrapper syntax names the resolved payload.
     if (
-      originalNode &&
-      ts.isTypeReferenceNode(originalNode) &&
-      originalNode.typeArguments
+      resolvedWrapper?.kind === targetKind &&
+      resolvedWrapper.node === originalNode
     ) {
-      return originalNode;
-    }
-    if (resolvedWrapper?.kind === targetKind) {
       return resolvedWrapper.node;
     }
     return undefined;

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -899,12 +899,21 @@ export class CommonFabricFormatter implements TypeFormatter {
       | undefined,
     targetKind: WrapperKind,
   ): ts.TypeReferenceNode | undefined {
-    // Alias declaration arguments can be unbound or describe a different
-    // parameter list. Only direct wrapper syntax names the resolved payload.
     if (
-      resolvedWrapper?.kind === targetKind &&
-      resolvedWrapper.node === originalNode
+      originalNode && ts.isTypeReferenceNode(originalNode) &&
+      originalNode.typeArguments
     ) {
+      // A generic Cell alias can map its parameters into a larger payload.
+      // Only direct Cell syntax names that payload in its first argument.
+      if (
+        isCellCapabilityKind(targetKind) &&
+        resolvedWrapper?.node !== originalNode
+      ) {
+        return undefined;
+      }
+      return originalNode;
+    }
+    if (resolvedWrapper?.kind === targetKind) {
       return resolvedWrapper.node;
     }
     return undefined;

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -134,24 +134,19 @@ export function qualifyCommonFabricTypeRefs(
     return matches.length === 1 ? matches[0] : undefined;
   };
 
-  // For a TypeReference Type, get its Nth type argument. Different
-  // TypeScript versions expose this via slightly different shapes; try the
-  // public ones first.
+  // Pair a printed alias with its own arguments before consulting the
+  // arguments of the reference it instantiates.
   const getTypeArgumentAt = (
     type: ts.Type | undefined,
     index: number,
   ): ts.Type | undefined => {
     if (!type) return undefined;
+    // Printed aliases carry their own arguments, which can differ from the
+    // arguments of the reference they instantiate.
+    if (type.aliasTypeArguments) return type.aliasTypeArguments[index];
     const asReference = type as ts.TypeReference;
     if (asReference.typeArguments) {
       return asReference.typeArguments[index];
-    }
-    // Alias-resolved generics expose aliasTypeArguments.
-    const aliased = (type as unknown as {
-      aliasTypeArguments?: readonly ts.Type[];
-    }).aliasTypeArguments;
-    if (aliased) {
-      return aliased[index];
     }
     return undefined;
   };

--- a/packages/ts-transformers/src/ast/type-inference.ts
+++ b/packages/ts-transformers/src/ast/type-inference.ts
@@ -300,6 +300,14 @@ export function isCollectionType(
     );
 }
 
+function getCellPayloadType(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+): ts.Type | undefined {
+  const ref = getCellWrapperInfo(type, checker)?.typeRef;
+  return ref && (ref.typeArguments ?? checker.getTypeArguments(ref))[0];
+}
+
 /**
  * Unwrap Reactive-like types to get the underlying type
  * Handles unions, intersections, and nested Reactive types
@@ -329,8 +337,7 @@ export function unwrapOpaqueLikeType(
     // Look for an OpaqueCell<T> part and extract its type argument
     for (const part of type.types) {
       if (isBrandedCellType(part, checker)) {
-        const inner = getCellWrapperInfo(part, checker)?.typeRef.typeArguments
-          ?.[0];
+        const inner = getCellPayloadType(part, checker);
         if (inner) {
           // Recursively unwrap in case T itself contains Reactive types
           return unwrapOpaqueLikeType(inner, checker, seen) ?? inner;
@@ -352,7 +359,7 @@ export function unwrapOpaqueLikeType(
 
   if (isBrandedCellType(type, checker)) {
     const inner = unwrapOpaqueLikeType(
-      getCellWrapperInfo(type, checker)?.typeRef.typeArguments?.[0],
+      getCellPayloadType(type, checker),
       checker,
       seen,
     );
@@ -376,7 +383,7 @@ export function unwrapCellLikeType(
     return opaqueUnwrapped;
   }
 
-  return getCellWrapperInfo(type, checker)?.typeRef.typeArguments?.[0] ?? type;
+  return getCellPayloadType(type, checker) ?? type;
 }
 
 /**

--- a/packages/ts-transformers/src/ast/type-inference.ts
+++ b/packages/ts-transformers/src/ast/type-inference.ts
@@ -1,3 +1,4 @@
+import { getCellWrapperInfo } from "@commonfabric/schema-generator/cell-brand";
 import ts from "typescript";
 import { getCellKind, isBrandedCellType } from "../transformers/cell-type.ts";
 import {
@@ -328,7 +329,8 @@ export function unwrapOpaqueLikeType(
     // Look for an OpaqueCell<T> part and extract its type argument
     for (const part of type.types) {
       if (isBrandedCellType(part, checker)) {
-        const inner = getTypeReferenceArgument(part);
+        const inner = getCellWrapperInfo(part, checker)?.typeRef.typeArguments
+          ?.[0];
         if (inner) {
           // Recursively unwrap in case T itself contains Reactive types
           return unwrapOpaqueLikeType(inner, checker, seen) ?? inner;
@@ -350,7 +352,7 @@ export function unwrapOpaqueLikeType(
 
   if (isBrandedCellType(type, checker)) {
     const inner = unwrapOpaqueLikeType(
-      getTypeReferenceArgument(type),
+      getCellWrapperInfo(type, checker)?.typeRef.typeArguments?.[0],
       checker,
       seen,
     );
@@ -374,7 +376,7 @@ export function unwrapCellLikeType(
     return opaqueUnwrapped;
   }
 
-  return getTypeReferenceArgument(type) ?? type;
+  return getCellWrapperInfo(type, checker)?.typeRef.typeArguments?.[0] ?? type;
 }
 
 /**

--- a/packages/ts-transformers/test/generic-cell-alias.test.ts
+++ b/packages/ts-transformers/test/generic-cell-alias.test.ts
@@ -1,0 +1,91 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { emittedSchemas, parseModule } from "./transformed-ast.ts";
+import { transformSource } from "./utils.ts";
+
+const types = {
+  ...COMMONFABRIC_TYPES,
+  "commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"] + `
+    export interface PairHandle<T> extends BrandedCell<T, "readonly"> {
+      lookup(key: unknown): Reactive<number>;
+    }
+    export type KeyedHandle<K, V> = PairHandle<{ key: K; value: V }>;
+  `,
+};
+
+describe("generic cell aliases", () => {
+  it("preserves alias arguments and Cell payloads in input and capture schemas", async () => {
+    const output = await transformSource(
+      `import { pattern, type KeyedHandle, type Cell } from "commonfabric";
+      export default pattern<{
+        index: KeyedHandle<Cell<{ id: string }>, { name: string }>;
+        key: Cell<{ id: string }>;
+      }>(({ index, key }) => index.lookup(key));`,
+      { types, typeCheck: true },
+    );
+    const indexSchemas = emittedSchemas(parseModule(output)).flatMap(
+      (schema) => {
+        const properties = schema.properties;
+        return properties !== null && typeof properties === "object" &&
+            "index" in properties
+          ? [properties.index]
+          : [];
+      },
+    );
+    expect(indexSchemas).toHaveLength(2);
+    for (const schema of indexSchemas) {
+      expect(schema).toEqual(expect.objectContaining({
+        asCell: ["readonly"],
+        properties: {
+          key: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+            asCell: ["cell"],
+          },
+          value: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            required: ["name"],
+          },
+        },
+      }));
+    }
+    expect(output).toContain("KeyedHandle<__cfHelpers.Cell<");
+    expect(output).not.toContain("KeyedHandle<__cfHelpers.PairHandle<");
+  });
+  it("preserves a direct generic Cell alias when narrowing a captured read", async () => {
+    const output = await transformSource(
+      `import { pattern, computed, type Cell } from "commonfabric";
+      type Pair<K, V> = Cell<{ key: K; value: V }>;
+      export default pattern<{ pair: Pair<string, { name: string }> }>(
+        ({ pair }) => computed(() => pair.get()),
+      );`,
+      { types: COMMONFABRIC_TYPES, typeCheck: true },
+    );
+    const pairSchemas = emittedSchemas(parseModule(output)).flatMap(
+      (schema) => {
+        const properties = schema.properties;
+        return properties !== null && typeof properties === "object" &&
+            "pair" in properties
+          ? [properties.pair]
+          : [];
+      },
+    );
+    expect(pairSchemas).toHaveLength(2);
+    for (const schema of pairSchemas) {
+      expect(schema).toEqual(expect.objectContaining({
+        properties: {
+          key: { type: "string" },
+          value: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            required: ["name"],
+          },
+        },
+      }));
+    }
+  });
+});

--- a/packages/ts-transformers/test/generic-cell-alias.test.ts
+++ b/packages/ts-transformers/test/generic-cell-alias.test.ts
@@ -1,8 +1,10 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
+import ts from "typescript";
+
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
-import { emittedSchemas, parseModule } from "./transformed-ast.ts";
+import { collect, emittedSchemas, parseModule } from "./transformed-ast.ts";
 import { transformSource } from "./utils.ts";
 
 const types = {
@@ -53,8 +55,26 @@ describe("generic cell aliases", () => {
         },
       }));
     }
-    expect(output).toContain("KeyedHandle<__cfHelpers.Cell<");
-    expect(output).not.toContain("KeyedHandle<__cfHelpers.PairHandle<");
+    const aliases = collect(parseModule(output), ts.isTypeReferenceNode).filter(
+      (node) =>
+        (ts.isQualifiedName(node.typeName)
+          ? node.typeName.right.text
+          : node.typeName.text) === "KeyedHandle",
+    );
+    expect(aliases.length).toBeGreaterThan(0);
+    for (const alias of aliases) {
+      expect(alias.typeArguments).toHaveLength(2);
+      const key = alias.typeArguments![0]!;
+      expect(ts.isTypeReferenceNode(key)).toBe(true);
+      if (!ts.isTypeReferenceNode(key)) throw new Error("Expected key wrapper");
+      const name = ts.isQualifiedName(key.typeName)
+        ? key.typeName.right.text
+        : key.typeName.text;
+      expect(name).toBe("Cell");
+      expect(key.typeArguments).toHaveLength(1);
+      expect(ts.isTypeLiteralNode(key.typeArguments![0]!)).toBe(true);
+      expect(ts.isTypeLiteralNode(alias.typeArguments![1]!)).toBe(true);
+    }
   });
   it("preserves a direct generic Cell alias when narrowing a captured read", async () => {
     const output = await transformSource(


### PR DESCRIPTION
## Why

Generic Cell aliases can lose their stored payload when their public type arguments differ from the underlying wrapper's arguments. For example, `Pair<K, V> = Cell<{ key: K; value: V }>` can produce a captured schema containing only `K`. A Cell-valued key can also be printed as the wrong nested generic type. These defects block the typed collection-index prototype for #7155.

## What changed

Preserve the alias's own type arguments when qualifying generated type references. Use canonical resolved Cell wrapper information when unwrapping payloads, and use source payload syntax only for direct generic Cell references while retaining non-generic alias defaults. Include TypeScript’s checker fallback when resolving wrapper arguments. Update the compiler specifications and add full-pipeline regressions covering both input and capture schemas, with structural AST assertions for generated type arguments.

## Test plan

- Regression fails on main and passes with the repair.
- Full schema-generator suite: 59 tests/401 steps pass.
- Full ts-transformers suite: 1167 tests/945 steps pass.
- Repository type checks, formatting, and lint pass.
- All 599 checked documentation blocks pass.
- Full pattern compatibility: 412 files checked; all 327 evaluable contracts remain compatible with every recorded baseline, with no new baselines or accepted breaks.
- Vintage replay: 8 snapshots, 134 recorded instantiations, 113 upgrade targets; 77 updated cleanly with no state stranded.
- Antagonistic review is clean after adding the direct Cell alias regression.

## Scope limitation

Generic Stream and SqliteDb alias remapping retain their existing behavior. Broadening this repair to those wrappers changes stored contracts such as shopping-list’s Reactive<Stream<...>> output and requires a separate compatibility-aware change. This PR repairs Cell capability aliases needed by the index prototype.
