### PR TITLE
Add typed collection-index lookup foundation

### DIFF
--- a/docs/plans/collection-index-contract.md
+++ b/docs/plans/collection-index-contract.md
@@ -65,11 +65,20 @@ whole-array callback arguments in the first API: they would make source
 reordering a dependency of every key extractor.
 
 The result is a typed index handle. Its `lookup(key)` returns an ordinary
-reactive Cell containing a group or an optional original element. A separate
+reactive value containing a group or an optional original element. A Cell passed
+as the key always denotes its identity; callers use an explicit value read when
+its stored primitive should be the key. This keeps Cell identity unambiguous
+when an index accepts both primitive and Cell keys. A separate
 `keys()` operation observes occupied-key membership. Each lookup subscribes to
 one key's bucket and the lookup key's resolution path; it must not subscribe to
-index enumeration. The exact type declarations and branded-handle lowering must
-be prototyped before the implementation contract is marked complete.
+index enumeration.
+
+The typed-handle prototype uses a read-only Cell descriptor with separately
+addressed buckets and occupied keys. Compiled lookup delegates to the descriptor
+Cell and returns an ordinary reactive value. Its acceptance tests cover
+primitive/Cell key separation, link retargeting, unrelated-bucket isolation,
+missing-key insertion, linked row contents, and durable lookup resume. Index
+construction, per-element extraction, and bucket ownership remain pending.
 
 The first join is a left lookup join against a `keyBy` index: one output per
 left occurrence, with its original left element and an optional right element.
@@ -113,7 +122,7 @@ groups.
 
 ## Implementation sequence and acceptance
 
-- [ ] Prototype the typed index handle and its transformer/schema boundary. Keep
+- [x] Prototype the typed index handle and its transformer/schema boundary. Keep
       key lookup separate from ordinary object-property `Cell.key`.
 - [ ] Implement shared key resolution and per-element extraction, reusing
       runtime identity and ownership machinery.

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -857,6 +857,54 @@ export interface IEquatable {
   equalLinks(other: AnyCell<any> | object | undefined): boolean;
 }
 
+/** Primitive or Cell identity accepted by a collection index. */
+export type CollectionIndexKey =
+  | string
+  | number
+  | boolean
+  | AnyBrandedCell<unknown>;
+
+/** Stored descriptor whose buckets are addressed independently by keyed lookup. */
+export interface CollectionIndexData<K extends CollectionIndexKey, V> {
+  /** Descriptor marker used to recognize an index receiver. */
+  readonly kind: "collection-index";
+
+  /** Missing-key behavior: an empty group or an absent unique match. */
+  readonly mode: "group" | "key";
+
+  /** Occupied keys in deterministic typed-key order. */
+  readonly keys: K[];
+
+  /** Per-key results addressed by the index's internal typed-key encoding. */
+  readonly buckets: Record<string, V>;
+}
+
+/** Read-only index handle with a single stored-payload type for schema extraction. */
+export interface CollectionIndexHandle<
+  T extends CollectionIndexData<CollectionIndexKey, unknown>,
+> extends BrandedCell<T, "readonly">, IAnyCell<T> {
+  /**
+   * Resolves one key without observing occupied-key enumeration. A Cell key
+   * identifies the Cell; read its value explicitly to use a primitive key.
+   */
+  lookup(
+    key: T["keys"][number] | null | undefined,
+  ): Reactive<T["buckets"][string]>;
+
+  /** Enumerates occupied keys in deterministic typed-key order. */
+  keys(): Reactive<T["keys"]>;
+}
+
+/** Index whose missing-key lookup yields an empty group. */
+export type GroupIndex<K extends CollectionIndexKey, T> = CollectionIndexHandle<
+  CollectionIndexData<K, T[]>
+>;
+
+/** Index whose missing-key lookup yields undefined. */
+export type KeyIndex<K extends CollectionIndexKey, T> = CollectionIndexHandle<
+  CollectionIndexData<K, T | undefined>
+>;
+
 /**
  * Cells that allow deriving new cells from existing cells via array methods:
  * direct helpers mirror supported Array methods and return Reactive results.

--- a/packages/api/test/collection-index-types.test.ts
+++ b/packages/api/test/collection-index-types.test.ts
@@ -1,0 +1,37 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { Cell, GroupIndex, KeyIndex } from "@commonfabric/api";
+
+/** Checks lookup cardinality, key domains, and the handle's read-only surface. */
+function checkIndexTypes(
+  grouped: GroupIndex<string, { name: string }>,
+  unique: KeyIndex<Cell<{ name: string }>, { score: number }>,
+  profile: Cell<{ name: string }>,
+  primitiveCell: Cell<string>,
+) {
+  const group: { name: string }[] = grouped.lookup("team");
+  const emptyGroup: { name: string }[] = grouped.lookup(undefined);
+  const match: { score: number } | undefined = unique.lookup(profile);
+  const keys: Cell<{ name: string }>[] = unique.keys();
+  const primitiveValue: { name: string }[] = grouped.lookup(
+    primitiveCell.get(),
+  );
+  // @ts-expect-error A Cell argument is an identity key, not its stored string.
+  grouped.lookup(primitiveCell);
+  // @ts-expect-error String indexes reject numeric keys.
+  grouped.lookup(1);
+  // @ts-expect-error A Cell-key index rejects a plain object with the same data.
+  unique.lookup({ name: "Ada" });
+  // @ts-expect-error Index handles do not expose direct stored-value reads.
+  grouped.get();
+  // @ts-expect-error Index handles do not expose writes.
+  unique.set({});
+  return { group, emptyGroup, match, keys, primitiveValue };
+}
+
+describe("collection index types", () => {
+  it("checks key domains and missing-result cardinality at compile time", () => {
+    expect(typeof checkIndexTypes).toBe("function");
+  });
+});

--- a/packages/runner/src/builtins/collection-index-key.ts
+++ b/packages/runner/src/builtins/collection-index-key.ts
@@ -1,0 +1,84 @@
+/** Resolves and orders collection keys using runtime Cell identity. */
+
+import { hashStringOf } from "@commonfabric/data-model";
+import { utf8Compare } from "@commonfabric/utils/utf8";
+
+import { type Cell, isCell } from "../cell.ts";
+import { resolveLink } from "../link-resolution.ts";
+import type { Runtime } from "../runtime.ts";
+import { UnresolvedInputError } from "../schema-view.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { cellIdentityKey } from "./scope-policy.ts";
+
+/** A typed routing key, suitable for inclusion in an owning index's cause. */
+export type CollectionKeyIdentity =
+  | { kind: "boolean"; value: boolean }
+  | { kind: "number"; value: number }
+  | { kind: "string"; value: string }
+  | { kind: "cell"; value: string };
+
+/** Public key and its routing identity, resolved in the caller's transaction. */
+export interface ResolvedCollectionKey {
+  key: string | number | boolean | Cell<unknown>;
+  identity: CollectionKeyIdentity;
+}
+
+/** Resolves Cell identity and rejects values outside the collection-key domain. */
+export function resolveCollectionKey(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  value: unknown,
+): ResolvedCollectionKey | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "boolean") {
+    return { key: value, identity: { kind: "boolean", value } };
+  }
+  if (typeof value === "string") {
+    return { key: value, identity: { kind: "string", value } };
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const key = value === 0 ? 0 : value;
+    return { key, identity: { kind: "number", value: key } };
+  }
+  if (isCell(value)) {
+    const link = resolveLink(runtime, tx, value.getAsNormalizedFullLink());
+    if (link.pendingHopDoc) {
+      tx.readValueOrThrow(link);
+      const refusal = new UnresolvedInputError(link);
+      tx.noteSchemaRefusal(refusal);
+      throw refusal;
+    }
+    const key = runtime.getCellFromLink<unknown>(link, undefined, tx);
+    return {
+      key,
+      identity: { kind: "cell", value: cellIdentityKey(key).dedupKey },
+    };
+  }
+  throw new Error(
+    "Collection keys must be strings, finite numbers, booleans, or Cells.",
+  );
+}
+
+const keyDomainOrder = { boolean: 0, number: 1, string: 2, cell: 3 } as const;
+
+/** Orders occupied keys independently of insertion order and source position. */
+export function compareCollectionKeys(
+  left: CollectionKeyIdentity,
+  right: CollectionKeyIdentity,
+): number {
+  if (left.kind !== right.kind) {
+    return keyDomainOrder[left.kind] - keyDomainOrder[right.kind];
+  }
+  if (left.kind === "boolean" && right.kind === "boolean") {
+    return Number(left.value) - Number(right.value);
+  }
+  if (left.kind === "number" && right.kind === "number") {
+    return left.value < right.value ? -1 : left.value > right.value ? 1 : 0;
+  }
+  return utf8Compare(String(left.value), String(right.value));
+}
+
+/** Names a bucket within its owning index without exposing raw keys as paths. */
+export function collectionKeyBucket(identity: CollectionKeyIdentity): string {
+  return hashStringOf(identity);
+}

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1,4 +1,9 @@
-import type { AnyBrandedCell, ReadonlyCell } from "@commonfabric/api";
+import type {
+  AnyBrandedCell,
+  CollectionIndexData,
+  CollectionIndexKey,
+  ReadonlyCell,
+} from "@commonfabric/api";
 import {
   assertValidFabricValueLayer,
   cloneIfNecessary,
@@ -50,6 +55,10 @@ import {
 import { toCell } from "./back-to-cell.ts";
 import { actingForEmission, waveRunContextOf } from "./executor/wave.ts";
 import { speculationRunContextOf } from "./speculation/overlay-destination.ts";
+import {
+  collectionKeyBucket,
+  resolveCollectionKey,
+} from "./builtins/collection-index-key.ts";
 import { createNodeFactory, lift } from "./builder/module.ts";
 import { assertNoReservedCauseKeys, getTopFrame } from "./builder/pattern.ts";
 import {
@@ -3579,6 +3588,42 @@ export class CellImpl<T extends FabricValue>
     });
     result.setSchema(listResultSchema(op.resultSchema));
     return result;
+  }
+
+  /** Reads one index bucket while retaining dependencies on key resolution. */
+  lookup(
+    key: CollectionIndexKey | null | undefined,
+  ): T extends CollectionIndexData<CollectionIndexKey, infer V> ? V : unknown {
+    const index = this as unknown as Cell<
+      CollectionIndexData<CollectionIndexKey, unknown>
+    >;
+    if (index.key("kind").get() !== "collection-index") {
+      throw new Error("lookup requires a collection index");
+    }
+    const resolved = resolveCollectionKey(
+      this.runtime,
+      this.runtime.readTx(this.tx),
+      key,
+    );
+    const value = resolved
+      ? index.key("buckets").key(collectionKeyBucket(resolved.identity)).get()
+      : undefined;
+    return (value === undefined
+      ? (index.key("mode").get() === "group" ? [] : undefined)
+      : value) as T extends CollectionIndexData<CollectionIndexKey, infer V> ? V
+        : unknown;
+  }
+
+  /** Reads occupied-key enumeration separately from bucket lookup. */
+  keys(): T extends CollectionIndexData<infer K, unknown> ? K[] : unknown[] {
+    const index = this as unknown as Cell<
+      CollectionIndexData<CollectionIndexKey, unknown>
+    >;
+    if (index.key("kind").get() !== "collection-index") {
+      throw new Error("keys requires a collection index");
+    }
+    return index.key("keys").get() as T extends
+      CollectionIndexData<infer K, unknown> ? K[] : unknown[];
   }
 
   /** @inheritDoc */

--- a/packages/runner/test/collection-index-key.test.ts
+++ b/packages/runner/test/collection-index-key.test.ts
@@ -1,0 +1,222 @@
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import {
+  type CollectionKeyIdentity,
+  compareCollectionKeys,
+  resolveCollectionKey,
+} from "../src/builtins/collection-index-key.ts";
+import { scopedCell } from "../src/builtins/scope-policy.ts";
+import { Runtime } from "../src/runtime.ts";
+import { UnresolvedInputError } from "../src/schema-view.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("collection-index-key");
+const space = signer.did();
+
+describe("collection index keys", () => {
+  let storage: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storage = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    if (tx.status().status === "ready") tx.abort();
+    await storage.synced();
+    await runtime.dispose();
+    await storage.close();
+  });
+
+  it("separates primitive domains and normalizes negative zero", () => {
+    const keys = ["1", 1, true, false, -0, 0].map((key) =>
+      resolveCollectionKey(runtime, tx, key)!
+    );
+    expect(keys[0]!.identity).not.toEqual(keys[1]!.identity);
+    expect(keys[1]!.identity).not.toEqual(keys[2]!.identity);
+    expect(keys[4]).toEqual(keys[5]);
+    expect(Object.is(keys[4]!.key, -0)).toBe(false);
+    expect(
+      keys.sort((a, b) => compareCollectionKeys(a.identity, b.identity)).map(
+        ({ key }) => key,
+      ),
+    ).toEqual([false, true, 0, 0, 1, "1"]);
+    expect(resolveCollectionKey(runtime, tx, null)).toBeUndefined();
+    expect(resolveCollectionKey(runtime, tx, undefined)).toBeUndefined();
+  });
+
+  it("orders strings by UTF-8 and keeps different Cell paths distinct", async () => {
+    const strings = ["\u{10000}", "\ue000"].map((value) =>
+      resolveCollectionKey(runtime, tx, value)!
+    );
+    expect(
+      strings.sort((a, b) => compareCollectionKeys(a.identity, b.identity))
+        .map(({ key }) => key),
+    ).toEqual(["\ue000", "\u{10000}"]);
+    const parent = runtime.getCell<{ left: number; right: number }>(
+      space,
+      "paths",
+      undefined,
+      tx,
+    );
+    parent.set({ left: 1, right: 1 });
+    await tx.commit();
+    tx = runtime.edit();
+    const left = resolveCollectionKey(runtime, tx, parent.key("left"))!;
+    const right = resolveCollectionKey(runtime, tx, parent.key("right"))!;
+    expect(left.identity).not.toEqual(right.identity);
+    expect(compareCollectionKeys(left.identity, left.identity)).toBe(0);
+    expect(compareCollectionKeys(left.identity, right.identity)).toBe(
+      -compareCollectionKeys(right.identity, left.identity),
+    );
+  });
+
+  it("rejects unsupported keys instead of coercing them into a bucket", () => {
+    for (
+      const key of [
+        NaN,
+        Infinity,
+        -Infinity,
+        {},
+        [],
+        Symbol("key"),
+        1n,
+        () => 1,
+      ]
+    ) {
+      expect(() => resolveCollectionKey(runtime, tx, key)).toThrow(
+        "Collection keys",
+      );
+    }
+  });
+
+  it("uses resolved Cell identity independently of schema and stored contents", async () => {
+    const first = runtime.getCell(space, "first", undefined, tx);
+    const second = runtime.getCell(space, "second", undefined, tx);
+    const alias = runtime.getCell(space, "alias", undefined, tx);
+    first.set({ name: "same" });
+    second.set({ name: "same" });
+    alias.set(first);
+    await tx.commit();
+    tx = runtime.edit();
+    const a = resolveCollectionKey(runtime, tx, first)!;
+    const b = resolveCollectionKey(runtime, tx, second)!;
+    expect(a.identity).not.toEqual(b.identity);
+    expect(resolveCollectionKey(runtime, tx, alias)!.identity).toEqual(
+      a.identity,
+    );
+    expect(resolveCollectionKey(runtime, tx, first.asSchema(true))!.identity)
+      .toEqual(a.identity);
+    alias.withTx(tx).set(second);
+    await tx.commit();
+    tx = runtime.edit();
+    expect(resolveCollectionKey(runtime, tx, alias)!.identity).toEqual(
+      b.identity,
+    );
+    first.withTx(tx).set({ name: "changed" });
+    expect(resolveCollectionKey(runtime, tx, first)!.identity).toEqual(
+      a.identity,
+    );
+  });
+  it("distinguishes cross-space and scoped Cells", async () => {
+    const otherSpace =
+      (await Identity.fromPassphrase("collection-index-other-space")).did();
+    const local = runtime.getCell(space, "scoped", undefined, tx);
+    local.set({ name: "same" });
+    await tx.commit();
+    tx = runtime.edit();
+    const remote = runtime.getCell(otherSpace, "scoped", undefined, tx);
+    remote.set({ name: "same" });
+    await tx.commit();
+    tx = runtime.edit();
+    const user = scopedCell(runtime, tx, local, "user");
+    user.set({ name: "same" });
+    await tx.commit();
+    tx = runtime.edit();
+    const localKey = resolveCollectionKey(runtime, tx, local)!;
+    const remoteKey = resolveCollectionKey(runtime, tx, remote)!;
+    const userKey = resolveCollectionKey(runtime, tx, user)!;
+    expect(localKey.identity).not.toEqual(remoteKey.identity);
+    expect(localKey.identity).not.toEqual(userKey.identity);
+    expect(userKey.identity).not.toEqual(remoteKey.identity);
+  });
+
+  it("refuses an unresolved alias target until its document arrives", async () => {
+    const missing = runtime.getCell(space, "unarrived", undefined, tx);
+    const alias = runtime.getCell(space, "unarrived-alias", undefined, tx);
+    alias.set(missing);
+    await tx.commit();
+    tx = runtime.edit();
+    expect(() => resolveCollectionKey(runtime, tx, alias)).toThrow(
+      UnresolvedInputError,
+    );
+    tx.abort();
+    tx = runtime.edit();
+    missing.withTx(tx).set({ name: "arrived" });
+    await tx.commit();
+    tx = runtime.edit();
+    expect(resolveCollectionKey(runtime, tx, alias)!.identity).toEqual(
+      resolveCollectionKey(runtime, tx, missing)!.identity,
+    );
+  });
+
+  it("reacts to alias retargeting without reacting to target field edits", async () => {
+    const first = runtime.getCell<{ name: string }>(
+      space,
+      "reactive-first",
+      undefined,
+      tx,
+    );
+    const second = runtime.getCell<{ name: string }>(
+      space,
+      "reactive-second",
+      undefined,
+      tx,
+    );
+    const alias = runtime.getCell(space, "reactive-alias", undefined, tx);
+    first.set({ name: "first" });
+    second.set({ name: "second" });
+    alias.set(first);
+    await tx.commit();
+    tx = runtime.edit();
+    const keys: CollectionKeyIdentity[] = [];
+    const observe = (read: IExtendedStorageTransaction) => {
+      keys.push(resolveCollectionKey(runtime, read, alias)!.identity);
+    };
+    runtime.scheduler.subscribe(observe, {
+      reads: [],
+      shallowReads: [],
+      writes: [],
+    }, { isEffect: true });
+    runtime.scheduler.queueExecution();
+    try {
+      await runtime.settled(Infinity);
+      expect(keys).toHaveLength(1);
+      first.withTx(tx).key("name").set("updated");
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.settled(Infinity);
+      expect(keys).toHaveLength(1);
+      alias.withTx(tx).set(second);
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.settled(Infinity);
+      expect(keys).toHaveLength(2);
+      expect(keys[1]).toEqual(
+        resolveCollectionKey(runtime, tx, second)!.identity,
+      );
+      expect(keys[1]).not.toEqual(keys[0]);
+    } finally {
+      runtime.scheduler.unsubscribe(observe);
+    }
+  });
+});

--- a/packages/runner/test/collection-index-lookup.test.ts
+++ b/packages/runner/test/collection-index-lookup.test.ts
@@ -1,0 +1,335 @@
+import type { CollectionIndexData } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import {
+  collectionKeyBucket,
+  resolveCollectionKey,
+} from "../src/builtins/collection-index-key.ts";
+import { Runtime } from "../src/runtime.ts";
+import { RuntimeTelemetryEvent } from "../src/telemetry.ts";
+
+const signer = await Identity.fromPassphrase("collection-index-lookup");
+const space = signer.did();
+
+describe("collection index lookup", () => {
+  let storage: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storage = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+  });
+
+  afterEach(async () => {
+    await storage.synced();
+    await runtime.dispose();
+    await storage.close();
+  });
+
+  it("compiles keyed reads and observes bucket and enumeration updates", async () => {
+    const compiled = await runtime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: `
+        import { pattern, GroupIndex } from "commonfabric";
+        export default pattern<{index: GroupIndex<string, number>; selected: string}>(
+          ({index, selected}) => ({ values: index.lookup(selected), keys: index.keys() })
+        );
+      `,
+      }],
+    });
+    let tx = runtime.edit();
+    const index = runtime.getCell<CollectionIndexData<string, number[]>>(
+      space,
+      "index",
+      undefined,
+      tx,
+    );
+    const a = collectionKeyBucket({ kind: "string", value: "a" });
+    const b = collectionKeyBucket({ kind: "string", value: "b" });
+    index.set({
+      kind: "collection-index",
+      mode: "group",
+      keys: ["a", "b"],
+      buckets: { [a]: [1], [b]: [2] },
+    });
+    const selected = runtime.getCell<string>(space, "selected", undefined, tx);
+    selected.set("a");
+    const output = runtime.getCell<{ values: number[]; keys: string[] }>(
+      space,
+      "output",
+      compiled.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, compiled, { index, selected }, output);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    const cancel = result.sink(() => {});
+    try {
+      await runtime.idle();
+      expect(await result.key("values").pull()).toEqual([1]);
+      expect(await result.key("keys").pull()).toEqual(["a", "b"]);
+      tx = runtime.edit();
+      index.withTx(tx).key("buckets").key(a).set([1, 3]);
+      await tx.commit();
+      await runtime.idle();
+      expect(await result.key("values").pull()).toEqual([1, 3]);
+      tx = runtime.edit();
+      selected.withTx(tx).set("b");
+      await tx.commit();
+      await runtime.idle();
+      expect(await result.key("values").pull()).toEqual([2]);
+      tx = runtime.edit();
+      selected.withTx(tx).set("missing");
+      index.withTx(tx).key("keys").set(["b"]);
+      await tx.commit();
+      await runtime.idle();
+      expect(await result.key("values").pull()).toEqual([]);
+      expect(await result.key("keys").pull()).toEqual(["b"]);
+      tx = runtime.edit();
+      index.withTx(tx).key("buckets").key(
+        collectionKeyBucket({ kind: "string", value: "missing" }),
+      ).set([9]);
+      await tx.commit();
+      await runtime.idle();
+      expect(await result.key("values").pull()).toEqual([9]);
+    } finally {
+      cancel();
+    }
+  });
+  it("ignores unrelated buckets and key enumeration while following its selected bucket", async () => {
+    const compiled = await runtime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: `
+        import { pattern, KeyIndex } from "commonfabric";
+        export default pattern<{index: KeyIndex<string, number | null>}>(
+          ({index}) => ({ value: index.lookup("a") })
+        );
+      `,
+      }],
+    });
+    let tx = runtime.edit();
+    const index = runtime.getCell<CollectionIndexData<string, number | null>>(
+      space,
+      "isolated-index",
+      undefined,
+      tx,
+    );
+    const a = collectionKeyBucket({ kind: "string", value: "a" });
+    const b = collectionKeyBucket({ kind: "string", value: "b" });
+    index.set({
+      kind: "collection-index",
+      mode: "key",
+      keys: ["b"],
+      buckets: { [b]: 2 },
+    });
+    const output = runtime.getCell<{ value: number | null | undefined }>(
+      space,
+      "isolated-output",
+      compiled.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, compiled, { index }, output);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    const cancel = result.sink(() => {});
+    let runs = 0;
+    const collect = (event: Event) => {
+      if (
+        (event as RuntimeTelemetryEvent).marker.type ===
+          "scheduler.run.complete"
+      ) runs++;
+    };
+    try {
+      await runtime.idle();
+      expect(await result.key("value").pull()).toBeUndefined();
+      runtime.telemetry.addEventListener("telemetry", collect);
+      tx = runtime.edit();
+      index.withTx(tx).key("buckets").key(b).set(20);
+      index.withTx(tx).key("keys").set(["b", "c"]);
+      await tx.commit();
+      await runtime.idle();
+      expect(runs).toBe(0);
+      tx = runtime.edit();
+      index.withTx(tx).key("buckets").key(a).set(10);
+      await tx.commit();
+      await runtime.idle();
+      expect(runs).toBeGreaterThan(0);
+      expect(await result.key("value").pull()).toBe(10);
+      tx = runtime.edit();
+      index.withTx(tx).key("buckets").key(a).set(null);
+      await tx.commit();
+      await runtime.idle();
+      expect(await result.key("value").pull()).toBeNull();
+      tx = runtime.edit();
+      index.withTx(tx).key("buckets").key(a).asSchema(true).set(undefined);
+      await tx.commit();
+      await runtime.idle();
+      expect(await result.key("value").pull()).toBeUndefined();
+    } finally {
+      runtime.telemetry.removeEventListener("telemetry", collect);
+      cancel();
+    }
+  });
+  it("preserves Cell key identity through compilation and reacts to alias retargeting", async () => {
+    const compiled = await runtime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: `
+        import { pattern, KeyIndex, Cell, Writable } from "commonfabric";
+        export default pattern<{index: KeyIndex<Cell<string> | string, number>; selected: Cell<string>; data: Writable<{lookup: string; keys: string}>}>(
+          ({index, selected, data}) => ({ value: index.lookup(selected), primitive: index.lookup("equal"), ordinary: data.get().lookup + data.get().keys })
+        );
+      `,
+      }],
+    });
+    let tx = runtime.edit();
+    const first = runtime.getCell<string>(space, "first-key", undefined, tx);
+    const second = runtime.getCell<string>(space, "second-key", undefined, tx);
+    const selected = runtime.getCell<string>(space, "alias-key", undefined, tx);
+    first.set("equal");
+    second.set("equal");
+    selected.set(first);
+    await tx.commit();
+    tx = runtime.edit();
+    const a = collectionKeyBucket(
+      resolveCollectionKey(runtime, tx, first)!.identity,
+    );
+    const b = collectionKeyBucket(
+      resolveCollectionKey(runtime, tx, second)!.identity,
+    );
+    const index = runtime.getCell(space, "identity-index", undefined, tx);
+    index.set({
+      kind: "collection-index",
+      mode: "key",
+      keys: [first, second, "equal"],
+      buckets: {
+        [a]: 1,
+        [b]: 2,
+        [collectionKeyBucket({ kind: "string", value: "equal" })]: 3,
+      },
+    });
+    const output = runtime.getCell<
+      { value: number | undefined; ordinary: string }
+    >(space, "identity-output", compiled.resultSchema, tx);
+    const result = runtime.run(tx, compiled, {
+      index,
+      selected,
+      data: { lookup: "look", keys: "up" },
+    }, output);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    const cancel = result.sink(() => {});
+    let runs = 0;
+    const collect = (event: Event) => {
+      if (
+        (event as RuntimeTelemetryEvent).marker.type ===
+          "scheduler.run.complete"
+      ) runs++;
+    };
+    try {
+      await runtime.idle();
+      expect(await result.key("value").pull()).toBe(1);
+      expect(await result.key("ordinary").pull()).toBe("lookup");
+      expect(await result.key("primitive").pull()).toBe(3);
+      runtime.telemetry.addEventListener("telemetry", collect);
+      tx = runtime.edit();
+      first.withTx(tx).set("changed");
+      await tx.commit();
+      await runtime.idle();
+      expect(runs).toBe(0);
+      tx = runtime.edit();
+      selected.withTx(tx).set(second);
+      await tx.commit();
+      await runtime.idle();
+      expect(runs).toBeGreaterThan(0);
+      expect(await result.key("value").pull()).toBe(2);
+    } finally {
+      runtime.telemetry.removeEventListener("telemetry", collect);
+      cancel();
+    }
+  });
+  it("preserves linked group rows without rerunning lookup on a non-key field edit", async () => {
+    const compiled = await runtime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: `
+        import {pattern, GroupIndex} from "commonfabric";
+        export default pattern<{index: GroupIndex<string, {name: string}>}>(
+          ({index}) => ({values: index.lookup("a")})
+        );
+      `,
+      }],
+    });
+    let tx = runtime.edit();
+    const row = runtime.getCell<{ name: string }>(
+      space,
+      "linked-row",
+      undefined,
+      tx,
+    );
+    row.set({ name: "first" });
+    const index = runtime.getCell(space, "linked-index", undefined, tx);
+    index.set({
+      kind: "collection-index",
+      mode: "group",
+      keys: ["a"],
+      buckets: { [collectionKeyBucket({ kind: "string", value: "a" })]: [row] },
+    });
+    const result = runtime.run(
+      tx,
+      compiled,
+      { index },
+      runtime.getCell<{ values: { name: string }[] }>(
+        space,
+        "linked-output",
+        compiled.resultSchema,
+        tx,
+      ),
+    );
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    const cancel = result.sink(() => {});
+    let runs = 0;
+    const collect = (event: Event) => {
+      const marker = (event as RuntimeTelemetryEvent).marker;
+      if (
+        marker.type === "scheduler.run.complete" &&
+        marker.actionInfo?.writes?.length
+      ) runs++;
+    };
+    try {
+      await runtime.idle();
+      expect(await result.key("values").pull()).toEqual([{ name: "first" }]);
+      runtime.telemetry.addEventListener("telemetry", collect);
+      tx = runtime.edit();
+      row.withTx(tx).key("name").set("second");
+      await tx.commit();
+      await runtime.idle();
+      expect(runs).toBe(0);
+      expect(await result.key("values").pull()).toEqual([{ name: "second" }]);
+      tx = runtime.edit();
+      index.withTx(tx).key("buckets").key(
+        collectionKeyBucket({ kind: "string", value: "a" }),
+      ).set([]);
+      await tx.commit();
+      await runtime.idle();
+      expect(runs).toBeGreaterThan(0);
+      expect(await result.key("values").pull()).toEqual([]);
+    } finally {
+      runtime.telemetry.removeEventListener("telemetry", collect);
+      cancel();
+    }
+  });
+});

--- a/packages/runner/test/collection-index-resume.test.ts
+++ b/packages/runner/test/collection-index-resume.test.ts
@@ -1,0 +1,115 @@
+import type { CollectionIndexData } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { collectionKeyBucket } from "../src/builtins/collection-index-key.ts";
+import { Runtime } from "../src/runtime.ts";
+import {
+  EmulatedStorageManager,
+  newLoopbackServer,
+} from "../src/storage/v2-emulate.ts";
+
+const signer = await Identity.fromPassphrase("collection-index-resume");
+
+describe("collection index resume", () => {
+  it("resumes a stored lookup in a fresh runtime and follows bucket insertion", async () => {
+    const server = newLoopbackServer({ subscriptionRefreshDelayMs: 0 });
+    const firstStorage = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const secondStorage = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const first = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: firstStorage,
+    });
+    const second = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: secondStorage,
+    });
+    const program = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: `
+      import {pattern, GroupIndex} from "commonfabric";
+      export default pattern<{index: GroupIndex<string, number>}>(
+        ({index}) => ({values: index.lookup("a")})
+      );
+    `,
+      }],
+    };
+    let cancelFirst: (() => void) | undefined;
+    let cancelSecond: (() => void) | undefined;
+    try {
+      const compiled = await first.patternManager.compilePattern(program);
+      const tx = first.edit();
+      const index = first.getCell<CollectionIndexData<string, number[]>>(
+        signer.did(),
+        "index",
+        undefined,
+        tx,
+      );
+      index.set({
+        kind: "collection-index",
+        mode: "group",
+        keys: [],
+        buckets: {},
+      });
+      const result = first.run(
+        tx,
+        compiled,
+        { index },
+        first.getCell<{ values: number[] }>(
+          signer.did(),
+          "output",
+          compiled.resultSchema,
+          tx,
+        ),
+      );
+      first.prepareTxForCommit(tx);
+      await tx.commit();
+      cancelFirst = result.sink(() => {});
+      await first.idle();
+      expect(await result.key("values").pull()).toEqual([]);
+      await firstStorage.synced();
+      cancelFirst();
+      cancelFirst = undefined;
+      first.runner.stop(result);
+      await first.dispose({ closeStorage: false });
+      await firstStorage.close();
+      await second.patternManager.compilePattern(program, {
+        space: signer.did(),
+      });
+      const restored = second.getCellFromLink<{ values: number[] }>(
+        result.getAsNormalizedFullLink(),
+      );
+      cancelSecond = restored.sink(() => {});
+      expect(await second.start(restored)).toBe(true);
+      await second.idle();
+      expect(await restored.key("values").pull()).toEqual([]);
+      const edit = second.edit();
+      const restoredIndex = second.getCellFromLink<
+        CollectionIndexData<string, number[]>
+      >(index.getAsNormalizedFullLink(), undefined, edit);
+      restoredIndex.key("buckets").key(
+        collectionKeyBucket({ kind: "string", value: "a" }),
+      ).set([7]);
+      restoredIndex.key("keys").set(["a"]);
+      await edit.commit();
+      await second.idle();
+      expect(await restored.key("values").pull()).toEqual([7]);
+    } finally {
+      cancelFirst?.();
+      cancelSecond?.();
+      await first.dispose({ closeStorage: false });
+      await secondStorage.synced();
+      await second.dispose({ closeStorage: false });
+      await firstStorage.close();
+      await secondStorage.close();
+      await server.close();
+    }
+  });
+});

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -1387,6 +1387,54 @@ export interface IEquatable {
   equalLinks(other: AnyCell<any> | object | undefined): boolean;
 }
 
+/** Primitive or Cell identity accepted by a collection index. */
+export type CollectionIndexKey =
+  | string
+  | number
+  | boolean
+  | AnyBrandedCell<unknown>;
+
+/** Stored descriptor whose buckets are addressed independently by keyed lookup. */
+export interface CollectionIndexData<K extends CollectionIndexKey, V> {
+  /** Descriptor marker used to recognize an index receiver. */
+  readonly kind: "collection-index";
+
+  /** Missing-key behavior: an empty group or an absent unique match. */
+  readonly mode: "group" | "key";
+
+  /** Occupied keys in deterministic typed-key order. */
+  readonly keys: K[];
+
+  /** Per-key results addressed by the index's internal typed-key encoding. */
+  readonly buckets: Record<string, V>;
+}
+
+/** Read-only index handle with a single stored-payload type for schema extraction. */
+export interface CollectionIndexHandle<
+  T extends CollectionIndexData<CollectionIndexKey, unknown>,
+> extends BrandedCell<T, "readonly">, IAnyCell<T> {
+  /**
+   * Resolves one key without observing occupied-key enumeration. A Cell key
+   * identifies the Cell; read its value explicitly to use a primitive key.
+   */
+  lookup(
+    key: T["keys"][number] | null | undefined,
+  ): Reactive<T["buckets"][string]>;
+
+  /** Enumerates occupied keys in deterministic typed-key order. */
+  keys(): Reactive<T["keys"]>;
+}
+
+/** Index whose missing-key lookup yields an empty group. */
+export type GroupIndex<K extends CollectionIndexKey, T> = CollectionIndexHandle<
+  CollectionIndexData<K, T[]>
+>;
+
+/** Index whose missing-key lookup yields undefined. */
+export type KeyIndex<K extends CollectionIndexKey, T> = CollectionIndexHandle<
+  CollectionIndexData<K, T | undefined>
+>;
+
 /**
  * Cells that allow deriving new cells from existing cells via array methods:
  * direct helpers mirror supported Array methods and return Reactive results.


### PR DESCRIPTION
## Why

The collection operators planned in #7155 need a typed lookup boundary that addresses one key without subscribing to every key or copying linked row contents. The contract in #7294 and generic Cell alias support in #7300 make that boundary testable before index construction and bucket maintenance are added.

## What Changed

Add read-only GroupIndex and KeyIndex handle types backed by independently addressed buckets. Native lookup resolves primitive or Cell identity keys through the runtime's canonical link resolution and hashing; occupied-key enumeration is a separate read. Missing groups return an empty array and missing unique matches return undefined. Cell arguments always denote identity, with explicit value reads for primitive keys.

Compiled-pattern acceptance covers independent bucket updates, missing-key insertion, mixed primitive/Cell keys, link-only retargeting, linked row payloads, ordinary Writable fields named lookup/keys, and durable lookup resume. Key resolution preserves scope and cross-space identity and refuses unresolved alias targets until data arrives.

This is the lookup foundation. groupBy/keyBy producers, extraction, bucket ownership and maintenance, joins, and scaling measurements remain pending in the implementation contract. No live poll is accessed.

## Test plan

- Seven key-resolution cases, four compiled lookup cases, and one fresh-runtime resume case pass.
- The isolation tests include positive selected-bucket controls; linked-row content edits update readers without rerunning the lookup.
- API package: 29 tests / 7 steps pass.
- All 46 type groups, all 599 checked documentation blocks, formatting, lint, and package-cycle checks pass.
- Full runner: 1,431 tests / 8,904 steps pass; the final combined focused run passes all twelve acceptance cases.
- Antagonistic review found no blocker in the foundation and identified acceptance work that remains explicit in the plan.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

