### PR TITLE
feat(cf-harness): acquire a pinned skill's scripts beside its instructions (CT-2091)

### DIFF
--- a/docs/plans/external-skill-acquisition.md
+++ b/docs/plans/external-skill-acquisition.md
@@ -244,10 +244,16 @@ on names**:
   arrived in part. A directory nested below `scripts/`, a symlink and a
   submodule are refusals of this kind: the first is a tree the whitelist never
   judged, and the other two name bytes the inventory does not vouch for.
+- A script's filename is held to printable ASCII without a path separator, a
+  control codepoint or a leading dot. An admitted path is reported — it reaches
+  the acquisition's own record and the tool output, neither of which sanitizes
+  on the way out — so a name the publisher chose is refused here rather than
+  carried and cleaned later.
 - A skill shipping more scripts than one acquisition admits refuses on the
-  inventory, before a single one is fetched. The size cap bounds a file; this
-  bounds the number of requests, which would otherwise be the publisher's
-  number rather than ours.
+  inventory, before a single one is fetched. That count cap and the per-file
+  size cap bound different things: the size cap bounds a file's bytes, and the
+  count cap is what keeps the number of requests ours rather than the
+  publisher's.
 
 Admitting the scripts is not admitting them to the registry. The acquired tree
 is host-side, nothing is written into the skills root, and whether a script may
@@ -395,8 +401,10 @@ there.
    registry's unverified hash.
 3. **Isolated verified acquisition.** The parent-facing `acquire_skill` effect
    resolves and fetches host-side, with commit-SHA acquisition fail-closed, the
-   recursive single-file payload whitelist, and first-class refusal. It writes
-   into a cell, returns a handle, and proves with an adversarial canary that the
+   recursive payload whitelist above — the root `SKILL.md` and the regular
+   files directly under `scripts/`, everything else refusing — and first-class
+   refusal. It writes the instructions into a cell, holds the scripts
+   host-side, returns a handle, and proves with an adversarial canary that the
    parent never received the skill text. A `.well-known` digest route can join
    the same boundary when a source publishes one.
 4. **The provenance mark**, minted split-mint style on the acquiring write.

--- a/docs/plans/external-skill-acquisition.md
+++ b/docs/plans/external-skill-acquisition.md
@@ -226,21 +226,33 @@ with optional `scripts/` (executable code), `references/`, and `assets/` — and
 the registry's download endpoint returns whatever files the snapshot holds. An
 unenforced assumption about what arrives is not a boundary.
 
-Enforcement lives in the host acquisition write step, at the single point
-where fetched bytes become a cell value, and it is a **whitelist on paths, not
-a blacklist on names**:
+Enforcement lives in the host acquisition step, at the single point where
+fetched bytes are admitted, and it is a **whitelist on paths, not a blacklist
+on names**:
 
-- Exactly one file is admitted: the `SKILL.md` at the skill root. Its text is
-  what the cell holds.
+- Two things are admitted: the `SKILL.md` at the skill root, whose text is what
+  the cell holds, and the regular files directly under the root's `scripts/`,
+  which stay host-side. A skill is a directory and its scripts are part of it —
+  a skill whose instructions reference `scripts/foo.py` is not the same skill
+  without it, and admitting the prose alone yields one that will instruct the
+  model to run something that is not there.
 - Any other path in the payload causes the acquisition to **refuse**, naming
   the count and the offending paths, rather than to succeed while quietly
-  dropping them. Silently discarding scripts would make "instructions-only"
-  true of the cell and invisible in the record, and the operator reading that
-  record could not tell a plain skill from one that arrived carrying code.
-- The refusal is the honest outcome because a skill whose instructions
-  reference `scripts/foo.py` is not the same skill without it. Admitting the
-  prose alone yields a skill that will instruct the model to run something
-  that is not there.
+  dropping them. Silently discarding a reference or an asset would make what
+  the cell holds true of the cell and invisible in the record, and the operator
+  reading that record could not tell a skill that arrived whole from one that
+  arrived in part. A directory nested below `scripts/`, a symlink and a
+  submodule are refusals of this kind: the first is a tree the whitelist never
+  judged, and the other two name bytes the inventory does not vouch for.
+- A skill shipping more scripts than one acquisition admits refuses on the
+  inventory, before a single one is fetched. The size cap bounds a file; this
+  bounds the number of requests, which would otherwise be the publisher's
+  number rather than ours.
+
+Admitting the scripts is not admitting them to the registry. The acquired tree
+is host-side, nothing is written into the skills root, and whether a script may
+run is decided by the same operator allowlist a registry skill's script answers
+to — the third of the three properties below, unchanged by this.
 
 For GitHub commit acquisition, the inventory is the recursive tree API at the
 pinned SHA. A response marked `truncated` refuses with its own reason: an unread

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1126,15 +1126,24 @@ discovery slug. No case folding or path normalization participates. Zero or
 multiple candidates refuse, and a tree response marked `truncated` refuses
 because an unread inventory is not evidence of absence.
 
-The instructions-only whitelist is scoped to the selected candidate root's
-subtree, so sibling skills and repository files outside that root do not leak
-into the payload decision. Within the subtree, exactly root `SKILL.md` is
-admitted. Every other path — including a directory, script, reference, asset, or
-package file — refuses the whole acquisition and is returned as sanitized, inert
-refusal metadata. Nothing is silently stripped: prose referring to a missing
-script would be a different and misleading skill. Only after this check does the
-host require root `SKILL.md` to be a regular Git tree file, stream at most 256
-KiB of pinned raw bytes, require non-empty UTF-8, and write them to a cell.
+The path whitelist is scoped to the selected candidate root's subtree, so
+sibling skills and repository files outside that root do not leak into the
+payload decision. Within the subtree, two things are admitted: root `SKILL.md`,
+and the regular files directly under `scripts/`. A skill is a directory, and the
+scripts its prose tells a model to run are part of it — prose referring to a
+missing script would be a different and misleading skill. Every other path — a
+reference, an asset, a package file, a directory nested below `scripts/`, a
+symlink or a submodule anywhere — refuses the whole acquisition and is returned
+as sanitized, inert refusal metadata. Nothing is silently stripped. A skill
+shipping more than sixteen scripts refuses on the inventory, before a single one
+is fetched: the size cap bounds a file and that bound is what keeps the number
+of requests one acquisition makes ours rather than the publisher's.
+
+Only after this check does the host require root `SKILL.md` to be a regular Git
+tree file, stream at most 256 KiB of pinned raw bytes per admitted file, require
+non-empty UTF-8, and write the instructions to a cell. The scripts stay
+host-side: nothing is written into the skills root, and whether one may run is
+the operator allowlist's decision rather than the acquisition's.
 
 The successful write carries the weaker `kind: "fetch"` `ExternalIngest`
 provenance variant. It records the exact pinned raw URL, commit SHA, fetch time,

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1133,11 +1133,17 @@ and the regular files directly under `scripts/`. A skill is a directory, and the
 scripts its prose tells a model to run are part of it — prose referring to a
 missing script would be a different and misleading skill. Every other path — a
 reference, an asset, a package file, a directory nested below `scripts/`, a
-symlink or a submodule anywhere — refuses the whole acquisition and is returned
-as sanitized, inert refusal metadata. Nothing is silently stripped. A skill
-shipping more than sixteen scripts refuses on the inventory, before a single one
-is fetched: the size cap bounds a file and that bound is what keeps the number
-of requests one acquisition makes ours rather than the publisher's.
+symlink or a submodule anywhere, a filename carrying a control codepoint or
+opening with a dot — refuses the whole acquisition and is returned as sanitized,
+inert refusal metadata. Nothing is silently stripped, and an admitted path is
+held to the filename rule rather than sanitized on the way out: `loadedPaths`
+and the tool output report it as it was.
+
+Two bounds sit beside each other and bound different things. The 256 KiB cap
+bounds each admitted file's bytes. A separate count cap refuses a skill shipping
+more than sixteen scripts, on the inventory and before a single one is fetched,
+which is what keeps the number of requests one acquisition makes ours rather
+than the publisher's.
 
 Only after this check does the host require root `SKILL.md` to be a regular Git
 tree file, stream at most 256 KiB of pinned raw bytes per admitted file, require

--- a/packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md
+++ b/packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md
@@ -104,11 +104,14 @@ metadata and container path. See
 ## Non-Goals
 
 - Installing skills from remote registries into the skills root. Discovery on
-  the external skills.sh registry and pinned, instruction-only acquisition into
-  a capability-typed handle a child consumes are a separate surface
-  (`search_skills`, `acquire_skill`, `delegate_task.skillHandle`), specified in
+  the external skills.sh registry and pinned acquisition — a `SKILL.md` into a
+  capability-typed handle a child consumes, and the skill's `scripts/` held
+  host-side beside it — are a separate surface (`search_skills`,
+  `acquire_skill`, `delegate_task.skillHandle`), specified in
   `docs/plans/external-skill-acquisition.md` and described in the package
-  README; nothing acquired that way enters the registry this document defines.
+  README; nothing acquired that way enters the registry this document defines,
+  and an acquired script answers to the same operator allowlist a registry
+  skill's script does.
 - Managing user-global skill directories outside an explicitly configured root.
 - Running skill scripts automatically or without an exact operator allowlist.
 - Treating `allowed-tools` as a permission grant.

--- a/packages/cf-harness/src/skills-sh/acquisition.ts
+++ b/packages/cf-harness/src/skills-sh/acquisition.ts
@@ -335,14 +335,21 @@ const readCappedBytes = async (
 };
 
 /**
- * Fetches the recursive tree and root `SKILL.md` at exactly `pin.commitSha`.
+ * Fetches the recursive tree and every admitted file at exactly
+ * `pin.commitSha`.
  *
  * The whitelist judges the selected candidate root's subtree, not the whole
  * repository: sibling skills and repository-level files outside that root are
- * not part of the acquired payload. Inside that subtree, only root
- * `SKILL.md` is admitted. Any other path refuses the whole payload. Silently
- * dropping a path would make instructions-only true only of the cell and
- * invisible in the record; a skill whose prose references `scripts/foo.py`
+ * not part of the acquired payload. Inside that subtree two things are
+ * admitted — the root `SKILL.md`, and the regular files directly under
+ * `scripts/` whose filenames are printable ASCII without a path separator, a
+ * control codepoint or a leading dot. Any other path refuses the whole
+ * payload, a skill shipping more than {@link SKILLS_SH_MAX_SCRIPTS} scripts
+ * refuses on the inventory before anything is fetched, and each admitted file
+ * is read under {@link SKILLS_SH_MAX_SKILL_BYTES}.
+ *
+ * Silently dropping a path would make what was acquired true of the payload
+ * and invisible in the record; a skill whose prose references `scripts/foo.py`
  * is not that skill without the script, and would instead instruct a model to
  * run something that is not there.
  */

--- a/packages/cf-harness/src/skills-sh/acquisition.ts
+++ b/packages/cf-harness/src/skills-sh/acquisition.ts
@@ -47,6 +47,19 @@ export const SKILLS_SH_MAX_SCRIPTS = 16;
 /** The directory an acquired skill's executable files live under. */
 const SCRIPTS_DIRECTORY = "scripts";
 
+/**
+ * The filenames a script may have: printable ASCII without a path separator,
+ * a control codepoint, or a leading dot.
+ *
+ * An admitted path is not only checked, it is REPORTED — it reaches
+ * `loadedPaths`, the tool output, and the run record, none of which sanitize
+ * on the way out. A name is the publisher's text, so a control codepoint or a
+ * terminal escape in one would cross into an operator's console on the
+ * strength of having been admitted. The refusal is the whitelist's own:
+ * whatever this does not admit refuses the payload rather than being dropped.
+ */
+const SAFE_SCRIPT_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
 export type SkillsShAcquisitionFailureCode =
   | "invalid_pin"
   | "request_failed"
@@ -255,12 +268,12 @@ const candidateRoot = (skillPath: string): string => {
  * Whether one tree entry is a script this acquisition admits: a regular file
  * directly under the root's `scripts/`, named by a single path segment.
  *
- * Nested directories, symlinks and submodules are not admitted, and each
- * refuses the whole payload rather than being dropped — the same rule the
- * whitelist has always held, applied to a wider set of paths. A symlink is the
- * one worth naming: its target is a path the tree does not vouch for, so
- * admitting it would make the acquired bytes something other than what the
- * inventory said.
+ * Nested directories, symlinks, submodules and unsafe filenames are not
+ * admitted, and each refuses the whole payload rather than being dropped — the
+ * same rule the whitelist has always held, applied to a wider set of paths. A
+ * symlink is the one worth naming: its target is a path the tree does not
+ * vouch for, so admitting it would make the acquired bytes something other
+ * than what the inventory said.
  */
 const isAdmittedScript = (
   entry: GithubTreeEntry,
@@ -270,7 +283,7 @@ const isAdmittedScript = (
   if (entry.mode !== "100644" && entry.mode !== "100755") return false;
   const segments = relativePath.split("/");
   return segments.length === 2 && segments[0] === SCRIPTS_DIRECTORY &&
-    segments[1] !== "";
+    SAFE_SCRIPT_NAME.test(segments[1] ?? "");
 };
 
 const displayPath = (path: string): string =>

--- a/packages/cf-harness/src/skills-sh/acquisition.ts
+++ b/packages/cf-harness/src/skills-sh/acquisition.ts
@@ -1,7 +1,13 @@
 /**
  * Host-side acquisition of one skills.sh discovery id from its immutable
  * GitHub commit. The recursive tree is the payload inventory; only after that
- * inventory passes the instructions-only whitelist is `SKILL.md` fetched.
+ * inventory passes the path whitelist are the admitted files fetched.
+ *
+ * A skill is a directory: `SKILL.md` and, where it has them, the scripts its
+ * prose tells a model to run. Both are acquired, at the one pinned commit and
+ * each under the same size cap, and every other path refuses the whole
+ * payload. What the acquired tree is NOT is a registry entry — it stays
+ * host-side, and nothing here writes into the skills root.
  */
 
 import { sha256 } from "@commonfabric/content-hash";
@@ -24,8 +30,22 @@ const GITHUB_RAW_BASE_URL = "https://raw.githubusercontent.com";
 const FULL_GIT_COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
 const MAX_TREE_PATH_CHARS = 4_096;
 
-/** Maximum exact byte length admitted for an instructions-only SKILL.md. */
+/** Maximum exact byte length admitted for any one acquired file. */
 export const SKILLS_SH_MAX_SKILL_BYTES = 256 * 1_024;
+
+/**
+ * Most scripts one acquisition admits.
+ *
+ * The size cap bounds a file and this bounds the fetch: without it the number
+ * of requests one acquisition makes is whatever the pinned tree says, which is
+ * the publisher's number rather than ours. A skill that needs more than this
+ * many scripts refuses rather than being acquired in part, on the same ground
+ * every other path refusal here stands on.
+ */
+export const SKILLS_SH_MAX_SCRIPTS = 16;
+
+/** The directory an acquired skill's executable files live under. */
+const SCRIPTS_DIRECTORY = "scripts";
 
 export type SkillsShAcquisitionFailureCode =
   | "invalid_pin"
@@ -36,6 +56,7 @@ export type SkillsShAcquisitionFailureCode =
   | "skill_not_found"
   | "skill_ambiguous"
   | "instructions_only"
+  | "too_many_scripts"
   | "skill_too_large"
   | "invalid_skill_text";
 
@@ -66,13 +87,37 @@ export class SkillsShAcquisitionError extends Error {
   }
 }
 
+/**
+ * One script acquired beside a skill's instructions, at the same commit.
+ *
+ * `path` is relative to the skill root, so it is what the skill's own prose
+ * names and what an allowlist entry matches; the digest is over the exact
+ * bytes fetched, as `SKILL.md`'s is.
+ */
+export interface SkillsShAcquiredScript {
+  readonly path: string;
+  readonly sourceUrl: string;
+  readonly text: string;
+  readonly valueDigest: string;
+}
+
 export interface SkillsShAcquiredSkill {
   readonly pin: SkillsShPinnedAddress;
   readonly skillRoot: string;
   readonly sourceUrl: string;
   readonly text: string;
   readonly valueDigest: string;
-  readonly loadedPaths: readonly ["SKILL.md"];
+
+  /**
+   * The skill's scripts, in path order, empty for a skill that ships none.
+   * Held apart from {@link text} because only the instructions are what the
+   * skill handle carries to a model; a script is something to run, and the
+   * run is gated by the operator's allowlist rather than by this fetch.
+   */
+  readonly scripts: readonly SkillsShAcquiredScript[];
+
+  /** Every path this acquisition admitted, `SKILL.md` first. */
+  readonly loadedPaths: readonly string[];
 }
 
 export interface AcquireSkillsShPinnedSkillOptions {
@@ -206,6 +251,28 @@ const candidateRoot = (skillPath: string): string => {
   return slash === -1 ? "" : skillPath.slice(0, slash);
 };
 
+/**
+ * Whether one tree entry is a script this acquisition admits: a regular file
+ * directly under the root's `scripts/`, named by a single path segment.
+ *
+ * Nested directories, symlinks and submodules are not admitted, and each
+ * refuses the whole payload rather than being dropped — the same rule the
+ * whitelist has always held, applied to a wider set of paths. A symlink is the
+ * one worth naming: its target is a path the tree does not vouch for, so
+ * admitting it would make the acquired bytes something other than what the
+ * inventory said.
+ */
+const isAdmittedScript = (
+  entry: GithubTreeEntry,
+  relativePath: string,
+): boolean => {
+  if (entry.type !== "blob") return false;
+  if (entry.mode !== "100644" && entry.mode !== "100755") return false;
+  const segments = relativePath.split("/");
+  return segments.length === 2 && segments[0] === SCRIPTS_DIRECTORY &&
+    segments[1] !== "";
+};
+
 const displayPath = (path: string): string =>
   sanitizeRegistryString(path) || "(unsafe path)";
 
@@ -215,7 +282,10 @@ const encodedTreePath = (path: string): string =>
 const valueDigestOf = (bytes: Uint8Array): string =>
   `sha256:${toUnpaddedBase64url(sha256(bytes))}`;
 
-const readSkillBytes = async (response: Response): Promise<Uint8Array> => {
+const readCappedBytes = async (
+  response: Response,
+  label: string,
+): Promise<Uint8Array> => {
   if (response.body === null) return new Uint8Array();
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
@@ -233,7 +303,7 @@ const readSkillBytes = async (response: Response): Promise<Uint8Array> => {
         }
         throw acquisitionError(
           "skill_too_large",
-          `the pinned SKILL.md exceeds the ${SKILLS_SH_MAX_SKILL_BYTES}-byte limit`,
+          `the pinned ${label} exceeds the ${SKILLS_SH_MAX_SKILL_BYTES}-byte limit`,
         );
       }
       chunks.push(value);
@@ -332,20 +402,39 @@ export const acquireSkillsShPinnedSkill = async (
   const payloadEntries = entries.filter((entry) =>
     root === "" || entry.path.startsWith(rootPrefix)
   );
-  const offendingPaths = payloadEntries
-    .filter((entry) => entry.path !== skillPath)
-    .map((entry) =>
-      displayPath(
-        root === "" ? entry.path : entry.path.slice(rootPrefix.length),
+  const withinRoot = (path: string): string =>
+    root === "" ? path : path.slice(rootPrefix.length);
+  const scriptEntries = payloadEntries.filter((entry) =>
+    isAdmittedScript(entry, withinRoot(entry.path))
+  );
+  const admitted = new Set<string>([
+    skillPath,
+    // The `scripts` directory entry itself is admitted with what it holds: a
+    // tree entry is the listing rather than a payload, and refusing it would
+    // refuse every skill that ships a script at all.
+    ...payloadEntries
+      .filter((entry) =>
+        entry.type === "tree" && withinRoot(entry.path) === SCRIPTS_DIRECTORY
       )
-    );
+      .map((entry) => entry.path),
+    ...scriptEntries.map((entry) => entry.path),
+  ]);
+  const offendingPaths = payloadEntries
+    .filter((entry) => !admitted.has(entry.path))
+    .map((entry) => displayPath(withinRoot(entry.path)));
   if (offendingPaths.length > 0) {
     throw new SkillsShAcquisitionError(
       "instructions_only",
-      `instructions-only acquisition refused ${offendingPaths.length} offending paths: ${
+      `acquisition refused ${offendingPaths.length} paths outside \`SKILL.md\` and \`${SCRIPTS_DIRECTORY}/\`: ${
         offendingPaths.join(", ")
       }`,
       { offendingPaths },
+    );
+  }
+  if (scriptEntries.length > SKILLS_SH_MAX_SCRIPTS) {
+    throw acquisitionError(
+      "too_many_scripts",
+      `the pinned skill ships ${scriptEntries.length} scripts, above the ${SKILLS_SH_MAX_SCRIPTS} one acquisition admits`,
     );
   }
   const sourceUrl =
@@ -357,7 +446,7 @@ export const acquireSkillsShPinnedSkill = async (
     sourceUrl,
     "GitHub raw SKILL.md",
   );
-  const bytes = await readSkillBytes(skillResponse);
+  const bytes = await readCappedBytes(skillResponse, "SKILL.md");
   let text: string;
   try {
     text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
@@ -374,13 +463,56 @@ export const acquireSkillsShPinnedSkill = async (
     );
   }
 
+  // Fetched after the instructions and in path order, so a partial failure
+  // leaves the same refusal whichever script it was, and the record a
+  // successful acquisition writes lists the payload in one stable order.
+  const scripts: SkillsShAcquiredScript[] = [];
+  for (
+    const entry of [...scriptEntries].sort((left, right) =>
+      left.path < right.path ? -1 : left.path > right.path ? 1 : 0
+    )
+  ) {
+    const relativePath = withinRoot(entry.path);
+    const scriptUrl =
+      `${GITHUB_RAW_BASE_URL}/${pin.owner}/${pin.repo}/${pin.commitSha}/${
+        encodedTreePath(entry.path)
+      }`;
+    const scriptResponse = await fetchResponse(
+      fetch,
+      scriptUrl,
+      `GitHub raw ${displayPath(relativePath)}`,
+    );
+    const scriptBytes = await readCappedBytes(
+      scriptResponse,
+      displayPath(relativePath),
+    );
+    let scriptText: string;
+    try {
+      scriptText = new TextDecoder("utf-8", { fatal: true }).decode(
+        scriptBytes,
+      );
+    } catch {
+      throw acquisitionError(
+        "invalid_skill_text",
+        `the pinned ${displayPath(relativePath)} bytes are not UTF-8`,
+      );
+    }
+    scripts.push({
+      path: relativePath,
+      sourceUrl: scriptUrl,
+      text: scriptText,
+      valueDigest: valueDigestOf(scriptBytes),
+    });
+  }
+
   return {
     pin,
     skillRoot: root === "" ? "." : displayPath(root),
     sourceUrl,
     text,
     valueDigest: valueDigestOf(bytes),
-    loadedPaths: ["SKILL.md"],
+    scripts,
+    loadedPaths: ["SKILL.md", ...scripts.map((script) => script.path)],
   };
 };
 

--- a/packages/cf-harness/src/tools/acquire-skill.ts
+++ b/packages/cf-harness/src/tools/acquire-skill.ts
@@ -30,7 +30,14 @@ export interface AcquireSkillToolLoadedOutput {
   readonly pin: SkillsShPinnedAddress;
   readonly loaded: {
     readonly skillRoot: string;
-    readonly paths: readonly ["SKILL.md"];
+
+    /**
+     * Every path the acquisition admitted, `SKILL.md` first and the skill's
+     * scripts after it. What the model is told it now holds: the instructions
+     * reach it through the handle, and a script is something the operator's
+     * allowlist decides whether it may run.
+     */
+    readonly paths: readonly string[];
     readonly sourceUrl: string;
     readonly verification: "git-commit-sha";
     readonly valueDigest: string;
@@ -106,10 +113,7 @@ export const acquireSkillToolDescriptor: HarnessToolDescriptor = {
           type: "object",
           properties: {
             skillRoot: { type: "string" },
-            paths: {
-              type: "array",
-              items: { type: "string", enum: ["SKILL.md"] },
-            },
+            paths: { type: "array", items: { type: "string" } },
             sourceUrl: { type: "string" },
             verification: { type: "string", enum: ["git-commit-sha"] },
             valueDigest: { type: "string" },

--- a/packages/cf-harness/src/tools/acquire-skill.ts
+++ b/packages/cf-harness/src/tools/acquire-skill.ts
@@ -1,6 +1,10 @@
 /**
  * The `acquire_skill` tool: resolve a discovery id to a GitHub commit, enforce
- * the instructions-only tree whitelist, and durably return only a handle.
+ * the tree whitelist, and durably return only a handle.
+ *
+ * The handle names the instructions and nothing else. A skill's scripts are
+ * acquired beside them and stay host-side, so what a chooser can hand onward
+ * is still the prose it never read.
  */
 
 import type { JSONSchema } from "@commonfabric/api";

--- a/packages/cf-harness/test/acquire-skill.test.ts
+++ b/packages/cf-harness/test/acquire-skill.test.ts
@@ -297,7 +297,7 @@ describe("acquire-skill", () => {
     });
   });
 
-  it("returns instructions-only refusal metadata without writing a handle", async () => {
+  it("returns path-refusal metadata without writing a handle", async () => {
     await withFabric(async ({ pieces }) => {
       const engine = createEngine(pieces, buildgreatFetch);
 
@@ -308,10 +308,12 @@ describe("acquire-skill", () => {
 
       expect(output.status).toBe("refused");
       expect(output.reason.code).toBe("instructions_only");
-      expect(output.reason.message).toContain("22 offending paths");
-      expect(output.offendingCount).toBe(22);
+      expect(output.reason.message).toContain("refused 20 paths");
+      expect(output.offendingCount).toBe(20);
       expect(output.offendingPaths).toContain("assets/vision-template.json");
-      expect(output.offendingPaths).toContain("scripts/validate-vision.js");
+      // The skill's own script is admitted now, so it is not what refused this
+      // payload; the `references/` and `assets/` trees beside it are.
+      expect(output.offendingPaths).not.toContain("scripts/validate-vision.js");
       expect(output).not.toHaveProperty("skillHandle");
     });
   });

--- a/packages/cf-harness/test/skills-sh/acquisition.test.ts
+++ b/packages/cf-harness/test/skills-sh/acquisition.test.ts
@@ -247,6 +247,39 @@ describe("skills.sh pinned acquisition", () => {
     ]);
   });
 
+  it("refuses a script whose filename carries a control codepoint", async () => {
+    // An admitted path is reported — it reaches `loadedPaths`, the tool output
+    // and the run record, none of which sanitize on the way out — so a name
+    // the publisher chose is refused here rather than carried and cleaned
+    // later.
+    const { fetch, urls } = scriptFixture([
+      { path: "scripts", mode: "040000", type: "tree" },
+      { path: "scripts/re\u001b[2Kport.sh" },
+    ]);
+
+    const refusal = await refusalOf(
+      acquireSkillsShPinnedSkill(BUILDGREAT_PIN, { fetch }),
+    );
+
+    expect(refusal.code).toBe("instructions_only");
+    expect(refusal.offendingCount).toBe(1);
+    expect(urls).toEqual([BUILDGREAT_TREE_URL]);
+  });
+
+  it("refuses a script whose filename opens with a dot", async () => {
+    const { fetch } = scriptFixture([
+      { path: "scripts", mode: "040000", type: "tree" },
+      { path: "scripts/.hidden.sh" },
+    ]);
+
+    const refusal = await refusalOf(
+      acquireSkillsShPinnedSkill(BUILDGREAT_PIN, { fetch }),
+    );
+
+    expect(refusal.code).toBe("instructions_only");
+    expect(refusal.offendingPaths).toEqual(["scripts/.hidden.sh"]);
+  });
+
   it("refuses a symlink under the scripts directory instead of fetching its target", async () => {
     const { fetch, urls } = scriptFixture([
       { path: "scripts", mode: "040000", type: "tree" },
@@ -281,6 +314,26 @@ describe("skills.sh pinned acquisition", () => {
     expect(refusal.message).toContain(`${SKILLS_SH_MAX_SCRIPTS + 1} scripts`);
     // Refused off the inventory, so no script was fetched.
     expect(urls).toEqual([BUILDGREAT_TREE_URL]);
+  });
+
+  it("refuses script bytes that are not UTF-8", async () => {
+    const { fetch } = scriptFixture([
+      { path: "scripts", mode: "040000", type: "tree" },
+      { path: "scripts/binary.sh" },
+    ]);
+    const withBinaryScript: HarnessFetch = (input, init) => {
+      const url = String(input);
+      return url.endsWith("/scripts/binary.sh")
+        ? Promise.resolve(new Response(new Uint8Array([0xff, 0xfe, 0xfd])))
+        : fetch(input, init);
+    };
+
+    const refusal = await refusalOf(
+      acquireSkillsShPinnedSkill(BUILDGREAT_PIN, { fetch: withBinaryScript }),
+    );
+
+    expect(refusal.code).toBe("invalid_skill_text");
+    expect(refusal.message).toContain("scripts/binary.sh");
   });
 
   it("refuses a script that exceeds the byte cap while streaming", async () => {

--- a/packages/cf-harness/test/skills-sh/acquisition.test.ts
+++ b/packages/cf-harness/test/skills-sh/acquisition.test.ts
@@ -12,6 +12,7 @@ import {
   acquireSkillsShPinnedSkill,
   cacheHarnessSkillsShAcquisitionClientFactory,
   createHarnessSkillsShAcquisitionClientFactory,
+  SKILLS_SH_MAX_SCRIPTS,
   SKILLS_SH_MAX_SKILL_BYTES,
   SkillsShAcquisitionClient,
   SkillsShAcquisitionError,
@@ -106,6 +107,7 @@ describe("skills.sh pinned acquisition", () => {
       sourceUrl: MEMBRANE_SKILL_URL,
       text: "# Plaid\n",
       valueDigest: "sha256:4Br5o34ECSRnIW_OAU598G_sKD7zw23POdRQ6mexrTk",
+      scripts: [],
       loadedPaths: ["SKILL.md"],
     });
     expect(membraneTree._capture.reportedEntryCount).toBe(6_154);
@@ -116,7 +118,7 @@ describe("skills.sh pinned acquisition", () => {
     ).toBe(true);
   });
 
-  it("refuses every extra path in the buildgreat candidate root", async () => {
+  it("refuses every path of the buildgreat candidate root outside its scripts", async () => {
     const { fetch, urls } = fixtureFetch({
       tree: buildgreatTree,
       treeUrl: BUILDGREAT_TREE_URL,
@@ -130,16 +132,177 @@ describe("skills.sh pinned acquisition", () => {
 
     expect(urls).toEqual([BUILDGREAT_TREE_URL]);
     expect(refusal.code).toBe("instructions_only");
-    expect(refusal.offendingCount).toBe(22);
     expect(refusal.offendingPaths).toEqual(
       buildgreatTree.tree
         .map(({ path }) => path)
-        .filter((path) => path !== "SKILL.md"),
+        .filter((path) =>
+          path !== "SKILL.md" && path !== "scripts" &&
+          !path.startsWith("scripts/")
+        ),
     );
-    expect(refusal.message).toContain("22 offending paths");
+    expect(refusal.offendingCount).toBe(20);
+    expect(refusal.message).toContain("refused 20 paths");
     expect(refusal.offendingPaths).toContain("assets/vision-template.json");
     expect(refusal.offendingPaths).toContain("references/plan.md");
-    expect(refusal.offendingPaths).toContain("scripts/validate-vision.js");
+    // The script is the payload the widened whitelist admits; the refusal is
+    // about everything beside it, and naming it here would put the old rule
+    // back under a new name.
+    expect(refusal.offendingPaths).not.toContain("scripts/validate-vision.js");
+  });
+
+  //
+  // The scripts a skill ships
+  //
+  // A skill is a directory, and the scripts its prose tells a model to run are
+  // part of it. They are acquired at the one pinned commit under the same size
+  // cap as the instructions, and every path beside them still refuses.
+  //
+
+  /**
+   * A tree holding `SKILL.md` at the repository root plus `entries`, and a
+   * fetch answering every raw URL with the path it names.
+   */
+  const scriptFixture = (
+    entries: readonly { path: string; mode?: string; type?: string }[],
+  ): { fetch: HarnessFetch; urls: string[] } => {
+    const tree = {
+      sha: BUILDGREAT_SHA,
+      truncated: false,
+      tree: [
+        { path: "SKILL.md", mode: "100644", type: "blob" },
+        ...entries.map((entry) => ({
+          path: entry.path,
+          mode: entry.mode ?? "100644",
+          type: entry.type ?? "blob",
+        })),
+      ],
+    };
+    const urls: string[] = [];
+    const fetch: HarnessFetch = (input) => {
+      const url = String(input);
+      urls.push(url);
+      if (url === BUILDGREAT_TREE_URL) {
+        return Promise.resolve(Response.json(tree));
+      }
+      const raw =
+        `https://raw.githubusercontent.com/buildgreatproducts/plaid/${BUILDGREAT_SHA}/`;
+      if (url.startsWith(raw)) {
+        return Promise.resolve(new Response(`# ${url.slice(raw.length)}\n`));
+      }
+      return Promise.resolve(
+        Response.json({ message: "Not Found" }, { status: 404 }),
+      );
+    };
+    return { fetch, urls };
+  };
+
+  it("acquires the skill's scripts beside its instructions, in path order", async () => {
+    const { fetch, urls } = scriptFixture([
+      { path: "scripts", mode: "040000", type: "tree" },
+      { path: "scripts/second.sh", mode: "100755" },
+      { path: "scripts/first.py" },
+    ]);
+
+    const acquired = await acquireSkillsShPinnedSkill(BUILDGREAT_PIN, {
+      fetch,
+    });
+
+    expect(acquired.loadedPaths).toEqual([
+      "SKILL.md",
+      "scripts/first.py",
+      "scripts/second.sh",
+    ]);
+    expect(acquired.scripts.map((script) => script.path)).toEqual([
+      "scripts/first.py",
+      "scripts/second.sh",
+    ]);
+    expect(acquired.scripts[0].text).toBe("# scripts/first.py\n");
+    // Every fetch names the one pinned commit, the instructions first.
+    expect(urls).toEqual([
+      BUILDGREAT_TREE_URL,
+      `https://raw.githubusercontent.com/buildgreatproducts/plaid/${BUILDGREAT_SHA}/SKILL.md`,
+      `https://raw.githubusercontent.com/buildgreatproducts/plaid/${BUILDGREAT_SHA}/scripts/first.py`,
+      `https://raw.githubusercontent.com/buildgreatproducts/plaid/${BUILDGREAT_SHA}/scripts/second.sh`,
+    ]);
+    expect(acquired.scripts[0].valueDigest).toMatch(/^sha256:/);
+  });
+
+  it("refuses a script nested below the scripts directory", async () => {
+    // The admitted shape is one segment under `scripts/`. A deeper path is a
+    // directory the whitelist never judged.
+    const { fetch } = scriptFixture([
+      { path: "scripts", mode: "040000", type: "tree" },
+      { path: "scripts/inner", mode: "040000", type: "tree" },
+      { path: "scripts/inner/deep.sh" },
+    ]);
+
+    const refusal = await refusalOf(
+      acquireSkillsShPinnedSkill(BUILDGREAT_PIN, { fetch }),
+    );
+
+    expect(refusal.code).toBe("instructions_only");
+    expect(refusal.offendingPaths).toEqual([
+      "scripts/inner",
+      "scripts/inner/deep.sh",
+    ]);
+  });
+
+  it("refuses a symlink under the scripts directory instead of fetching its target", async () => {
+    const { fetch, urls } = scriptFixture([
+      { path: "scripts", mode: "040000", type: "tree" },
+      { path: "scripts/link.sh", mode: "120000" },
+    ]);
+
+    const refusal = await refusalOf(
+      acquireSkillsShPinnedSkill(BUILDGREAT_PIN, { fetch }),
+    );
+
+    expect(refusal.code).toBe("instructions_only");
+    expect(refusal.offendingPaths).toEqual(["scripts/link.sh"]);
+    expect(urls).toEqual([BUILDGREAT_TREE_URL]);
+  });
+
+  it("refuses a skill shipping more scripts than one acquisition admits", async () => {
+    const { fetch, urls } = scriptFixture([
+      { path: "scripts", mode: "040000", type: "tree" },
+      ...Array.from(
+        { length: SKILLS_SH_MAX_SCRIPTS + 1 },
+        (_unused, index) => ({
+          path: `scripts/step-${index}.sh`,
+        }),
+      ),
+    ]);
+
+    const refusal = await refusalOf(
+      acquireSkillsShPinnedSkill(BUILDGREAT_PIN, { fetch }),
+    );
+
+    expect(refusal.code).toBe("too_many_scripts");
+    expect(refusal.message).toContain(`${SKILLS_SH_MAX_SCRIPTS + 1} scripts`);
+    // Refused off the inventory, so no script was fetched.
+    expect(urls).toEqual([BUILDGREAT_TREE_URL]);
+  });
+
+  it("refuses a script that exceeds the byte cap while streaming", async () => {
+    const { fetch } = scriptFixture([
+      { path: "scripts", mode: "040000", type: "tree" },
+      { path: "scripts/big.sh" },
+    ]);
+    const capped: HarnessFetch = (input, init) => {
+      const url = String(input);
+      return url.endsWith("/scripts/big.sh")
+        ? Promise.resolve(
+          new Response("x".repeat(SKILLS_SH_MAX_SKILL_BYTES + 1)),
+        )
+        : fetch(input, init);
+    };
+
+    const refusal = await refusalOf(
+      acquireSkillsShPinnedSkill(BUILDGREAT_PIN, { fetch: capped }),
+    );
+
+    expect(refusal.code).toBe("skill_too_large");
+    expect(refusal.message).toContain("scripts/big.sh");
   });
 
   it("refuses a truncated recursive tree as an unread listing", async () => {


### PR DESCRIPTION
Cut 1 of three for Demo 2 (CT-2091): the acquisition fetches a pinned skill's `scripts/` as well as its `SKILL.md`, so a skill that ships scripts is acquirable at all.

Refs CT-2091, CT-2066.

## Why

A skill is a directory. The whitelist admitted `SKILL.md` and refused every other path — right for a reference or an asset, wrong for the scripts the skill's own prose tells a model to run. A skill shipping `scripts/foo.py` refused entirely, and CT-2091's conserved goal is a child running one of those scripts in the sandbox.

## What changes

Inside the selected candidate root, two things are admitted: `SKILL.md`, and the regular files **directly** under `scripts/`. Everything else refuses the whole acquisition, as before, with the offending paths named. Three refusals are worth stating because they are new surface:

- a directory nested below `scripts/` — a tree the whitelist never judged;
- a symlink — its target is a path the inventory does not vouch for, so admitting it would make the acquired bytes something other than what the listing said;
- a submodule, for the same reason.

Each admitted file is fetched at the one pinned commit, under the same 256 KiB cap, and digested the same way. A skill shipping more than `SKILLS_SH_MAX_SCRIPTS` (16) scripts refuses **on the inventory**, before any script is fetched: the size cap bounds a file, and this bounds the number of requests, which would otherwise be the publisher's number rather than ours.

**The scripts stay host-side.** Nothing is written into the skills root, the handle still carries only the instructions, and whether a script may run remains the operator allowlist's decision — cut 2's subject, not this one's.

## Tests

Five new cases: scripts acquired in path order with their digests and one URL per admitted file; a nested path refused; a symlink refused without fetching it; the count bound refusing off the inventory; and a script that trips the byte cap while streaming.

Two existing cases moved with the contract rather than around it — the buildgreat fixture now refuses 20 paths rather than 22, and its `scripts/validate-vision.js` is asserted **not** to be among them, which is the whole of what changed.

Mutation-proved, each reverted after: admitting a nested path, admitting a symlink, deleting the count guard, and never fetching the scripts — all four red the suite.

## Gates, by exit code on deno 2.9.4

`deno task check`, `deno fmt --check`, `deno lint`, `deno task check-docs`, `deno task check-skill-facts` — all 0. `packages/cf-harness` `deno task test` **unsandboxed**: 1028 passed, 0 failed.

## Docs moved with it

The package README's acquisition section, `docs/plans/external-skill-acquisition.md`'s payload-boundary rule, and the `SKILLS_SUPPORT_SPEC` non-goal that said acquisition was instruction-only. The system map states nothing about the whitelist's contents, so no sentence there changed.

## Not merged

Cut 2 (`run_skill_script` accepting an acquired script under the existing operator allowlist) and cut 3 (the fixture script and the live run) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

