### PR TITLE
Verify scoped snapshot memo isolation and label-view reuse

### DIFF
--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -426,3 +426,23 @@ The command reports measured totals and per-run maxima for every interval. Keep
 the functional assertions, declared collection sizes, and render windows when
 adjusting a ceiling; a budget failure should lead to attribution of the added
 reads before changing the limit.
+
+## Scoped snapshot memo reuse
+
+`packages/runner/test/snapshot-memo.bench.ts` measures repeated CFC label-view
+requests within an ambient metadata scope, both at the current instant and at a
+historical read epoch. Each sample opens a fresh transaction and makes 74, 296,
+or 1,184 requests for one labeled address. Setup and transaction cleanup are
+outside the timed interval.
+
+The reused-memo case includes its first miss. The cleared-memo control clears
+only the active snapshot memo before each request; storage read caches remain
+active. That control includes clearing the map and journaling the additional
+reads. Both cases still merge label views for every request. They measure the
+cost of repeated derivation in this fixture, not a whole-pattern speedup.
+
+Untimed diagnostics verify one metadata read with reuse and one per request
+with clearing. These are transaction read activities, not proxy-access counts
+or storage network requests. Run with `deno bench -A --json
+packages/runner/test/snapshot-memo.bench.ts`; the JSON timing report goes to
+stdout and the exact read counts go to stderr.

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -148,6 +148,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Investigations, journals, and working notes
 
+- [Scoped snapshot memo verification](development/performance/2026-09-10-scoped-snapshot-memo.md) — D3 metadata/epoch isolation regressions and exact label-view reuse counts at three sizes.
+
 - [Pattern read accounting: first-batch baseline](development/performance/2026-09-pattern-read-accounting.md) — 2026-09-10: transaction-scoped read counters, generic reduction update costs, headless lunch-poll attribution, and instrumentation overhead measurements.
 - [Incremental aggregate comparison](development/performance/2026-09-incremental-aggregates.md) — 2026-09-10: compiled aggregate initialization costs, paired update timings, read-work scaling, and coordinator rescan findings.
 

--- a/docs/history/development/performance/2026-09-10-scoped-snapshot-memo.md
+++ b/docs/history/development/performance/2026-09-10-scoped-snapshot-memo.md
@@ -1,0 +1,65 @@
+---
+status: historical
+created: 2026-09-10
+archived: 2026-09-10
+reason: "D3 verification and scoped label-view reuse measurements for design #7155."
+---
+
+# Scoped snapshot memo verification
+
+The D3 verification used runtime revision `be92af0510` with two added
+regressions and `packages/runner/test/snapshot-memo.bench.ts`. The machine was
+an Apple M5 running Deno 2.9.4 on macOS arm64. No live poll was accessed.
+
+## Correctness
+
+The snapshot-memo suite passed all 41 steps. Its existing cases cover link
+retargeting, replacement, path/schema/resolution-mode separation, per-call
+trace replay, cross-space pull kicks, write invalidation, blind-write mode,
+nonreactive reads, closed transactions, and proxy-view reuse.
+
+Two added regressions check the intersections relevant to scoped memo reuse:
+
+- A metadata-scoped label view remains reusable at its historical read epoch
+  after the stored label changes. Current reads return the new label;
+  historical reads return the old label. A read without the ambient metadata
+  journals its own metadata access even at that historical epoch.
+- Distinct ambient metadata objects, despite having equal fields, each journal
+  an initial metadata read. Reentering either original object's scope reuses
+  its own memo. An unscoped read journals separately.
+
+These assertions check returned label values as well as read activity. The
+measurements did not establish a need for another memoization mechanism.
+
+## Exact read measurements
+
+Each sample requests the label view of one stored, labeled address repeatedly.
+Source and target name the same address. Each sample has a fresh transaction;
+the historical case advances the transaction with an unrelated write before
+entering the earlier read epoch. Setup is excluded from the measured interval.
+
+| Scope | Calls | Metadata reads with reuse | Metadata reads with clearing |
+| --- | ---: | ---: | ---: |
+| Ambient metadata | 74 | 1 | 74 |
+| Ambient metadata | 296 | 1 | 296 |
+| Ambient metadata | 1,184 | 1 | 1,184 |
+| Read epoch and ambient metadata | 74 | 1 | 74 |
+| Read epoch and ambient metadata | 296 | 1 | 296 |
+| Read epoch and ambient metadata | 1,184 | 1 | 1,184 |
+
+The reused case includes its first miss. The control clears only the active
+snapshot memo before each request; underlying storage read caches remain
+active. The benchmark verifies these exact counts before registering timing
+samples, and writes them to stderr. Reproduction from the repository root:
+
+```sh
+deno test -A packages/runner/test/snapshot-memo.test.ts
+deno bench -A --json packages/runner/test/snapshot-memo.bench.ts
+```
+
+The counts describe transaction read activities, not proxy accesses, network
+requests, or distinct documents. Both cases still merge views for every call.
+The cleared control includes map clearing and additional journaling cost.
+Timing was captured while other validation ran, so no timing comparison or
+product speedup is inferred. This one-address fixture verifies reuse; it does
+not model a full pattern with independently labeled documents or rendering.

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -4,13 +4,13 @@ Status: A1/A2 instrumentation shipped in #7246; worker control shipped in #7256.
 The controlled A0 fixture, accounting regressions, and dashboard shipped in
 #7241, with browser and remote-row demonstrations added in #7264. A3 budgets
 landed in #7257 after full validation, all 69 CI gates, and clean Cubic and
-antagonistic reviews. A4's browser benchmark shipped in #7261; count limits are
-implemented and validated in #7282, pending its own CI and review. C1's remote-row
+antagonistic reviews. A4's browser benchmark shipped in #7261; count limits
+landed in #7282. C1's remote-row
 reproductions and C3's inline-element dependency repair landed in #7265;
 removal/restoration acceptance landed in #7285 and first-browser-materialization
 acceptance landed in #7302, both with local demonstrations. Reconnect and
 remaining row-invalidation acceptance stay open. B1/B2's contract landed in
-#7294; the typed lookup foundation is under review in #7304. Producer lowering,
+#7294; the typed lookup foundation landed in #7304. Producer lowering,
 bucket maintenance, and joins remain pending.
 
 B3's named aggregates are implemented and validated in
@@ -335,10 +335,12 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
       removal. Keep implementation ownership there.
 - [ ] **D2 — Re-run the A baseline when that dependency changes** and separate
       reduced access count from reduced per-access cost.
-- [ ] **D3 — Verify scoped snapshot memoization and measure its effect.**
-      Inspect existing snapshot-memo tests for metadata/epoch isolation,
-      invalidation, and journaling correctness; add missing coverage only where
-      needed. Measure label-view reuse before proposing further work.
+- [x] **D3 — Verify scoped snapshot memoization and measure its effect.**
+      The snapshot-memo suite passes 41 steps, including combined epoch/metadata
+      label-view isolation. The benchmark verifies one metadata read across
+      74, 296, and 1,184 requests in each scope. The
+      [verification report](../history/development/performance/2026-09-10-scoped-snapshot-memo.md)
+      records the control and measurement limits.
 
 ## 14. Validation and closeout
 
@@ -373,16 +375,16 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 
 ## Next task
 
-Complete A4's merge review in #7282. Verify C1's rendered rows after
+A3/A4 and the typed lookup foundation are landed. Verify C1's rendered rows after
 reconnect, and complete C1/C3's remaining acceptance checks while retaining the
 production workaround. The first-materialization cases in
 [PR #7302](https://github.com/commontoolsinc/labs/pull/7302) pass all four
 nested/mapped and same/cross-space browser combinations.
-A4's browser benchmark is available; validated count limits await review. A5 still
+A4's browser benchmark and count limits are available. A5 still
 needs cross-space and deployed measurements before product performance claims.
 Live poll access requires coordination with Mike.
 
-For the pending collection operators, review the typed lookup foundation in
+For the pending collection operators, build on the typed lookup foundation in
 [PR #7304](https://github.com/commontoolsinc/labs/pull/7304), implement
 `groupBy`/`keyBy` and bucket maintenance against the
 [agreed index contract](collection-index-contract.md), then build the left join. Their

--- a/packages/runner/test/snapshot-memo.bench.ts
+++ b/packages/runner/test/snapshot-memo.bench.ts
@@ -1,0 +1,109 @@
+/** Measures repeated label-view derivation within one metadata and epoch scope. */
+
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { Identity } from "@commonfabric/identity";
+
+import { cfcLabelViewForDereference } from "../src/cfc/label-view-state.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { machineryRead } from "../src/storage/reactivity-log.ts";
+import { benchDiagnostic } from "./bench-diagnostics.ts";
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "./cfc-seed-envelope.ts";
+
+const signer = await Identity.fromPassphrase("scoped-snapshot-memo-bench");
+const storageManager = StorageManager.emulate({ as: signer });
+const runtime = new Runtime({
+  apiUrl: new URL("https://example.com"),
+  storageManager,
+});
+const seed = runtime.edit();
+const address = runtime.getCell(signer.did(), "labeled-source", undefined, seed)
+  .getAsNormalizedFullLink();
+writeSeedEnvelopeDoc(seed, signer.did());
+seed.writeOrThrow({ ...address, path: [] }, {
+  value: "source",
+  cfc: {
+    version: 1,
+    schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+    labelMap: {
+      version: 1,
+      entries: [{
+        path: [],
+        label: {
+          confidentiality: [{
+            type: CFC_ATOM_TYPE.User,
+            subject: signer.did(),
+          }],
+        },
+      }],
+    },
+  },
+});
+const committed = await seed.commit();
+if (committed.error) throw committed.error;
+
+/** Times derivation alone; fresh transactions bound retained journals and memos. */
+function measure(
+  count: number,
+  historical: boolean,
+  cold: boolean,
+  timer?: Deno.BenchContext,
+): number {
+  const tx = runtime.edit();
+  let previous: number | undefined;
+  try {
+    if (historical) {
+      const epoch = tx.issueReadEpoch()!;
+      runtime.getCell(signer.did(), "epoch-advance", undefined, tx).set(count);
+      previous = tx.enterReadEpoch(epoch);
+    }
+    const before = [...(tx.getReadActivities?.() ?? [])].length;
+    tx.runWithAmbientReadMeta(machineryRead, () => {
+      timer?.start();
+      for (let index = 0; index < count; index++) {
+        // Clearing only this memo supplies a repeated-derivation control;
+        // storage's own read caches remain active in both measurements.
+        if (cold) tx.getSnapshotMemo?.()?.clear();
+        cfcLabelViewForDereference(tx, address, address);
+      }
+      timer?.end();
+    });
+    return [...(tx.getReadActivities?.() ?? [])].length - before;
+  } finally {
+    if (historical) tx.exitReadEpoch(previous);
+    tx.abort();
+  }
+}
+
+for (const historical of [false, true]) {
+  for (const count of [74, 296, 1184]) {
+    const scope = historical ? "epoch and metadata" : "metadata";
+    const warmReads = measure(count, historical, false);
+    const coldReads = measure(count, historical, true);
+    if (warmReads !== 1 || coldReads !== count) {
+      throw new Error(
+        `Unexpected label-read counts: ${warmReads}/${coldReads}`,
+      );
+    }
+    benchDiagnostic(JSON.stringify({ scope, count, warmReads, coldReads }));
+    for (const cold of [false, true]) {
+      Deno.bench({
+        name: `${count} calls ${cold ? "cleared memo" : "reused memo"}`,
+        group: `label views ${scope}`,
+        fn: (timer) => {
+          measure(count, historical, cold, timer);
+        },
+      });
+    }
+  }
+}
+
+globalThis.addEventListener("unload", () => {
+  void (async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  })();
+});

--- a/packages/runner/test/snapshot-memo.test.ts
+++ b/packages/runner/test/snapshot-memo.test.ts
@@ -358,6 +358,86 @@ describe("snapshot memo", () => {
     });
   });
 
+  it("keeps scoped label views at their read epoch after metadata changes", () => {
+    const cell = runtime.getCell(space, "scoped-label-epochs", undefined, tx);
+    const address = cell.getAsNormalizedFullLink();
+    const writeLabel = (name: string) =>
+      tx.writeOrThrow({
+        space,
+        id: address.id,
+        type: "application/json",
+        path: [],
+      }, {
+        value: "unchanged",
+        cfc: {
+          version: 1,
+          schemaHash: "test-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: [],
+              label: { confidentiality: [name] },
+            }],
+          },
+        },
+      });
+    const readLabel = () =>
+      cfcLabelViewForDereference(tx, address, address)
+        ?.entries[0].label.confidentiality;
+    const scopedLabel = () =>
+      tx.runWithAmbientReadMeta(machineryRead, readLabel);
+    writeLabel("first");
+    const epoch = tx.issueReadEpoch()!;
+    expect(scopedLabel()).toEqual(["first"]);
+    const afterFirst = cfcMetadataReadCount();
+    expect(scopedLabel()).toEqual(["first"]);
+    expect(cfcMetadataReadCount()).toBe(afterFirst);
+
+    writeLabel("second");
+    expect(scopedLabel()).toEqual(["second"]);
+    const afterCurrent = cfcMetadataReadCount();
+    const previous = tx.enterReadEpoch(epoch);
+    try {
+      expect(scopedLabel()).toEqual(["first"]);
+      expect(cfcMetadataReadCount()).toBe(afterCurrent);
+      expect(readLabel()).toEqual(["first"]);
+      expect(cfcMetadataReadCount()).toBeGreaterThan(afterCurrent);
+    } finally {
+      tx.exitReadEpoch(previous);
+    }
+    expect(readLabel()).toEqual(["second"]);
+  });
+
+  it("journals label metadata separately for distinct ambient metadata objects", () => {
+    const { holder } = linkingCell(
+      "metadata-identity-holder",
+      "metadata-identity-target",
+    );
+    const { traces } = resolveLinkTracingDereferences(
+      runtime,
+      tx,
+      holder.key("target").getAsNormalizedFullLink(),
+    );
+    const firstMeta = { ...machineryRead };
+    const secondMeta = { ...machineryRead };
+    const readLabels = () => cfcLabelViewForDereferenceTraces(tx, traces);
+    const before = cfcMetadataReadCount();
+    tx.runWithAmbientReadMeta(firstMeta, readLabels);
+    const afterFirst = cfcMetadataReadCount();
+    expect(afterFirst).toBeGreaterThan(before);
+    tx.runWithAmbientReadMeta(firstMeta, readLabels);
+    expect(cfcMetadataReadCount()).toBe(afterFirst);
+    tx.runWithAmbientReadMeta(secondMeta, readLabels);
+    const afterSecond = cfcMetadataReadCount();
+    expect(afterSecond).toBeGreaterThan(afterFirst);
+    tx.runWithAmbientReadMeta(firstMeta, readLabels);
+    expect(cfcMetadataReadCount()).toBe(afterSecond);
+    tx.runWithAmbientReadMeta(secondMeta, readLabels);
+    expect(cfcMetadataReadCount()).toBe(afterSecond);
+    readLabels();
+    expect(cfcMetadataReadCount()).toBeGreaterThan(afterSecond);
+  });
+
   it("keeps resolutions of two paths in one document apart", () => {
     const first = runtime.getCell<{ value: string }>(
       space,

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,10 +1,10 @@
 {
-  "updated": "2026-09-11T03:39:35.462449+00:00",
+  "updated": "2026-09-11T04:31:12.890540+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7282",
-  "activity": "#7257 landed with all 69 checks and clean reviews. #7282 scale limits pass all six assertions, 413 pattern checks, the full pattern package, and 46 type groups against main; preparing its own CI and review. The lookup foundation is under review in #7304.",
-  "review": "#7257 is merged with clean Cubic/antagonistic reviews. #7282 requires its own current-head CI and clean Cubic review before landing.",
+  "activity": "D3 verification is implemented: 1,431 runner tests / 8,923 steps, 46 type-check groups, 599 documentation blocks, formatting/lint, history index, and all six exact benchmark-count checks pass. Preparing the slice for PR review.",
+  "review": "Antagonistic D3 review is clean after correcting status wording and verifying reentry of both metadata scopes. The D3 PR requires its own CI and Cubic review before landing.",
   "checks": [
     "#7241: all 69 CI gates passed; latest Cubic run reported zero issues; merged as e70704f206.",
     "#7256: all 69 CI gates passed with clean Cubic/antagonistic reviews; merged as 8d3c7dbc3c.",
@@ -20,7 +20,12 @@
     "#7300 merged as efc91a38b6 after all 69 current-head checks and clean Cubic/antagonistic reviews; generic Cell aliases preserve resolved payload types.",
     "#7257 current implementation validation (2b24f0823f): 1,428 runner tests / 8,909 steps; full CLI suites; 1,168 transformer tests / 961 steps; 46 type groups; 599 documentation blocks; four synthetic browser row cases; formatting and lint pass. Generated-pattern, vintage, and scale acceptance checkpoints are detailed in the PR.",
     "#7257 merged as c122d6a9fc after all 69 current-head checks and zero-issue full Cubic review across 43 files, with clean antagonistic review.",
-    "#7282 main integration: all six functional assertions and declared budgets, 413 authoritative pattern checks, full pattern package including browser tests, and all 46 type groups pass."
+    "#7282 main integration: all six functional assertions and declared budgets, 413 authoritative pattern checks, full pattern package including browser tests, and all 46 type groups pass.",
+    "#7302 merged as 360d07680f: all 69 current-head CI gates, clean Cubic review, and clean antagonistic review.",
+    "#7300 merged as efc91a38b6: all 69 CI gates; clean full Cubic review across 6 files; clean antagonistic review; all 327 stored contracts remain compatible.",
+    "#7257 merged as c122d6a9fc: all 69 exact-head checks passed, full Cubic review found zero issues across 43 files, and antagonistic review passed.",
+    "#7304 merged as c0454ab24e after all 69 exact-head checks, zero issues in the full nine-file Cubic rereview, and clean antagonistic review.",
+    "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean."
   ],
   "stages": [
     {
@@ -45,13 +50,13 @@
       "id": "A3",
       "title": "Read budgets and whole-step coverage",
       "status": "done",
-      "detail": "Read budgets and whole-step attempt coverage landed in #7257 after all CI and review gates passed."
+      "detail": "Read budgets and whole-step attempt accounting landed in #7257 after all CI and review gates passed."
     },
     {
       "id": "A4",
       "title": "Read-side benchmark",
-      "status": "review",
-      "detail": "Browser benchmark landed in #7261. Scale-limit fixtures at 74, 296, and 1,184 votes are implemented and validated in #7282; its CI and reviews remain before merge."
+      "status": "done",
+      "detail": "Browser benchmark landed in #7261. Scale assertions for 74, 296, and 1,184 votes landed in #7282 after all six assertions, full package/type checks, CI, and clean reviews."
     },
     {
       "id": "A5",
@@ -69,13 +74,13 @@
       "id": "B1",
       "title": "Grouping and unique-key indexing",
       "status": "active",
-      "detail": "Contract and compiler support landed in #7294/#7300. Typed lookup foundation is under review in #7304. Group/key producers and bucket maintenance remain pending."
+      "detail": "Typed lookup and key-resolution foundation landed in #7304. GroupBy/keyBy producers, bucket maintenance, and ownership work continue."
     },
     {
       "id": "B2",
       "title": "Keyed lookup and join",
       "status": "todo",
-      "detail": "Lookup foundation in #7304 demonstrates bucket isolation, Cell identity, and durable resume. Join implementation remains pending."
+      "detail": "Typed lookup landed in #7304 with bucket isolation, Cell identity, linked rows, and durable resume. Join implementation remains pending."
     },
     {
       "id": "B3",
@@ -134,8 +139,8 @@
     {
       "id": "D3",
       "title": "Scoped snapshot memo verification",
-      "status": "todo",
-      "detail": "Implementation exists; verify isolation and measure reuse."
+      "status": "review",
+      "detail": "Implemented and validated: 41 snapshot-memo steps, full runner suite, and exact reuse counts at three sizes in metadata and historical scopes. Awaiting D3 PR gates."
     },
     {
       "id": "E1",

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,9 +1,9 @@
 {
-  "updated": "2026-09-11T04:31:12.890540+00:00",
+  "updated": "2026-09-11T04:49:55.656447+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
-  "pr": "https://github.com/commontoolsinc/labs/pull/7282",
-  "activity": "D3 verification is implemented: 1,431 runner tests / 8,923 steps, 46 type-check groups, 599 documentation blocks, formatting/lint, history index, and all six exact benchmark-count checks pass. Preparing the slice for PR review.",
+  "pr": "https://github.com/commontoolsinc/labs/pull/7307",
+  "activity": "D3 verification is published in #7307: full runner validation, 46 type groups, 599 docs blocks, and six exact benchmark-count checks pass. CI and Cubic review are running.",
   "review": "Antagonistic D3 review is clean after correcting status wording and verifying reentry of both metadata scopes. The D3 PR requires its own CI and Cubic review before landing.",
   "checks": [
     "#7241: all 69 CI gates passed; latest Cubic run reported zero issues; merged as e70704f206.",
@@ -227,9 +227,9 @@
       "detail": "Compare the same interaction before and after migration, with read work and measured time."
     }
   ],
-  "validatedRevision": "21fc2fb6a9c0055a2d2e3055dcd7e1fba1bbeed3",
+  "validatedRevision": "4f2057b0d64c95e35558ff224786f4b7712fa173",
   "validationProvenance": {
-    "revisionUrl": "https://github.com/commontoolsinc/labs/commit/21fc2fb6a9c0055a2d2e3055dcd7e1fba1bbeed3",
-    "scope": "Local package, type, pattern, browser, and vintage validation of the integrated implementation. This is the parent of published dashboard checkpoint d67c923566146faa6f7b2493b1828140295f7d47. It does not identify the separately recorded browser baseline capture."
+    "revisionUrl": "https://github.com/commontoolsinc/labs/commit/4f2057b0d64c95e35558ff224786f4b7712fa173",
+    "scope": "D3 tests, benchmark, and documentation checkpoint. Full runner and final focused snapshot tests pass; this revision does not identify separately recorded browser captures."
   }
 }

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -3,7 +3,7 @@
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
-  "activity": "D3 verification is published in #7307: full runner validation, 46 type groups, 599 docs blocks, and six exact benchmark-count checks pass. CI and Cubic review are running.",
+  "activity": "D3 validation passes. Cubic identified two dashboard ledger inconsistencies; both are repaired for a fresh review.",
   "review": "Antagonistic D3 review is clean after correcting status wording and verifying reentry of both metadata scopes. The D3 PR requires its own CI and Cubic review before landing.",
   "checks": [
     "#7241: all 69 CI gates passed; latest Cubic run reported zero issues; merged as e70704f206.",
@@ -21,11 +21,9 @@
     "#7257 current implementation validation (2b24f0823f): 1,428 runner tests / 8,909 steps; full CLI suites; 1,168 transformer tests / 961 steps; 46 type groups; 599 documentation blocks; four synthetic browser row cases; formatting and lint pass. Generated-pattern, vintage, and scale acceptance checkpoints are detailed in the PR.",
     "#7257 merged as c122d6a9fc after all 69 current-head checks and zero-issue full Cubic review across 43 files, with clean antagonistic review.",
     "#7282 main integration: all six functional assertions and declared budgets, 413 authoritative pattern checks, full pattern package including browser tests, and all 46 type groups pass.",
-    "#7302 merged as 360d07680f: all 69 current-head CI gates, clean Cubic review, and clean antagonistic review.",
-    "#7300 merged as efc91a38b6: all 69 CI gates; clean full Cubic review across 6 files; clean antagonistic review; all 327 stored contracts remain compatible.",
-    "#7257 merged as c122d6a9fc: all 69 exact-head checks passed, full Cubic review found zero issues across 43 files, and antagonistic review passed.",
     "#7304 merged as c0454ab24e after all 69 exact-head checks, zero issues in the full nine-file Cubic rereview, and clean antagonistic review.",
-    "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean."
+    "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean.",
+    "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass."
   ],
   "stages": [
     {


### PR DESCRIPTION
## Why

Design #7155's D3 requires evidence that scoped snapshot memoization preserves read semantics and actually reuses label derivations. The existing implementation had separate scope and epoch tests, but no combined label-metadata/epoch regression or repeatable scoped reuse measurement.

## What Changed

- Add label-view regressions across metadata changes, historical read epochs, and distinct ambient metadata objects.
- Add a benchmark with fresh transactions and a cleared-memo control at 74, 296, and 1,184 requests. Reuse journals one metadata read in both current and historical scopes; the control journals one per request.
- Record the measurement limits and close D3's verification item in the implementation tracker. Synchronize landed A3/A4/lookup status from #7257, #7282, and #7304.

The benchmark measures one repeated labeled address. It does not establish a whole-pattern speedup; timing was captured during other validation and is not used for a performance claim. No live poll was accessed.

## Test plan

- Full runner: 1,431 tests / 8,923 steps; no failures.
- Snapshot memo: 41 steps, including the final review assertions.
- All six benchmark count comparisons pass; timing output is valid Deno benchmark JSON.
- 46 repository type-check groups; 599 documentation blocks; history index; repo-wide formatting and lint.
- Antagonistic cf-review is clean after resolving status and assertion-coverage feedback. CI and Cubic must pass before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

