### PR TITLE
fix(memory): wait for session restoration before queries

### DIFF
--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -211,6 +211,8 @@ passed before merge, with clean Cubic and antagonistic reviews.
   - [x] Establish failure before repair, or demonstrate that the current system
         already passes the faithful reproduction. Record the cause or evidence
         before deciding what C2/C3 need to change.
+  - [x] Exercise two reader transport outages with nested and mapped rows;
+        verify catch-up and subsequent updates through headless result reads.
   - [ ] Verify rendered rows after reconnect.
 
   The
@@ -226,6 +228,11 @@ passed before merge, with clean Cubic and antagonistic reviews.
   profiles are created in a separate transaction and edited directly in their
   own space. Headless result reads explicitly pull data, so browser rendering
   owns the passive-update check. C1 remains open for reconnect verification.
+  The [reconnect probe](../../packages/patterns/integration/reactive-vote-rows-reconnect.test.ts)
+  closes the reader's storage sockets while the writer changes membership and
+  profiles. Ordinary memory queries wait for session restoration before
+  constructing their requests. This guards the handshake-to-session interval;
+  a subsequent disconnect during request issue remains a separate boundary.
   These synthetic probes do not authorize removing the lunch-poll workaround or
   accessing the live poll.
 

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -54,6 +54,17 @@ so they pass through admission again; document contents do not need migration.
 The [protocol specification](../../docs/specs/memory-v2/04-protocol.md)
 describes the terminal refusal and its reconnect behavior.
 
+## Client queries during reconnect
+
+`Client.restoreConnection()` waits for the transport handshake and restoration
+of existing space sessions. A connected transport can still be restoring its
+sessions. Ordinary graph, operation-field, entity, and SQLite queries wait for
+that restoration before constructing their request with the active session ID.
+Event-attention requests and SQLite source registration use the same boundary. A
+session closed or permanently refused during restoration fails the request with
+its session error. This boundary does not guarantee completion across a
+subsequent transport failure during request issuance.
+
 ## Layout
 
 - `v2.ts` — the protocol vocabulary: documents, operations, commits, queries,

--- a/packages/memory/test/v2-operation-client.test.ts
+++ b/packages/memory/test/v2-operation-client.test.ts
@@ -153,6 +153,7 @@ describe("v2-operation-client", () => {
     const client = {
       serverFlags: { applyOp: false },
       isConnected: () => true,
+      restoreConnection: () => Promise.resolve(),
       request: () => Promise.reject(new Error("request should not be sent")),
     };
     const session = new SpaceSession(

--- a/packages/memory/test/v2-query-reconnect.test.ts
+++ b/packages/memory/test/v2-query-reconnect.test.ts
@@ -1,0 +1,126 @@
+/** Exercises ordinary queries while a connected transport restores its session. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  connect,
+  loopback,
+  type SpaceSession,
+  type Transport,
+} from "../v2/client.ts";
+import { Server } from "../v2/server.ts";
+import { decodeMemoryBoundary } from "../v2.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
+
+describe("v2-query-reconnect", () => {
+  const cases: {
+    name: string;
+    type: string;
+    query: (session: SpaceSession) => Promise<unknown>;
+  }[] = [
+    {
+      name: "graph query",
+      type: "graph.query",
+      query: (session) => session.queryGraph({ roots: [] }),
+    },
+    {
+      name: "entity listing",
+      type: "entity-id.list",
+      query: (session) => session.listEntityIds(),
+    },
+    {
+      name: "entity lookup",
+      type: "entity-id.exists",
+      query: (session) => session.entityIdExists("of:absent"),
+    },
+  ];
+  for (const { name, type, query: invoke } of cases) {
+    for (const outcome of ["restored", "closed", "revoked"]) {
+      it(`handles ${name} when its restoring session is ${outcome}`, async () => {
+        const server = new Server({
+          ...testSessionOpenServerOptions,
+          store: new URL("memory://query-during-reopen"),
+        });
+        let active = loopback(server);
+        let receiver = (_payload: string) => {};
+        let disconnected = (_error?: Error) => {};
+        let opening = false;
+        let prematureQueries = 0;
+        let queries = 0;
+        const transport: Transport = {
+          send(payload) {
+            const message = decodeMemoryBoundary(payload) as { type: string };
+            if (message.type === type) {
+              queries++;
+              if (opening) prematureQueries++;
+            }
+            return active.send(payload);
+          },
+          close: () => active.close(),
+          setReceiver(next) {
+            receiver = next;
+            active.setReceiver(next);
+          },
+          setCloseReceiver(next) {
+            disconnected = next;
+          },
+        };
+        const entered = Promise.withResolvers<void>();
+        const release = Promise.withResolvers<void>();
+        const client = await connect({ transport });
+        let opened = false;
+        try {
+          const session = await client.mount(
+            "did:key:z6Mk-query-reconnect",
+            {},
+            async (...args) => {
+              if (opened) {
+                opening = true;
+                entered.resolve();
+                await release.promise;
+                opening = false;
+              }
+              opened = true;
+              return testSessionOpenAuthFactory(...args);
+            },
+          );
+          await active.close();
+          active = loopback(server);
+          active.setReceiver(receiver);
+          disconnected(new Error("synthetic outage"));
+          await entered.promise;
+          expect(client.isConnected()).toBe(true);
+          const query = invoke(session);
+          query.catch(() => {});
+          if (outcome === "closed") await session.close();
+          if (outcome === "revoked") session.handleRevoked("taken-over");
+          // request() yields once at its connected-transport guard before send().
+          await Promise.resolve();
+          release.resolve();
+          if (outcome === "restored") {
+            await query;
+            expect(prematureQueries).toBe(0);
+            expect(queries).toBe(1);
+            await invoke(session);
+            expect(queries).toBe(2);
+          } else {
+            await expect(query).rejects.toThrow(
+              outcome === "closed"
+                ? "memory session closed"
+                : "memory session revoked",
+            );
+            expect(queries).toBe(0);
+          }
+        } finally {
+          release.resolve();
+          await client.close();
+          await server.close();
+        }
+      });
+    }
+  }
+});

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -476,8 +476,10 @@ export class Client {
     this.#sessionOpenAuthContext = requireSessionOpenAuthMetadata(sessionOpen);
   }
 
+  /** Waits for the transport handshake and restoration of existing sessions. */
   async restoreConnection(): Promise<void> {
     await this.#ensureConnected();
+    await this.#reconnecting;
   }
 
   async #hello(): Promise<void> {
@@ -897,6 +899,13 @@ export class SpaceSession {
     }
   }
 
+  /** Waits for restored session identity before constructing an ordinary request. */
+  async #ensureSessionRestored(): Promise<void> {
+    this.#assertOpen();
+    await this.#client.restoreConnection();
+    this.#assertOpen();
+  }
+
   /**
    * `beforeIssue` runs after the open-session check and before this mutation
    * enters the session's outstanding request state. Throwing prevents issue.
@@ -941,7 +950,7 @@ export class SpaceSession {
   }
 
   async queryGraph(query: GraphQuery): Promise<GraphQueryResult> {
-    this.#assertOpen();
+    await this.#ensureSessionRestored();
     const result = await this.#client.request<GraphQueryResult>({
       type: "graph.query",
       requestId: crypto.randomUUID(),
@@ -957,7 +966,7 @@ export class SpaceSession {
   async queryOperationField(
     query: Omit<OperationFieldQuery, "principal" | "sessionId">,
   ): Promise<OperationFieldQueryResult> {
-    this.#assertOpen();
+    await this.#ensureSessionRestored();
     if (this.#client.serverFlags?.applyOp !== true) {
       throw protocolError("memory server does not support apply-op");
     }
@@ -978,7 +987,7 @@ export class SpaceSession {
     sidecarId: string,
     action: "retry" | "dismiss",
   ): Promise<EventAttentionResolveResult> {
-    this.#assertOpen();
+    await this.#ensureSessionRestored();
     const result = await this.#client.request<EventAttentionResolveResult>({
       type: "event.attention.resolve",
       requestId: crypto.randomUUID(),
@@ -996,7 +1005,7 @@ export class SpaceSession {
   async listEntityIds(
     options: EntityIdListOptions = {},
   ): Promise<EntityIdListResult | undefined> {
-    this.#assertOpen();
+    await this.#ensureSessionRestored();
     if (this.#client.serverFlags?.entityIdListing !== true) {
       return undefined;
     }
@@ -1021,7 +1030,7 @@ export class SpaceSession {
   async entityIdExists(
     id: EntityId,
   ): Promise<EntityIdLookupResult | undefined> {
-    this.#assertOpen();
+    await this.#ensureSessionRestored();
     if (this.#client.serverFlags?.entityIdLookup !== true) {
       return undefined;
     }
@@ -1043,7 +1052,7 @@ export class SpaceSession {
     sql: string,
     params?: SqliteParamsWire,
   ): Promise<SqliteQueryResult> {
-    this.#assertOpen();
+    await this.#ensureSessionRestored();
     const paramFields = params === undefined
       ? {}
       : !Array.isArray(params) && unsafeObjectKeyIn(params) !== undefined
@@ -1078,7 +1087,7 @@ export class SpaceSession {
     path: string,
     beforeIssue?: () => void,
   ): Promise<SqliteRegisterDiskSourceResult> {
-    this.#assertOpen();
+    await this.#ensureSessionRestored();
     const requestId = crypto.randomUUID();
     beforeIssue?.();
     return await this.#client.request<SqliteRegisterDiskSourceResult>({

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -80,6 +80,9 @@ export interface MultiRuntimeSessionSpec {
    * near-zero in-process latency hides.
    */
   wsDelayMs?: number;
+
+  /** Routes this session through a test relay backed by the same storage server. */
+  apiUrl?: URL;
   /**
    * Write-side `requiredIntegrity` floor for this session's runtime,
    * overriding the harness-wide setting. Set it per session to model a fleet
@@ -513,7 +516,7 @@ export class MultiRuntimeHarness {
         await client.call("init", {
           identity: identity.keyPair,
           spaceName,
-          apiUrl,
+          apiUrl: normalized.apiUrl?.href ?? apiUrl,
           diagnostics: options.diagnostics === true,
           ...(normalized.wsDelayMs !== undefined
             ? { wsDelayMs: normalized.wsDelayMs }

--- a/packages/patterns/integration/reactive-vote-rows-reconnect.test.ts
+++ b/packages/patterns/integration/reactive-vote-rows-reconnect.test.ts
@@ -1,0 +1,109 @@
+/** Verifies row catch-up after a real storage transport outage in the reader. */
+
+import { env } from "@commonfabric/integration";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
+import { MultiRuntimeHarness } from "./multi-runtime-harness.ts";
+import { StorageNetworkGate } from "./storage-network-gate.ts";
+
+const rootPath = join(import.meta.dirname!, "..");
+
+describe("reactive vote rows after reconnect", () => {
+  for (const variant of ["nested", "mapped"]) {
+    it(`catches up ${variant} membership and profiles and continues reacting`, async () => {
+      const apiUrl = new URL(env.API_URL);
+      const gate = new StorageNetworkGate(apiUrl);
+      let harness: MultiRuntimeHarness | undefined;
+      try {
+        harness = await MultiRuntimeHarness.create({
+          rootPath,
+          programPath: join(
+            import.meta.dirname!,
+            `fixtures/reactive-vote-rows/${variant}.tsx`,
+          ),
+          apiUrl,
+          sessions: ["writer", { label: "reader", apiUrl: gate.url }],
+        });
+        const writer = harness.session("writer");
+        const reader = harness.session("reader");
+        const expected = (alice: boolean, bobColor: string) =>
+          variant === "nested"
+            ? [
+              {
+                id: "one",
+                colors: alice ? ["yellow"] : [],
+                names: alice ? ["Alice Offline"] : [],
+              },
+              { id: "two", colors: [bobColor], names: ["bob"] },
+            ]
+            : [
+              {
+                id: "one",
+                color: alice ? "yellow" : "",
+                names: alice ? "Alice Offline" : "",
+              },
+              { id: "two", color: bobColor, names: "bob" },
+            ].sort((a, b) =>
+              Number(Boolean(b.color)) - Number(Boolean(a.color))
+            );
+        await writer.send("cast", {
+          key: "alice",
+          optionId: "one",
+          color: "red",
+        });
+        await harness.settle();
+        const initial = await reader.read(["rows"]);
+        expect(initial).toEqual(
+          variant === "nested"
+            ? [
+              { id: "one", colors: ["red"], names: ["alice"] },
+              { id: "two", colors: [], names: [] },
+            ]
+            : [
+              { id: "one", color: "red", names: "alice" },
+              { id: "two", color: "", names: "" },
+            ],
+        );
+
+        await gate.pause();
+        await writer.send("cast", {
+          key: "alice",
+          optionId: "one",
+          color: "yellow",
+        });
+        await writer.send("rename", { key: "alice", name: "Alice Offline" });
+        await writer.send("cast", {
+          key: "bob",
+          optionId: "two",
+          color: "green",
+        });
+        gate.resume();
+        await harness.settle();
+        expect(await reader.read(["rows"])).toEqual(expected(true, "green"));
+
+        await gate.pause();
+        await writer.send("retract", { key: "alice" });
+        gate.resume();
+        await harness.settle();
+        expect(await reader.read(["rows"])).toEqual(expected(false, "green"));
+
+        await writer.send("cast", {
+          key: "bob",
+          optionId: "two",
+          color: "blue",
+        });
+        await harness.settle();
+        expect(await reader.read(["rows"])).toEqual(expected(false, "blue"));
+      } finally {
+        gate.resume();
+        try {
+          await harness?.dispose();
+        } finally {
+          await gate.close();
+        }
+      }
+    });
+  }
+});

--- a/packages/patterns/integration/storage-network-gate.test.ts
+++ b/packages/patterns/integration/storage-network-gate.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+
+import { StorageNetworkGate } from "./storage-network-gate.ts";
+
+describe("storage network gate", () => {
+  it("closes a connecting upstream when its reader disconnects", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const captured = Promise.withResolvers<WebSocket>();
+    const downstreamClosed = Promise.withResolvers<void>();
+    const NativeWebSocket = WebSocket;
+    const nativeUpgrade = Deno.upgradeWebSocket;
+    const server = Deno.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      onListen: () => {},
+    }, async () => {
+      entered.resolve();
+      await release.promise;
+      return new Response("Handshake held by test", { status: 503 });
+    });
+    const gate = new StorageNetworkGate(
+      new URL(`http://127.0.0.1:${server.addr.port}`),
+    );
+    globalThis.WebSocket = class extends NativeWebSocket {
+      constructor(...args: ConstructorParameters<typeof NativeWebSocket>) {
+        super(...args);
+        captured.resolve(this);
+      }
+    };
+    const upgrade = stub(Deno, "upgradeWebSocket", (request, options) => {
+      const result = nativeUpgrade(request, options);
+      result.socket.addEventListener(
+        "close",
+        () => downstreamClosed.resolve(),
+        {
+          once: true,
+        },
+      );
+      return result;
+    });
+    const url = gate.url;
+    url.protocol = "ws:";
+    const reader = new NativeWebSocket(url);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        reader.addEventListener("open", () => resolve(), { once: true });
+        reader.addEventListener(
+          "error",
+          () => reject(new Error("Reader failed")),
+          {
+            once: true,
+          },
+        );
+      });
+      await entered.promise;
+      const upstream = await captured.promise;
+      expect(upstream.readyState).toBe(WebSocket.CONNECTING);
+      const upstreamClosed = new Promise<void>((resolve) => {
+        upstream.addEventListener("close", () => resolve(), { once: true });
+      });
+      reader.close();
+      await downstreamClosed.promise;
+      expect([WebSocket.CLOSING, WebSocket.CLOSED]).toContain(
+        upstream.readyState,
+      );
+      await upstreamClosed;
+      expect(upstream.readyState).toBe(WebSocket.CLOSED);
+    } finally {
+      reader.close();
+      globalThis.WebSocket = NativeWebSocket;
+      upgrade.restore();
+      try {
+        await gate.close();
+      } finally {
+        release.resolve();
+        await server.shutdown();
+      }
+    }
+  });
+});

--- a/packages/patterns/integration/storage-network-gate.test.ts
+++ b/packages/patterns/integration/storage-network-gate.test.ts
@@ -5,6 +5,40 @@ import { stub } from "@std/testing/mock";
 import { StorageNetworkGate } from "./storage-network-gate.ts";
 
 describe("storage network gate", () => {
+  it("forwards HTTP requests with the target host and original body", async () => {
+    const server = Deno.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      onListen: () => {},
+    }, async (request) =>
+      Response.json({
+        host: request.headers.get("host"),
+        path: new URL(request.url).pathname,
+        query: new URL(request.url).search,
+        method: request.method,
+        body: await request.text(),
+      }));
+    const gate = new StorageNetworkGate(
+      new URL(`http://127.0.0.1:${server.addr.port}`),
+    );
+    try {
+      const response = await fetch(new URL("inspect?case=host", gate.url), {
+        method: "POST",
+        body: "relay payload",
+      });
+      expect(await response.json()).toEqual({
+        host: `127.0.0.1:${server.addr.port}`,
+        path: "/inspect",
+        query: "?case=host",
+        method: "POST",
+        body: "relay payload",
+      });
+    } finally {
+      await gate.close();
+      await server.shutdown();
+    }
+  });
+
   it("closes a connecting upstream when its reader disconnects", async () => {
     const entered = Promise.withResolvers<void>();
     const release = Promise.withResolvers<void>();

--- a/packages/patterns/integration/storage-network-gate.ts
+++ b/packages/patterns/integration/storage-network-gate.ts
@@ -63,7 +63,9 @@ export class StorageNetworkGate {
     const incoming = new URL(request.url);
     const target = new URL(incoming.pathname + incoming.search, this.#target);
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
-      return await fetch(new Request(target, request));
+      const forwarded = new Request(target, request);
+      forwarded.headers.delete("host");
+      return await fetch(forwarded);
     }
     target.protocol = target.protocol === "https:" ? "wss:" : "ws:";
     const upstream = new WebSocket(target);

--- a/packages/patterns/integration/storage-network-gate.ts
+++ b/packages/patterns/integration/storage-network-gate.ts
@@ -1,0 +1,98 @@
+/** Relays a test client's storage traffic and holds reconnections during an outage. */
+
+/** Owns a local relay whose paused requests wait for an explicit resume. */
+export class StorageNetworkGate {
+  #server: Deno.HttpServer<Deno.NetAddr>;
+  #target: URL;
+  #sockets = new Set<WebSocket>();
+  #gate: ReturnType<typeof Promise.withResolvers<void>> | undefined;
+  #closed = false;
+
+  /** Starts an ephemeral relay for the given storage server. */
+  constructor(target: URL) {
+    this.#target = target;
+    this.#server = Deno.serve(
+      { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+      (request) => this.#serve(request),
+    );
+  }
+
+  /** The relay address supplied to one independent reader. */
+  get url(): URL {
+    return new URL(`http://127.0.0.1:${this.#server.addr.port}`);
+  }
+
+  /** Closes current sockets and holds new requests until resume(). */
+  async pause(): Promise<void> {
+    if (this.#gate || this.#closed) throw new Error("Network gate is not open");
+    this.#gate = Promise.withResolvers<void>();
+    await Promise.all(
+      [...this.#sockets].map((socket) => this.#closeSocket(socket)),
+    );
+  }
+
+  /** Releases requests held by pause(). */
+  resume(): void {
+    const gate = this.#gate;
+    this.#gate = undefined;
+    gate?.resolve();
+  }
+
+  /** Releases pending requests and closes the relay and its sockets. */
+  async close(): Promise<void> {
+    this.#closed = true;
+    this.resume();
+    await Promise.all(
+      [...this.#sockets].map((socket) => this.#closeSocket(socket)),
+    );
+    await this.#server.shutdown();
+  }
+
+  async #closeSocket(socket: WebSocket): Promise<void> {
+    if (socket.readyState === WebSocket.CLOSED) return;
+    const closed = new Promise<void>((resolve) => {
+      socket.addEventListener("close", () => resolve(), { once: true });
+    });
+    socket.close();
+    await closed;
+  }
+
+  async #serve(request: Request): Promise<Response> {
+    if (this.#gate) await this.#gate.promise;
+    if (this.#closed) return new Response("Closed", { status: 503 });
+    const incoming = new URL(request.url);
+    const target = new URL(incoming.pathname + incoming.search, this.#target);
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return await fetch(new Request(target, request));
+    }
+    target.protocol = target.protocol === "https:" ? "wss:" : "ws:";
+    const upstream = new WebSocket(target);
+    const { socket, response } = Deno.upgradeWebSocket(request);
+    const opened = new Promise<void>((resolve, reject) => {
+      upstream.addEventListener("open", () => resolve(), { once: true });
+      upstream.addEventListener(
+        "error",
+        () => reject(new Error("Relay connection failed")),
+        { once: true },
+      );
+    });
+    for (const peer of [socket, upstream]) {
+      this.#sockets.add(peer);
+      peer.addEventListener("close", () => {
+        this.#sockets.delete(peer);
+        const other = peer === socket ? upstream : socket;
+        if (other.readyState === WebSocket.OPEN) other.close();
+      }, { once: true });
+    }
+    socket.addEventListener("message", (event) => {
+      void opened.then(() => {
+        if (upstream.readyState === WebSocket.OPEN) upstream.send(event.data);
+      }).catch(() => socket.close());
+    });
+    upstream.addEventListener("message", (event) => {
+      if (socket.readyState === WebSocket.OPEN) socket.send(event.data);
+    });
+    void opened.catch(() => socket.close());
+    return response;
+  }
+}

--- a/packages/patterns/integration/storage-network-gate.ts
+++ b/packages/patterns/integration/storage-network-gate.ts
@@ -81,7 +81,10 @@ export class StorageNetworkGate {
       peer.addEventListener("close", () => {
         this.#sockets.delete(peer);
         const other = peer === socket ? upstream : socket;
-        if (other.readyState === WebSocket.OPEN) other.close();
+        if (
+          other.readyState === WebSocket.CONNECTING ||
+          other.readyState === WebSocket.OPEN
+        ) other.close();
       }, { once: true });
     }
     socket.addEventListener("message", (event) => {


### PR DESCRIPTION
## Why

A reader reconnecting after an outage can have an open transport while its memory session is still being restored. A query issued in that interval carries the old session ID and fails with “Session is not open on this connection.” This surfaced during the reconnect acceptance work for #7155, following the remote-row coverage in #7302.

## What Changed

Ordinary session requests await restoration before constructing their payloads and recheck whether the session closed or was revoked while waiting. Internal session-restoration requests retain their existing path.

A synthetic storage relay closes only the reader's connections and holds reconnects while an independent writer changes votes and profiles. Nested and mapped row tests verify catch-up after two outages, removal, and a later update. These are headless result assertions; rendered browser reconnect and cross-space outage acceptance remain open in the tracker. A subsequent transport failure during request issue is outside this restoration boundary.

## Test plan

- Nine deterministic memory query cases cover restoration, closure, and revocation for graph queries, entity listing, and entity lookup. The original client fails the restoration regression.
- Full memory package: 619 tests / 612 steps pass.
- Both focused reader-outage integration cases pass; full patterns package including browser tests passes.
- All 46 type-check groups and 599 documentation blocks pass; repository formatting, lint, and integration waiting gate pass.
- Full downstream runner: 1,431 tests / 8,921 steps pass. Final PR CI is required before landing.
- Antagonistic cf-review found no blockers within the documented restoration boundary. Cubic review must be clean before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

