### PR TITLE
fix(local-dev): prove the console this launch started holds its port

### DIFF
--- a/packages/cf-harness/docs/WEAVER.md
+++ b/packages/cf-harness/docs/WEAVER.md
@@ -208,7 +208,9 @@ The daemon's proxy and the console read the same inputs in the same order —
 `--port` above all three — so **recording a port in `pieces.json` moves both.**
 That is what to do for a second instance on a machine that already has a
 console: the port is not derived from the offset, so two instances left at the
-default contend for one.
+default contend for one. A launch whose console port is held by something it did
+not start says so and names the pid holding it, because the console already
+there answers the health check the launch makes.
 
 The inherited variable is the one to check when the route reaches nothing. A
 daemon started from a shell that exported the console's own variable proxies

--- a/scripts/common/port-utils.sh
+++ b/scripts/common/port-utils.sh
@@ -37,6 +37,34 @@ get_pids_on_port() {
     } | grep -E '^[0-9]+$' || true
 }
 
+# Report the pid listening on a port when it belongs to no process in a given
+# pid's tree. A caller that started a server of its own reads this to tell its
+# child's bind from a survivor of an earlier launch holding the same port and
+# answering for it. Prints nothing when the listener is that pid or one of its
+# descendants, and nothing when there is no listener to name: get_pids_on_port
+# is how a holder is found, and a machine where it finds none has nothing to
+# say about whose server is there. The walk up from the listener stops below
+# init, which is every process's ancestor and so tells no two servers apart.
+# Usage: foreign_port_holder <port> <pid>
+foreign_port_holder() {
+    local port=$1
+    local owner=$2
+    local holder
+    local ancestor
+
+    for holder in $(get_pids_on_port "$port"); do
+        ancestor=$holder
+        while [[ -n "$ancestor" ]] && (( ancestor > 1 )); do
+            if (( ancestor == owner )); then
+                continue 2
+            fi
+            ancestor=$(ps -p "$ancestor" -o ppid= 2>/dev/null | tr -d ' ')
+        done
+        echo "$holder"
+        return
+    done
+}
+
 # Locate ports.json at repo root, requiring the jq used to read it
 # Usage: ports_json_path
 ports_json_path() {

--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -460,7 +460,17 @@ if [[ "$CF_HARNESS" == "true" ]]; then
             curl -s -o /dev/null -w "%{http_code}" --max-time 2 \
                 "http://127.0.0.1:$CONSOLE_PORT/api/health" 2>/dev/null
         )" == "200" ]]; then
-            echo "  cf-harness console is ready."
+            # A console left over from an earlier launch answers this health
+            # check too, out of its own code and its own store. What makes the
+            # 200 this launch's is the pid listening on the port being the
+            # child started above, or one of its descendants.
+            console_holder=$(foreign_port_holder "$CONSOLE_PORT" "$CONSOLE_PID")
+            if [[ -n "$console_holder" ]]; then
+                console_unavailable "port $CONSOLE_PORT is held by pid \
+$console_holder, not the console this launch started"
+            else
+                echo "  cf-harness console is ready."
+            fi
             break
         fi
         sleep 1

--- a/tasks/local-dev-scripts.test.ts
+++ b/tasks/local-dev-scripts.test.ts
@@ -58,6 +58,20 @@ async function runScript(
   }
 }
 
+/**
+ * Run a bash snippet with the local dev scripts' shared port utilities
+ * sourced, and return what it printed.
+ */
+async function runWithPortUtils(script: string): Promise<string> {
+  const { stdout } = await new Deno.Command("bash", {
+    args: ["-c", `source scripts/common/port-utils.sh\n${script}`],
+    cwd: repoRoot,
+    stdout: "piped",
+    stderr: "inherit",
+  }).output();
+  return new TextDecoder().decode(stdout).trim();
+}
+
 describe("local-dev-scripts", () => {
   describe("start-local-dev.sh", () => {
     it("names the server and the port an offset makes unreachable", async () => {
@@ -111,6 +125,56 @@ describe("local-dev-scripts", () => {
       expect(code).toBe(PORT_UNREACHABLE_EXIT);
       expect(stderr).toContain("inspector port 10080");
       expect(stdout).not.toContain("Stopping local dev servers");
+    });
+  });
+
+  describe("port-utils.sh", () => {
+    describe("foreign_port_holder()", () => {
+      // Each case listens on a port here, so the pid the utility has to find
+      // is one the test already knows: this process.
+
+      it("returns nothing for a port the given pid listens on", async () => {
+        const listener = Deno.listen({ port: 0 });
+        try {
+          expect(
+            await runWithPortUtils(
+              `foreign_port_holder ${listener.addr.port} ${Deno.pid}`,
+            ),
+          ).toBe("");
+        } finally {
+          listener.close();
+        }
+      });
+
+      it("returns nothing for a port a descendant of the given pid listens on", async () => {
+        // `Deno.ppid` is the process that spawned this one, so the
+        // listener below is a descendant of it rather than the pid itself.
+        const listener = Deno.listen({ port: 0 });
+        try {
+          expect(
+            await runWithPortUtils(
+              `foreign_port_holder ${listener.addr.port} ${Deno.ppid}`,
+            ),
+          ).toBe("");
+        } finally {
+          listener.close();
+        }
+      });
+
+      it("returns the listening pid for a port held outside the given pid's tree", async () => {
+        // `$$` is the bash the snippet runs in, a child of this process and so
+        // an ancestor of nothing that listens here.
+        const listener = Deno.listen({ port: 0 });
+        try {
+          expect(
+            await runWithPortUtils(
+              `foreign_port_holder ${listener.addr.port} $$`,
+            ),
+          ).toBe(String(Deno.pid));
+        } finally {
+          listener.close();
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
## The defect

`scripts/start-local-dev.sh --cf-harness` declared the console ready on a
`curl /api/health` 200 on the console port. A console surviving an earlier
launch answers that too, so the script printed ready whether or not its own
child bound the port. Observed on 2026-09-11: after a pin bump the old console
kept the port and served the old code against the old store while the new pair
served the new one, and every log line said ready.

## The fix

`foreign_port_holder <port> <pid>` in `scripts/common/port-utils.sh` prints the
pid listening on a port when it is neither the given pid nor one of its
descendants — the console runs as `deno task`, so the listener is normally a
descendant of `CONSOLE_PID` rather than that pid itself. The console step reads
it after the 200: a foreign holder fails the console step through the existing
`console_unavailable`, naming the pid, and the shell and toolshed are left
running exactly as they are for a console that exited.

The utility prints nothing when no listener can be identified at all, which is
what `get_pids_on_port` already returns on a machine with neither `lsof` nor
`ss`: with no holder to name there is nothing to set against the 200.

## Tests

Three cases in `tasks/local-dev-scripts.test.ts`, the script harness that was
already there. Each listens on an ephemeral port in the test process, so the
pid the utility has to find is one the test knows:

- the listener is the pid itself → nothing
- the listener is a descendant of the pid → nothing
- the listener is outside the pid's tree → that pid

Each was shown to fail: dropping the `continue 2` that recognizes the owner
fails the first two, and dropping the `echo "$holder"` fails the third. A
machine where `ps` cannot report a parent fails the descendant case alone,
which is the case that rests on the walk.

A shell-level run of the console step against the actual defect — an old
console answering 200 on the port while this launch's child holds nothing:

```
health 200 from port 8139 (old console pid 86727)
cf-harness console did not start: port 8139 is held by pid 86727, not the console this launch started
--- and with the child that does hold the port ---
  cf-harness console is ready.
```

`deno fmt --check` and `deno lint` on the changed TypeScript, `bash -n` on both
shell files, and the full `tasks/local-dev-scripts.test.ts` suite pass. The
repository has no shellcheck or shfmt gate.

## Documentation

`packages/cf-harness/docs/WEAVER.md` already tells a reader that two instances
left on the default console port contend for one; it now says what a launch
that loses the contention reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

