### PR TITLE
feat(cf-harness): the console records a pattern vote against the index

### DIFF
--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -196,6 +196,7 @@ one.
 | `GET`  | `/api/runs`                  | Run summaries                                                                           |
 | `GET`  | `/api/runs/<runId>/...`      | Run detail, flow, graph, artifacts, and tool outputs                                    |
 | `POST` | `/api/index/call`            | One allowlisted pattern-index read                                                      |
+| `POST` | `/api/index/feedback`        | Records one up or down vote on a pattern in the index                                   |
 | `GET`  | `/live/<sessionId>`          | The live pane for one session; takes `?turn=<turnId>` and `?piecesBase=<url-prefix>`    |
 
 Health returns `ok`, `fabricApiUrl`, and `fabricSession`. The last field is
@@ -710,6 +711,9 @@ events, and a pattern's source is read through the CLI.
 
 The route sits under `/api/`, so it is behind the same `Host` gate as the rest.
 
+Voting is the console's one write to the index, and it has a route of its own
+rather than a name in that allowlist: `POST /api/index/feedback`, below.
+
 Three panes:
 
 - **Patterns** — everything the index holds, by score. A row carries the pattern
@@ -728,6 +732,42 @@ Three panes:
   rather than what it answered once. Each hit reads `matched/asked` on its text
   terms: matching is disjunctive and ranked, so the ratio is what says how close
   a hit is.
+
+## Voting on a pattern
+
+`POST /api/index/feedback` records one vote on a published pattern. The body is
+a pattern id and a verdict and nothing else:
+
+```json
+{ "patternId": "ss-2w4nQ8", "verdict": "up" }
+```
+
+An `up` is recorded as a `thumbs_up` and a `down` as a `thumbs_down`, through
+the same verdict mapping the `record_feedback` tool records through, so a vote
+cast here and a vote cast by a run are the same event. The server signs it with
+its fabric identity, so the index attributes the vote to the operator's own
+principal — the one it answers `recordedBy` with:
+
+```json
+{
+  "patternId": "ss-2w4nQ8",
+  "eventType": "thumbs_up",
+  "recordedBy": "did:key:z…"
+}
+```
+
+The index ranks on these votes, so a pattern that keeps disappointing stops
+being offered first and one that keeps working is offered sooner. That is why
+this is a route and not a page control: whoever is working with a pattern votes
+on it from wherever they are working, and Weaver's command pill is the first
+such caller.
+
+The route answers 400 for a body naming no pattern or a verdict that is neither
+`up` nor `down`, 503 when this server was started without `--pattern-index-url`,
+and the index's own status when the index faulted the call. Nothing is recorded
+in any of those cases. Like the read route, it is under `/api/` and behind the
+same `Host` gate, and takes one bare request with no cookie and no preceding
+one.
 
 ## How the configuration reaches the run
 

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -106,6 +106,10 @@ import {
   PatternIndexError,
 } from "../src/pattern-index/client.ts";
 import {
+  feedbackEventType,
+  recordPatternFeedback,
+} from "../src/tools/record-feedback.ts";
+import {
   CFC_INVOCATION_CONTEXT_DIR_ENV,
   CFC_RESULT_DIR_ENV,
 } from "../src/sandbox/docker-runsc.ts";
@@ -237,10 +241,14 @@ const CONSOLE_CREDENTIAL_OWNER = {
 /**
  * The index functions the Index view may reach through the proxy. Every one of
  * them reads: this surface inspects what the index holds and never writes to
- * it, so a page that asked for `publishPattern` or `recordEvent` is refused by
- * name rather than by the index. `getPattern` is called without
+ * it, so a caller that asked for `publishPattern` or `recordEvent` is refused
+ * by name rather than by the index. `getPattern` is called without
  * `includeSource`, which is why a pattern's source cannot arrive at the page
  * whatever the page sends.
+ *
+ * The console's one write to the index is `/api/index/feedback`, which takes a
+ * pattern id and a verdict and composes the event itself. Widening this
+ * allowlist is not how a second write is added.
  */
 const INDEX_FUNCTIONS = [
   "searchPatterns",
@@ -250,6 +258,10 @@ const INDEX_FUNCTIONS = [
 ] as const;
 
 type IndexFunction = typeof INDEX_FUNCTIONS[number];
+
+/** What a server with no pattern index tells a caller who wanted one. */
+const NO_PATTERN_INDEX =
+  "this server was started without a pattern index; restart it with --pattern-index-url or CF_HARNESS_PATTERN_INDEX_URL";
 
 const isIndexFunction = (value: unknown): value is IndexFunction =>
   typeof value === "string" &&
@@ -1059,6 +1071,9 @@ export class ConsoleServer {
     if (request.method === "POST" && url.pathname === "/api/index/call") {
       return await this.#indexCall(request);
     }
+    if (request.method === "POST" && url.pathname === "/api/index/feedback") {
+      return await this.#indexFeedback(request);
+    }
     if (request.method === "POST" && url.pathname === "/api/cancel") {
       return await this.#cancel(request);
     }
@@ -1423,10 +1438,7 @@ export class ConsoleServer {
   async #indexCall(request: Request): Promise<Response> {
     const factory = this.#patternIndexClientFactory;
     if (factory === undefined) {
-      return Response.json({
-        error:
-          "this server was started without a pattern index; restart it with --pattern-index-url or CF_HARNESS_PATTERN_INDEX_URL",
-      }, { status: 404 });
+      return Response.json({ error: NO_PATTERN_INDEX }, { status: 404 });
     }
     let parsed: unknown;
     try {
@@ -1454,28 +1466,89 @@ export class ConsoleServer {
       const client = await factory();
       return Response.json(await callPatternIndex(client, envelope.fn, body));
     } catch (error) {
-      // The index's own status is passed through when it named a fault in the
-      // request — a pattern that is not there, an identity it will not take —
-      // and anything else reads as this server failing to reach it. The
-      // message alone: a `PatternIndexError`'s detail is the index's body,
-      // which is not what an operator page renders.
-      // Only the typed index error's stable message crosses to the page: a
-      // host-side failure — an unreadable identity keyfile among them — can
-      // name paths this machine's operator configured, which the browser has
-      // no business reading.
-      if (error instanceof PatternIndexError) {
-        const status = error.status >= 400 && error.status < 500
-          ? error.status
-          : 502;
-        return Response.json({ error: error.message }, { status });
-      }
-      // The generic answer promises the log carries the detail, so it must.
-      console.error("index proxy failed host-side:", error);
-      return Response.json(
-        { error: "the index request failed on this server; see its log" },
-        { status: 502 },
-      );
+      return this.#indexFailure(error, "index proxy");
     }
+  }
+
+  /**
+   * One vote on a pattern, recorded against the index under this server's
+   * fabric identity. The caller supplies a pattern id and a verdict and
+   * nothing else: the event is composed here, from the same verdict mapping
+   * the `record_feedback` tool records through, so the two surfaces cannot
+   * come to vote differently.
+   *
+   * Separate from `#indexCall` rather than another name in its allowlist.
+   * That route is reads, composed from what a caller asked for; this one is
+   * the console's only write to the index, and keeping it a route of its own
+   * is what leaves the allowlist meaning what it says.
+   */
+  async #indexFeedback(request: Request): Promise<Response> {
+    const factory = this.#patternIndexClientFactory;
+    if (factory === undefined) {
+      return Response.json({ error: NO_PATTERN_INDEX }, { status: 503 });
+    }
+    let parsed: unknown;
+    try {
+      parsed = await request.json();
+    } catch {
+      return Response.json({ error: "request body is not JSON" }, {
+        status: 400,
+      });
+    }
+    const { patternId, verdict } =
+      (typeof parsed === "object" && parsed !== null ? parsed : {}) as {
+        patternId?: unknown;
+        verdict?: unknown;
+      };
+    if (typeof patternId !== "string" || patternId === "") {
+      return Response.json({ error: "patternId is required" }, { status: 400 });
+    }
+    const eventType = feedbackEventType(verdict);
+    if (eventType === undefined) {
+      return Response.json({ error: 'verdict must be "up" or "down"' }, {
+        status: 400,
+      });
+    }
+    try {
+      const client = await factory();
+      const recorded = await recordPatternFeedback(client, {
+        patternId,
+        eventType,
+      });
+      return recorded.ok
+        ? Response.json({ patternId, eventType, recordedBy: client.did })
+        : Response.json({ error: recorded.message }, { status: 502 });
+    } catch (error) {
+      return this.#indexFailure(error, "index feedback");
+    }
+  }
+
+  /**
+   * Renders one failed index call for whoever asked. The index's own status is
+   * passed through when it named a fault in the request — a pattern that is
+   * not there, an identity it will not take — and anything else reads as this
+   * server failing to reach it.
+   *
+   * Only the typed index error's stable message crosses the wire. A
+   * `PatternIndexError`'s detail is the index's body, which is not what an
+   * operator page renders; and a host-side failure — an unreadable identity
+   * keyfile among them — can name paths this machine's operator configured,
+   * which the caller has no business reading. `where` says which route was
+   * being served, for the log alone.
+   */
+  #indexFailure(error: unknown, where: string): Response {
+    if (error instanceof PatternIndexError) {
+      const status = error.status >= 400 && error.status < 500
+        ? error.status
+        : 502;
+      return Response.json({ error: error.message }, { status });
+    }
+    // The generic answer promises the log carries the detail, so it must.
+    console.error(`${where} failed host-side:`, error);
+    return Response.json(
+      { error: "the index request failed on this server; see its log" },
+      { status: 502 },
+    );
   }
 
   /**

--- a/packages/cf-harness/src/pattern-index/client.ts
+++ b/packages/cf-harness/src/pattern-index/client.ts
@@ -301,6 +301,14 @@ export class PatternIndexClient {
   }
 
   /**
+   * The DID every call from this client is signed as, which is the principal
+   * the index attributes what this client did to.
+   */
+  get did(): string {
+    return this.#signer.did();
+  }
+
+  /**
    * Posts `payload` to one index function and returns its parsed answer.
    *
    * @throws PatternIndexError when the index answers non-2xx, or when a 2xx

--- a/packages/cf-harness/src/tools/record-feedback.ts
+++ b/packages/cf-harness/src/tools/record-feedback.ts
@@ -3,6 +3,7 @@ import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type {
   PatternIndexClient,
   PatternIndexEventType,
+  PatternIndexRecordEventRequest,
 } from "../pattern-index/client.ts";
 import type { HarnessToolDefinition } from "./types.ts";
 
@@ -97,6 +98,52 @@ const FEEDBACK_EVENT_TYPES: Record<
   down: "thumbs_down",
 };
 
+/**
+ * The index event a verdict records as, or `undefined` for a value naming no
+ * verdict. A verdict is the whole of what feedback records, so one the index
+ * has no event for is refused rather than guessed at — and every surface that
+ * takes a verdict asks this rather than listing the words again.
+ */
+export const feedbackEventType = (
+  verdict: unknown,
+): PatternIndexEventType | undefined =>
+  // `hasOwn` first: a plain object literal inherits `constructor` and the
+  // rest of `Object.prototype`, so an unchecked lookup answers a function for
+  // words that are not verdicts.
+  typeof verdict === "string" && Object.hasOwn(FEEDBACK_EVENT_TYPES, verdict)
+    ? FEEDBACK_EVENT_TYPES[verdict as RecordFeedbackVerdict]
+    : undefined;
+
+/** What an index that answered made of the event it was sent. */
+export type RecordPatternFeedbackResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly message: string };
+
+/**
+ * Records one verdict against the pattern index and says what became of it.
+ *
+ * Awaited, unlike the usage events a run reports on its own: recording is
+ * what the caller called for, so whether it landed is the result — including
+ * a 2xx answer that says the event was not taken, which is the `ok: false`
+ * case here.
+ *
+ * @throws PatternIndexError when the index faulted the call, and whatever the
+ * transport raised when it could not be reached at all. Those are failures of
+ * the call rather than answers to it, and each caller phrases its own message
+ * from the type, so they are not flattened to a string here.
+ */
+export const recordPatternFeedback = async (
+  client: PatternIndexClient,
+  request: PatternIndexRecordEventRequest,
+): Promise<RecordPatternFeedbackResult> => {
+  const answer = await client.recordEvent(request);
+  return answer.ok === true ? { ok: true } : {
+    ok: false,
+    message:
+      `the pattern index answered but did not record the ${request.eventType} event`,
+  };
+};
+
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
@@ -117,9 +164,7 @@ export const recordFeedbackTool: HarnessToolDefinition<
         "record_feedback requires a pattern index; configure --pattern-index-url",
       );
     }
-    // A verdict is the whole of what this tool records, so one the index has
-    // no event for is refused rather than guessed at.
-    const eventType = FEEDBACK_EVENT_TYPES[input.verdict];
+    const eventType = feedbackEventType(input.verdict);
     if (eventType === undefined) {
       return errorOutput('record_feedback verdict must be "up" or "down"');
     }
@@ -133,18 +178,13 @@ export const recordFeedbackTool: HarnessToolDefinition<
       return errorOutput(`pattern index unavailable: ${errorMessage(error)}`);
     }
     try {
-      // Awaited, unlike the usage events a run reports on its own: this one
-      // is what the tool was called to do, so whether it landed is the
-      // result — including a 2xx answer that says the event was not taken.
-      const answer = await client.recordEvent({
+      const recorded = await recordPatternFeedback(client, {
         patternId: input.patternId,
         eventType,
         ...(input.note !== undefined ? { note: input.note } : {}),
       });
-      if (answer.ok !== true) {
-        return errorOutput(
-          `the pattern index answered but did not record the ${eventType} event`,
-        );
+      if (!recorded.ok) {
+        return errorOutput(recorded.message);
       }
     } catch (error) {
       return errorOutput(errorMessage(error));

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -1698,6 +1698,127 @@ describe("console/server", () => {
     });
   });
 
+  describe("POST /api/index/feedback", () => {
+    /** Posts one verdict at a server that has an index. */
+    const vote = async (
+      indexed: { server: ConsoleServer },
+      body: unknown,
+    ): Promise<Response> =>
+      await indexed.server.handle(
+        jsonRequest("/api/index/feedback", body),
+      );
+
+    it("records an up verdict as a thumbs_up under the server's own identity", async () => {
+      const indexed = await indexServer([Response.json({ ok: true })]);
+
+      const response = await vote(indexed, {
+        patternId: "ss-2w4nQ8",
+        verdict: "up",
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        patternId: "ss-2w4nQ8",
+        eventType: "thumbs_up",
+        recordedBy: signer.did(),
+      });
+      expect(indexed.requests[0].url).toBe(
+        "https://index.test/api/recordEvent",
+      );
+      expect(JSON.parse(indexed.requests[0].body)).toEqual({
+        patternId: "ss-2w4nQ8",
+        eventType: "thumbs_up",
+      });
+    });
+
+    it("records a down verdict as a thumbs_down", async () => {
+      const indexed = await indexServer([Response.json({ ok: true })]);
+
+      const response = await vote(indexed, {
+        patternId: "ss-2w4nQ8",
+        verdict: "down",
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).eventType).toBe("thumbs_down");
+      expect(JSON.parse(indexed.requests[0].body)).toEqual({
+        patternId: "ss-2w4nQ8",
+        eventType: "thumbs_down",
+      });
+    });
+
+    it("answers 400 for a verdict the index has no event for", async () => {
+      const indexed = await indexServer([]);
+
+      // `constructor` is the one that passes an unguarded lookup on the
+      // verdict map, so it stands beside the ordinary misspellings.
+      for (const verdict of ["sideways", "thumbs_up", "constructor", "", 1]) {
+        const response = await vote(indexed, {
+          patternId: "ss-2w4nQ8",
+          verdict,
+        });
+        expect(response.status).toBe(400);
+        expect((await response.json()).error).toBe(
+          'verdict must be "up" or "down"',
+        );
+      }
+      expect(indexed.requests).toEqual([]);
+    });
+
+    it("answers 400 for a body that names no pattern", async () => {
+      const indexed = await indexServer([]);
+
+      for (const patternId of [undefined, "", 7]) {
+        const response = await vote(indexed, { patternId, verdict: "up" });
+        expect(response.status).toBe(400);
+        expect((await response.json()).error).toBe("patternId is required");
+      }
+      expect(indexed.requests).toEqual([]);
+    });
+
+    it("answers 503 when the server was started without an index", async () => {
+      const response = await server.handle(
+        jsonRequest("/api/index/feedback", {
+          patternId: "ss-2w4nQ8",
+          verdict: "up",
+        }),
+      );
+
+      expect(response.status).toBe(503);
+      expect((await response.json()).error).toContain(
+        "started without a pattern index",
+      );
+    });
+
+    it("answers 502 when the index took the request and did not record it", async () => {
+      const indexed = await indexServer([Response.json({ ok: false })]);
+
+      const response = await vote(indexed, {
+        patternId: "ss-2w4nQ8",
+        verdict: "up",
+      });
+
+      expect(response.status).toBe(502);
+      expect((await response.json()).error).toContain("thumbs_up");
+    });
+
+    it("passes through the status the index gave a request it faulted", async () => {
+      const indexed = await indexServer([
+        Response.json({ error: "unknown pattern" }, { status: 404 }),
+      ]);
+
+      const response = await vote(indexed, {
+        patternId: "missing",
+        verdict: "up",
+      });
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).error).toBe(
+        "pattern index recordEvent failed (404)",
+      );
+    });
+  });
+
   describe("the served page", () => {
     it("confines the page to this origin with a content security policy", async () => {
       const response = await server.handle(getRequest("/"));

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -1776,6 +1776,32 @@ describe("console/server", () => {
       expect(indexed.requests).toEqual([]);
     });
 
+    it("answers 400 for a body that is not JSON", async () => {
+      const indexed = await indexServer([]);
+
+      const response = await indexed.server.handle(
+        new Request("http://127.0.0.1:8100/api/index/feedback", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "not json",
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe("request body is not JSON");
+      expect(indexed.requests).toEqual([]);
+    });
+
+    it("answers 400 for a JSON body that is not an object", async () => {
+      const indexed = await indexServer([]);
+
+      const response = await vote(indexed, "ss-2w4nQ8");
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe("patternId is required");
+      expect(indexed.requests).toEqual([]);
+    });
+
     it("answers 503 when the server was started without an index", async () => {
       const response = await server.handle(
         jsonRequest("/api/index/feedback", {

--- a/packages/cf-harness/test/record-feedback.test.ts
+++ b/packages/cf-harness/test/record-feedback.test.ts
@@ -58,8 +58,15 @@ interface IndexStub {
   calls: { fn: string; body: Record<string, unknown> }[];
 }
 
-/** An index answering every call with `status`, recording what it was sent. */
-const stubIndex = (status = 200): IndexStub => {
+/**
+ * An index answering every call with `status`, recording what it was sent.
+ * `body` replaces the answer, for the case a 2xx carries a refusal rather than
+ * a confirmation.
+ */
+const stubIndex = (
+  status = 200,
+  body?: Record<string, unknown>,
+): IndexStub => {
   const calls: { fn: string; body: Record<string, unknown> }[] = [];
   const fetchFn: HarnessFetch = (input, init) => {
     const fn = String(input).split("/").pop() ?? "";
@@ -70,7 +77,8 @@ const stubIndex = (status = 200): IndexStub => {
     return Promise.resolve(
       new Response(
         JSON.stringify(
-          status === 200 ? { ok: true } : { error: "no such pattern" },
+          body ??
+            (status === 200 ? { ok: true } : { error: "no such pattern" }),
         ),
         { status },
       ),
@@ -164,6 +172,17 @@ describe("record-feedback", () => {
     const output = result.output as RecordFeedbackToolErrorOutput;
     expect(output.status).toBe("error");
     expect(output.message).toContain("404");
+  });
+
+  it("reports an index that answered without recording the event", async () => {
+    const index = stubIndex(200, { ok: false });
+    const result = await createEngine(index).invokeBuiltinTool(
+      "record_feedback",
+      { patternId: "pat-expenses", verdict: "up" },
+    );
+    const output = result.output as RecordFeedbackToolErrorOutput;
+    expect(output.status).toBe("error");
+    expect(output.message).toContain("did not record the thumbs_up event");
   });
 
   it("refuses a verdict the index has no event for", async () => {


### PR DESCRIPTION
Anyone working with a pattern can vote on it without a page. The console takes
`POST /api/index/feedback` with a pattern id and a verdict and records it
against the pattern index, signed with its own fabric identity. The index ranks
on these votes, so a pattern that keeps disappointing stops being offered first.
The caller this is for is Weaver's command pill, which has an id and a verdict
and no console page.

## The contract

```
POST /api/index/feedback
{ "patternId": "ss-2w4nQ8", "verdict": "up" | "down" }

200 { "patternId": "ss-2w4nQ8", "eventType": "thumbs_up", "recordedBy": "did:key:z…" }
400 a body naming no pattern, or a verdict that is neither `up` nor `down`
503 this server was started without a pattern index
502 the index was reached and did not take the event, or could not be reached
```

One bare request, no cookie and no preceding one, behind the same `Host` gate as
every other console route.

## What moved, and why

`feedbackEventType` and `recordPatternFeedback` move out of
`src/tools/record-feedback.ts` and both surfaces go through them, so a vote cast
from the pill and a vote cast by a run are the same event. The tool keeps its
own wording for its own refusals; what is shared is the mapping and the rule
that a 2xx answer saying the event was not taken is a failure.

The map lookup is now guarded with `Object.hasOwn`. A plain object literal
answers a function for `constructor` and the rest of `Object.prototype`, and
this input arrives off the wire — `{"verdict":"constructor"}` is in the tests.

It is a route of its own rather than a fifth name in `INDEX_FUNCTIONS`. That
allowlist's whole claim is that the proxy never writes to the index; a write
added there would leave it saying something false.

`PatternIndexClient` exposes the DID it signs as, which is what `recordedBy`
answers. Both index routes now render a failure through one `#indexFailure`, so
the rule that only a typed index error's message crosses the wire — a host-side
failure can name the operator's own configured paths — holds for both by
construction rather than by two copies agreeing.

`console/README.md` gains the route in its table, a section on it, and a
correction to the Index-view paragraph that said the console never writes to the
index.

## Proof

Gates, by exit code, on the pinned Deno 2.9.4: `deno fmt --check`, `deno lint`,
`deno task check`, `check-docs`, `check-command-docs`, `check-conflict-markers`,
`check-skill-facts`, `check-package-cycles`, `check-control-characters` — all 0.

`packages/cf-harness` `deno task test`: 1007 passed, 23 failed — the 23 are an
identical set to a clean `origin/main` worktree run of the same two files
(`test/cli.test.ts`, `test/prompt-loop.test.ts`), diffed name-for-name. This
change adds none.

Seven new tests in `test/console/server.test.ts`. Both required mutations fail
them: dropping the `hasOwn` guard fails the verdict test, and answering 404
instead of 503 fails the no-index test.

Live, over real HTTP, against a console built from this branch with an index
configured at an unresolvable host, so nothing could be recorded:

```
400 {"error":"verdict must be \"up\" or \"down\""}      verdict=sideways
400 {"error":"verdict must be \"up\" or \"down\""}      verdict=constructor
400 {"error":"patternId is required"}                   no patternId / empty patternId
400 {"error":"request body is not JSON"}                body=not json
502 {"error":"the index request failed on this server; see its log"}   valid verdict, index unreachable — detail in the log, not the answer
503 {"error":"this server was started without a pattern index; …"}     console started with no --pattern-index-url
```

Those probes recorded nothing. The console on `127.0.0.1:8135` was probed
read-only: `/api/health` 200, and `/api/index/feedback` 404, since it runs the
build without this change. A real vote was recorded later, deliberately — see
**Live proof on Ben's stack** below.

## Live proof on Ben's stack

Ben started a console from this branch in his own terminal at 16:22 local, on a
spare port against the real pair — his enrolled identity, the loom instance's
toolshed on `localhost:8001`, and the deployed pattern index. The console of
record on 8135 was not touched.

```
deno run -A packages/cf-harness/console/launch.ts --port 8146 \
  --fabric-api-url http://localhost:8001 --instance loom \
  --console-dir ~/.bb/thread-storage/thr_qehir9qcip-probe
```

**A verdict the index has no event for is refused, and nothing is sent.**

```
POST /api/index/feedback  {"patternId":"...","verdict":"sideways"}
400 {"error":"verdict must be \"up\" or \"down\""}
```

**A real thumbs up, on Ben's own `ledger-month-transactions` atom.**

```
POST /api/index/feedback
{"patternId":"ss-2w4nQ8sd648sX-wyShStxRYHekQkGIaFXYPBMKXc","verdict":"up"}

200 {"patternId":"ss-2w4nQ8sd648sX-wyShStxRYHekQkGIaFXYPBMKXc",
     "eventType":"thumbs_up",
     "recordedBy":"did:key:z6MkmPfWUUyFMehEAjTpYaR1U7MBaNuHnyB3y83DgTkPXJGq"}
```

**Read back from the deployed index**, with the pattern-index repository's own
`scripts/signed-curl.ts` signing as Ben's DID — a different client from the one
that wrote it, so the read is not the write repeating itself. Newest event:

```
listEvents -> thumbs_up
             did:key:z6MkmPfWUUyFMehEAjTpYaR1U7MBaNuHnyB3y83DgTkPXJGq
             2026-09-11T06:22:49.443Z
```

The DID the route answered `recordedBy` with is the DID the index recorded the
event under. That is the whole claim of the endpoint, end to end.

Ben ran the console and the three exchanges above; the probes were driven from
the supervising thread. This agent's own attempts to start a console against the
real stack were refused by its permission gate, which is why the proof is in
Ben's hands rather than in a transcript here.

The pill verb that calls this is a separate change in the Weaver repository.
`docs/WEAVER.md` opens by naming the pill's two verbs; that sentence is the
pill side's to update when the verb lands, and is deliberately untouched here.
