### PR TITLE
test: verify rendered rows after browser storage outages

### DIFF
--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -131,6 +131,44 @@ a focused browser regression with a plain Deno unit test for any extracted
 policy or state machine, because code executed inside Chrome does not enter
 Deno's V8 coverage profile.
 
+### Browser row reconnect acceptance
+
+The row browser test can place real reader storage outages around remote color,
+profile, and removal writes. Its normal CI run covers connected readers. The
+reconnect mode requires a local relay and a shell compiled against that relay;
+the independent writer continues to use the toolshed directly.
+
+Start local toolshed and shell servers using
+[the local server procedure](LOCAL_DEV_SERVERS.md). For a toolshed on port 8089,
+run this relay in a separate terminal from the repository root:
+
+```bash
+deno run -A packages/patterns/integration/storage-network-gate-server.ts http://127.0.0.1:8089 58848 58849
+```
+
+The relay accepts a loopback API URL, a relay port, and a control port. It binds
+both listeners to loopback. Dedicate the relay to this run; its socket count
+includes every connected reader. Use free ports and substitute them consistently.
+Start a separate shell against the relay in another terminal:
+
+```bash
+TOOLSHED_PORT=58848 SHELL_PORT=5263 EXPERIMENTAL_SERVER_EXECUTION=false deno task --cwd packages/shell dev-local
+```
+
+After the shell reports that it is listening, run the browser test:
+
+```bash
+API_URL=http://127.0.0.1:8089 FRONTEND_URL=http://127.0.0.1:5263/ EXPERIMENTAL_SERVER_EXECUTION=false CF_ROW_RECONNECT_CONTROL_URL=http://127.0.0.1:58849/ CF_ROW_REPRO_ARTIFACT_DIR=/tmp/row-reconnect deno test -A packages/patterns/integration/reactive-vote-rows-browser.test.ts
+```
+
+Each outage asserts that the relay closed live socket endpoints before the
+writer changes data. Requests remain held until the test resumes the relay.
+The four cases cover nested and mapped rows with same-space and cross-space
+profiles, and assert rendered content after reconnect and after later updates.
+Captures include a `reconnect` field in their metadata. These are synthetic
+spaces; testing a live poll requires separate coordination. Stop the relay and
+the extra shell after testing.
+
 ### Running a test under a server-execution posture
 
 `serverExecution`'s first-party default is the constant

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -138,9 +138,16 @@ profile, and removal writes. Its normal CI run covers connected readers. The
 reconnect mode requires a local relay and a shell compiled against that relay;
 the independent writer continues to use the toolshed directly.
 
-Start local toolshed and shell servers using
-[the local server procedure](LOCAL_DEV_SERVERS.md). For a toolshed on port 8089,
-run this relay in a separate terminal from the repository root:
+Start the local servers with offset 89, following
+[the local server procedure](LOCAL_DEV_SERVERS.md):
+
+```bash
+EXPERIMENTAL_SERVER_EXECUTION=false ./scripts/start-local-dev.sh --port-offset 89
+```
+
+This starts toolshed on port 8089 and the ordinary shell on port 5262. The test
+uses the separate relay-connected shell on port 5263 started below. Run this
+relay in another terminal from the repository root:
 
 ```bash
 deno run -A packages/patterns/integration/storage-network-gate-server.ts http://127.0.0.1:8089 58848 58849

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -5,12 +5,12 @@ The controlled A0 fixture, accounting regressions, and dashboard shipped in
 #7241, with browser and remote-row demonstrations added in #7264. A3 budgets
 landed in #7257 after full validation, all 69 CI gates, and clean Cubic and
 antagonistic reviews. A4's browser benchmark shipped in #7261; count limits
-landed in #7282. C1's remote-row
-reproductions and C3's inline-element dependency repair landed in #7265;
-removal/restoration acceptance landed in #7285 and first-browser-materialization
-acceptance landed in #7302, both with local demonstrations. Reconnect and
-remaining row-invalidation acceptance stay open. B1/B2's contract landed in
-#7294; the typed lookup foundation landed in #7304. Producer lowering,
+landed in #7282. C1's remote-row reproductions and C3's inline-element dependency
+repair landed in #7265; removal/restoration acceptance landed in #7285 and
+first-browser-materialization acceptance landed in #7302. Reconnect repair
+landed in #7308; rendered acceptance is validated in #7312, pending merge gates.
+Remaining row-invalidation acceptance stays open. B1/B2's contract landed in
+#7294 and its typed lookup foundation landed in #7304. Producer lowering,
 bucket maintenance, and joins remain pending.
 
 B3's named aggregates are implemented and validated in
@@ -386,8 +386,8 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 
 ## Next task
 
-A3/A4 and the typed lookup foundation are landed. Verify C1's rendered rows after
-reconnect, and complete C1/C3's remaining acceptance checks while retaining the
+Complete merge review for C1's rendered reconnect acceptance in #7312. Complete
+C3's remaining acceptance checks while retaining the
 production workaround. The first-materialization cases in
 [PR #7302](https://github.com/commontoolsinc/labs/pull/7302) pass all four
 nested/mapped and same/cross-space browser combinations.

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -203,7 +203,7 @@ passed before merge, with clean Cubic and antagonistic reviews.
 
 ## 5, 10. Repair incremental correctness: C1–C4
 
-- [ ] **C1 — Reproduce both documented failures.**
+- [x] **C1 — Reproduce both documented failures.**
   - [x] Add a multi-replica nested-filter case whose reader has not locally
         materialized every vote.
   - [x] Add a remote element-update case asserting rendered per-row content.
@@ -213,7 +213,7 @@ passed before merge, with clean Cubic and antagonistic reviews.
         before deciding what C2/C3 need to change.
   - [x] Exercise two reader transport outages with nested and mapped rows;
         verify catch-up and subsequent updates through headless result reads.
-  - [ ] Verify rendered rows after reconnect.
+  - [x] Verify rendered rows after reconnect.
 
   The
   [independent-replica probes](../../packages/patterns/integration/reactive-vote-rows.test.ts)
@@ -227,7 +227,11 @@ passed before merge, with clean Cubic and antagonistic reviews.
   changed remotely, then observes further edits while subscribed. Cross-space
   profiles are created in a separate transaction and edited directly in their
   own space. Headless result reads explicitly pull data, so browser rendering
-  owns the passive-update check. C1 remains open for reconnect verification.
+  owns the passive-update check. The optional browser reconnect mode closes
+  live reader sockets around color, profile, and removal writes; all four
+  nested/mapped and same/cross-space cases pass. The
+  [repeatable relay procedure](../development/TESTING.md#browser-row-reconnect-acceptance)
+  keeps the writer connected and asserts that each outage closes live sockets.
   The [reconnect probe](../../packages/patterns/integration/reactive-vote-rows-reconnect.test.ts)
   closes the reader's storage sockets while the writer changes membership and
   profiles. Ordinary memory queries wait for session restoration before

--- a/packages/patterns/integration/reactive-vote-rows-browser.test.ts
+++ b/packages/patterns/integration/reactive-vote-rows-browser.test.ts
@@ -12,6 +12,21 @@ import { initializePiecesController } from "./pieces-controller.ts";
 import { settleView, waitForSettledText } from "./cfc-browser-helpers.ts";
 import { waitForPieceView } from "./topics-navigation-helpers.ts";
 
+const networkControlUrl = Deno.env.get("CF_ROW_RECONNECT_CONTROL_URL");
+
+/** Controls the local relay used by the optional browser reconnect run. */
+async function controlNetwork(action: "pause" | "resume"): Promise<void> {
+  if (!networkControlUrl) return;
+  const response = await fetch(new URL(action, networkControlUrl), {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(`Network relay ${action}: ${response.status}`);
+  }
+  const result = await response.json();
+  if (action === "pause") expect(result.closedSockets).toBeGreaterThan(0);
+}
+
 const root = join(import.meta.dirname!, "..");
 const fixtureRoot = join(import.meta.dirname!, "fixtures/reactive-vote-rows");
 
@@ -162,6 +177,7 @@ describe("rendered vote rows across replicas", () => {
           await page.screenshot(join(artifactDir, `${artifactName}-cold.png`));
         }
         for (const color of ["green", "yellow"]) {
+          await controlNetwork("pause");
           const sent = await cc.runtime.editWithRetry((tx) =>
             output.key("cast").withTx(tx).send({
               key: "alice",
@@ -172,6 +188,7 @@ describe("rendered vote rows across replicas", () => {
           if (sent.error) throw new Error(sent.error.message);
           await cc.runtime.settled(Infinity);
           await cc.synced();
+          await controlNetwork("resume");
           await waitForSettledText(
             page,
             variant === "mapped"
@@ -199,6 +216,7 @@ describe("rendered vote rows across replicas", () => {
             expect(swatches).toEqual([color]);
           }
         }
+        await controlNetwork("pause");
         const renamed = await cc.runtime.editWithRetry((tx) => {
           if (externalProfiles) {
             externalProfiles.withTx(tx).elementById("alice").key("name")
@@ -213,6 +231,7 @@ describe("rendered vote rows across replicas", () => {
         if (renamed.error) throw new Error(renamed.error.message);
         await cc.runtime.settled(Infinity);
         await cc.synced();
+        await controlNetwork("resume");
         await waitForSettledText(
           page,
           '[data-row="one"][title="Alice Updated"]',
@@ -261,6 +280,7 @@ describe("rendered vote rows across replicas", () => {
               {
                 variant,
                 profileLocation,
+                reconnect: Boolean(networkControlUrl),
                 url: `${env.FRONTEND_URL}${spaceName}/${piece.id}`,
                 assertions: [
                   "linked values and profiles before first browser materialization",
@@ -278,12 +298,14 @@ describe("rendered vote rows across replicas", () => {
           );
         }
         for (const key of ["bob", "carol"]) {
+          await controlNetwork("pause");
           const removed = await cc.runtime.editWithRetry((tx) =>
             output.key("retract").withTx(tx).send({ key })
           );
           if (removed.error) throw new Error(removed.error.message);
           await cc.runtime.settled(Infinity);
           await cc.synced();
+          await controlNetwork("resume");
           await waitForSettledText(
             page,
             `[data-row="two"][title="${key === "bob" ? "carol" : ""}"]`,
@@ -335,9 +357,13 @@ describe("rendered vote rows across replicas", () => {
         expect(errors).toEqual([]);
       } finally {
         try {
-          await browser?.close();
+          await controlNetwork("resume");
         } finally {
-          await cc.dispose();
+          try {
+            await browser?.close();
+          } finally {
+            await cc.dispose();
+          }
         }
       }
     });

--- a/packages/patterns/integration/storage-network-gate-server.ts
+++ b/packages/patterns/integration/storage-network-gate-server.ts
@@ -6,7 +6,7 @@ if (import.meta.main) {
   const [target, relayPort, controlPort] = Deno.args;
   const ports = [relayPort, controlPort].map(Number);
   if (
-    !target || Deno.args.length !== 3 ||
+    !target || Deno.args.length !== 3 || ports[0] === ports[1] ||
     ports.some((port) => !Number.isInteger(port) || port < 1 || port > 65535)
   ) {
     throw new Error(

--- a/packages/patterns/integration/storage-network-gate-server.ts
+++ b/packages/patterns/integration/storage-network-gate-server.ts
@@ -1,0 +1,58 @@
+/** Runs a local storage relay with an explicit browser-test outage control port. */
+
+import { StorageNetworkGate } from "./storage-network-gate.ts";
+
+if (import.meta.main) {
+  const [target, relayPort, controlPort] = Deno.args;
+  const ports = [relayPort, controlPort].map(Number);
+  if (
+    !target || Deno.args.length !== 3 ||
+    ports.some((port) => !Number.isInteger(port) || port < 1 || port > 65535)
+  ) {
+    throw new Error(
+      "Usage: storage-network-gate-server.ts <local-api-url> <relay-port> <control-port>",
+    );
+  }
+  const apiUrl = new URL(target);
+  if (!["127.0.0.1", "localhost", "[::1]"].includes(apiUrl.hostname)) {
+    throw new Error("The browser outage relay requires a loopback test server");
+  }
+  const gate = new StorageNetworkGate(apiUrl, ports[0]);
+  const shutdown = new AbortController();
+  const stop = () => shutdown.abort();
+  Deno.addSignalListener("SIGINT", stop);
+  Deno.addSignalListener("SIGTERM", stop);
+  try {
+    const server = Deno.serve({
+      hostname: "127.0.0.1",
+      port: ports[1],
+      signal: shutdown.signal,
+      onListen: () =>
+        console.log(JSON.stringify({
+          apiUrl: apiUrl.href,
+          relayUrl: gate.url.href,
+          controlUrl: `http://127.0.0.1:${ports[1]}/`,
+        })),
+    }, async (request) => {
+      if (request.method !== "POST") {
+        return new Response("POST required", { status: 405 });
+      }
+      const action = new URL(request.url).pathname;
+      if (action === "/pause") {
+        const closedSockets = gate.socketCount;
+        await gate.pause();
+        return Response.json({ closedSockets });
+      }
+      if (action === "/resume") {
+        gate.resume();
+        return Response.json({ resumed: true });
+      }
+      return new Response("Unknown relay action", { status: 404 });
+    });
+    await server.finished;
+  } finally {
+    Deno.removeSignalListener("SIGINT", stop);
+    Deno.removeSignalListener("SIGTERM", stop);
+    await gate.close();
+  }
+}

--- a/packages/patterns/integration/storage-network-gate-server.ts
+++ b/packages/patterns/integration/storage-network-gate-server.ts
@@ -6,7 +6,8 @@ if (import.meta.main) {
   const [target, relayPort, controlPort] = Deno.args;
   const ports = [relayPort, controlPort].map(Number);
   if (
-    !target || Deno.args.length !== 3 || ports[0] === ports[1] ||
+    !target || !URL.canParse(target) || Deno.args.length !== 3 ||
+    ports[0] === ports[1] ||
     ports.some((port) => !Number.isInteger(port) || port < 1 || port > 65535)
   ) {
     throw new Error(
@@ -14,8 +15,13 @@ if (import.meta.main) {
     );
   }
   const apiUrl = new URL(target);
-  if (!["127.0.0.1", "localhost", "[::1]"].includes(apiUrl.hostname)) {
-    throw new Error("The browser outage relay requires a loopback test server");
+  if (
+    !["http:", "https:"].includes(apiUrl.protocol) ||
+    !["127.0.0.1", "localhost", "[::1]"].includes(apiUrl.hostname)
+  ) {
+    throw new Error(
+      "The browser outage relay requires a loopback HTTP(S) test server",
+    );
   }
   const gate = new StorageNetworkGate(apiUrl, ports[0]);
   const shutdown = new AbortController();

--- a/packages/patterns/integration/storage-network-gate.ts
+++ b/packages/patterns/integration/storage-network-gate.ts
@@ -9,10 +9,10 @@ export class StorageNetworkGate {
   #closed = false;
 
   /** Starts an ephemeral relay for the given storage server. */
-  constructor(target: URL) {
+  constructor(target: URL, port = 0) {
     this.#target = target;
     this.#server = Deno.serve(
-      { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+      { hostname: "127.0.0.1", port, onListen: () => {} },
       (request) => this.#serve(request),
     );
   }
@@ -20,6 +20,11 @@ export class StorageNetworkGate {
   /** The relay address supplied to one independent reader. */
   get url(): URL {
     return new URL(`http://127.0.0.1:${this.#server.addr.port}`);
+  }
+
+  /** Number of live relay socket endpoints, including both sides. */
+  get socketCount(): number {
+    return this.#sockets.size;
   }
 
   /** Closes current sockets and holds new requests until resume(). */


### PR DESCRIPTION
## Why

The reconnect fix in #7308 is covered by headless result reads. #7155 also requires evidence that rendered rows recover after storage outages, including profiles stored in another space. A browser test must prove that it interrupted an actual reader connection before its catch-up assertions can establish that behavior.

## What Changed

The row browser test has an opt-in reconnect mode backed by a loopback-only storage relay. Each outage asserts that live socket endpoints were closed, keeps the independent writer connected, and resumes the reader after color, profile, or removal writes. The existing rendered assertions then check catch-up and subsequent updates across nested/mapped rows and same/cross-space profiles.

The testing guide documents the relay, the shell compiled against it, and the test command. A dedicated relay is required: endpoint counts cover all clients using it. Normal CI runs retain connected-reader coverage; the relay mode is run explicitly. No live poll is accessed.

## Test plan

- Four browser reconnect cases pass on the final relay repair, with positive socket-closure assertions, removals, and later updates.
- Four ordinary connected-reader browser cases pass.
- Full patterns package including browser tests, all 46 type groups, 599 documentation blocks, repository formatting/lint, and the integration waiting gate pass.
- Antagonistic cf-review found no blockers. CI and clean Cubic review are required before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

