### PR TITLE
fix(runner): preserve scope for list callback children

### DIFF
--- a/docs/specs/runner-child-run-ownership.md
+++ b/docs/specs/runner-child-run-ownership.md
@@ -44,8 +44,11 @@ Each rule below is one of these two authorities applied to a case.
 A pattern that launches a child registers a *release* for it, which runs when
 the launching pattern is torn down. A list coordinator releases a child
 earlier than that: when the list no longer holds the element that child
-belongs to. The child would otherwise run, and hold a result nothing reads,
-for as long as the coordinator lives.
+belongs to, or when the result container changes scope. Each per-element
+result uses the container's scope; the coordinator releases a child from the
+previous scope even when the element identity remains present. Reconciliation
+and cold resume derive the same scoped child identity. The child would otherwise
+run, and hold a result nothing reads, for as long as the coordinator lives.
 
 A release stops the child's registration only when both of these hold:
 

--- a/packages/cli/test/fixtures/projection-replay-process.ts
+++ b/packages/cli/test/fixtures/projection-replay-process.ts
@@ -80,6 +80,15 @@ async function readFrames(): Promise<Frame[]> {
     .map((line) => JSON.parse(line) as Frame);
 }
 
+/** Counts mutable shared writes in an observed frame window. */
+function countMutableSharedWrites(frames: Frame[]): number {
+  return frames.filter((frame) =>
+    frame.dir === "out" && frame.type === "transact"
+  ).flatMap((frame) => frame.commit?.operations ?? []).filter((operation) =>
+    operation.scope === "space" && !operation.id.startsWith("cid:")
+  ).length;
+}
+
 try {
   if (mode === "seed") {
     const tx = runtime.edit();
@@ -110,7 +119,8 @@ try {
   }
   const source = runtime.getCell(space, "survey", schema);
   await source.pull();
-  const before = (await readFrames()).length;
+  const setupFrames = await readFrames();
+  const before = setupFrames.length;
   const value = await deriveSelectedValue(runtime, space, source, {
     projection: parseSelectProjection(
       "@,title,createdAt,lastActivityAt,commentCount",
@@ -136,11 +146,8 @@ try {
     unanswered: requests.filter((request) =>
       !responses.has(request.requestId)
     ).length,
-    mutableSharedWrites: requests.flatMap((request) =>
-      request.commit?.operations ?? []
-    ).filter((operation) =>
-      operation.scope === "space" && !operation.id.startsWith("cid:")
-    ).length,
+    setupMutableSharedWrites: countMutableSharedWrites(setupFrames),
+    mutableSharedWrites: countMutableSharedWrites(frames),
   }));
 } finally {
   await runtime.dispose();

--- a/packages/cli/test/projection-replay.test.ts
+++ b/packages/cli/test/projection-replay.test.ts
@@ -41,6 +41,9 @@ interface ReplayResult {
   /** Commit requests with no response when the projection settled. */
   unanswered: number;
 
+  /** Mutable shared writes from source setup before the projection. */
+  setupMutableSharedWrites: number;
+
   /** Shared write operations excluding immutable content-addressed documents. */
   mutableSharedWrites: number;
 }
@@ -96,7 +99,8 @@ describe("CLI projection replay", () => {
           commentCount: index,
         })),
       );
-      expect(seed.mutableSharedWrites).toBeGreaterThan(0);
+      expect(seed.setupMutableSharedWrites).toBeGreaterThan(0);
+      expect(seed.mutableSharedWrites).toBe(0);
       expect(seed.rejected).toEqual([]);
       expect(seed.unanswered).toBe(0);
       expect(seed.errors).toEqual([]);
@@ -114,6 +118,8 @@ describe("CLI projection replay", () => {
           index === 3 ? { ...row, title: "Updated row", commentCount: 99 } : row
         ),
       );
+      expect(changed.setupMutableSharedWrites).toBeGreaterThan(0);
+      expect(changed.mutableSharedWrites).toBe(0);
       expect(changed.rejected).toEqual([]);
       expect(changed.unanswered).toBe(0);
       expect(changed.errors).toEqual([]);

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -378,6 +378,7 @@ export function filter(
       runtime,
       elementRuns,
       new Set(elementKeys.values()),
+      outputScope,
     );
 
     if (list.length > 0) resumeBatchAwaitSync = false;

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -381,6 +381,7 @@ export function flatMap(
       runtime,
       elementRuns,
       new Set(elementKeys.values()),
+      outputScope,
     );
 
     if (list.length > 0) resumeBatchAwaitSync = false;

--- a/packages/runner/src/builtins/list-coordinator-plan.ts
+++ b/packages/runner/src/builtins/list-coordinator-plan.ts
@@ -177,8 +177,9 @@ export function listSlotResolutions(
 
 /**
  * The result cell of one per-element child run: deterministic in the
- * coordinator's container and the element's identity key, so a reload
- * resumes the same child and a pre-sync can name it before the reload's
+ * coordinator's container and the element's identity key, at the container's
+ * scope, so a reload resumes the same child and a pre-sync can name it before
+ * the reload's
  * reconcile runs it.
  */
 export function listElementResultCell(
@@ -193,5 +194,6 @@ export function listElementResultCell(
     { [op]: container, elementKey },
     undefined,
     tx,
+    container.getAsNormalizedFullLink().scope,
   );
 }

--- a/packages/runner/src/builtins/list-element-keys.ts
+++ b/packages/runner/src/builtins/list-element-keys.ts
@@ -1,3 +1,4 @@
+import type { CellScope } from "../builder/types.ts";
 import type { Cell } from "../cell.ts";
 import type { Runtime } from "../runtime.ts";
 import type { ElementRun } from "./list-element-rollback.ts";
@@ -26,7 +27,8 @@ export function listElementKeys(list: Cell<any>[]): Map<number, string> {
 
 /**
  * Drop the element runs whose elements the list no longer holds, releasing the
- * child each one launched.
+ * child each one launched. When a scope is supplied, a child from another
+ * scope is released even if its element remains present.
  *
  * It is a release rather than a stop, so an element result that something
  * opened in its own right keeps running; `docs/specs/runner-child-run-ownership.md`
@@ -46,10 +48,15 @@ export function releaseRemovedElements(
   runtime: Runtime,
   elementRuns: Map<string, ElementRun>,
   currentKeys: ReadonlySet<string>,
+  scope?: CellScope,
 ): void {
   const errors: unknown[] = [];
   for (const [elementKey, entry] of [...elementRuns]) {
-    if (currentKeys.has(elementKey)) continue;
+    if (
+      currentKeys.has(elementKey) &&
+      (scope === undefined ||
+        entry.resultCell.getAsNormalizedFullLink().scope === scope)
+    ) continue;
     try {
       runtime.runner.releaseChild(entry.resultCell, undefined);
       elementRuns.delete(elementKey);

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -354,6 +354,7 @@ export function map(
       runtime,
       elementRuns,
       new Set(elementKeys.values()),
+      listScope,
     );
 
     const newArrayValue = new Array<any>(list.length);

--- a/packages/runner/test/scoped-list-children.test.ts
+++ b/packages/runner/test/scoped-list-children.test.ts
@@ -1,0 +1,298 @@
+/** Exercises compiled scoped list callbacks across scope changes and runtime reloads. */
+
+import { Identity } from "@commonfabric/identity";
+import { getLogger } from "@commonfabric/utils/logger";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { Cell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import {
+  EmulatedStorageManager,
+  newLoopbackServer,
+} from "../src/storage/v2-emulate.ts";
+
+const signer = await Identity.fromPassphrase("scoped-list-children");
+
+/** Builds a compiled fixture whose row computations observe viewer-local state. */
+function program(scope: "user" | "session") {
+  const wrapper = scope === "user" ? "PerUser" : "PerSession";
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: `
+        import {pattern, computed, Writable, ${wrapper}} from "commonfabric";
+        export default pattern<{source:number[]; viewer:${wrapper}<Writable<number>>}>(
+          ({source,viewer})=>{
+            const ranked=computed(()=>source.map(value=>({value,self:value===viewer.get()})));
+            return {
+              selected: viewer,
+              mapped: ranked.map(row=><span>{row.value}:{row.self}</span>),
+              filtered: ranked.filter(row=>row.self),
+              flat: ranked.flatMap(row=>row.self?[row.value]:[]),
+            };
+          }
+        );
+      `,
+    }],
+  };
+}
+
+describe("scoped-list-children", () => {
+  it("replaces filter and flatMap children when scope changes with stable element identities", async () => {
+    const storage = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    let cancel: (() => void) | undefined;
+    try {
+      const compiled = await runtime.patternManager.compilePattern({
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: `
+          import {pattern, Writable} from "commonfabric";
+          export default pattern<{items:Writable<{n:number}[]>}>(({items})=>({
+            mapped:items.map(row=>row.n+0),
+            filtered:items.filter(row=>row.n===1),
+            flat:items.flatMap(row=>[row.n]),
+          }));
+        `,
+        }],
+      });
+      let tx = runtime.edit();
+      const first = runtime.getCell<{ n: number }>(
+        signer.did(),
+        "first-element",
+        undefined,
+        tx,
+      );
+      const second = runtime.getCell<{ n: number }>(
+        signer.did(),
+        "second-element",
+        undefined,
+        tx,
+      );
+      first.set({ n: 1 });
+      second.set({ n: 2 });
+      const lists = (["space", "user", "session"] as const).map((scope) =>
+        runtime.getCell<unknown[]>(
+          signer.did(),
+          "scope-list",
+          undefined,
+          tx,
+          scope,
+        )
+      );
+      for (const list of lists) list.set([first, second]);
+      const selected = runtime.getCell<unknown>(
+        signer.did(),
+        "selected-list",
+        undefined,
+        tx,
+      );
+      selected.set(lists[0]);
+      const result = runtime.run(
+        tx,
+        compiled,
+        { items: selected },
+        runtime.getCell<Record<string, unknown>>(
+          signer.did(),
+          "scope-output",
+          compiled.resultSchema,
+          tx,
+        ),
+      );
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+      cancel = result.sink(() => {});
+      await runtime.idle();
+      const childScopes: string[] = [];
+      const run = runtime.runner.run;
+      runtime.runner.run = (...args: Parameters<typeof run>) => {
+        if (args[4]?.doNotUpdateOnPatternChange) {
+          childScopes.push(
+            (args[3] as Cell<unknown>).getAsNormalizedFullLink().scope,
+          );
+        }
+        return Reflect.apply(run, runtime.runner, args);
+      };
+      const values = { mapped: [1, 2], filtered: [{ n: 1 }], flat: [1, 2] };
+      expect(await result.pull()).toEqual(values);
+      for (const index of [1, 2, 0]) {
+        childScopes.length = 0;
+        tx = runtime.edit();
+        selected.withTx(tx).set(lists[index]);
+        await tx.commit();
+        await runtime.idle();
+        expect(await result.pull()).toEqual(values);
+        expect(childScopes).toEqual(
+          Array(4).fill(lists[index].getAsNormalizedFullLink().scope),
+        );
+        for (const operation of ["filtered", "flat"]) {
+          expect(
+            result.key(operation).resolveAsCell().getAsNormalizedFullLink()
+              .scope,
+          )
+            .toBe(lists[index].getAsNormalizedFullLink().scope);
+        }
+      }
+      tx = runtime.edit();
+      first.withTx(tx).key("n").set(3);
+      await tx.commit();
+      await runtime.idle();
+      expect(await result.pull()).toEqual({
+        mapped: [3, 2],
+        filtered: [],
+        flat: [3, 2],
+      });
+    } finally {
+      cancel?.();
+      await storage.synced();
+      await runtime.dispose();
+      await storage.close();
+    }
+  });
+
+  it("keeps viewers independent and resumes their user-scoped children", async () => {
+    const other = await Identity.fromPassphrase("scoped-list-other-viewer");
+    const server = newLoopbackServer({ subscriptionRefreshDelayMs: 0 });
+    const storages = [signer, other, signer].map((as) =>
+      EmulatedStorageManager.connectTo(server, { as })
+    );
+    const runtimes = storages.map((storageManager) =>
+      new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      })
+    );
+    const [first, second, resumed] = runtimes;
+    const cancellations: (() => void)[] = [];
+    try {
+      const compiled = await first.patternManager.compilePattern(
+        program("user"),
+      );
+      let tx = first.edit();
+      const result = first.run(
+        tx,
+        compiled,
+        { source: [1, 2], viewer: 1 },
+        first.getCell<Record<string, unknown>>(
+          signer.did(),
+          "shared-output",
+          compiled.resultSchema,
+          tx,
+        ),
+      );
+      first.prepareTxForCommit(tx);
+      await tx.commit();
+      const cancelFirst = result.sink(() => {});
+      cancellations.push(cancelFirst);
+      await first.idle();
+      expect(await result.key("flat").pull()).toEqual([1]);
+      await storages[0].synced();
+      const link = result.getAsNormalizedFullLink();
+
+      await second.patternManager.compilePattern(program("user"), {
+        space: signer.did(),
+      });
+      const otherResult = second.getCellFromLink<Record<string, unknown>>(link);
+      await otherResult.sync();
+      tx = second.edit();
+      otherResult.key("selected").withTx(tx).set(2);
+      await tx.commit();
+      cancellations.push(otherResult.sink(() => {}));
+      expect(await second.start(otherResult)).toBe(true);
+      await second.idle();
+      expect(await otherResult.key("flat").pull()).toEqual([2]);
+      await storages[1].synced();
+      await first.idle();
+      expect(await result.key("flat").pull()).toEqual([1]);
+
+      cancelFirst();
+      first.runner.stop(result);
+      await first.dispose({ closeStorage: false });
+      await storages[0].close();
+      await resumed.patternManager.compilePattern(program("user"), {
+        space: signer.did(),
+      });
+      const restored = resumed.getCellFromLink<Record<string, unknown>>(link);
+      cancellations.push(restored.sink(() => {}));
+      expect(await resumed.start(restored)).toBe(true);
+      await resumed.idle();
+      expect(await restored.key("flat").pull()).toEqual([1]);
+      tx = resumed.edit();
+      restored.key("selected").withTx(tx).set(2);
+      await tx.commit();
+      await resumed.idle();
+      expect(await restored.key("flat").pull()).toEqual([2]);
+    } finally {
+      for (const cancel of cancellations) cancel();
+      for (const runtime of runtimes) {
+        await runtime.dispose({ closeStorage: false });
+      }
+      for (const storage of storages) await storage.close();
+      await server.close();
+    }
+  });
+
+  for (const scope of ["user", "session"] as const) {
+    it(`maps, filters and flattens ${scope} results without sharing scoped arguments`, async () => {
+      const storage = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: storage,
+      });
+      let cancel: (() => void) | undefined;
+      try {
+        const compiled = await runtime.patternManager.compilePattern(
+          program(scope),
+        );
+        let tx = runtime.edit();
+        const warnings = getLogger("normalizeAndDiff").counts.warn;
+        const result = runtime.run(
+          tx,
+          compiled,
+          { source: [1, 2], viewer: 1 },
+          runtime.getCell<Record<string, unknown>>(
+            signer.did(),
+            "output",
+            compiled.resultSchema,
+            tx,
+          ),
+        );
+        runtime.prepareTxForCommit(tx);
+        await tx.commit();
+        cancel = result.sink(() => {});
+        const expected = (selected: number) => ({
+          selected,
+          mapped: [1, 2].map((value) => ({
+            type: "vnode",
+            name: "span",
+            props: {},
+            children: [value, ":", value === selected],
+          })),
+          filtered: [{ value: selected, self: true }],
+          flat: [selected],
+        });
+        await runtime.idle();
+        expect(await result.pull()).toEqual(expected(1));
+        expect(getLogger("normalizeAndDiff").counts.warn).toBe(warnings);
+        tx = runtime.edit();
+        result.key("selected").withTx(tx).set(2);
+        await tx.commit();
+        await runtime.idle();
+        expect(await result.pull()).toEqual(expected(2));
+        expect(getLogger("normalizeAndDiff").counts.warn).toBe(warnings);
+      } finally {
+        cancel?.();
+        await storage.synced();
+        await runtime.dispose();
+        await storage.close();
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Why

List callbacks over user- or session-scoped results create their per-element result cells in space scope. Their argument metadata then stores narrower scoped element links in shared data, producing scope warnings and defeating the intended callback boundary. The repository-only reactive lunch-row migration for #7155 exposed this after the reconnect repair in #7308.

## What Changed

Derive each map/filter/flatMap child at its result container's scope through the shared reconciliation/resume helper. Release cached children when a container changes scope even if element identities remain present, using the existing ownership and rollback paths.

Regression cases cover user/session VNodes without scope warnings, independent viewers, user-scoped cold resume, and filter/flatMap scope transitions with stable element identities. The ownership specification describes the scoped lifetime rule. The projection replay test requires zero mutable shared writes for seed, cold, and changed-source projections. Explicit source setup supplies the positive write-counter control. The lunch-poll migration remains separate.

## Test plan

- Full runner package: 1,432 tests / 8,927 steps pass.
- Focused scope, ownership, and rollback regressions: 43 tests / 40 steps pass.
- Negative controls: dropping child scope fails three new cases; omitting scope-aware release fails the transition case.
- Full CLI package: 1,824 parallel tests / 2,932 steps and 218 serial tests / 684 steps pass.
- All 46 type groups, 599 documentation blocks, repository formatting/lint pass.
- Antagonistic cf-review: no blockers. Cold-resume assertions explicitly verify flatMap; mapped VNodes have separate user/session coverage.
