### PR TITLE
Bound headless render demand to the renderer VDOM schema

### DIFF
--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -176,8 +176,9 @@ return {
 };
 ```
 
-The step runs the target through the same worker reconciler implementation used
-by the renderer, discards the generated DOM operations, waits for recursively
+The step initially pulls the target through the renderer's VDOM schema, validates
+the root value, and mounts the same worker reconciler implementation used by the
+renderer. It discards the generated DOM operations, waits for recursively
 discovered VDOM cells to settle, and immediately unmounts. It is transparent
 to assertion counts, honors `skip: true`, and is supported in both single- and
 multi-user tests.

--- a/packages/cli/lib/materialize-test-vdom.ts
+++ b/packages/cli/lib/materialize-test-vdom.ts
@@ -50,7 +50,10 @@ export async function mountTestVDOM(
   vdomCell: Cell<unknown>,
   onError: (error: Error) => void,
 ): Promise<() => void> {
-  const root = await vdomCell.pull();
+  // Demand the same bounded shape the renderer consumes. Root validation reads
+  // the original value so a schema mismatch still reports invalid VDOM.
+  await vdomCell.asSchema(rendererVDOMSchema).pull();
+  const root = vdomCell.get();
   if (!isRenderableRoot(root)) {
     throw new Error(
       `VDOM materialization failed: Invalid VDOM content: expected ` +

--- a/packages/cli/test/fixtures/render-step/bounded-root-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/bounded-root-render.test.tsx
@@ -1,0 +1,18 @@
+import { assert, computed, pattern, TESTS } from "commonfabric";
+import { afterRenderBranch, lateVDOMBranch } from "./subject.tsx";
+
+export default pattern(() => {
+  const view = {
+    type: "vnode",
+    name: "div",
+    props: {},
+    children: [computed(() => lateVDOMBranch())],
+    ignoredMetadata: computed(() => afterRenderBranch()),
+  };
+  return {
+    [TESTS]: [
+      { render: view },
+      { assertion: assert(() => true) },
+    ],
+  };
+});

--- a/packages/cli/test/test-runner-render-step.test.ts
+++ b/packages/cli/test/test-runner-render-step.test.ts
@@ -89,6 +89,13 @@ describe(
       expect(result.passed).toBe(1);
     });
 
+    it("demands rendered children without evaluating unrelated VNode metadata", async () => {
+      const result = await withCoverage("bounded-root-render.test.tsx");
+      expect(result.lateHitCount).toBeGreaterThan(0);
+      expect(result.afterRenderHitCount).toBe(0);
+      expect(result.passed).toBe(1);
+    });
+
     it("accepts primitive VDOM roots", async () => {
       const { failed, passed } = await runTests(
         fixture("primitive-render.test.tsx"),


### PR DESCRIPTION
## Why

The headless render step pulls an entire schemaless VDOM value before mounting the worker reconciler. That evaluates reactive metadata the renderer does not consume and distorts render read budgets in #7155. Reactive lunch-poll rows exposed this extra demand while validating the scoped-child repair in #7313.

## What Changed

Pull the initial VDOM through the renderer schema, retain validation against the original root value, then let the worker reconciler discover rendered children. A coverage regression proves that a visible computed child executes while unrelated VNode metadata stays unevaluated. The pattern testing guide documents this demand boundary.

This corrects headless test demand; it does not establish a browser speedup.

## Test plan

- All 14 render-step contract cases pass, including invalid roots, nested children, multi-user tests, and cleanup. Restoring the schemaless pull makes the new regression fail.
- Full CLI parallel and serial test suites pass with the injected NO_COLOR variable removed for color-sensitive tests.
- All 46 type groups and 599 documentation blocks pass; repository formatting and lint pass.
- Antagonistic cf-review reports no blockers. CI and a clean Cubic review are required before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

