### PR TITLE
Preserve attempted-write evidence for ignored scheduling reads

### DIFF
--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -1120,7 +1120,9 @@ What remains live here:
   still exists because of them. Self-suppressed changes (P5) never enter
   `invalidCauses` — a change that did not cause scheduling must not taint it.
 - **`attemptedWrites`** remain CFC prepare/digest evidence only — never
-  dependency or scheduling evidence. v2 removes the one v1 use that blurred
+  dependency or scheduling evidence. Reads marked as attempted writes retain
+  that evidence when they are ignored for scheduling, including no-op writes.
+  v2 removes the one v1 use that blurred
   this (dependency prefetch marking output reads as attempted writes).
 - **Event preflight transactions** commit as no-ops and stay out of CFC
   gating (unchanged).

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -455,23 +455,24 @@ export function reactivityLogFromActivities(
   };
   for (const activity of activities) {
     if ("read" in activity && activity.read) {
-      if (isReadIgnoredForScheduling(activity.read.meta)) {
-        continue;
-      }
+      const ignored = isReadIgnoredForScheduling(activity.read.meta);
+      const attempted = isReadMarkedAsAttemptedWrite(activity.read.meta);
+      if (ignored && !attempted) continue;
       const address: IMemorySpaceAddress = {
         space: activity.read.space,
         scope: normalizeCellScope(activity.read.scope),
         id: activity.read.id,
         path: [...activity.read.path],
       };
+      if (attempted) {
+        log.attemptedWrites ??= [];
+        log.attemptedWrites.push(address);
+      }
+      if (ignored) continue;
       if (activity.read.nonRecursive === true) {
         log.shallowReads.push(address);
       } else {
         log.reads.push(address);
-      }
-      if (isReadMarkedAsAttemptedWrite(activity.read.meta)) {
-        log.attemptedWrites ??= [];
-        log.attemptedWrites.push(address);
       }
       continue;
     }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -2949,9 +2949,9 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     for (const read of this.#readActivities) {
       const meta = read.meta ?? EMPTY_META;
-      if (isReadIgnoredForScheduling(meta)) {
-        continue;
-      }
+      const ignored = isReadIgnoredForScheduling(meta);
+      const attempted = isReadMarkedAsAttemptedWrite(meta);
+      if (ignored && !attempted) continue;
 
       const instance = this.#instanceOf(read.scope);
       const address = {
@@ -2962,15 +2962,15 @@ export class V2StorageTransaction implements IStorageTransaction {
         path: read.path,
       };
 
+      if (attempted) {
+        attemptedWrites ??= [];
+        attemptedWrites.push(address);
+      }
+      if (ignored) continue;
       if (read.nonRecursive === true) {
         shallowReads.push(address);
       } else {
         reads.push(address);
-      }
-
-      if (isReadMarkedAsAttemptedWrite(meta)) {
-        attemptedWrites ??= [];
-        attemptedWrites.push(address);
       }
     }
 

--- a/packages/runner/test/storage/reactivity-log.test.ts
+++ b/packages/runner/test/storage/reactivity-log.test.ts
@@ -1,0 +1,123 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+
+import { Runtime } from "../../src/runtime.ts";
+import { txToReactivityLog } from "../../src/scheduler.ts";
+import { StorageManager } from "../../src/storage/cache.deno.ts";
+import {
+  ignoreReadForScheduling,
+  markReadAsAttemptedWrite,
+  reactivityLogFromActivities,
+} from "../../src/storage/reactivity-log.ts";
+import { getDirectTransactionReactivityLog } from "../../src/storage/transaction-inspection.ts";
+
+const signer = await Identity.fromPassphrase("ignored-attempted-writes");
+const space = signer.did();
+
+describe("reactivity-log", () => {
+  it("retains ignored attempted writes independently of scheduling read depth", () => {
+    const address = {
+      space,
+      scope: "space" as const,
+      id: "of:test" as const,
+      path: ["value", "slot"],
+    };
+    for (const nonRecursive of [false, true]) {
+      const log = reactivityLogFromActivities([{
+        read: {
+          ...address,
+          nonRecursive,
+          meta: { ...ignoreReadForScheduling, ...markReadAsAttemptedWrite },
+        },
+      }]);
+      expect(log).toEqual({
+        reads: [],
+        shallowReads: [],
+        writes: [],
+        attemptedWrites: [address],
+      });
+      expect(reactivityLogFromActivities([{
+        read: { ...address, nonRecursive, meta: ignoreReadForScheduling },
+      }])).toEqual({ reads: [], shallowReads: [], writes: [] });
+    }
+  });
+
+  it("keeps no-op Cell writes in native transaction evidence without scheduling reads", async () => {
+    const storage = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    try {
+      let tx = runtime.edit();
+      const cell = runtime.getCell<{ slot: number }>(
+        space,
+        "target",
+        undefined,
+        tx,
+      );
+      cell.set({ slot: 1 });
+      expect((await tx.commit()).error).toBeUndefined();
+      tx = runtime.edit();
+      tx.runWithAmbientReadMeta(
+        ignoreReadForScheduling,
+        () => cell.withTx(tx).key("slot").set(1),
+      );
+      const log = getDirectTransactionReactivityLog(tx)!;
+      expect(log.attemptedWrites).toContainEqual({
+        space,
+        scope: "space",
+        id: cell.getAsNormalizedFullLink().id,
+        path: ["value", "slot"],
+      });
+      expect(log.reads).toEqual([]);
+      expect(log.shallowReads).toEqual([]);
+      expect(log.writes).toEqual([]);
+      expect(txToReactivityLog(tx)).toEqual({
+        reads: [],
+        shallowReads: [],
+        writes: [],
+      });
+      expect((await tx.commit()).error).toBeUndefined();
+    } finally {
+      await storage.synced();
+      await runtime.dispose();
+      await storage.close();
+    }
+  });
+  it("keeps ignored attempted reads in transaction conflict validation", async () => {
+    const storage = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    try {
+      const seed = runtime.edit();
+      const source = runtime.getCell<number>(
+        space,
+        "conflict-source",
+        undefined,
+        seed,
+      );
+      source.set(1);
+      expect((await seed.commit()).error).toBeUndefined();
+      const stale = runtime.edit();
+      expect(stale.readValueOrThrow(source.getAsNormalizedFullLink(), {
+        meta: { ...ignoreReadForScheduling, ...markReadAsAttemptedWrite },
+      })).toBe(1);
+      runtime.getCell<number>(space, "conflict-output", undefined, stale).set(
+        1,
+      );
+      const concurrent = runtime.edit();
+      source.withTx(concurrent).set(2);
+      expect((await concurrent.commit()).error).toBeUndefined();
+      expect((await stale.commit()).error).toBeDefined();
+    } finally {
+      await storage.synced();
+      await runtime.dispose();
+      await storage.close();
+    }
+  });
+});


### PR DESCRIPTION
## Why

Runtime maintenance can ignore its bookkeeping reads for scheduling while still attempting writes that CFC must check. Both transaction-log paths currently discard ignored reads before collecting attempted-write targets, so a no-op Cell write inside that scope loses its policy evidence. Index bucket maintenance for #7155 exposed this combination.

## What Changed

Collect attempted-write addresses independently of scheduling-read suppression in native v2 and activity-derived transaction logs. Preserve the fast path for ignored reads with no attempted-write marker. The scheduler specification makes the independent evidence channels explicit.

## Test plan

- Focused regressions verify ignored shallow/recursive reads retain attempted targets, real no-op Cell writes retain evidence with no actual writes or scheduler dependencies, and ignored reads still cause stale transaction rejection.
- Full runner package: 1,433 tests / 8,937 steps pass, with one existing ignored step.
- All 46 type groups, 599 documentation blocks, repository formatting and lint pass.
- An index deletion regression fails without this correction and passes with it.
- Antagonistic cf-review found no blockers. CI and clean Cubic review are required before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


Coverage review: all added lines are covered. The gate reports a net +3 uncovered lines in unchanged filter.ts and resume-republish.ts deferred-child reconciliation paths. Apply the documented unchanged-file exception in docs/development/COVERAGE.md; deterministic coverage of those paths is tracked separately in the local #7155 execution dashboard.

ACCEPT_COVERAGE_DEBT: packages/runner +3 lines
