### PR TITLE
Restore reactive lunch-poll option and voter rows

### DIFF
--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -5,6 +5,7 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 ## Audits and reports
 
 - [2026-09-11-pending-schema-policy-index.md](development/performance/2026-09-11-pending-schema-policy-index.md) — document-indexed pending schema-policy lookup CPU attribution and 1,184-vote fixture acceptance with unchanged read budgets.
+- [2026-09-11-reactive-lunch-rows.md](development/performance/2026-09-11-reactive-lunch-rows.md) — repository-only reactive lunch-row acceptance: 93 assertions, unchanged budgets at three sizes, matched two-browser voting, and headless settlement limits.
 
 - [2026-09-10-lunch-poll-read-baseline.md](development/performance/2026-09-10-lunch-poll-read-baseline.md) — controlled A0 baseline with 14 options, eight same-space voters, 74 keyed votes, continuous headless UI demand, and per-action read counts.
 - [2026-09-10-read-accounting-probes.md](development/performance/2026-09-10-read-accounting-probes.md) — disabled-probe comparison for initial reactive action read accounting: five alternating control/candidate windows over 1,000 lazy-view elements, and the limits of the lunch-poll functional smoke check.

--- a/docs/history/development/performance/2026-09-11-reactive-lunch-rows.md
+++ b/docs/history/development/performance/2026-09-11-reactive-lunch-rows.md
@@ -1,0 +1,75 @@
+---
+status: historical
+created: 2026-09-11
+archived: 2026-09-11
+reason: "Repository-only reactive lunch-row migration acceptance record."
+---
+
+# Reactive lunch-poll row acceptance
+
+The C4 candidate used main `a8b081978ab98a5f1df853360d88a8232f913525`
+with lunch-poll `main.tsx` blob `ac706b7fc746556e3c5d5297455a2966172910c0`. Its dependencies
+were scoped list children (#7313) and bounded headless render demand (#7315).
+The change removed the outer computed wrapper around the ranked option rows,
+leaving direct reactive option and voter maps. Tally construction and ordering
+were unchanged.
+
+All data was synthetic. No deployed poll was read or updated.
+
+## Acceptance
+
+All eight lunch-poll pattern tests passed, totaling 93 assertions. The full
+patterns package passed, including its browser tests, and the authoritative
+pattern checker accepted all 413 patterns.
+
+The existing A4 scale fixtures passed both assertions and their unchanged
+render budgets at all three sizes:
+
+| Votes | Voters | Options | First-render total / per-run limit | Update-render total / per-run limit |
+| --- | --- | --- | --- | --- |
+| 74 | 8 | 14 | 36,000 / 14,000 | 30,000 / 14,000 |
+| 296 | 24 | 14 | 76,000 / 31,000 | 67,000 / 31,000 |
+| 1,184 | 87 | 14 | 236,000 / 96,000 | 214,000 / 96,000 |
+
+These are acceptance limits, not measured counts. The final 1,184-vote run took
+245,335 ms in the headless harness with idempotency verification enabled. The
+existing CLI action timeout was configured to 600,000 ms for these scale runs;
+no read budget was raised. A preceding 60,000 ms action limit interrupted the
+largest workload and produced no valid budget measurement.
+
+A diagnostic candidate run placed the initial bounded pull, original-root
+validation, and reconciler mount return within 11 ms; the expensive phase was
+subsequent settlement. This is not a browser latency measurement or evidence
+of constant-cost vote updates. `tallyOptions` still constructs ranked inline
+objects, and row-identity reuse across every tally update is not guaranteed.
+
+The two-browser voting test passed in 14 seconds on a matched local toolshed
+and shell built from this candidate. It verified concurrent votes from Alice
+and Bob, both names' swatches on both browsers, and an independent second-option
+vote. An earlier candidate recording of the same scenario is available in the
+local implementation dashboard. It is a functional demo, not a timing benchmark.
+
+## Reproduction
+
+Run the eight `packages/patterns/lunch-poll/*.test.tsx` files with `deno task cf
+test`. Run each A4 fixture with the measurement action limit:
+
+```sh
+deno task cf test packages/patterns/integration/fixtures/lunch-poll-read-scale/main.test.tsx --timeout 600000
+deno task cf test packages/patterns/integration/fixtures/lunch-poll-read-scale/296-votes.test.tsx --timeout 600000
+deno task cf test packages/patterns/integration/fixtures/lunch-poll-read-scale/1184-votes.test.tsx --timeout 600000
+```
+
+Use a fresh synthetic store and matching client/server revisions for browser
+acceptance. The recorded local pair used port offset 93 (toolshed 8093, shell
+5266):
+
+```sh
+EXPERIMENTAL_SERVER_EXECUTION=false MEMORY_DIR=file:///tmp/reactive-lunch-acceptance-memory ./scripts/start-local-dev.sh --port-offset 93
+HEADLESS=true API_URL=http://localhost:8093/ FRONTEND_URL=http://localhost:5266/ EXPERIMENTAL_SERVER_EXECUTION=false deno test -A packages/patterns/integration/lunch-poll-vote.test.ts
+```
+
+A run against toolshed revision `8f271a72ac` quarantined result documents for
+missing schema references before rendering the poll. That server predates the
+content-addressed result-schema metadata change in #7299. The matched pair
+passed; this record makes no mixed-version compatibility claim.

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -8,8 +8,10 @@ antagonistic reviews. A4's browser benchmark shipped in #7261; count limits
 landed in #7282. C1's remote-row reproductions and C3's inline-element dependency
 repair landed in #7265; removal/restoration acceptance landed in #7285 and
 first-browser-materialization acceptance landed in #7302. Reconnect repair
-landed in #7308; rendered acceptance is validated in #7312, pending merge gates.
-Remaining row-invalidation acceptance stays open. B1/B2's contract landed in
+landed in #7308 and rendered reconnect acceptance in #7312. C4's repository-only
+reactive row migration is implemented and validated on the scoped-child and
+bounded-render repairs in #7313 and #7315. Remaining row-invalidation acceptance
+stays open. B1/B2's contract landed in
 #7294 and its typed lookup foundation landed in #7304. Producer lowering,
 bucket maintenance, and joins remain pending.
 
@@ -265,9 +267,13 @@ passed before merge, with clean Cubic and antagonistic reviews.
       reads, remote inserts/removals, and reconnect where relevant.
 - [ ] **C3 — Repair remote row invalidation.** Verify affected rows update,
       stable element identities survive, and untouched rows do not rerun.
-- [ ] **C4 — Restore reactive lunch-poll rows.** Remove the workaround and its
-      explanatory comment only after both regressions pass. Re-run A4 and
-      coordinate with B5 to keep one coherent pattern migration.
+- [x] **C4 — Restore reactive lunch-poll rows.** Direct reactive option and
+      voter maps use the scoped callback-child repair. Repository acceptance
+      includes 93 assertions, unchanged A4 budgets at all three sizes, and
+      concurrent two-browser voting. The
+      [acceptance record](../history/development/performance/2026-09-11-reactive-lunch-rows.md)
+      states measurement limits. B5's operator migration remains separate;
+      deployed poll updates require coordination with Mike.
 
 ## 6–9. Complete the collection algebra: B1–B4
 
@@ -386,9 +392,9 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 
 ## Next task
 
-Complete merge review for C1's rendered reconnect acceptance in #7312. Complete
-C3's remaining acceptance checks while retaining the
-production workaround. The first-materialization cases in
+Complete C3's remaining acceptance checks. C4's repository migration is
+implemented and validated; updating any deployed poll requires coordination
+with Mike. The first-materialization cases in
 [PR #7302](https://github.com/commontoolsinc/labs/pull/7302) pass all four
 nested/mapped and same/cross-space browser combinations.
 A4's browser benchmark and count limits are available. A5 still

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -1437,11 +1437,8 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const optionCount = options.length;
     const voteCount = votes.length;
     // Current-day filter: the UI only shows votes cast on the current day
-    // (local calendar), per the shared tick. Derived at top level so every
-    // remote voter's vote entity resolves (same reason `ranked` is computed
-    // here, not per-option — see the swatch comment below). While `#now/300`
-    // is still resolving the day key reads "" and the current-day vote set is
-    // empty.
+    // (local calendar), per the shared tick. While `#now/300` is still
+    // resolving, the day key reads "" and the current-day vote set is empty.
     const todayKey = computed(() => (nowTick ? dayKeyOf(nowTick) : ""));
     const todaysVotes = computed(() => {
       if (!nowTick) return EMPTY_VOTES;
@@ -1792,88 +1789,66 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                           gap: "4px",
                         }}
                       >
-                        {
-                          /* Build every row's swatches in ONE top-level
-                            `computed` over the resolved `ranked` tally, with
-                            plain JS maps. Two reasons this shape, not a reactive
-                            `ranked.map(...)`/subpattern or an inline
-                            `votes.filter(...)`:
-                            1. Votes are links to separate entities; the
-                               top-level `tallyOptions` call resolves every
-                               voter's entity (including remote ones on another
-                               replica), so reading `ranked` here sees them,
-                               whereas a `votes.filter` in a nested map sees only
-                               the votes a replica has materialized locally.
-                            2. A reactive map / subpattern re-renders its per-item
-                               swatches unreliably when a remote vote updates a
-                               row's voters; a single `computed` re-runs as a
-                               whole when `ranked` changes (like the count above),
-                               so the swatches track cross-replica votes
-                               reliably. `ranked` is pre-sorted, so this also
-                               gives the row order with no `order` CSS hack. */
-                        }
-                        {computed(() =>
-                          ranked.map((tally) => (
+                        {ranked.map((tally) => (
+                          <div
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              gap: "8px",
+                              padding: "6px 10px",
+                              backgroundColor: "white",
+                              border: "1px solid #e5e7eb",
+                              borderRadius: "6px",
+                            }}
+                          >
+                            <div
+                              style={{
+                                flex: 1,
+                                fontSize: "13px",
+                                fontWeight: 500,
+                                color: "#111827",
+                              }}
+                            >
+                              {tally.option.title}
+                            </div>
                             <div
                               style={{
                                 display: "flex",
-                                alignItems: "center",
-                                gap: "8px",
-                                padding: "6px 10px",
-                                backgroundColor: "white",
-                                border: "1px solid #e5e7eb",
-                                borderRadius: "6px",
+                                gap: "4px",
+                                flexWrap: "wrap",
+                                justifyContent: "flex-end",
                               }}
                             >
-                              <div
-                                style={{
-                                  flex: 1,
-                                  fontSize: "13px",
-                                  fontWeight: 500,
-                                  color: "#111827",
-                                }}
-                              >
-                                {tally.option.title}
-                              </div>
-                              <div
-                                style={{
-                                  display: "flex",
-                                  gap: "4px",
-                                  flexWrap: "wrap",
-                                  justifyContent: "flex-end",
-                                }}
-                              >
-                                {tally.voters.map((voter) => (
-                                  <span
-                                    title={voter.name}
-                                    role="img"
-                                    aria-label={`${voter.name}: ${voter.voteType} vote`}
-                                    data-vote-swatch-name={voter.name}
-                                    style={{
-                                      display: "inline-flex",
-                                      alignItems: "center",
-                                      justifyContent: "center",
-                                      minWidth: "22px",
-                                      height: "22px",
-                                      padding: "0 6px",
-                                      borderRadius: "9999px",
-                                      backgroundColor:
-                                        VOTE_SWATCH[voter.voteType],
-                                      color: "white",
-                                      fontSize: "11px",
-                                      fontWeight: 700,
-                                      boxShadow: voter.isSelf
-                                        ? "0 0 0 2px white, 0 0 0 3px #111827"
-                                        : "none",
-                                    }}
-                                  >
-                                    {voter.initials}
-                                  </span>
-                                ))}
-                              </div>
+                              {tally.voters.map((voter) => (
+                                <span
+                                  title={voter.name}
+                                  role="img"
+                                  aria-label={`${voter.name}: ${voter.voteType} vote`}
+                                  data-vote-swatch-name={voter.name}
+                                  style={{
+                                    display: "inline-flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    minWidth: "22px",
+                                    height: "22px",
+                                    padding: "0 6px",
+                                    borderRadius: "9999px",
+                                    backgroundColor:
+                                      VOTE_SWATCH[voter.voteType],
+                                    color: "white",
+                                    fontSize: "11px",
+                                    fontWeight: 700,
+                                    boxShadow: voter.isSelf
+                                      ? "0 0 0 2px white, 0 0 0 3px #111827"
+                                      : "none",
+                                  }}
+                                >
+                                  {voter.initials}
+                                </span>
+                              ))}
                             </div>
-                          ))
-                        )}
+                          </div>
+                        ))}
                       </div>
                     </div>
                   )


### PR DESCRIPTION
## Why

The lunch poll rebuilds its option-row VDOM inside a coarse computed wrapper used to work around incomplete reactive row updates. The first-render, remote-update, reconnect, and scoped-child repairs now support direct reactive rows. This completes the repository portion of C4 in #7155, following #7313, #7315, #7320 (serving identity), and #7321 (policy lookup cost).

## What Changed

Remove the outer computed wrapper and render options and voter swatches through direct reactive maps. Preserve tally construction, ordering, identity highlighting, and vote behavior. Update the implementation tracker and attach an acceptance record with measured limits.

No deployed poll was accessed or updated. Tally construction still rebuilds ranked inline values; this change does not claim bounded per-vote computation or universal row identity reuse.

## Test plan

- All eight lunch-poll tests: 93 assertions pass.
- Existing 74-, 296-, and 1,184-vote fixtures: all six assertions and unchanged read budgets pass. The largest fixture passes with CI settings, idempotency checks enabled, and unchanged budgets (127.9 seconds in the recorded local run).
- Full patterns package, all 413 authoritative pattern checks, all 46 repository type groups, 599 documentation blocks, history index, formatting, and lint pass.
- Two-browser concurrent voting passes with server execution enabled and disabled against isolated matched local builds (2m11s and 16s respectively). The earlier candidate demo is available on the local implementation dashboard.
- Antagonistic cf-review is clean after tracker corrections. CI and clean Cubic review are required before merge.
