### PR TITLE
test(runner): make deferred list rearm coverage deterministic

### DIFF
--- a/packages/runner/test/filter-resume-rearm.test.ts
+++ b/packages/runner/test/filter-resume-rearm.test.ts
@@ -1,0 +1,157 @@
+import { Identity } from "@commonfabric/identity";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+
+import type { Pattern } from "../src/builder/types.ts";
+import { filter } from "../src/builtins/filter.ts";
+import {
+  listCoordinatorPlan,
+  listElementResultCell,
+} from "../src/builtins/list-coordinator-plan.ts";
+import type { Cell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { Action } from "../src/scheduler.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+/** Holds predicate arrival while an index change makes its setup stale. */
+describe("filter-resume-rearm", () => {
+  it("invalidates the registered coordinator after deferred setup becomes writable", async () => {
+    const signer = await Identity.fromPassphrase("filter-resume-rearm");
+    const storage = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    const held = Promise.withResolvers<void>();
+    const cancellations: (() => void)[] = [];
+    try {
+      const { pattern } = createTrustedBuilder(runtime).commonfabric;
+      const op = pattern((
+        { element, index }: { element: number; index: number },
+      ) => ({ element, index }));
+      let tx = runtime.edit();
+      const first = runtime.getCell<number>(
+        signer.did(),
+        "first",
+        undefined,
+        tx,
+      );
+      const second = runtime.getCell<number>(
+        signer.did(),
+        "second",
+        undefined,
+        tx,
+      );
+      first.set(1);
+      second.set(2);
+      const inputs = runtime.getCell<{ list: unknown[]; op: Pattern }>(
+        signer.did(),
+        "inputs",
+        undefined,
+        tx,
+      );
+      inputs.set({ list: [first, second], op });
+      const parent = runtime.getCell(signer.did(), "parent", undefined, tx);
+      const output = runtime.getCell(signer.did(), "output", undefined, tx)
+        .getAsNormalizedFullLink();
+      const inputSchema = {
+        type: "object",
+        properties: { op: { asCell: ["cell"] } },
+      } as const;
+      const plan = listCoordinatorPlan(
+        runtime,
+        tx,
+        "filter",
+        inputs,
+        inputSchema,
+        parent,
+        output,
+      );
+      plan.container.set([]);
+      const children = new Set(
+        [...plan.elementKeys.values()].map((key) =>
+          listElementResultCell(runtime, tx, "filter", plan.container, key)
+            .getAsNormalizedFullLink().id
+        ),
+      );
+      expect((await tx.commit()).error).toBeUndefined();
+      const prototype = Object.getPrototypeOf(first) as Cell<unknown>;
+      const originalSync = prototype.sync;
+      using _sync = stub(
+        prototype,
+        "sync",
+        function (
+          this: Cell<unknown>,
+          ...args: Parameters<typeof originalSync>
+        ) {
+          return children.has(this.getAsNormalizedFullLink().id)
+            ? held.promise.then(() => this)
+            : Reflect.apply(originalSync, this, args);
+        },
+      );
+      // Predicate execution is held absent; the real coordinator still writes
+      // its setup metadata and tracks whether a reordered child owes setup.
+      let setups = 0;
+      using _run = stub(
+        runtime.runner,
+        "run",
+        ((...args: unknown[]) => {
+          setups++;
+          return args[3];
+        }) as typeof runtime.runner.run,
+      );
+      const invalidated: Action[] = [];
+      using _invalidate = stub(
+        runtime.scheduler,
+        "invalidateAction",
+        (action) => {
+          invalidated.push(action);
+        },
+      );
+      const coordinator = filter(
+        inputs.withTx(),
+        () => {},
+        (cancel) => {
+          if (cancel) cancellations.push(cancel);
+        },
+        {},
+        parent.withTx(),
+        runtime,
+        output,
+        true,
+      );
+      if (typeof coordinator === "function") {
+        throw new Error("Expected registered filter coordinator");
+      }
+      const registered: Action = () => {};
+      coordinator.onActionRegistered?.(registered);
+      tx = runtime.edit();
+      coordinator.action(tx);
+      expect((await tx.commit()).error).toBeUndefined();
+      expect(setups).toBe(2);
+      tx = runtime.edit();
+      inputs.withTx(tx).key("list").set([second, first]);
+      expect((await tx.commit()).error).toBeUndefined();
+      tx = runtime.edit();
+      coordinator.action(tx);
+      expect((await tx.commit()).error).toBeUndefined();
+      expect(setups).toBe(2);
+      expect(invalidated).toEqual([]);
+      held.resolve();
+      await storage.synced();
+      expect(invalidated).toEqual([registered]);
+      tx = runtime.edit();
+      coordinator.action(tx);
+      expect((await tx.commit()).error).toBeUndefined();
+      expect(setups).toBe(4);
+    } finally {
+      held.resolve();
+      for (const cancel of cancellations) cancel();
+      await storage.synced();
+      await runtime.dispose();
+      await storage.close();
+    }
+  });
+});

--- a/packages/runner/test/resume-republish-unit.test.ts
+++ b/packages/runner/test/resume-republish-unit.test.ts
@@ -159,6 +159,7 @@ function makeRepublisher(opts: {
   elementRuns: Map<string, ElementRun>;
   runtime: Runtime;
   contribute?: ElementContribution;
+  rearmReconcile?: () => void;
 }) {
   return createResumeRepublisher({
     runtime: opts.runtime,
@@ -172,10 +173,7 @@ function makeRepublisher(opts: {
     contribute: opts.contribute ?? filterContribution,
     aggregateNoun: "filtered list",
     elementNoun: "predicate",
-    // The owed-setup re-arm path is pinned by the integration suites
-    // (resume-append-exclusion*); these unit cases exercise the republish
-    // fold only.
-    rearmReconcile: () => {},
+    rearmReconcile: opts.rearmReconcile ?? (() => {}),
   });
 }
 
@@ -205,6 +203,38 @@ function runsFor(
 }
 
 describe("resume-republish unit", () => {
+  it("rearms owed setup after an absent predicate confirms without a membership change", async () => {
+    const held = Promise.withResolvers<void>();
+    const inputs = [new FakeCell("input", null)];
+    const predicate = new FakeCell("predicate", undefined, () => held.promise);
+    const result = new FakeCell("container", []);
+    const runs = runsFor(inputs, [predicate]);
+    for (const entry of runs.values()) entry.needsSetup = true;
+    const { runtime, tracked } = makeRuntime();
+    let rearms = 0;
+    const republisher = makeRepublisher({
+      result,
+      inputsList: inputs,
+      elementRuns: runs,
+      runtime,
+      rearmReconcile: () => rearms++,
+    });
+    republisher.awaitPendingThenRepublish(
+      [predicate] as unknown as Cell<any>[],
+    );
+    expect(rearms).toBe(0);
+    expect(republisher.awaitingResult(predicate as unknown as Cell<any>)).toBe(
+      true,
+    );
+    held.resolve();
+    await drain(tracked);
+    expect(result.setValues).toEqual([[]]);
+    expect(republisher.awaitingResult(predicate as unknown as Cell<any>)).toBe(
+      false,
+    );
+    expect(rearms).toBe(1);
+  });
+
   it("reports an element result as awaited only while its sync runs", async () => {
     const inputs = [new FakeCell("e0", null)];
     let arrive = () => {};


### PR DESCRIPTION
## Why

Unchanged deferred-list setup branches were covered inconsistently across CI runs, making the runner coverage gate fail on unrelated PRs such as #7316. The tests now explicitly control the predicate-confirmation event that must rearm a coordinator whose child setup is still owed.

## What Changed

A real filter coordinator is driven through a held predicate sync and a source reorder. Confirmation must invalidate its registered action, and the next reconcile must issue both deferred setups. A focused republisher case also verifies rearming when an absent predicate confirms without changing membership.

## Test plan

- Full runner: 1,434 tests / 8,940 steps passed, one existing ignored step.
- All 46 repository type groups, repository formatting and lint passed.
- Isolated LCOV: filter.ts lines 160–164 each have one hit; resume-republish.ts lines 239–241 each have two hits.
- Removing the rearm call fails both new tests; restoring it passes the focused suites.
- Antagonistic cf-review checked the held-event setup, actual registered-action assertion, and positive setup-count control; no blockers found.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

