### PR TITLE
docs(cf-harness): the Weaver pill's third verb, /feedback, in WEAVER.md

### DIFF
--- a/packages/cf-harness/docs/WEAVER.md
+++ b/packages/cf-harness/docs/WEAVER.md
@@ -278,6 +278,10 @@ Mac. Then, in Weaver's settings under Services:
   current loom. A turn runs for minutes; the panel streams throughout, and the
   piece replaces it when the turn ends.
 - `more <text>` continues the last session.
+- `/feedback <patternId> up|down` records one vote on a pattern the index holds,
+  signed with the console's fabric identity; the pill answers "recorded up for
+  <patternId>" or the console's own refusal. An up vote is what promotes a
+  contributed pattern's discoverability.
 - The console at its base URL holds every run: transcript, policy trace, the CFC
   withheld markers, and `deno task cfc-audit <run dir>` audits a family.
 

--- a/packages/cf-harness/docs/WEAVER.md
+++ b/packages/cf-harness/docs/WEAVER.md
@@ -1,13 +1,14 @@
 # Driving the console from Weaver
 
-Weaver's command pill offers two verbs backed by the cf-harness console:
-`/patterns <query>` searches the pattern index, and `/cf-harness <task>` runs a
-harness session. A task places a panel in the current loom that streams the
-session live, and when the turn ends the panel is replaced by the finished
-piece, rendered in the person's own loom space under their own identity.
-`more
-<text>` continues the last session; a task that names a pattern id from
-`/patterns` has the session use that pattern.
+Weaver's command pill offers three verbs backed by the cf-harness console:
+`/patterns <query>` searches the pattern index, `/cf-harness <task>` runs a
+harness session, and `/feedback <patternId> up|down` records one vote on a
+pattern in the index through the console's `POST /api/index/feedback` route,
+signed with the console's fabric identity. A task places a panel in the current
+loom that streams the session live, and when the turn ends the panel is replaced
+by the finished piece, rendered in the person's own loom space under their own
+identity. `more <text>` continues the last session; a task that names a pattern
+id from `/patterns` has the session use that pattern.
 
 The arrangement rests on one fact: **the console and loom share one fabric.**
 The console runs against loom's toolshed, signs with loom's identity key, and


### PR DESCRIPTION
## Why

Two labs changes this pin carries.

- **labs #7310** — `scripts/start-local-dev.sh --cf-harness` declared the console ready on any `200` from `/api/health` on the console port, so a console left over from an earlier launch made a new pair report ready while it kept serving old code against the old store; the console step now fails when the port is held by a pid that is neither the console this launch started nor one of its descendants.
- **labs #7311** — the console takes `POST /api/index/feedback` with a pattern id and an `up`/`down` verdict and records it against the pattern index signed with its own fabric identity, so a caller with an id and a verdict and no console page — Weaver's command pill — can vote on a pattern.

## What Changed

`vendor/config/vendors.json` pins labs at `loom-stable-2026-09-11` (`99c5ed9e1a`), and `deno.json`'s generated labs block follows it. Nothing else: `deno.lock` regenerated byte-identical, and labs' Deno pin is unmoved at 2.9.4, so there is no `src/DENO_VERSION` move and no `.ops/SETUP_VERSION` bump.

Prior bump: #5757.

## Test plan

- `loom vendor sync labs --ref loom-stable-2026-09-11` → `loom vendor adopt labs --use-existing-tag loom-stable-2026-09-11`. **Space-compat gate PASSED** against a CoW clone of the live space store, with 3 non-blocking findings, each established PRE-EXISTING under the incumbent `loom-stable-2026-09-10-3` by the differential (`default-pattern-cold-load`, `deployed-piece-get`, `aged-root-fixture` / pre-4740-clock era). `generic-piece-deploy`, `aged-pattern-sweep` (118 pattern source docs over 10 space dbs, no legacy envelopes), `piece-new`, and `share-editor-stranding` all PASS.
- `tests/ci/` plus the vendor deploy gates (`test_vendor_lockfile_gate`, `test_vendor_materialization_gate`, `test_cf_bundles_lockfile`, `test_update_generated_vendor_files`): **4176 passed, 0 failed**.
- `src/bin/check-generated-vendor-files.sh` and `src/bin/check-worktree-clean.sh` both exit 0; the vendored labs checkout has no modified tracked files, so its lockfile is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

