### PR TITLE
Separate list coordinator state across serving principals and sessions

### DIFF
--- a/docs/specs/runner-child-run-ownership.md
+++ b/docs/specs/runner-child-run-ownership.md
@@ -65,6 +65,22 @@ leaves the start running. The start may go on to install a registration of
 its own and claim a lifetime for it, by the rule below. A stop of the same
 result instead terminates that start when it resolves.
 
+## List setup across serving instances
+
+A serving runtime can invoke one registered raw action for several principals
+and sessions. Map, filter, and flatMap keep separate coordinator bookkeeping for
+each demander's full resolution identity: result-container setup, element setup,
+resume flags, and pending synchronization. Completing one principal's child
+setup does not satisfy another principal's setup obligation.
+
+Durable child identities continue to derive from the owning container, source
+occurrence, and scope kind. The principal and session select the physical scoped
+instance of those addresses; they do not enter the canonical element key.
+Deferred synchronization and recovery writes retain the resolution identity that
+started them, including empty-container seeding and filter/flatMap republishing.
+The coordinator retains that identity independently of the transaction that
+first invoked it.
+
 ## Independent lifetimes
 
 A result acquires a lifetime of its own when something starts it in its own

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -1,9 +1,10 @@
 import { internSchema } from "@commonfabric/data-model-schema";
+import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import { getLogger } from "@commonfabric/utils/logger";
 
 import type { Pattern } from "../builder/types.ts";
 import type { AddCancel } from "../cancel.ts";
-import type { Cell } from "../cell.ts";
+import { type Cell, syncCellForIdentity } from "../cell.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
 import type { RawBuiltinReturnType } from "../module.ts";
 import { setPatternCell, setResultCell } from "../result-utils.ts";
@@ -27,6 +28,7 @@ import {
   type SetupRecord,
   trackListSetupRollback,
 } from "./list-element-rollback.ts";
+import { listInstanceCoordinator } from "./list-instance-coordinator.ts";
 import { seedResultContainerWhenPullSettles } from "./list-result-container-seed.ts";
 import { issueResultContainerSetup } from "./list-result-container.ts";
 import {
@@ -88,6 +90,36 @@ export function filter(
   outputBinding?: NormalizedFullLink,
   awaitSync?: boolean,
 ): RawBuiltinReturnType {
+  return listInstanceCoordinator((identity) =>
+    createFilterInstance(
+      inputsCell,
+      sendResult,
+      addCancel,
+      _cause,
+      parentCell,
+      runtime,
+      outputBinding,
+      awaitSync,
+      identity,
+    ), addCancel);
+}
+
+/** Creates bookkeeping and deferred work for one resolution identity. */
+function createFilterInstance(
+  inputsCell: Cell<{
+    list: any[];
+    op: Pattern;
+    params?: Record<string, any>;
+  }>,
+  sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
+  addCancel: AddCancel,
+  _cause: any,
+  parentCell: Cell<any>,
+  runtime: Runtime,
+  outputBinding?: NormalizedFullLink,
+  awaitSync?: boolean,
+  identity?: ScopeKeyIdentity,
+): RawBuiltinReturnType {
   let result: Cell<any[]> | undefined;
   // The containing piece's root: every element sub-piece this coordinator
   // starts is that piece's structure, so its actions' demand roots carry
@@ -148,6 +180,7 @@ export function filter(
       isActive: () => active,
       getResult: () => result,
       inputsCell,
+      identity,
       inputSchema: FILTER_INPUT_SCHEMA,
       resultSchema: RESULT_PRESENCE_SCHEMA,
       elementRuns,
@@ -175,10 +208,11 @@ export function filter(
     inputListCell: Cell<any>,
   ): void => {
     runtime.storageManager.trackUntilSettled(
-      inputListCell.sync()
+      syncCellForIdentity(inputListCell, identity)
         .then(() =>
           !active ? undefined : runtime.editWithRetry((settleTx) => {
             if (!active || !result) return;
+            if (identity !== undefined) settleTx.tx.scopeKeyIdentity = identity;
             // Out-of-band recovery write; the kind decision (bookkeeping
             // on the serving posture, derivation on clients — the settle
             // writes DERIVED content) is shared across map/filter/flatMap
@@ -186,6 +220,7 @@ export function filter(
             runtime.stampServerRun(settleTx, {
               actionId: `filter/resume-settle/${parentCell.sourceURI}`,
               kind: resumeSettleRunKind(runtime),
+              scopeKeyIdentity: identity,
             });
             const { list } = inputsCell.asSchema(FILTER_INPUT_SCHEMA)
               .withTx(settleTx).get();
@@ -325,9 +360,10 @@ export function filter(
         runtime,
         container,
         () => active && result === container,
-        container.sync(),
+        syncCellForIdentity(container, identity),
         logger,
         `filter/resume-seed/${parentCell.sourceURI}`,
+        identity,
       );
       return;
     }

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -1,9 +1,10 @@
 import { internSchema } from "@commonfabric/data-model-schema";
+import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import { getLogger } from "@commonfabric/utils/logger";
 
 import type { Pattern } from "../builder/types.ts";
 import type { AddCancel } from "../cancel.ts";
-import type { Cell } from "../cell.ts";
+import { type Cell, syncCellForIdentity } from "../cell.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
 import type { RawBuiltinReturnType } from "../module.ts";
 import { setPatternCell } from "../result-utils.ts";
@@ -27,6 +28,7 @@ import {
   type SetupRecord,
   trackListSetupRollback,
 } from "./list-element-rollback.ts";
+import { listInstanceCoordinator } from "./list-instance-coordinator.ts";
 import { seedResultContainerWhenPullSettles } from "./list-result-container-seed.ts";
 import { issueResultContainerSetup } from "./list-result-container.ts";
 import {
@@ -106,6 +108,36 @@ export function flatMap(
   outputBinding?: NormalizedFullLink,
   awaitSync?: boolean,
 ): RawBuiltinReturnType {
+  return listInstanceCoordinator((identity) =>
+    createFlatMapInstance(
+      inputsCell,
+      sendResult,
+      addCancel,
+      _cause,
+      parentCell,
+      runtime,
+      outputBinding,
+      awaitSync,
+      identity,
+    ), addCancel);
+}
+
+/** Creates bookkeeping and deferred work for one resolution identity. */
+function createFlatMapInstance(
+  inputsCell: Cell<{
+    list: any[];
+    op: Pattern;
+    params?: Record<string, any>;
+  }>,
+  sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
+  addCancel: AddCancel,
+  _cause: any,
+  parentCell: Cell<any>,
+  runtime: Runtime,
+  outputBinding?: NormalizedFullLink,
+  awaitSync?: boolean,
+  identity?: ScopeKeyIdentity,
+): RawBuiltinReturnType {
   let result: Cell<any[]> | undefined;
   // The containing piece's root: every element sub-piece this coordinator
   // starts is that piece's structure, so its actions' demand roots carry
@@ -160,6 +192,7 @@ export function flatMap(
       isActive: () => active,
       getResult: () => result,
       inputsCell,
+      identity,
       inputSchema: FLATMAP_INPUT_SCHEMA,
       resultSchema: RESULT_PRESENCE_SCHEMA,
       elementRuns,
@@ -182,10 +215,11 @@ export function flatMap(
   // normal reconcile via its journaled read, so it converges either way.
   const awaitInputThenSettle = (inputListCell: Cell<any>): void => {
     runtime.storageManager.trackUntilSettled(
-      inputListCell.sync()
+      syncCellForIdentity(inputListCell, identity)
         .then(() =>
           !active ? undefined : runtime.editWithRetry((settleTx) => {
             if (!active || !result) return;
+            if (identity !== undefined) settleTx.tx.scopeKeyIdentity = identity;
             // Out-of-band recovery write; the kind decision (bookkeeping
             // on the serving posture, derivation on clients — the settle
             // writes DERIVED content) is shared across map/filter/flatMap
@@ -193,6 +227,7 @@ export function flatMap(
             runtime.stampServerRun(settleTx, {
               actionId: `flatMap/resume-settle/${parentCell.sourceURI}`,
               kind: resumeSettleRunKind(runtime),
+              scopeKeyIdentity: identity,
             });
             const { list } = inputsCell.asSchema(FLATMAP_INPUT_SCHEMA)
               .withTx(settleTx).get();
@@ -328,9 +363,10 @@ export function flatMap(
         runtime,
         container,
         () => active && result === container,
-        container.sync(),
+        syncCellForIdentity(container, identity),
         logger,
         `flatMap/resume-seed/${parentCell.sourceURI}`,
+        identity,
       );
       return;
     }

--- a/packages/runner/src/builtins/list-instance-coordinator.ts
+++ b/packages/runner/src/builtins/list-instance-coordinator.ts
@@ -1,0 +1,58 @@
+/** Separates list coordinator bookkeeping for each serving resolution identity. */
+
+import {
+  resolveScopeKey,
+  type ScopeKeyIdentity,
+} from "@commonfabric/memory/v2";
+
+import type { AddCancel } from "../cancel.ts";
+import { isRawBuiltinResult, type RawBuiltinReturnType } from "../module.ts";
+import type { Action } from "../scheduler.ts";
+
+/**
+ * Creates a coordinator lazily for each demander's full resolution identity.
+ * The scheduler may invoke one registered raw action for several principals or
+ * sessions. Their setup records and pending sync work belong to separate
+ * closures even when the durable child addresses share a scope kind.
+ */
+export function listInstanceCoordinator(
+  create: (identity: ScopeKeyIdentity | undefined) => RawBuiltinReturnType,
+  addCancel: AddCancel,
+): RawBuiltinReturnType {
+  const instances = new Map<string, RawBuiltinReturnType>();
+  let registeredAction: Action | undefined;
+  let active = true;
+  addCancel(() => {
+    active = false;
+    instances.clear();
+  });
+  return {
+    action: (tx) => {
+      if (!active) return;
+      const identity = tx.tx.scopeKeyIdentity;
+      const scope = identity?.sessionId !== undefined
+        ? "session"
+        : identity?.principal !== undefined
+        ? "user"
+        : "space";
+      const key = identity === undefined
+        ? "space"
+        : resolveScopeKey(scope, identity);
+      let instance = instances.get(key);
+      if (!instance) {
+        instance = create(identity === undefined ? undefined : { ...identity });
+        instances.set(key, instance);
+        if (registeredAction && isRawBuiltinResult(instance)) {
+          instance.onActionRegistered?.(registeredAction);
+        }
+      }
+      return isRawBuiltinResult(instance) ? instance.action(tx) : instance(tx);
+    },
+    onActionRegistered: (action) => {
+      registeredAction = action;
+      for (const instance of instances.values()) {
+        if (isRawBuiltinResult(instance)) instance.onActionRegistered?.(action);
+      }
+    },
+  };
+}

--- a/packages/runner/src/builtins/list-result-container-seed.ts
+++ b/packages/runner/src/builtins/list-result-container-seed.ts
@@ -1,3 +1,4 @@
+import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import type { Logger } from "@commonfabric/utils/logger";
 
 import type { Cell } from "../cell.ts";
@@ -66,14 +67,17 @@ export function seedResultContainerWhenPullSettles(
   pull: Promise<unknown>,
   logger: Logger,
   seedActionId: string,
+  identity?: ScopeKeyIdentity,
 ): Promise<void> {
   const seedIfStillAbsent = (): Promise<void> => {
     if (!stillHeld()) return Promise.resolve();
     return runtime.editWithRetry((seedTx) => {
       if (!stillHeld()) return;
+      if (identity !== undefined) seedTx.tx.scopeKeyIdentity = identity;
       runtime.stampServerRun(seedTx, {
         actionId: seedActionId,
         kind: "bookkeeping",
+        scopeKeyIdentity: identity,
       });
       const scoped = container.withTx(seedTx);
       if (scoped.getRaw() === undefined) scoped.set([]);

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -1,9 +1,10 @@
 import { internSchema } from "@commonfabric/data-model-schema";
+import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import { getLogger } from "@commonfabric/utils/logger";
 
 import { type Pattern } from "../builder/types.ts";
 import { type AddCancel } from "../cancel.ts";
-import { type Cell } from "../cell.ts";
+import { type Cell, syncCellForIdentity } from "../cell.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
 import type { RawBuiltinReturnType } from "../module.ts";
 import { setPatternCell, setResultCell } from "../result-utils.ts";
@@ -27,6 +28,7 @@ import {
   type SetupRecord,
   trackListSetupRollback,
 } from "./list-element-rollback.ts";
+import { listInstanceCoordinator } from "./list-instance-coordinator.ts";
 import { seedResultContainerWhenPullSettles } from "./list-result-container-seed.ts";
 import { issueResultContainerSetup } from "./list-result-container.ts";
 import { resumeSettleRunKind } from "./resume-republish.ts";
@@ -95,6 +97,36 @@ export function map(
   outputBinding?: NormalizedFullLink,
   awaitSync?: boolean,
 ): RawBuiltinReturnType {
+  return listInstanceCoordinator((identity) =>
+    createMapInstance(
+      inputsCell,
+      sendResult,
+      addCancel,
+      _cause,
+      parentCell,
+      runtime,
+      outputBinding,
+      awaitSync,
+      identity,
+    ), addCancel);
+}
+
+/** Creates bookkeeping and deferred work for one resolution identity. */
+function createMapInstance(
+  inputsCell: Cell<{
+    list: any[];
+    op: Pattern;
+    params?: Record<string, any>;
+  }>,
+  sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
+  addCancel: AddCancel,
+  _cause: any,
+  parentCell: Cell<any>,
+  runtime: Runtime, // Runtime will be injected by the registration function
+  outputBinding?: NormalizedFullLink,
+  awaitSync?: boolean,
+  identity?: ScopeKeyIdentity,
+): RawBuiltinReturnType {
   let result: Cell<any[]> | undefined;
   // The containing piece's root: every element sub-piece this coordinator
   // starts is that piece's structure, so its actions' demand roots carry
@@ -151,10 +183,11 @@ export function map(
   // either way.
   const awaitInputThenSettle = (inputListCell: Cell<any>): void => {
     runtime.storageManager.trackUntilSettled(
-      inputListCell.sync()
+      syncCellForIdentity(inputListCell, identity)
         .then(() =>
           !active ? undefined : runtime.editWithRetry((settleTx) => {
             if (!active || !result) return;
+            if (identity !== undefined) settleTx.tx.scopeKeyIdentity = identity;
             // Out-of-band recovery write; the kind decision (bookkeeping
             // on the serving posture, derivation on clients — the settle
             // writes DERIVED content) is shared across map/filter/flatMap
@@ -162,6 +195,7 @@ export function map(
             runtime.stampServerRun(settleTx, {
               actionId: `map/resume-settle/${parentCell.sourceURI}`,
               kind: resumeSettleRunKind(runtime),
+              scopeKeyIdentity: identity,
             });
             const raw = inputsCell.key("list").withTx(settleTx).resolveAsCell()
               .withTx(settleTx).getRaw();
@@ -299,9 +333,10 @@ export function map(
         runtime,
         container,
         () => active && result === container,
-        container.sync(),
+        syncCellForIdentity(container, identity),
         logger,
         `map/resume-seed/${parentCell.sourceURI}`,
+        identity,
       );
       return;
     }

--- a/packages/runner/src/builtins/resume-republish.ts
+++ b/packages/runner/src/builtins/resume-republish.ts
@@ -1,7 +1,8 @@
+import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import type { Logger } from "@commonfabric/utils/logger";
 
 import type { JSONSchema } from "../builder/types.ts";
-import type { Cell } from "../cell.ts";
+import { type Cell, syncCellForIdentity } from "../cell.ts";
 import type { Runtime } from "../runtime.ts";
 import {
   linkResolutionProbe,
@@ -85,6 +86,9 @@ export interface ResumeRepublisherOptions {
    */
   getResult: () => Cell<any[]> | undefined;
 
+  /** Resolution identity shared by this coordinator's deferred work. */
+  identity?: ScopeKeyIdentity;
+
   inputsCell: Cell<any>;
   inputSchema: JSONSchema;
   resultSchema: JSONSchema;
@@ -137,6 +141,7 @@ export function createResumeRepublisher(
     getResult,
     inputsCell,
     inputSchema,
+    identity,
     resultSchema,
     elementRuns,
     contribute,
@@ -156,7 +161,7 @@ export function createResumeRepublisher(
     const id = cell.getAsNormalizedFullLink().id;
     const inFlight = waiting.get(id);
     if (inFlight) return inFlight;
-    const sync = cell.sync().finally(() => {
+    const sync = syncCellForIdentity(cell, identity).finally(() => {
       if (waiting.get(id) === sync) waiting.delete(id);
     });
     waiting.set(id, sync);
@@ -168,6 +173,7 @@ export function createResumeRepublisher(
 
   const republishFromConfirmed = (awaited: Set<string>): Promise<void> =>
     runtime.editWithRetry((tx): Cell<any>[] => {
+      if (identity !== undefined) tx.tx.scopeKeyIdentity = identity;
       const result = isActive() ? getResult() : undefined;
       if (!result) return [];
       // Out-of-band recovery write (serving-loop.md §3d, RULED
@@ -178,6 +184,7 @@ export function createResumeRepublisher(
       runtime.stampServerRun(tx, {
         actionId: `list-republish/${result.sourceURI}`,
         kind: "bookkeeping",
+        scopeKeyIdentity: identity,
       });
       const inputs = inputsCell.asSchema(inputSchema).withTx(tx).get() as {
         list?: unknown;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -35,6 +35,7 @@ import {
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import { isCfLinkColumn } from "@commonfabric/memory/sqlite/columns";
 import {
+  type ScopeKeyIdentity,
   type SqliteDbRef,
   type SqliteParamsWire,
   streamEntriesDocId,
@@ -932,6 +933,18 @@ export function markCellDocumentSynced(cell: Cell<any>): void {
     throw new TypeError("Expected a runner CellImpl handle");
   }
   cell[markDocumentSynced]();
+}
+
+/** Loads a document for a captured resolution identity without retaining a transaction. */
+export function syncCellForIdentity<T>(
+  cell: Cell<T>,
+  identity: ScopeKeyIdentity | undefined,
+): Promise<Cell<T>> {
+  if (identity === undefined) return cell.sync();
+  markCellDocumentSynced(cell);
+  return cell.runtime.storageManager.syncCell(cell, {
+    scopeKeyIdentity: identity,
+  });
 }
 
 /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -69,6 +69,7 @@ import {
   createCell,
   isCell,
   markCellDocumentSynced,
+  syncCellForIdentity,
 } from "./cell.ts";
 import {
   ContextualFlowControl,
@@ -5517,11 +5518,7 @@ export class Runner {
     cell: Cell<T>,
     identity: ScopeKeyIdentity | undefined,
   ): Promise<Cell<T>> {
-    if (identity === undefined) return cell.sync();
-    markCellDocumentSynced(cell);
-    return this.#runtime.storageManager.syncCell(cell, {
-      scopeKeyIdentity: identity,
-    });
+    return syncCellForIdentity(cell, identity);
   }
 
   /**

--- a/packages/runner/test/list-coordinator-instances.test.ts
+++ b/packages/runner/test/list-coordinator-instances.test.ts
@@ -191,7 +191,7 @@ describe("list-coordinator-instances", () => {
                 identity,
               );
             } finally {
-              await actorRuntime.dispose();
+              await actorRuntime.dispose({ closeStorage: false });
               await actorStorage.close();
             }
           }
@@ -254,7 +254,7 @@ describe("list-coordinator-instances", () => {
         } finally {
           for (const cancel of cancellations) cancel();
           await storage.synced();
-          await runtime.dispose();
+          await runtime.dispose({ closeStorage: false });
           await storage.close();
           await server.close();
         }

--- a/packages/runner/test/list-coordinator-instances.test.ts
+++ b/packages/runner/test/list-coordinator-instances.test.ts
@@ -1,0 +1,221 @@
+import { Identity } from "@commonfabric/identity";
+import {
+  acquireExecutionLease,
+  executionLeaseHolder,
+} from "@commonfabric/memory/v2/execution-lease";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { Pattern } from "../src/builder/types.ts";
+import { filter } from "../src/builtins/filter.ts";
+import { flatMap } from "../src/builtins/flatmap.ts";
+import { map } from "../src/builtins/map.ts";
+import {
+  listCoordinatorPlan,
+  listElementResultCell,
+} from "../src/builtins/list-coordinator-plan.ts";
+import { listInstanceCoordinator } from "../src/builtins/list-instance-coordinator.ts";
+import { useCancelGroup } from "../src/cancel.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { getMetaCell } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import {
+  EmulatedStorageManager,
+  newLoopbackServer,
+} from "../src/storage/v2-emulate.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+/** One serving coordinator must stage each principal's physical child instance. */
+describe("list-coordinator-instances", () => {
+  it("does not instantiate a coordinator for an action invoked after cancellation", () => {
+    const [cancel, addCancel] = useCancelGroup();
+    let created = 0;
+    let ran = 0;
+    const coordinator = listInstanceCoordinator(() => {
+      created++;
+      return {
+        action: () => {
+          ran++;
+        },
+      };
+    }, addCancel);
+    if (typeof coordinator === "function") {
+      throw new Error("Expected a coordinator wrapper");
+    }
+    cancel();
+    // A canceled owner must be rejected before inspecting or retaining a queued transaction.
+    coordinator.action({} as IExtendedStorageTransaction);
+    expect(created).toBe(0);
+    expect(ran).toBe(0);
+  });
+
+  for (
+    const [name, builtin] of [["map", map], ["filter", filter], [
+      "flatMap",
+      flatMap,
+    ]] as const
+  ) {
+    for (const scope of ["user", "session"] as const) {
+      it(`sets up the same named ${scope}-scoped ${name} child for both serving identities`, async () => {
+        const signer = await Identity.fromPassphrase(
+          "list-coordinator-instances",
+        );
+        const server = newLoopbackServer({ subscriptionRefreshDelayMs: 0 });
+        const storage = EmulatedStorageManager.connectTo(server, {
+          as: signer,
+        });
+        const engine = await server.engineForSpace(signer.did());
+        expect(
+          acquireExecutionLease(engine, {
+            space: signer.did(),
+            holder: executionLeaseHolder(signer.did()),
+            now: Date.now(),
+            ttlMs: 60000,
+          }),
+        ).toBe(true);
+        const runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: storage,
+          servingPosture: true,
+          experimental: { serverExecution: true },
+        });
+        const actors = await Promise.all([
+          Identity.fromPassphrase("map-alice"),
+          Identity.fromPassphrase(
+            scope === "session" ? "map-alice" : "map-bob",
+          ),
+        ]);
+        const identities = actors.map((actor, index) => ({
+          principal: actor.did(),
+          sessionId: `session-${index}` as never,
+        }));
+        const cancellations: (() => void)[] = [];
+        try {
+          const { pattern } = createTrustedBuilder(runtime).commonfabric;
+          const op = pattern(({ element }: { element: number }) => ({
+            value: element,
+          }));
+          const inputs = runtime.getCell<{ list: unknown[]; op: Pattern }>(
+            signer.did(),
+            "inputs",
+            undefined,
+            undefined,
+            scope,
+          );
+          const parent = runtime.getCell(signer.did(), "parent");
+          const output = runtime.getCell(
+            signer.did(),
+            "output",
+            undefined,
+            undefined,
+            scope,
+          ).getAsNormalizedFullLink();
+          for (const position of identities.keys()) {
+            const actorStorage = EmulatedStorageManager.connectTo(server, {
+              as: actors[position],
+            });
+            const actorRuntime = new Runtime({
+              apiUrl: new URL(import.meta.url),
+              storageManager: actorStorage,
+              experimental: { serverExecution: false },
+            });
+            try {
+              identities[position] = actorRuntime
+                .scopeKeyIdentity as typeof identities[number];
+              const identity = identities[position];
+              const tx = actorRuntime.edit();
+              const element = actorRuntime.getCell<number>(
+                signer.did(),
+                "element",
+                undefined,
+                tx,
+                scope,
+              );
+              element.set(position + 1);
+              actorRuntime.getCellFromLink(
+                inputs.getAsNormalizedFullLink(),
+                undefined,
+                tx,
+              ).set({ list: [element], op });
+              expect((await tx.commit()).error).toBeUndefined();
+              await actorStorage.synced();
+              await storage.syncInstance(
+                inputs.getAsNormalizedFullLink(),
+                identity,
+              );
+              await storage.syncInstance(
+                element.getAsNormalizedFullLink(),
+                identity,
+              );
+            } finally {
+              await actorRuntime.dispose();
+              await actorStorage.close();
+            }
+          }
+          expect(identities[0].sessionId).not.toBe(identities[1].sessionId);
+          if (scope === "session") {
+            expect(identities[0].principal).toBe(identities[1].principal);
+          } else {
+            expect(identities[0].principal).not.toBe(identities[1].principal);
+          }
+          const coordinator = builtin(
+            inputs,
+            () => {},
+            (cancel) => {
+              if (cancel) cancellations.push(cancel);
+            },
+            {},
+            parent,
+            runtime,
+            output,
+          );
+          if (typeof coordinator === "function") {
+            throw new Error("Expected a map coordinator");
+          }
+          const childNames: string[] = [];
+          for (const identity of identities) {
+            const tx = runtime.edit();
+            tx.tx.scopeKeyIdentity = identity;
+            const plan = listCoordinatorPlan(
+              runtime,
+              tx,
+              name,
+              inputs,
+              {
+                type: "object",
+                properties: { op: { asCell: ["cell"] } },
+              },
+              parent,
+              output,
+            );
+            const child = listElementResultCell(
+              runtime,
+              tx,
+              name,
+              plan.container,
+              [...plan.elementKeys.values()][0],
+            );
+            childNames.push(child.getAsNormalizedFullLink().id);
+            coordinator.action(tx);
+            const argument = getMetaCell(child, "argument", tx).getRaw();
+            expect(
+              argument,
+              `missing staged child setup for ${
+                identity === identities[0] ? "Alice" : "Bob"
+              }`,
+            ).toBeDefined();
+            runtime.prepareTxForCommit(tx);
+            expect((await tx.commit()).error).toBeUndefined();
+          }
+          expect(childNames[0]).toBe(childNames[1]);
+        } finally {
+          for (const cancel of cancellations) cancel();
+          await storage.synced();
+          await runtime.dispose();
+          await storage.close();
+          await server.close();
+        }
+      });
+    }
+  }
+});

--- a/packages/runner/test/list-coordinator-instances.test.ts
+++ b/packages/runner/test/list-coordinator-instances.test.ts
@@ -15,6 +15,7 @@ import {
   listElementResultCell,
 } from "../src/builtins/list-coordinator-plan.ts";
 import { listInstanceCoordinator } from "../src/builtins/list-instance-coordinator.ts";
+import type { Action } from "../src/scheduler.ts";
 import { useCancelGroup } from "../src/cancel.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { getMetaCell } from "../src/link-utils.ts";
@@ -47,6 +48,48 @@ describe("list-coordinator-instances", () => {
     coordinator.action({} as IExtendedStorageTransaction);
     expect(created).toBe(0);
     expect(ran).toBe(0);
+  });
+
+  it("forwards registration to existing instances and instances created afterward", () => {
+    const [cancel, addCancel] = useCancelGroup();
+    const registrations: Action[][] = [];
+    const coordinator = listInstanceCoordinator(() => {
+      const registered: Action[] = [];
+      registrations.push(registered);
+      return {
+        action: () => {},
+        onActionRegistered: (action) => {
+          registered.push(action);
+        },
+      };
+    }, addCancel);
+    if (typeof coordinator === "function") {
+      throw new Error("Expected coordinator wrapper");
+    }
+    try {
+      const transaction = { tx: {} } as IExtendedStorageTransaction;
+      coordinator.action(transaction);
+      expect(registrations).toEqual([[]]);
+      const first: Action = () => {};
+      coordinator.onActionRegistered?.(first);
+      expect(registrations).toEqual([[first]]);
+      coordinator.action(
+        {
+          tx: { scopeKeyIdentity: { principal: "did:key:second" } },
+        } as IExtendedStorageTransaction,
+      );
+      expect(registrations).toEqual([[first], [first]]);
+      const replacement: Action = () => {};
+      coordinator.onActionRegistered?.(replacement);
+      expect(registrations).toEqual([[first, replacement], [
+        first,
+        replacement,
+      ]]);
+      coordinator.action(transaction);
+      expect(registrations).toHaveLength(2);
+    } finally {
+      cancel();
+    }
   });
 
   for (

--- a/packages/runner/test/list-deferred-identity.test.ts
+++ b/packages/runner/test/list-deferred-identity.test.ts
@@ -126,7 +126,7 @@ describe("list deferred identity", () => {
       } finally {
         held.resolve();
         cancel();
-        await runtime.dispose();
+        await runtime.dispose({ closeStorage: false });
         await storage.close();
       }
     });
@@ -240,7 +240,7 @@ describe("list deferred identity", () => {
       }]);
     } finally {
       held.resolve();
-      await runtime.dispose();
+      await runtime.dispose({ closeStorage: false });
       await storage.close();
     }
   });

--- a/packages/runner/test/list-deferred-identity.test.ts
+++ b/packages/runner/test/list-deferred-identity.test.ts
@@ -1,0 +1,247 @@
+import { Identity } from "@commonfabric/identity";
+import { getLogger } from "@commonfabric/utils/logger";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+
+import { filter, FILTER_INPUT_SCHEMA } from "../src/builtins/filter.ts";
+import { flatMap, FLATMAP_INPUT_SCHEMA } from "../src/builtins/flatmap.ts";
+import { map, MAP_INPUT_SCHEMA } from "../src/builtins/map.ts";
+import { listCoordinatorPlan } from "../src/builtins/list-coordinator-plan.ts";
+import { listElementKeys } from "../src/builtins/list-element-keys.ts";
+import { createResumeRepublisher } from "../src/builtins/resume-republish.ts";
+import { useCancelGroup } from "../src/cancel.ts";
+import { Runtime } from "../src/runtime.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+/** Deferred writes use captured identities after their initiating transactions settle. */
+describe("list deferred identity", () => {
+  for (
+    const [name, builtin, schema] of [
+      ["map", map, MAP_INPUT_SCHEMA],
+      ["filter", filter, FILTER_INPUT_SCHEMA],
+      ["flatMap", flatMap, FLATMAP_INPUT_SCHEMA],
+    ] as const
+  ) {
+    it(`retains the ${name} input until its identity-bound sync confirms emptiness`, async () => {
+      const signer = await Identity.fromPassphrase(`deferred-${name}`);
+      const storage = EmulatedStorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: storage,
+      });
+      const [cancel, addCancel] = useCancelGroup();
+      const held = Promise.withResolvers<void>();
+      try {
+        const identity = { ...runtime.scopeKeyIdentity };
+        const { pattern } = createTrustedBuilder(runtime).commonfabric;
+        const op = pattern(({ element }: { element: number }) => ({
+          value: element,
+        }));
+        let tx = runtime.edit();
+        const list = runtime.getCell<number[]>(
+          signer.did(),
+          "list",
+          undefined,
+          tx,
+        );
+        list.set([]);
+        const inputs = runtime.getCell<{ list: number[]; op: typeof op }>(
+          signer.did(),
+          "inputs",
+          undefined,
+          tx,
+        );
+        inputs.set({ list, op });
+        const parent = runtime.getCell(signer.did(), "parent", undefined, tx);
+        const output = runtime.getCell(signer.did(), "output")
+          .getAsNormalizedFullLink();
+        const plan = listCoordinatorPlan(
+          runtime,
+          tx,
+          name,
+          inputs,
+          schema,
+          parent,
+          output,
+        );
+        const element = runtime.getCell<number>(
+          signer.did(),
+          "old-element",
+          undefined,
+          tx,
+        );
+        element.set(42);
+        plan.container.set([element]);
+        expect((await tx.commit()).error).toBeUndefined();
+        await storage.synced();
+        const sync = storage.syncCell.bind(storage);
+        const syncIdentities: unknown[] = [];
+        using _sync = stub(storage, "syncCell", (cell, options) => {
+          if (
+            cell.getAsNormalizedFullLink().id !==
+              list.getAsNormalizedFullLink().id
+          ) return sync(cell, options);
+          syncIdentities.push(options?.scopeKeyIdentity);
+          return held.promise.then(() => cell);
+        });
+        const stamp = runtime.stampServerRun.bind(runtime);
+        const stamps: unknown[] = [];
+        using _stamp = stub(runtime, "stampServerRun", (transaction, info) => {
+          stamps.push({ identity: transaction.tx.scopeKeyIdentity, info });
+          stamp(transaction, info);
+        });
+        const coordinator = builtin(
+          inputs.withTx(),
+          () => {},
+          addCancel,
+          {},
+          parent.withTx(),
+          runtime,
+          output,
+          true,
+        );
+        if (typeof coordinator === "function") {
+          throw new Error("Expected coordinator");
+        }
+        tx = runtime.edit();
+        tx.tx.scopeKeyIdentity = identity;
+        coordinator.action(tx);
+        expect((await tx.commit()).error).toBeUndefined();
+        expect(plan.container.withTx().get()).toEqual([42]);
+        expect(syncIdentities).toEqual([identity]);
+        expect(stamps).toEqual([]);
+        held.resolve();
+        await storage.synced();
+        expect(plan.container.withTx().get()).toEqual([]);
+        expect(stamps).toEqual([{
+          identity,
+          info: {
+            actionId: `${name}/resume-settle/${parent.sourceURI}`,
+            kind: "derivation",
+            scopeKeyIdentity: identity,
+          },
+        }]);
+      } finally {
+        held.resolve();
+        cancel();
+        await runtime.dispose();
+        await storage.close();
+      }
+    });
+  }
+
+  it("republishes with the captured identity after a predicate sync settles", async () => {
+    const signer = await Identity.fromPassphrase("deferred-republisher");
+    const storage = EmulatedStorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    const held = Promise.withResolvers<void>();
+    try {
+      const identity = { ...runtime.scopeKeyIdentity };
+      const tx = runtime.edit();
+      const element = runtime.getCell<number>(
+        signer.did(),
+        "element",
+        undefined,
+        tx,
+      );
+      element.set(42);
+      const predicate = runtime.getCell<boolean>(
+        signer.did(),
+        "predicate",
+        undefined,
+        tx,
+      );
+      predicate.set(false);
+      const inputs = runtime.getCell<{ list: number[] }>(
+        signer.did(),
+        "inputs",
+        undefined,
+        tx,
+      );
+      inputs.set({ list: [element] });
+      const result = runtime.getCell<number[]>(
+        signer.did(),
+        "result",
+        undefined,
+        tx,
+      );
+      result.set([element]);
+      expect((await tx.commit()).error).toBeUndefined();
+      await storage.synced();
+      const sync = storage.syncCell.bind(storage);
+      const syncIdentities: unknown[] = [];
+      using _sync = stub(storage, "syncCell", (cell, options) => {
+        if (
+          cell.getAsNormalizedFullLink().id !==
+            predicate.getAsNormalizedFullLink().id
+        ) return sync(cell, options);
+        syncIdentities.push(options?.scopeKeyIdentity);
+        return held.promise.then(() => cell);
+      });
+      const stamp = runtime.stampServerRun.bind(runtime);
+      const stamps: unknown[] = [];
+      using _stamp = stub(runtime, "stampServerRun", (transaction, info) => {
+        stamps.push({ identity: transaction.tx.scopeKeyIdentity, info });
+        stamp(transaction, info);
+      });
+      const key = listElementKeys([element]).get(0)!;
+      const republisher = createResumeRepublisher({
+        runtime,
+        identity,
+        logger: getLogger("deferred-republisher"),
+        isActive: () => true,
+        getResult: () => result.withTx(),
+        inputsCell: inputs.withTx(),
+        inputSchema: {
+          type: "object",
+          properties: {
+            list: {
+              type: "array",
+              items: { asCell: ["cell"], type: "unknown" },
+            },
+          },
+        },
+        resultSchema: {
+          type: "array",
+          items: { asCell: ["cell"], type: "unknown" },
+        },
+        elementRuns: new Map([[key, {
+          resultCell: predicate.withTx(),
+          lastIndex: 0,
+          needsSetup: false,
+        }]]),
+        contribute: (value, original, out) => {
+          if (value) out.push(original);
+          return value === undefined ? "pending" : undefined;
+        },
+        aggregateNoun: "filtered list",
+        elementNoun: "predicate",
+        rearmReconcile: () => {},
+      });
+      republisher.awaitPendingThenRepublish([predicate.withTx()]);
+      expect(syncIdentities).toEqual([identity]);
+      expect(result.withTx().get()).toEqual([42]);
+      expect(stamps).toEqual([]);
+      held.resolve();
+      await storage.synced();
+      expect(result.withTx().get()).toEqual([]);
+      expect(stamps).toEqual([{
+        identity,
+        info: {
+          actionId: `list-republish/${result.sourceURI}`,
+          kind: "bookkeeping",
+          scopeKeyIdentity: identity,
+        },
+      }]);
+    } finally {
+      held.resolve();
+      await runtime.dispose();
+      await storage.close();
+    }
+  });
+});

--- a/packages/runner/test/list-result-container-seed.test.ts
+++ b/packages/runner/test/list-result-container-seed.test.ts
@@ -269,6 +269,54 @@ describe("list-result-container-seed", () => {
       expect(logger.reportedError(0)).toBe(rejection);
     });
 
+    it("retains each deferred seed's identity when pulls settle in reverse order", async () => {
+      const firstIdentity = { ...runtime.scopeKeyIdentity };
+      const other = await Identity.fromPassphrase("other deferred seed owner");
+      const secondIdentity = { ...firstIdentity, principal: other.did() };
+      const identities = [firstIdentity, secondIdentity];
+      const pulls = identities.map(() => Promise.withResolvers<void>());
+      const containers = identities.map((_, index) =>
+        newContainer(`identity-seed-${index}`)
+      );
+      const stamped: ServerRunInfo[] = [];
+      const transactionIdentities: unknown[] = [];
+      const stamp = runtime.stampServerRun.bind(runtime);
+      (runtime as any).stampServerRun = (
+        tx: IExtendedStorageTransaction,
+        info: ServerRunInfo,
+      ) => {
+        transactionIdentities.push(tx.tx.scopeKeyIdentity);
+        stamped.push(info);
+        stamp(tx, info);
+      };
+      const pending = identities.map((identity, index) =>
+        seedResultContainerWhenPullSettles(
+          runtime,
+          containers[index],
+          () => true,
+          pulls[index].promise,
+          logger,
+          `identity-seed-${index}`,
+          identity,
+        )
+      );
+      expect(stamped).toEqual([]);
+      pulls[1].resolve();
+      await pending[1];
+      expect(valueOf(containers[0])).toBeUndefined();
+      expect(valueOf(containers[1])).toEqual([]);
+      pulls[0].resolve();
+      await pending[0];
+      expect(valueOf(containers[0])).toEqual([]);
+      expect(transactionIdentities).toEqual([secondIdentity, firstIdentity]);
+      expect(stamped).toEqual([1, 0].map((index) => ({
+        actionId: `identity-seed-${index}`,
+        kind: "bookkeeping",
+        scopeKeyIdentity: identities[index],
+      })));
+      expect(logger.warnings).toEqual([]);
+    });
+
     it("stamps every seed attempt's transaction as sanctioned bookkeeping", async () => {
       const container = newContainer("stamped-seed");
       // The seed transaction is minted outside any scheduler run, so nothing


### PR DESCRIPTION
## Why

With server execution enabled, Alice and Bob can both see updated lunch-poll vote totals while Bob's nested voter rows remain empty. One registered list coordinator shares its setup records across serving principals and incorrectly treats Alice's scoped child setup as satisfying Bob's. This blocks the reactive-row migration in #7317, following the scope-kind repair in #7313.

## What Changed

Partition map, filter, and flatMap coordinator closures by the full resolution identity while preserving canonical child addresses. Carry that identity through deferred pulls, empty-container seeding, and republishing. Reuse the runner's scoped synchronization behavior through a shared Cell helper. Released coordinators refuse queued invocations before creating new instance state.

## Test plan

- Real serving transactions exercise all three list operators with different principals and with two sessions of one principal; each stages its own child setup at the same canonical child address. Removing the partition fails Bob's setup assertion.
- Deferred input-settle and republisher tests hold real sync promises and verify preserved values followed by confirmed updates, plus captured transaction and server-run identities. Isolated before/after LCOV verifies every line flagged by the coverage check changes from zero to positive hits.
- Deferred seed tests resolve identity-specific pulls in reverse order and verify transaction and server-run identities; a canceled coordinator cannot create new state.
- Focused runtime suites: 5 passed, 33 steps. Additional typed verification of the two changed test files passes (2 suites, 12 steps). Repository type checks, formatting, lint, and 599 documentation checks pass.
- Complete local two-user browser tests pass with server execution enabled and disabled; the client run uses an isolated build and finishes in 16 seconds. These runs include the reactive-row candidate and use synthetic local data only.
- Full runner package validation: 1,436 tests / 8,954 steps passed, with one existing ignored step.

Antagonistic cf-review found no blocking findings. Browser assertions establish rendered rows and subsequent updates; they do not claim zero scheduler diagnostics or a performance bound.
