### PR TITLE
Index pending schema policies to bound document lookup work

### DIFF
--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -4,6 +4,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Audits and reports
 
+- [2026-09-11-pending-schema-policy-index.md](development/performance/2026-09-11-pending-schema-policy-index.md) — document-indexed pending schema-policy lookup CPU attribution and 1,184-vote fixture acceptance with unchanged read budgets.
+
 - [2026-09-10-lunch-poll-read-baseline.md](development/performance/2026-09-10-lunch-poll-read-baseline.md) — controlled A0 baseline with 14 options, eight same-space voters, 74 keyed votes, continuous headless UI demand, and per-action read counts.
 - [2026-09-10-read-accounting-probes.md](development/performance/2026-09-10-read-accounting-probes.md) — disabled-probe comparison for initial reactive action read accounting: five alternating control/candidate windows over 1,000 lazy-view elements, and the limits of the lunch-poll functional smoke check.
 - [coverage-status-audit-2026-09-09.md](plans/server-execution-v2/optimize/coverage-status-audit-2026-09-09.md) — OW28 landing-provenance and coverage-status audit at `16de7e0c87`: the preserved compile-and-run port and its end-to-end test were omitted from #6096 despite the completion claim; current writeback refusal and an OFF-path program-proxy cache collision reproduced, with OW18, OW30, OW31, OW55, OW56, OW58, OW60, and rollout statements reconciled against current source and focused suites.

--- a/docs/history/development/performance/2026-09-11-pending-schema-policy-index.md
+++ b/docs/history/development/performance/2026-09-11-pending-schema-policy-index.md
@@ -1,0 +1,58 @@
+---
+status: historical
+created: 2026-09-11
+archived: 2026-09-11
+reason: "CPU attribution and acceptance snapshot for document-indexed pending schema policies."
+---
+
+# Pending schema-policy lookup profile
+
+The synthetic 1,184-vote lunch-poll fixture used the reactive-row candidate from
+PR #7317 at `14ece16b0437c73dc5280c6ac9190007c098d57c`, with the serving-instance
+coordinator repair copied from its checkout based on main
+`c92e122bd7ecf39b95d09abaad83ef79dccec355`. The indexed candidate additionally
+contained this change's transaction-local schema-policy index. No live poll
+was accessed.
+
+The initial worker CPU profile attributed 65,426 ms of sampled self time to
+`hasPendingSchemaPolicyInput()`, 20,556 ms to the transaction read-only proxy's
+getter, and 13,831 ms to `readOnlyCfcView()`. Link writes repeatedly scanned the
+whole transaction's policy-input history to find schemas for one document.
+
+The candidate indexed the same frozen schema records by exact space and document
+ID. It retained cross-scope matching and the existing path/IFC relevance checks.
+The complete policy-input array remained available to commit preparation.
+
+| Sampled self time | Initial profile | Indexed profile |
+| --- | ---: | ---: |
+| Pending schema-policy predicate | 65,426 ms | 6 ms |
+| Read-only transaction proxy getter | 20,556 ms | 33 ms |
+| Read-only view helper | 13,831 ms | 160 ms |
+| Indexed document query | Not present | 26 ms |
+
+Both profiled runs used `profile-cf.ts test` with `--timeout 600000` and
+`--no-idempotency-check` for attribution. Both fixture assertions passed. Reported
+fixture totals were 199,870 ms and 127,230 ms respectively. Other local validation
+ran concurrently, and this was not an alternating controlled timing experiment;
+these totals establish completed workloads, not a general speedup guarantee.
+The indexed profile's largest named costs were garbage collection and dependency
+ordering.
+
+A separate candidate run used the CI action limit and ordinary idempotency checks:
+
+```sh
+deno task cf test \
+  packages/patterns/integration/fixtures/lunch-poll-read-scale/1184-votes.test.tsx \
+  --timeout 180000
+```
+
+It passed both assertions and unchanged read budgets in 127,868 ms. The first
+render budgets remained 236,000 total / 96,000 maximum per run, and the update
+budgets remained 214,000 / 96,000. An earlier invocation omitted `--timeout`, used
+the CLI's 5,000 ms default, and failed teardown; it is excluded from acceptance.
+
+The index narrows lookup to one document's schema history. It does not bound
+that history, path traversal, dependency topology, or all CFC preparation work.
+Raw CPU profiles and logs were retained locally under
+`/tmp/b13-lunch-1184-{cpu,indexed-cpu}.*` and
+`/tmp/b13-lunch-1184-policy-index-ci.log`.

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -218,10 +218,7 @@ const hasPendingSchemaPolicyInput = (
   source: NormalizedFullLink,
 ): boolean => {
   const sourcePath = canonicalizeLogicalPath(source.path);
-  return tx.getCfcState().writePolicyInputs.some((input) =>
-    input.kind === "schema" &&
-    input.target.space === source.space &&
-    input.target.id === source.id &&
+  return tx.getCfcSchemaPolicyInputs(source.space, source.id).some((input) =>
     pathsOverlap(canonicalizeLogicalPath(input.target.path), sourcePath) &&
     schemaIfcOverlapsPath(
       input.schema,

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -169,6 +169,9 @@ import {
  */
 const CURRENT_INSTANT = "now";
 
+/** The immutable result of a schema-input query for an unrecorded document. */
+const NO_SCHEMA_POLICY_INPUTS = Object.freeze([]);
+
 let nextReadMetaIdentity = 0;
 const readMetaIdentities = new WeakMap<Metadata, number>();
 
@@ -455,6 +458,11 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     labelMetadataObservations: [],
     refusalDetails: [],
   };
+
+  #schemaPolicyInputs = new Map<
+    MemorySpace,
+    Map<string, Extract<WritePolicyInput, { kind: "schema" }>[]>
+  >();
 
   #reportedCfcRelevant = false;
   #reportedCfcPrepared = false;
@@ -1732,6 +1740,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // `compareWritePolicyInput` then re-hashes each element via the cache.
     const frozen = deepFreeze(input);
     this.#cfcState.writePolicyInputs.push(frozen);
+    if (frozen.kind === "schema") {
+      let documents = this.#schemaPolicyInputs.get(frozen.target.space);
+      if (!documents) {
+        documents = new Map();
+        this.#schemaPolicyInputs.set(frozen.target.space, documents);
+      }
+      let inputs = documents.get(frozen.target.id);
+      if (!inputs) {
+        inputs = [];
+        documents.set(frozen.target.id, inputs);
+      }
+      inputs.push(frozen);
+    }
     // Capture the identity active right now so writeAuthorizedBy is verified
     // against the trust context that authored this write, even if a later run
     // in the same transaction changes the identity.
@@ -1765,6 +1786,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     if (this.#cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-policy-input-added");
     }
+  }
+
+  /**
+   * Returns a read-only view of schema inputs for a document across scopes.
+   * Queries visit only that document's recorded schema inputs.
+   */
+  getCfcSchemaPolicyInputs(
+    space: MemorySpace,
+    id: string,
+  ): readonly Extract<WritePolicyInput, { kind: "schema" }>[] {
+    return readOnlyCfcView(
+      this.#schemaPolicyInputs.get(space)?.get(id) ?? NO_SCHEMA_POLICY_INPUTS,
+    );
   }
 
   isRuntimeWritePolicyInput(input: WritePolicyInput): boolean {
@@ -3738,6 +3772,14 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     authorization?: RuntimeWritePolicyAuthorization,
   ): void {
     this.#wrapped.recordCfcWritePolicyInput(input, authorization);
+  }
+
+  /** Delegates document schema-input queries to the wrapped transaction. */
+  getCfcSchemaPolicyInputs(
+    space: MemorySpace,
+    id: string,
+  ): readonly Extract<WritePolicyInput, { kind: "schema" }>[] {
+    return this.#wrapped.getCfcSchemaPolicyInputs(space, id);
   }
 
   isRuntimeWritePolicyInput(input: WritePolicyInput): boolean {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1997,6 +1997,16 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   ): void;
 
   /**
+   * Returns read-only schema inputs recorded for the document across scopes.
+   * Each query includes inputs appended since earlier queries, including a
+   * query that found none. Path and IFC relevance remain the caller's checks.
+   */
+  getCfcSchemaPolicyInputs(
+    space: MemorySpace,
+    id: string,
+  ): readonly Extract<WritePolicyInput, { kind: "schema" }>[];
+
+  /**
    * Whether `input` was recorded by the runtime, under
    * `runtimeWritePolicyAuthorization`.
    *

--- a/packages/runner/test/extended-storage-transaction.test.ts
+++ b/packages/runner/test/extended-storage-transaction.test.ts
@@ -319,6 +319,79 @@ describe("extended-storage-transaction", () => {
     });
   });
 
+  describe("document schema-policy inputs", () => {
+    it("includes later inputs across scopes while excluding other documents", async () => {
+      const otherSpace = (await Identity.fromPassphrase("policy-input-other"))
+        .did();
+      const tx = runtime.edit();
+      const wrapped = createNonReactiveTransaction(tx);
+      const target = {
+        space,
+        id: "of:policy",
+        scope: "space",
+        path: [],
+      } as const;
+      expect(wrapped.getCfcSchemaPolicyInputs(space, target.id)).toEqual([]);
+      const first = { kind: "schema", target, schema: SCHEMA } as const;
+      tx.recordCfcWritePolicyInput(first);
+      tx.recordCfcWritePolicyInput({
+        kind: "schema",
+        target: { ...target, id: "of:other" },
+        schema: SCHEMA,
+      });
+      tx.recordCfcWritePolicyInput({
+        kind: "schema",
+        target: { ...target, space: otherSpace },
+        schema: SCHEMA,
+      });
+      tx.recordCfcWritePolicyInput({
+        kind: "custom",
+        target,
+        name: "other-kind",
+        value: null,
+      });
+      const second = {
+        kind: "schema",
+        target: { ...target, scope: "user", path: ["title"] },
+        schema: { type: "string" },
+      } as const;
+      wrapped.recordCfcWritePolicyInput(second);
+      expect(tx.getCfcSchemaPolicyInputs(space, target.id)).toEqual([
+        first,
+        second,
+      ]);
+      expect(wrapped.getCfcSchemaPolicyInputs(space, target.id)).toEqual([
+        first,
+        second,
+      ]);
+      expect(tx.getCfcState().writePolicyInputs).toHaveLength(5);
+      tx.abort();
+      const fresh = runtime.edit();
+      expect(fresh.getCfcSchemaPolicyInputs(space, target.id)).toEqual([]);
+      fresh.abort();
+    });
+
+    it("protects the indexed inputs and their nested schema from mutation", () => {
+      const tx = runtime.edit();
+      const target = {
+        space,
+        id: "of:immutable-policy",
+        scope: "space",
+        path: [],
+      } as const;
+      tx.recordCfcWritePolicyInput({ kind: "schema", target, schema: SCHEMA });
+      const inputs = tx.getCfcSchemaPolicyInputs(space, target.id);
+      expect(() => Reflect.set(inputs, "length", 0)).toThrow("read-only");
+      expect(Reflect.set(inputs[0].target, "id", "of:corrupted")).toBe(false);
+      expect(Reflect.set(SCHEMA.properties.title, "type", "number")).toBe(
+        false,
+      );
+      expect(tx.getCfcSchemaPolicyInputs(space, target.id)).toHaveLength(1);
+      expect(tx.getCfcState().writePolicyInputs).toHaveLength(1);
+      tx.abort();
+    });
+  });
+
   describe("a write-policy input's recorder", () => {
     // A gate that ACTS on a write-policy input asks who recorded it, because
     // this method is on the public interface and pattern-authored code


### PR DESCRIPTION
## Why

The reactive lunch-row candidate in #7317 makes the 1,184-vote fixture spend much of its CPU time repeatedly scanning all pending schema policies for each link write. Its CI render action exceeds the existing limit. A transaction-local document index removes that repeated whole-transaction scan without changing which policies apply.

## What Changed

Index the same deep-frozen schema records by exact space and document ID at the existing recording chokepoint. Keep cross-scope matching, path/IFC relevance checks, read-only state access, and complete commit-boundary policy inputs. Delegate queries through transaction wrappers. Record the CPU attribution and synthetic fixture acceptance in the linked performance report.

## Test plan

- Full runner package: 1,434 tests / 8,944 steps passed, one existing ignored step.
- All 46 workspace type groups, 599 documentation blocks, history index, repository formatting and lint pass.
- Focused transaction/CFC boundary suites cover later appends after a miss, other document/space/kind exclusion, cross-scope inclusion, wrappers, immutability, and new-transaction isolation.
- With #7317's reactive rows and #7320's coordinator repair, the 1,184-vote fixture passes both assertions at `--timeout 180000`, idempotency enabled, and unchanged read budgets (127,868 ms total).
- Worker CPU profiles reduce pending-policy predicate sampled self time from 65,426 ms to 6 ms. Profile totals are not a controlled wall-time comparison; the report states the concurrency and instrumentation limits.

Antagonistic cf-review found no blocking findings. Queries still scan the selected document's schema history; this does not bound total CFC preparation work. Synthetic local data only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

