### PR TITLE
Share pending read bases across paths within a commit

### DIFF
--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -6543,6 +6543,13 @@ export class SpaceReplica
     // nonRecursive read at this parent (emitted after the loop).
     const structuralTarget = getBlindStructuralTarget(source);
 
+    // Pending bases belong to a document instance and the speculative-layer
+    // policy. Every path read in this synchronous build shares that same stack.
+    const pendingLayersByDocument = [
+      new Map<string, number[]>(),
+      new Map<string, number[]>(),
+    ];
+
     // Emit one commit read for `id`, baselined against the most recent in-flight
     // local version of that doc below this commit's localSeq if one exists, else
     // the confirmed seq (or an explicit `confirmedSeq` override, e.g. a read that
@@ -6601,9 +6608,8 @@ export class SpaceReplica
       confirmedSeq?: number,
       excludeSpeculativeLayers = false,
     ) => {
-      const record = this.#docs.get(
-        docKey(id, this.instanceKey(scope, identity)),
-      );
+      const recordKey = docKey(id, this.instanceKey(scope, identity));
+      const record = this.#docs.get(recordKey);
       // The read's materialized view sat on EVERY lower pending layer, not
       // just the nearest one: name them ALL (ascending; the last element is
       // the doc's top-of-stack below this commit) so a dropped deeper layer
@@ -6615,17 +6621,24 @@ export class SpaceReplica
       // servers base staleness at the highest element only — a lower-layer
       // basis WITHOUT that exclusion would false-conflict with the
       // session's own later stacked writes (CT-1872 1c).
-      const layers = [
-        ...new Set(
-          record?.pending
-            .filter((version) => version.localSeq < localSeq)
-            .filter((version) =>
-              !excludeSpeculativeLayers ||
-              !this.#speculativeLocalSeqs.has(version.localSeq)
-            )
-            .map((version) => version.localSeq) ?? [],
-        ),
-      ].sort((left, right) => left - right);
+      const layersByDocument = pendingLayersByDocument[
+        excludeSpeculativeLayers ? 1 : 0
+      ];
+      let layers = layersByDocument.get(recordKey);
+      if (layers === undefined) {
+        layers = [
+          ...new Set(
+            record?.pending
+              .filter((version) => version.localSeq < localSeq)
+              .filter((version) =>
+                !excludeSpeculativeLayers ||
+                !this.#speculativeLocalSeqs.has(version.localSeq)
+              )
+              .map((version) => version.localSeq) ?? [],
+          ),
+        ].sort((left, right) => left - right);
+        layersByDocument.set(recordKey, layers);
+      }
       const shape = nonRecursive ? { nonRecursive: true } : {};
       if (layers.length > 0) {
         pending.push({

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -5,6 +5,8 @@ import {
   assertStrictEquals,
 } from "@std/assert";
 
+import { expect } from "@std/expect";
+
 import type { FabricValue } from "@commonfabric/api";
 import { NullLiveEnvironment } from "@commonfabric/data-model/codec-common";
 import {
@@ -1904,6 +1906,23 @@ Deno.test("memory v2 stacked commits: pending-read compaction keeps localSeq bou
         { id: DOCS.A, localSeq: [1, 2], path: ["value"] },
       ],
     );
+    const siblingReads = harness.replica.accessForTestingOnly.buildReads(
+      sourceFromReads(Array.from({ length: 100 }, (_, index) => ({
+        id: DOCS.A,
+        path: [`field-${index}`],
+      }))),
+      3,
+    );
+    expect(siblingReads.pending).toHaveLength(100);
+    expect(new Set(siblingReads.pending.map((read) => read.localSeq)).size)
+      .toBe(1);
+    expect(siblingReads.pending[0].localSeq).toEqual([1, 2]);
+    const earlierReads = harness.replica.accessForTestingOnly.buildReads(
+      sourceFromReads([{ id: DOCS.A, path: ["field-0"] }]),
+      2,
+    );
+    expect(earlierReads.pending[0].localSeq).toBe(1);
+    expect(siblingReads.pending[0].localSeq).toEqual([1, 2]);
     await assertResultOk(c1.promise);
     await assertResultOk(c2.promise);
   } finally {


### PR DESCRIPTION
## Why

A commit that reads many paths of one document builds the same pending-version list for each path. With P paths and L pending versions, those lists retain O(P × L) entries before read compaction. Collection-index initialization in #7323 exposes this cost.

## What Changed

Share pending-version lists within one synchronous read-set build, keyed by the canonical document instance and whether speculative versions must be excluded. Each build computes its own lists; confirmed bases and path granularity stay per read. Wire data and conflict semantics are unchanged.

This is a bounded allocation improvement. The 512-row collection-index probe still exhausts the heap with this change, so it does not resolve #7323's scale blocker.

## Test plan

- Full runner: 1,437 tests / 8,959 steps passed; one existing ignored step.
- Focused stacked-commit and read-basis suites: 87 tests / 13 steps passed.
- The regression uses 100 sibling paths: they retain one shared dependency list. Removing this change fails with 100 lists. A separate earlier-sequence build names only the older layer and leaves the first build unchanged.
- All 46 repository type groups, repository formatting and lint pass.
- Antagonistic cf-review found no blocking issue. The cache is local to one synchronous build, partitions speculative-read policy, and uses the existing canonical instance key. Existing pending-list consumers were checked for mutation.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

