### PR TITLE
Preserve metadata when merging primitive union schemas

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -403,7 +403,10 @@ pre-cleanup schemas.
   formats member-wise, preserving `{ type: "undefined" }` / `{ type: "null" }`,
   skipping conditional/type-parameter members, deduping identical member
   schemas (`isWrapperUnion` / `formatWrapperUnion` / `maybeWrapInAnyOf`).
-  Mixed unions fall to `UnionFormatter`.
+  Mixed unions fall to `UnionFormatter`. Primitive alternatives merge only
+  when both schemas contain exclusively `type` and `enum`; metadata-bearing
+  alternatives, including Cell wrappers, remain separate even when their
+  underlying primitive types match.
 - `Cell<Stream<T>>` **throws** with a boxing suggestion, from both the node
   path and the type path; tested (cell-type.test.ts).
 - `FactoryInput<T>` (alias-name detection) formats the inner type

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -1016,8 +1016,12 @@ export class UnionFormatter implements TypeFormatter {
     if (anyOf.some((option) => hashStringOf(option) === curHash)) {
       return false;
     }
-    // See if we can merge into one of the anyOf options
+    const isCurPrimitive = PRIMITIVE_SCHEMA_KEY_SET.isSupersetOf(
+      new Set(Object.keys(cur)),
+    );
+    // Merge only schemas whose complete meaning is a primitive type and enum.
     const matchingTypeIdx = anyOf.findIndex((option) =>
+      isCurPrimitive &&
       isObjectOrArray(option) &&
       PRIMITIVE_SCHEMA_KEY_SET.isSupersetOf(new Set(Object.keys(option))) &&
       "type" in option && option.type === cur.type
@@ -1025,9 +1029,6 @@ export class UnionFormatter implements TypeFormatter {
     const matchingType = matchingTypeIdx !== -1
       ? anyOf[matchingTypeIdx]
       : undefined;
-    const isCurPrimitive = PRIMITIVE_SCHEMA_KEY_SET.isSupersetOf(
-      new Set(Object.keys(cur)),
-    );
     if (
       isObjectOrArray(cur) && Array.isArray(cur.enum) &&
       isObjectOrArray(matchingType) &&

--- a/packages/schema-generator/test/schema/cell-type.test.ts
+++ b/packages/schema-generator/test/schema/cell-type.test.ts
@@ -4,6 +4,24 @@ import { SchemaGenerator } from "../../src/schema-generator.ts";
 import { asObjectSchema, getTypeFromCode } from "../utils.ts";
 
 describe("Schema: Cell types", () => {
+  for (const primitive of ["string", "number"] as const) {
+    it(`preserves Cell metadata beside a matching ${primitive} union member`, async () => {
+      const { type, checker } = await getTypeFromCode(
+        `interface X { value: ${primitive} | Cell<${primitive}>; }`,
+        "X",
+      );
+      const result = asObjectSchema(
+        new SchemaGenerator().generateSchema(type, checker),
+      );
+      const value = asObjectSchema(result.properties!.value!);
+      expect(value.anyOf).toHaveLength(2);
+      expect(value.anyOf).toEqual(expect.arrayContaining([
+        { type: primitive },
+        { type: primitive, asCell: ["cell"] },
+      ]));
+    });
+  }
+
   it("handles Cell<string>", async () => {
     const code = `
       interface X { name: Cell<string>; }


### PR DESCRIPTION
## Why

A union such as `string | Cell<string>` must retain the Cell alternative. Primitive-union merging checked only the existing alternative for extra metadata, so adding a Cell schema with the same primitive type silently discarded its `asCell` marker. This surfaced while validating collection-index enumeration in #7323, following #7324.

## What changed

Merge primitive alternatives only when both schemas contain exclusively `type` and `enum`. Preserve metadata-bearing alternatives separately and document that rule.

This fixes schema generation. It does not claim that mixed primitive/Cell index enumeration is fully supported: runtime union materialization still needs a separate API/semantics decision.

## Test plan

- Full schema-generator package: 59 tests / 403 steps pass.
- Full transformer package: 1,169 tests / 963 steps pass.
- All 46 type-check groups, 599 documentation blocks, repo-wide formatting and lint pass.
- Both new string/number Cell-union cases fail against the unchanged formatter and pass with this fix.

Antagonistic cf-review: no blocking findings. Reviewed both merging operands, metadata retention, existing primitive/enum merging, and generated-schema compatibility through the full fixture suites.

cf-review via Codex (GPT-6), on behalf of Mike.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

