### PR TITLE
Fix nested callback captures after parameter lowering

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1090,6 +1090,12 @@ narrower paths beside it. The lift is then applied to the whole object and
 re-runs for any field of it, where it could have been applied to the one field
 the body reads.
 
+Callback-local declarations are excluded from captures using parameter lineage
+and the owning function's authored range. Rebuilt callbacks carry that range in
+their source maps. Matching requires the same function kind and exact range;
+ancestor traversal stops at intervening function boundaries, keeping nested
+parameters out of an enclosing callback's capture object.
+
 The set has one deliberately narrow reader on the way out. When the rewriter
 synthesizes an `ifElse`/`when`/`unless` call, `unwrapParentheses` tidies the
 operands placed in the call, and the probe recognizing a zero-arg inline IIFE

--- a/packages/ts-transformers/src/ast/scope-analysis.ts
+++ b/packages/ts-transformers/src/ast/scope-analysis.ts
@@ -1,7 +1,7 @@
 import ts from "typescript";
 import { isFunctionLikeExpression } from "./function-predicates.ts";
 import { detectCallKind } from "./call-kind.ts";
-import { isSyntheticNode } from "./utils.ts";
+import { recoverAuthoredPosition } from "./utils.ts";
 
 /**
  * Check if a declaration is at module scope (top-level of source file).
@@ -69,52 +69,39 @@ export function isFunctionDeclaration(
 }
 
 /**
- * Check if a declaration is within a specific function's scope using node identity.
- *
- * IMPORTANT LIMITATION: This function may not work correctly when comparing
- * synthetic nodes (created by transformers) to source nodes, because:
- * - Symbol.getDeclarations() returns nodes from the original AST
- * - The `func` parameter may be from a transformed AST
- * - Synthetic nodes have pos=-1, so position-based comparison fails
- *
- * This is acceptable for current usage because collectCaptures is called on
- * source nodes before creating synthetic nodes. If this changes in the future,
- * we'll need to add a WeakMap to track synthetic→source node relationships.
- *
- * @param decl - The declaration to check
- * @param func - The function to check against
- * @returns true if decl is within func's scope (but stops at nested function boundaries)
+ * Checks whether a declaration belongs to a function's local scope.
+ * Parameter comparisons follow authored lineage through transformed clones;
+ * distinct same-named bindings remain separate declarations.
  */
 export function isDeclaredWithinFunction(
   decl: ts.Declaration,
   func: ts.FunctionLikeDeclaration,
 ): boolean {
-  // SPECIAL CASE: For parameters, check directly in the parameters array
-  // The visitor reuses parameter objects, so we can use simple object identity.
-  // This avoids broken parent chains when func is a synthetic/transformed node.
+  // Parameter parents may belong to the source tree while the callback is cloned.
   if (ts.isParameter(decl)) {
-    return func.parameters.includes(decl);
+    const original = ts.getOriginalNode(decl);
+    if (
+      func.parameters.some((parameter) =>
+        ts.getOriginalNode(parameter) === original
+      )
+    ) return true;
   }
 
-  // For other declarations, walk up the tree from the declaration
+  const functionRange = recoverAuthoredPosition(func);
+  const functionSource = func.getSourceFile();
   let current: ts.Node | undefined = decl;
   while (current) {
-    // Found our callback function - try multiple matching strategies:
-    // 1. Object identity (works if nodes haven't been cloned)
-    if (current === func) {
-      return true;
-    }
+    if (current === func) return true;
 
-    // 2. Position-based comparison (works for source nodes that have been cloned during transformation)
-    //    The type checker returns declarations from the original AST, but func may be from a
-    //    transformed AST. If both are source nodes, they'll have matching positions.
-    //    Skip synthetic nodes (pos=-1) as they won't match source positions.
+    // Rebuilt callbacks retain authored ranges through their source maps.
+    const currentRange = recoverAuthoredPosition(current);
+    const currentSource = current.getSourceFile();
     if (
-      !isSyntheticNode(current) &&
-      !isSyntheticNode(func) &&
-      current.pos === func.pos &&
-      current.end === func.end &&
-      current.kind === func.kind
+      functionRange && currentRange &&
+      currentRange.pos === functionRange.pos &&
+      currentRange.end === functionRange.end &&
+      current.kind === func.kind &&
+      (!functionSource || !currentSource || functionSource === currentSource)
     ) {
       return true;
     }

--- a/packages/ts-transformers/test/parameter-capture-lineage.test.ts
+++ b/packages/ts-transformers/test/parameter-capture-lineage.test.ts
@@ -1,0 +1,142 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import ts from "typescript";
+
+import { preserveSourceMapRange } from "../src/ast/utils.ts";
+import { isDeclaredWithinFunction } from "../src/ast/scope-analysis.ts";
+
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { callsNamed, parseModule } from "./transformed-ast.ts";
+import { transformSource } from "./utils.ts";
+
+describe("parameter capture lineage", () => {
+  it("keeps a cloned parameter local without conflating same-named bindings", () => {
+    const source = ts.createSourceFile(
+      "input.ts",
+      "const first = (row: string) => row; const second = (row: string) => row;",
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const callbacks: ts.ArrowFunction[] = [];
+    const visit = (node: ts.Node) => {
+      if (ts.isArrowFunction(node)) callbacks.push(node);
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+    const [first, second] = callbacks;
+    const parameter = first.parameters[0];
+    const clonedParameter = ts.factory.updateParameterDeclaration(
+      parameter,
+      parameter.modifiers,
+      parameter.dotDotDotToken,
+      parameter.name,
+      parameter.questionToken,
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+      parameter.initializer,
+    );
+    const cloned = ts.factory.updateArrowFunction(
+      first,
+      first.modifiers,
+      first.typeParameters,
+      [clonedParameter],
+      first.type,
+      first.equalsGreaterThanToken,
+      first.body,
+    );
+    expect(clonedParameter).not.toBe(parameter);
+    expect(isDeclaredWithinFunction(parameter, cloned)).toBe(true);
+    expect(isDeclaredWithinFunction(clonedParameter, first)).toBe(true);
+    expect(isDeclaredWithinFunction(second.parameters[0], cloned)).toBe(false);
+  });
+
+  it("recognizes a rebuilt callback by its authored range", () => {
+    const source = ts.createSourceFile(
+      "input.ts",
+      "const first = (row: string) => row; const second = (row: string) => row;",
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const callbacks: ts.ArrowFunction[] = [];
+    const visit = (node: ts.Node) => {
+      if (ts.isArrowFunction(node)) callbacks.push(node);
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+    const [first, second] = callbacks;
+    const rebuilt = preserveSourceMapRange(
+      ts.factory.createArrowFunction(
+        undefined,
+        undefined,
+        [ts.factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          ts.factory.createObjectBindingPattern([
+            ts.factory.createBindingElement(undefined, "element", "row"),
+          ]),
+        )],
+        undefined,
+        undefined,
+        first.body,
+      ),
+      first,
+    );
+    expect(ts.getOriginalNode(rebuilt)).toBe(rebuilt);
+    expect(isDeclaredWithinFunction(first.parameters[0], rebuilt)).toBe(true);
+    expect(isDeclaredWithinFunction(second.parameters[0], rebuilt)).toBe(false);
+  });
+
+  it("separates nested bindings and equal ranges in different source files", () => {
+    const text = "const outer = (row: string) => (row: string) => row;";
+    const sources = ["first.ts", "second.ts"].map((name) =>
+      ts.createSourceFile(
+        name,
+        text,
+        ts.ScriptTarget.Latest,
+        true,
+      )
+    );
+    const callbacks = sources.map((source) => {
+      const found: ts.ArrowFunction[] = [];
+      const visit = (node: ts.Node) => {
+        if (ts.isArrowFunction(node)) found.push(node);
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+      return found;
+    });
+    const [outer, inner] = callbacks[0];
+    expect(isDeclaredWithinFunction(inner.parameters[0], outer)).toBe(false);
+    expect(isDeclaredWithinFunction(outer.parameters[0], inner)).toBe(false);
+    expect(isDeclaredWithinFunction(callbacks[1][0].parameters[0], outer)).toBe(
+      false,
+    );
+  });
+
+  it("keeps inner lookup-map parameters out of the outer capture object", async () => {
+    const output = await transformSource(
+      `
+      import { pattern, GroupIndex } from "commonfabric";
+      export default pattern<{ groups: GroupIndex<string, { title: string }> }>(({ groups }) => ({
+        enumerated: groups.keys().map(key => groups.lookup(key).map(row => row.title)),
+      }));
+    `,
+      { types: COMMONFABRIC_TYPES, typeCheck: true },
+    );
+    const maps = callsNamed(parseModule(output), "mapWithPattern");
+    expect(maps).toHaveLength(2);
+    const captureNames = maps.map((call) => {
+      const captures = call.arguments[1];
+      if (!captures || !ts.isObjectLiteralExpression(captures)) {
+        throw new Error("Expected a map capture object");
+      }
+      return captures.properties.map((property) => {
+        if (!property.name || !ts.isIdentifier(property.name)) {
+          throw new Error("Expected a named capture");
+        }
+        return property.name.text;
+      });
+    });
+    expect(captureNames.flat()).not.toContain("row");
+    expect(captureNames.flat()).toContain("groups");
+  });
+});


### PR DESCRIPTION
## Why

Nested index enumeration such as `groups.keys().map(key => groups.lookup(key).map(row => row.title))` can capture `row.title` outside the inner callback, where `row` does not exist. Callback lowering rebuilds parameters and preserves the callback's authored source-map range, so identity-only scope detection misclassifies the inner parameter. This independent compiler repair supports the collection work in #7155 and follows #7325.

## What Changed

Recognize cloned parameters through original-node identity and rebuilt callbacks through the existing authored-range helper. Keep exact range/kind matching, source-file identity where available, and nested-function boundaries. Update the current-behavior specification.

## Test plan

- Transformer package: 1,170 tests / 966 steps pass; final focused suite: four cases pass.
- Removing the fix fails clone, rebuilt-callback, and full nested-map regressions; nested/sibling binding controls remain separate.
- All 46 type-check groups, 599 documentation blocks, repo formatting/lint, and final focused type checking pass.
- Antagonistic cf-review of scope detection, capture-collector callers, validation caller, tests, and specification found no blocking issues. CI and Cubic review remain required before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

