### PR TITLE
Measure computed and lift collection-loop reads

### DIFF
--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -288,3 +288,25 @@ const stats = computed(() => ({
 
 For the hierarchical summary string convention used by container patterns, see
 [Summary Convention](../../conventions/summary.md).
+
+## Collection-loop cost
+
+Choose `computed` for an inline derivation and a module-level `lift` for a
+reusable derivation. Changing that spelling alone does not make a collection
+scan incremental. With lazy argument materialization enabled by default, the
+callback reads the paths it touches; a broadly declared argument does not by
+itself imply that every declared payload field is read.
+
+The [collection-loop comparison](../../../history/development/performance/2026-09-11-computed-lift-collection-loops.md)
+measured identical reductions under computed, broad lift, and narrow lift at
+three sizes. All three ignored edits to an unread field, and all three scanned
+the collection when a summed field changed. The measurement covers action-body
+reads, not network traffic or elapsed-time equivalence.
+
+A scan inside another scan can still perform work proportional to both
+collection sizes. Measure the reads and update behavior of the demanded result.
+For supported operations, consider the
+[named incremental aggregates](../../../features/collection-aggregates.md),
+checking their numeric, ordering, and membership-update contracts first.
+Ordinary `reduce` remains appropriate when its order-dependent semantics are
+required.

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -4,6 +4,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Audits and reports
 
+- [2026-09-11-computed-lift-collection-loops.md](development/performance/2026-09-11-computed-lift-collection-loops.md) — E1 compiled computed/broad-lift/narrow-lift comparison at 32/128/512 linked rows, identical default-posture read counts, and unread-field invalidation controls.
+
 - [2026-09-11-pending-schema-policy-index.md](development/performance/2026-09-11-pending-schema-policy-index.md) — document-indexed pending schema-policy lookup CPU attribution and 1,184-vote fixture acceptance with unchanged read budgets.
 - [2026-09-11-reactive-lunch-rows.md](development/performance/2026-09-11-reactive-lunch-rows.md) — repository-only reactive lunch-row acceptance: 93 assertions, unchanged budgets at three sizes, matched two-browser voting, and headless settlement limits.
 

--- a/docs/history/development/performance/2026-09-11-computed-lift-collection-loops.md
+++ b/docs/history/development/performance/2026-09-11-computed-lift-collection-loops.md
@@ -1,0 +1,66 @@
+---
+status: historical
+created: 2026-09-11
+archived: 2026-09-11
+reason: "E1 comparison of equivalent compiled collection loops under default lazy materialization."
+---
+
+# Computed and lift collection-loop reads
+
+At runtime revision `94a5cf92b3e8241f222bfc745557589f88f8542d`, equivalent
+`computed`, broadly typed `lift`, and narrowly typed `lift` reductions produced
+identical completed action-body read counts at 32, 128, and 512 independently
+linked rows. `lazyMaterialization` was left at its default and reported `true`.
+
+## Workload and reproduction
+
+From the repository root, run:
+
+```sh
+deno run --unsafe-proto -A packages/runner/test/collection-loop-read-counts.ts
+```
+
+The [report command](../../../../packages/runner/test/collection-loop-read-counts.ts)
+compiles three authored patterns through the runtime compiler. Each sums the
+`amount` field using the same left-to-right JavaScript reduction. The computed
+captures the input collection; the two module-level lifts receive it explicitly.
+The broad row type declares `amount` and an unread `title`; the narrow lift
+argument declares only `amount`. Inspection of emitted schemas confirmed both
+fields in the computed and broad lift, and only `amount` in the narrow lift.
+
+Each row is a distinct same-space cell. Initial amounts are the integers from
+zero through N−1. The numeric result stays demanded while the final row's title
+is changed, then its amount is changed from N−1 to N. The command checks the
+initial sum and both subsequent results. Fresh emulated storage and a fresh
+runtime isolate each form and collection size.
+
+Read statistics are enabled immediately before the initial run. Each phase sums
+`reads` from completed `scheduler.run.complete` events, counting writing runs
+separately. Distinct documents are summed per action, not unioned across the
+phase. These counters exclude compilation, setup outside action bodies, and
+commit costs outside that boundary. This is a headless synthetic measurement;
+it reports neither elapsed-time improvement nor deployed-poll behavior.
+
+## Results
+
+All three forms had the following identical counts. Initialization ran three
+actions, one writing; an amount update ran two, one writing. A title update ran
+zero actions and recorded zero reads at every size.
+
+| Rows | Proxy accesses, initial/update | Link resolutions, initial/update | Documents, initial/update | Dependencies, initial/update |
+| --- | ---: | ---: | ---: | ---: |
+| 32 | 65 / 65 | 35 / 35 | 39 / 38 | 172 / 171 |
+| 128 | 257 / 257 | 131 / 131 | 135 / 134 | 652 / 651 |
+| 512 | 1,025 / 1,025 | 515 / 515 | 519 / 518 | 2,572 / 2,571 |
+
+The amount update scans the collection in every form. Changing from computed
+to lift, or narrowing this lift's declared argument, did not remove that scan.
+The unread title did not cause invalidation even when the argument schema
+included it. This agrees with lazy argument materialization registering the
+paths the callback actually reads.
+
+The result is limited to these valid, linked rows and this reduction. It does
+not establish equivalence for invalid data, schema defaults, nested objects,
+network subscriptions, handlers, other experimental postures, or timing.
+Named incremental aggregates have separate numeric and update contracts; they
+are not automatically interchangeable with an order-dependent reduction.

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -337,8 +337,11 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 
 ## 12–13. Guidance and related runtime work: D, E
 
-- [ ] **E1 — Measure identical `computed` and `lift` collection loops** under
-      current defaults and compare declared read width and access counts.
+- [x] **E1 — Measure identical `computed` and `lift` collection loops** under
+      current defaults and compare declared read width and access counts. The
+      [reproducible comparison](../history/development/performance/2026-09-11-computed-lift-collection-loops.md)
+      validates three forms at 32, 128, and 512 linked rows, including unread-field
+      edits. The dashboard tracks publication and review status.
 - [ ] **E2 — Publish the measured advice** where pattern authors encounter
       collections, `computed`, and `lift`. Explain nested-scan cost and use only
       available operators in replacement examples.

--- a/packages/runner/test/collection-loop-read-counts.ts
+++ b/packages/runner/test/collection-loop-read-counts.ts
@@ -142,9 +142,15 @@ async function report(): Promise<void> {
         );
       } finally {
         runtime?.telemetry.removeEventListener("telemetry", collect);
-        cancel?.();
-        await runtime?.dispose({ closeStorage: false });
-        await storage.close();
+        try {
+          cancel?.();
+        } finally {
+          try {
+            await runtime?.dispose({ closeStorage: false });
+          } finally {
+            await storage.close();
+          }
+        }
       }
     }
   }

--- a/packages/runner/test/collection-loop-read-counts.ts
+++ b/packages/runner/test/collection-loop-read-counts.ts
@@ -1,0 +1,156 @@
+// Reports completed action-body reads for equivalent compiled collection loops.
+
+import { Identity } from "@commonfabric/identity";
+
+import type { Cell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { type RuntimeTelemetryEvent } from "../src/telemetry.ts";
+
+async function report(): Promise<void> {
+  for (const size of [32, 128, 512]) {
+    for (const mode of ["computed", "lift-wide", "lift-narrow"]) {
+      const identity = await Identity.fromPassphrase(
+        `collection-loop-${size}-${mode}`,
+      );
+      const storage = StorageManager.emulate({ as: identity });
+      let runtime: Runtime | undefined;
+      let cancel: (() => void) | undefined;
+      let counts = {
+        runs: 0,
+        writingRuns: 0,
+        proxyAccesses: 0,
+        linkResolutions: 0,
+        distinctDocuments: 0,
+        registeredDependencies: 0,
+      };
+      const collect = (event: Event) => {
+        const marker = (event as RuntimeTelemetryEvent).marker;
+        if (marker.type !== "scheduler.run.complete") return;
+        counts.runs++;
+        if (marker.actionInfo?.writes?.length) counts.writingRuns++;
+        if (marker.reads) {
+          for (
+            const key of [
+              "proxyAccesses",
+              "linkResolutions",
+              "distinctDocuments",
+              "registeredDependencies",
+            ] as const
+          ) counts[key] += marker.reads[key];
+        }
+      };
+      try {
+        runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: storage,
+        });
+        const isComputed = mode === "computed";
+        const declaration = isComputed
+          ? ""
+          : "const sumRows=lift(({rows}: {rows: " +
+            (mode === "lift-wide" ? "Row" : "{amount:number}") +
+            "[]}) => rows.reduce((sum,row)=>sum+row.amount,0));";
+        const body = isComputed
+          ? "computed(() => rows.reduce((sum, row) => sum + row.amount, 0))"
+          : "sumRows({rows})";
+        const compiled = await runtime.patternManager.compilePattern({
+          main: "/main.tsx",
+          files: [{
+            name: "/main.tsx",
+            contents: `
+    import {pattern, computed, lift} from "commonfabric";
+    interface Row { amount:number; title:string }
+    ${declaration}
+    export default pattern<{rows:Row[]}>(({rows})=>({value:${body}}));
+   `,
+          }],
+        });
+        const tx = runtime.edit();
+        const cells: Cell<{ amount: number; title: string }>[] = [];
+        for (let i = 0; i < size; i++) {
+          const cell = runtime.getCell<{ amount: number; title: string }>(
+            identity.did(),
+            `row-${i}`,
+            undefined,
+            tx,
+          );
+          cell.set({ amount: i, title: `Row ${i}` });
+          cells.push(cell.withTx());
+        }
+        const rows = runtime.getCell<{ amount: number; title: string }[]>(
+          identity.did(),
+          "rows",
+          undefined,
+          tx,
+        );
+        rows.set(cells);
+        runtime.scheduler.setReadStatsEnabled(true);
+        runtime.telemetry.addEventListener("telemetry", collect);
+        const result = runtime.run(
+          tx,
+          compiled,
+          { rows },
+          runtime.getCell<{ value: number }>(
+            identity.did(),
+            "result",
+            compiled.resultSchema,
+            tx,
+          ),
+        );
+        runtime.prepareTxForCommit(tx);
+        if ((await tx.commit()).error) {
+          throw new Error("Initialization commit failed");
+        }
+        cancel = result.sink(() => {});
+        await runtime.idle();
+        const initial = result.key("value").get();
+        const expected = size * (size - 1) / 2;
+        if (initial !== expected) throw new Error("Incorrect initial sum");
+        const steps = [{ phase: "initialize", ...counts }];
+        for (const phase of ["unread title", "read amount"]) {
+          counts = {
+            runs: 0,
+            writingRuns: 0,
+            proxyAccesses: 0,
+            linkResolutions: 0,
+            distinctDocuments: 0,
+            registeredDependencies: 0,
+          };
+          const edit = runtime.edit();
+          if (phase === "unread title") {
+            cells[size - 1].withTx(edit).key("title").set("Updated");
+          } else cells[size - 1].withTx(edit).key("amount").set(size);
+          if ((await edit.commit()).error) {
+            throw new Error("Edit commit failed");
+          }
+          await runtime.idle();
+          const value = result.key("value").get();
+          if (value !== expected + (phase === "read amount" ? 1 : 0)) {
+            throw new Error(`Incorrect sum after ${phase}`);
+          }
+          steps.push({ phase, ...counts });
+        }
+        console.log(
+          "LOOP_SCALE=" +
+            JSON.stringify({
+              size,
+              mode,
+              lazyMaterialization: runtime.experimental.lazyMaterialization,
+              steps,
+            }),
+        );
+      } finally {
+        runtime?.telemetry.removeEventListener("telemetry", collect);
+        cancel?.();
+        await runtime?.dispose({ closeStorage: false });
+        await storage.close();
+      }
+    }
+  }
+}
+
+await report().catch((error: unknown) => {
+  console.error(error);
+  Deno.exitCode = 1;
+});

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T04:49:55.656447+00:00",
+  "updated": "2026-09-11T11:41:56.081484+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -143,8 +143,8 @@
     {
       "id": "E1",
       "title": "Computed versus lift measurements",
-      "status": "todo",
-      "detail": "Measure current defaults and declared read width."
+      "status": "review",
+      "detail": "PR #7327 implements and validates the computed/broad-lift/narrow-lift comparison at 32/128/512 linked rows. The report and reproduction command are linked from the implementation tracker. CI and Cubic review govern landing."
     },
     {
       "id": "E2",


### PR DESCRIPTION
## Why

The collection-cost plan #7155 needs evidence for whether replacing `computed` with `lift`, or narrowing a lift's declared input, reduces reactive reads under current defaults. Equivalent compiled reductions at 32, 128, and 512 linked rows performed identical reads in all three forms, and edits to an unread field caused no runs. This completes the E1 measurement and supplies the first measured E2 guidance.

## What Changed

Add a reproducible report command that compiles all three forms, validates each result through two edits, reports completed action-body counters, and returns a failing status when validation fails. Preserve the measurement protocol and results in a historical report. Explain collection-loop cost in the computed/lift guide and link the evidence from the implementation tracker.

The report does not claim elapsed-time, network, or deployed-poll equivalence. It distinguishes broad/narrow emitted schemas and preserves the separate numeric contract of named aggregates.

## Test plan

- Nine measured cases pass; all three forms agree at each size. An intentionally wrong expected sum returns exit status 1.
- Emitted-schema inspection confirms both fields in computed/broad lift and only the numeric field in narrow lift.
- Full runner: 1,437 tests / 8,959 steps pass.
- All 46 type-check groups, 599 docs blocks, history-index validation, repo formatting/lint, and the final report command's type check pass.
- Antagonistic cf-review of the command, counter boundary, cleanup, report claims, and live guidance found no blocking issues. CI and Cubic remain required before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

