### PR TITLE
Warn about nested scans of captured reactive collections

### DIFF
--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -20,6 +20,11 @@ const filteredItems = computed(() => {
 rendering or other simple conditional values in normal pattern code, use plain
 ternaries — see [Conditional Rendering](../../patterns/conditional.md).
 
+The compiler's [nested-scan warning](../../../features/read-accounting.md#compiler-hints-for-nested-scans)
+points out some repeated scans of captured collections. It is a hint to measure
+and examine the computation's structure, not a failing budget or a complete
+complexity analysis.
+
 ## When NOT to Use computed()
 
 **Never inside JSX for interpolation or property access** — reactivity is

--- a/docs/features/read-accounting.md
+++ b/docs/features/read-accounting.md
@@ -140,8 +140,7 @@ sequential scans, and unrelated function scopes are excluded. It does not trace
 arbitrary helper calls, complex receivers, or other loop forms. Absence of this
 warning is not a complexity guarantee.
 
-Move shared work outside the callback when possible. An
-[indexed lookup](collection-indexes.md) or
+Move shared work outside the callback when possible. A
 [named aggregate](collection-aggregates.md) can fit some workloads; check its
 cardinality, numeric, ordering, and update contract before changing the pattern.
 Use the counters and budgets above to validate the resulting behavior.

--- a/docs/features/read-accounting.md
+++ b/docs/features/read-accounting.md
@@ -124,3 +124,24 @@ unrelated transactions, standalone harness reads, storage-server work, and
 network traffic are outside the measure. Plain eager values and primitive Cell
 reads are not proxy accesses. A zero count does not mean zero CPU work or zero
 storage reads.
+
+## Compiler hints for nested scans
+
+The non-fatal `collection:nested-scan` warning identifies an inline reactive
+array callback that scans another captured reactive collection. For example,
+filtering the same captured entries separately for each group can make work
+grow with both collection sizes. The warning asks for a measurement of the
+demanded output; it does not assert that every update performs that work.
+
+The check covers `map`, `filter`, `flatMap`, `count`, `minBy`, and `maxBy` with
+inline callbacks and receivers that resolve to captured root bindings. Plain
+local arrays, each row's own child arrays, callback-local derived lists,
+sequential scans, and unrelated function scopes are excluded. It does not trace
+arbitrary helper calls, complex receivers, or other loop forms. Absence of this
+warning is not a complexity guarantee.
+
+Move shared work outside the callback when possible. An
+[indexed lookup](collection-indexes.md) or
+[named aggregate](collection-aggregates.md) can fit some workloads; check its
+cardinality, numeric, ordering, and update contract before changing the pattern.
+Use the counters and budgets above to validate the resulting behavior.

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -4,6 +4,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Audits and reports
 
+- [2026-09-11-nested-collection-scan-diagnostic.md](development/performance/2026-09-11-nested-collection-scan-diagnostic.md) — E3 warning acceptance across 413 pattern entries and 1,731 modules: seven occurrences at five source sites, guarded-UI limits, and callback-local exclusions.
+
 - [2026-09-11-pending-schema-policy-index.md](development/performance/2026-09-11-pending-schema-policy-index.md) — document-indexed pending schema-policy lookup CPU attribution and 1,184-vote fixture acceptance with unchanged read budgets.
 - [2026-09-11-reactive-lunch-rows.md](development/performance/2026-09-11-reactive-lunch-rows.md) — repository-only reactive lunch-row acceptance: 93 assertions, unchanged budgets at three sizes, matched two-browser voting, and headless settlement limits.
 

--- a/docs/history/development/performance/2026-09-11-nested-collection-scan-diagnostic.md
+++ b/docs/history/development/performance/2026-09-11-nested-collection-scan-diagnostic.md
@@ -1,0 +1,67 @@
+---
+status: historical
+created: 2026-09-11
+archived: 2026-09-11
+reason: "E3 diagnostic acceptance and authored-pattern warning-volume inspection."
+---
+
+# Nested collection scan warning acceptance
+
+The `collection:nested-scan` candidate was evaluated on the authored-pattern
+corpus at base `b112dfdce5594bf47b7f84f5a9c2cf87a7934b96`. Its final rule reports
+an inline reactive array callback scanning a collection whose root binding is
+captured from outside that callback. It does not rewrite execution or fail
+compilation.
+
+## Corpus and results
+
+The collector used by `deno task cfcheck` selected 413 pattern entries. Their
+resolved module graphs contained 1,731 modules. Batched type checking,
+transformation, and SES verification completed with zero errors. The compiler
+pipeline's diagnostic stream was captured before the batch API discarded
+warning-severity diagnostics; the normal batch result alone cannot establish
+warning volume.
+
+There were seven warning occurrences at five distinct source sites. Imported
+module graphs account for the duplicate occurrences of the two factory-output
+sites. Deduplication for this report removed each program's internal `fid1`
+prefix and grouped by source path and position.
+
+| Source | Observed shape | Interpretation |
+| --- | --- | --- |
+| `factory-outputs/lot-watch/main.tsx` | Shared people list rendered inside sighting rows | Guarded UI; actual demand determines how many lists run. |
+| `factory-outputs/parking-coordinator/main.tsx` | Shared edit-vehicle rows rendered inside people rows | Guarded edit UI; a structural hint, not proof of multiplicative update work. |
+| `gideon-tests/test-pattern-composition-index-based.tsx` | Every item inspected inside each category | Direct category-by-item scan example. |
+| `gideon-tests/test-pattern-composition-shared-cells.tsx` | Every item inspected inside each category | Direct category-by-item scan example. |
+| `nested-map-ifelse-test.tsx` | Every item inspected inside each category | Direct category-by-item scan example. |
+
+Paths in the table are relative to `packages/patterns`. Every distinct finding
+was inspected in source. The guarded UI findings are retained as non-fatal
+measurement prompts. No timing or per-update complexity claim follows from the
+warning alone, and the three category examples are fixtures rather than a
+representative sample of production performance problems.
+
+An initial candidate also reported a callback-local derived relationship list
+in `contacts/contact-book.tsx`. That receiver did not satisfy the intended
+captured-root contract. The final rule excludes callback-local declarations,
+and a derived-child-list regression pins that exclusion.
+
+## Validation and limits
+
+The full transformer suite passed 1,171 tests and 975 steps with the final
+production rule. Focused cases cover captured scans, outside const aliases,
+parenthesized callbacks, child arrays, plain local arrays, sequential work,
+shared work outside the callback, and callback-local derivations. A subsequent
+focused case verifies that an indexed lookup's returned members do not warn.
+
+A real `cf check <pattern> --no-run` invocation emitted the warning for
+`groups.map(group => entries.filter(entry => entry.key === group.key))` and
+completed successfully. Its output is displayed in the local implementation
+dashboard. No live poll was accessed.
+
+The check covers the existing inline callback array families: `map`, `filter`,
+`flatMap`, `count`, `minBy`, and `maxBy`. It does not follow arbitrary helpers,
+complex receivers, other loop forms, or callback-local derivations. Those
+exclusions keep this first diagnostic conservative and leave false negatives;
+absence of a warning is not a cost guarantee. Escalation to an error would need
+separate evidence about relevance and false positives.

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -239,8 +239,8 @@ passed before merge, with clean Cubic and antagonistic reviews.
   profiles. Ordinary memory queries wait for session restoration before
   constructing their requests. This guards the handshake-to-session interval;
   a subsequent disconnect during request issue remains a separate boundary.
-  These synthetic probes do not authorize removing the lunch-poll workaround or
-  accessing the live poll.
+  These synthetic probes cover repository behavior. Live poll changes require
+  coordination with Mike.
 
   C3's landed fix records the mutable inline element used when resolving a
   nested array to a content-addressed snapshot. The
@@ -405,7 +405,7 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 
 ## Next task
 
-Complete C3's remaining acceptance checks. C4's repository migration is
+Finish review and publication of C3 acceptance, then continue the collection-operator work. C4's repository migration is
 implemented and validated; updating any deployed poll requires coordination
 with Mike. The first-materialization cases in
 [PR #7302](https://github.com/commontoolsinc/labs/pull/7302) pass all four

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -342,11 +342,15 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 - [ ] **E2 — Publish the measured advice** where pattern authors encounter
       collections, `computed`, and `lift`. Explain nested-scan cost and use only
       available operators in replacement examples.
-- [ ] **E3 — Add a transformer warning** through the existing diagnostic
+- [x] **E3 — Add a transformer warning** through the existing diagnostic
       collector. Test recognizable nested reactive scans and negative cases
       involving plain arrays and unrelated scopes; inspect warning volume across
       authored patterns before shipping. Escalation to error requires separate
       evidence about false positives.
+      The [diagnostic acceptance report](../history/development/performance/2026-09-11-nested-collection-scan-diagnostic.md)
+      records the focused cases, full transformer suite, and all five distinct
+      findings across 413 pattern entries. Publication and review remain visible
+      in the dashboard.
 - [ ] **D1 — Follow the remaining lazy-materialization work** in its
       [own plan](lazy-cell-materialization.md), including handlers and flag
       removal. Keep implementation ownership there.

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -830,6 +830,21 @@ followed by a push to the same collection, and reports:
   - the message text is produced per classification by `diagnosticMessage`;
     capability analysis feeds the findings via `mergeablePushMisuseSink`
 
+`PatternContextValidationTransformer` also reports **Warning**
+`collection:nested-scan` (`src/diagnostics/nested-collection-scan.ts`) for an
+inline reactive array-method callback scanning a captured reactive collection.
+It recognizes the array-method families classified by `classifyArrayMethodCallSite`
+and checks the receiver's array type and reactive provenance. Callback parameters
+and callback-local declarations as collection roots are excluded, so a row's
+own child array or a locally derived
+child list does not trigger this warning. The reported receiver must resolve to
+a captured root binding; complex receiver expressions are outside this check.
+Plain local arrays, sequential scans, lowered calls, and scans
+inside unrelated function boundaries are excluded. The warning does not change
+execution or claim that every update scans both collections; it asks the author
+to measure potentially multiplicative work and consider contract-compatible
+shared work, indexed lookups, or named aggregates.
+
 ### 6.10 Verb-return validation
 
 `VerbReturnValidationTransformer` (stage 6; verb contract WS-C/C2) inspects

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -830,7 +830,9 @@ followed by a push to the same collection, and reports:
   - the message text is produced per classification by `diagnosticMessage`;
     capability analysis feeds the findings via `mergeablePushMisuseSink`
 
-`PatternContextValidationTransformer` also reports **Warning**
+### 6.9a Nested collection scan validation
+
+`PatternContextValidationTransformer` reports **Warning**
 `collection:nested-scan` (`src/diagnostics/nested-collection-scan.ts`) for an
 inline reactive array-method callback scanning a captured reactive collection.
 It recognizes the array-method families classified by `classifyArrayMethodCallSite`
@@ -839,7 +841,7 @@ and callback-local declarations as collection roots are excluded, so a row's
 own child array or a locally derived
 child list does not trigger this warning. The reported receiver must resolve to
 a captured root binding; complex receiver expressions are outside this check.
-Plain local arrays, sequential scans, lowered calls, and scans
+Indexed receiver results, plain local arrays, sequential scans, lowered calls, and scans
 inside unrelated function boundaries are excluded. The warning does not change
 execution or claim that every update scans both collections; it asks the author
 to measure potentially multiplicative work and consider contract-compatible

--- a/packages/ts-transformers/src/diagnostics/nested-collection-scan.ts
+++ b/packages/ts-transformers/src/diagnostics/nested-collection-scan.ts
@@ -1,0 +1,81 @@
+/** Warns about scans of captured collections inside reactive array callbacks. */
+
+import ts from "typescript";
+
+import {
+  classifyArrayMethodCallSite,
+  hasReactiveCollectionProvenance,
+  isCollectionType,
+  unwrapOpaqueLikeType,
+} from "../ast/mod.ts";
+import { isDeclaredWithinFunction } from "../ast/scope-analysis.ts";
+import type { TransformationContext } from "../core/mod.ts";
+import { getOpaqueAccessInfo } from "../transformers/opaque-roots.ts";
+import { unwrapExpression } from "../utils/expression.ts";
+
+/** Reports authored nested scans without changing their execution. */
+export function reportNestedCollectionScans(
+  context: TransformationContext,
+): void {
+  const checker = context.checker;
+  const visit = (
+    node: ts.Node,
+    insideCollection: ts.ArrowFunction | ts.FunctionExpression | undefined,
+  ): void => {
+    if (ts.isCallExpression(node)) {
+      const site = classifyArrayMethodCallSite(node, checker);
+      const target = unwrapExpression(node.expression);
+      const callback = node.arguments[0] && unwrapExpression(node.arguments[0]);
+      if (
+        site?.ownership === "reactive" && !site.lowered &&
+        (ts.isPropertyAccessExpression(target) ||
+          ts.isElementAccessExpression(target)) &&
+        callback &&
+        (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback)) &&
+        isCollectionType(
+          unwrapOpaqueLikeType(
+            checker.getTypeAtLocation(target.expression),
+            checker,
+          ),
+          checker,
+        )
+      ) {
+        const root =
+          getOpaqueAccessInfo(target.expression, context).rootIdentifier;
+        const declarations = root &&
+          checker.getSymbolAtLocation(root)?.getDeclarations();
+        if (
+          insideCollection && declarations?.length &&
+          !declarations.some((declaration) =>
+            isDeclaredWithinFunction(declaration, insideCollection)
+          ) &&
+          hasReactiveCollectionProvenance(target.expression, checker, {
+            allowTypeBasedRoot: false,
+            allowReactiveArrayCallbackParameters: false,
+          })
+        ) {
+          context.reportDiagnostic({
+            severity: "warning",
+            type: "collection:nested-scan",
+            message:
+              "This scan reads a captured reactive collection inside another " +
+              "collection callback. Work can grow with the product of the collection " +
+              "sizes. Measure the demanded result; move shared work outside the " +
+              "callback or use an indexed lookup or named aggregate when its " +
+              "contract matches.",
+            node,
+          });
+        }
+        ts.forEachChild(node, (child) => {
+          if (child === node.arguments[0]) visit(callback.body, callback);
+          else visit(child, insideCollection);
+        });
+        return;
+      }
+    }
+    // A different function owns its own work, even when declared in a callback.
+    const nested = ts.isFunctionLike(node) ? undefined : insideCollection;
+    ts.forEachChild(node, (child) => visit(child, nested));
+  };
+  visit(context.sourceFile, undefined);
+}

--- a/packages/ts-transformers/src/diagnostics/nested-collection-scan.ts
+++ b/packages/ts-transformers/src/diagnostics/nested-collection-scan.ts
@@ -46,6 +46,7 @@ export function reportNestedCollectionScans(
           checker.getSymbolAtLocation(root)?.getDeclarations();
         if (
           insideCollection && declarations?.length &&
+          !ts.isElementAccessExpression(unwrapExpression(target.expression)) &&
           !declarations.some((declaration) =>
             isDeclaredWithinFunction(declaration, insideCollection)
           ) &&

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -40,6 +40,7 @@
  */
 
 import ts from "typescript";
+import { reportNestedCollectionScans } from "../diagnostics/nested-collection-scan.ts";
 import { COMMONFABRIC_REACTIVE_ORIGIN_BUILDER_NAMES } from "../core/commonfabric-runtime-registry.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import {
@@ -158,6 +159,7 @@ function objectMemberMessage(kind: ObjectMemberKind): string {
 export class PatternContextValidationTransformer
   extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
+    reportNestedCollectionScans(context);
     const checker = context.checker;
     const analyze = context.getDataFlowAnalyzer();
 

--- a/packages/ts-transformers/test/nested-collection-scan.test.ts
+++ b/packages/ts-transformers/test/nested-collection-scan.test.ts
@@ -1,0 +1,100 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { validateSource } from "./utils.ts";
+
+async function warnings(body: string) {
+  const result = await validateSource(
+    `
+    import {pattern,computed} from "commonfabric";
+    export default pattern<{rows:{key:string;children:string[]}[];other:{key:string}[]}>(({rows,other})=>{
+      ${body}
+    });
+  `,
+    { types: COMMONFABRIC_TYPES, typeCheck: true },
+  );
+  expect(
+    result.diagnostics.filter((diagnostic) => diagnostic.severity === "error"),
+  ).toEqual([]);
+  return result.diagnostics.filter((diagnostic) =>
+    diagnostic.type === "collection:nested-scan"
+  );
+}
+
+describe("nested collection scan warnings", () => {
+  it("warns for a captured collection scanned per reactive row", async () => {
+    const found = await warnings(
+      "return rows.map(row=>other.filter(item=>item.key===row.key));",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].severity).toBe("warning");
+  });
+  it("leaves a row's own child collection unreported", async () => {
+    expect(
+      await warnings("return rows.map(row=>row.children.map(child=>child));"),
+    ).toHaveLength(0);
+  });
+  it("leaves plain local arrays unreported", async () => {
+    expect(
+      await warnings(
+        'const plain=["a","b"]; return rows.map(row=>({key:row.key,values:plain.map(item=>item)}));',
+      ),
+    ).toHaveLength(0);
+  });
+  it("leaves sequential scans unreported", async () => {
+    expect(
+      await warnings(
+        "return {left:rows.map(row=>row.key),right:other.map(item=>item.key)};",
+      ),
+    ).toHaveLength(0);
+  });
+  it("leaves shared work computed outside the enclosing scan unreported", async () => {
+    expect(
+      await warnings(
+        "const shared = other.map(item=>item.key); return rows.map(row=>({key:row.key,shared}));",
+      ),
+    ).toHaveLength(0);
+  });
+  it("recognizes a captured collection through a const alias", async () => {
+    expect(
+      await warnings(
+        "const candidates=other; return rows.map(row=>candidates.filter(item=>item.key===row.key));",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("preserves the warning through parenthesized callbacks", async () => {
+    expect(
+      await warnings(
+        "return rows.map((row=>other.filter((item=>item.key===row.key))));",
+      ),
+    ).toHaveLength(1);
+  });
+  it("leaves callback-local derived child lists unreported", async () => {
+    expect(
+      await warnings(
+        "return rows.map(row=>{const children=computed(()=>row.children);return children.map(child=>child);});",
+      ),
+    ).toHaveLength(0);
+  });
+  it("leaves an indexed lookup's returned members unreported", async () => {
+    const result = await validateSource(
+      `
+      import {pattern,GroupIndex} from "commonfabric";
+      export default pattern<{rows:{key:string}[];index:GroupIndex<string,{title:string}>}>(({rows,index})=>({
+        values:rows.map(row=>index.lookup(row.key).map(item=>item.title)),
+      }));
+    `,
+      { types: COMMONFABRIC_TYPES, typeCheck: true },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+  it("warns for nested captured scans within a computed body", async () => {
+    expect(
+      await warnings(
+        "return computed(()=>rows.map(row=>other.filter(item=>item.key===row.key)));",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/ts-transformers/test/nested-collection-scan.test.ts
+++ b/packages/ts-transformers/test/nested-collection-scan.test.ts
@@ -8,7 +8,7 @@ async function warnings(body: string) {
   const result = await validateSource(
     `
     import {pattern,computed} from "commonfabric";
-    export default pattern<{rows:{key:string;children:string[]}[];other:{key:string}[]}>(({rows,other})=>{
+    export default pattern<{rows:{key:string;children:string[]}[];other:{key:string}[];collections:string[][]}>(({rows,other,collections})=>{
       ${body}
     });
   `,
@@ -89,6 +89,13 @@ describe("nested collection scan warnings", () => {
       { types: COMMONFABRIC_TYPES, typeCheck: true },
     );
     expect(result.diagnostics).toEqual([]);
+  });
+  it("leaves a captured collection selected by element access unreported", async () => {
+    expect(
+      await warnings(
+        "return rows.map(row=>collections[0].map(child=>child));",
+      ),
+    ).toHaveLength(0);
   });
   it("warns for nested captured scans within a computed body", async () => {
     expect(

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T12:28:54.331336+00:00",
+  "updated": "2026-09-11T12:43:53.407507+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -25,6 +25,8 @@
     "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean.",
     "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass.",
     "#7327 merged as b135f7f067ca8112ac7bf6f638b9511b26361944: all current-head CI gates succeeded or were skipped; Cubic run 103250197793 reported zero issues on dae8319a23; antagonistic review was clean. All nine measurement cases and the forced-disposal cleanup control passed.",
+    "#7308 merged as e435590cf4c94c91a32260315efe1eedc5e66a7b: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
+    "#7312 merged as c00a2581f13b3183986f4d30c6d4ad86e28a34ab: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
     "#7329 merged as 593c341b27a8baff681374bd01b3125a70ffeca8: all 69 exact-head checks succeeded or were skipped; Cubic run 103258387302 reported zero issues on 9e28f27015; antagonistic review was clean. Client remote-row identity and narrow-invalidation acceptance is landed."
   ],
   "stages": [

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,10 +1,10 @@
 {
-  "updated": "2026-09-11T12:51:46.919867+00:00",
+  "updated": "2026-09-11T12:59:52.897720+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
-  "pr": "https://github.com/commontoolsinc/labs/pull/7307",
-  "activity": "D3 validation passes. Cubic identified two dashboard ledger inconsistencies; both are repaired for a fresh review.",
-  "review": "Antagonistic D3 review is clean after correcting status wording and verifying reentry of both metadata scopes. The D3 PR requires its own CI and Cubic review before landing.",
+  "pr": "https://github.com/commontoolsinc/labs/pull/7331",
+  "activity": "Finish review of the validated compiler guidance and remote-row acceptance while advancing the remaining collection operators. Live poll changes require coordination.",
+  "review": "Each slice requires clean current-head CI, actual Cubic review, and antagonistic review before landing. The checks ledger records completed merges.",
   "checks": [
     "#7241: all 69 CI gates passed; latest Cubic run reported zero issues; merged as e70704f206.",
     "#7256: all 69 CI gates passed with clean Cubic/antagonistic reviews; merged as 8d3c7dbc3c.",
@@ -25,8 +25,8 @@
     "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean.",
     "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass.",
     "#7327 merged as b135f7f067ca8112ac7bf6f638b9511b26361944: all current-head CI gates succeeded or were skipped; Cubic run 103250197793 reported zero issues on dae8319a23; antagonistic review was clean. All nine measurement cases and the forced-disposal cleanup control passed.",
-    "#7308 merged as e435590cf4c94c91a32260315efe1eedc5e66a7b: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
-    "#7312 merged as c00a2581f13b3183986f4d30c6d4ad86e28a34ab: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
+    "#7308 merged as e435590cf4c94c91a32260315efe1eedc5e66a7b: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. Memory queries wait for session restoration before issuing requests.",
+    "#7312 merged as c00a2581f13b3183986f4d30c6d4ad86e28a34ab: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. Rendered row acceptance covers storage outages, catch-up, and subsequent updates.",
     "#7329 merged as 593c341b27a8baff681374bd01b3125a70ffeca8: all 69 exact-head checks succeeded or were skipped; Cubic run 103258387302 reported zero issues on 9e28f27015; antagonistic review was clean. Client remote-row identity and narrow-invalidation acceptance is landed."
   ],
   "stages": [
@@ -99,8 +99,8 @@
     {
       "id": "C2",
       "title": "Partial materialization correctness",
-      "status": "todo",
-      "detail": "Repair only after C1 establishes the failure."
+      "status": "review",
+      "detail": "Cold first-demand, remote membership, and reconnect acceptance are validated. Session-restoration repair #7308 and rendered reconnect acceptance #7312 are merged. Tracker reconciliation is in review in #7332; C3 producer checks are separate."
     },
     {
       "id": "C3",
@@ -160,7 +160,7 @@
       "id": "E3",
       "title": "Nested-scan diagnostic",
       "status": "review",
-      "detail": "PR #7328 implements and validates the nested-scan warning, with ten focused cases and a 413-entry corpus review. The acceptance report is linked from the tracker. CI and Cubic review govern landing."
+      "detail": "PR #7328 implements and validates the nested-scan warning with eleven focused cases and a 413-entry corpus review. CI and Cubic review govern landing."
     }
   ],
   "questions": [

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T12:04:33.232541+00:00",
+  "updated": "2026-09-11T12:15:16.962178+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -23,7 +23,8 @@
     "#7282 main integration: all six functional assertions and declared budgets, 413 authoritative pattern checks, full pattern package including browser tests, and all 46 type groups pass.",
     "#7304 merged as c0454ab24e after all 69 exact-head checks, zero issues in the full nine-file Cubic rereview, and clean antagonistic review.",
     "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean.",
-    "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass."
+    "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass.",
+    "#7327 merged as b135f7f067ca8112ac7bf6f638b9511b26361944: all current-head CI gates succeeded or were skipped; Cubic run 103250197793 reported zero issues on dae8319a23; antagonistic review was clean. All nine measurement cases and the forced-disposal cleanup control passed."
   ],
   "stages": [
     {

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T04:49:55.656447+00:00",
+  "updated": "2026-09-11T11:42:48.685339+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -155,8 +155,8 @@
     {
       "id": "E3",
       "title": "Nested-scan diagnostic",
-      "status": "todo",
-      "detail": "Warning with negative cases and corpus noise assessment."
+      "status": "review",
+      "detail": "PR #7328 implements and validates the nested-scan warning, with ten focused cases and a 413-entry corpus review. The acceptance report is linked from the tracker. CI and Cubic review govern landing."
     }
   ],
   "questions": [

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T12:43:53.407507+00:00",
+  "updated": "2026-09-11T12:51:46.919867+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -69,8 +69,8 @@
     {
       "id": "C1",
       "title": "Multi-replica reproductions",
-      "status": "active",
-      "detail": "Remote edits, removal, and restoration landed in #7285; first-browser-materialization acceptance landed in #7302. Four nested/mapped \u00d7 same/cross-space cases pass, with local demos. Reconnect remains pending."
+      "status": "done",
+      "detail": "Remote edits, removal/restoration, and cold first-browser materialization are validated in nested/mapped and same/cross-space fixtures. Session-restoration repair #7308 and rendered reconnect acceptance #7312 are merged; local recordings remain available."
     },
     {
       "id": "B1",
@@ -105,8 +105,8 @@
     {
       "id": "C3",
       "title": "Remote row invalidation",
-      "status": "active",
-      "detail": "Client identity and narrow-invalidation acceptance is in PR #7329: edits to either row preserve both normalized output links and producer IDs, rerun the edited producer, and leave the untouched producer idle. Serving-host producer counts remain separate acceptance work."
+      "status": "review",
+      "detail": "Client acceptance landed in #7329. Serving-host acceptance is in review in #7331: correct values, stable full output links/producer identities, and untouched-row inactivity in both edit directions. Full runner validation and all 27 final serving-loop cases pass. Publication completes when #7331 lands."
     },
     {
       "id": "C4",
@@ -221,7 +221,7 @@
     {
       "title": "See remote updates",
       "state": "Available \u00b7 C1/C3",
-      "detail": "The row demo shows remote membership, colors, ranking, cross-space profiles, and first browser materialization. Reconnect acceptance remains pending."
+      "detail": "The row demo shows remote membership, colors, ranking, cross-space profiles, and cold first browser materialization. Rendered reconnect acceptance is validated and merged in #7312."
     },
     {
       "title": "Compare optimized vote updates",


### PR DESCRIPTION
## Why

A scan of the same reactive collection inside each outer row can multiply collection work without being obvious in authored code. Track E3 of #7155 calls for a warning through the existing diagnostic collector, with negative cases and corpus inspection before shipping. This change adds that conservative, non-fatal hint.

## What Changed

Use existing array ownership, type, root-binding, and scope analysis to recognize captured collection scans inside inline reactive array callbacks. Exclude child arrays, callback-local derived lists, plain arrays, separate function scopes, complex receivers, and indexed lookup results. Update the author guide, accounting guide, current-behavior specification, and implementation tracker.

The corpus report records seven warning occurrences at five source sites across 413 pattern entries / 1,731 modules. Three are category-by-item fixtures; two are guarded UI lists where actual demand matters. These remain measurement prompts, not claims that every update is multiplicative. An initial callback-local finding was excluded and given a regression test.

## Test plan

- Full transformer suite: 1,171 tests / 978 steps pass with the final production rule; final focused suite: eleven cases pass.
- Entire authored-pattern batch: 413 entries, 1,731 modules, zero errors; all five distinct warning sites inspected.
- Real `cf check --no-run` emits the warning and exits successfully; recorded output is visible in the local dashboard.
- All 46 type-check groups, 599 documentation blocks, history index, repo formatting/lint, and antagonistic cf-review pass.
- CI and clean Cubic review remain required before merge.
