### PR TITLE
test: verify remote row producer identity and narrow invalidation

### DIFF
--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -266,7 +266,13 @@ passed before merge, with clean Cubic and antagonistic reviews.
 - [ ] **C2 — Repair partial materialization.** Verify complete inputs under cold
       reads, remote inserts/removals, and reconnect where relevant.
 - [ ] **C3 — Repair remote row invalidation.** Verify affected rows update,
-      stable element identities survive, and untouched rows do not rerun.
+      stable element identities survive, and untouched rows do not rerun. The
+      client-execution acceptance in
+      [reactive vote rows](../../packages/patterns/integration/reactive-vote-rows.test.ts)
+      edits each of two rows from another replica, checks stable normalized
+      output links and producer identities, and verifies that only the edited
+      row producer runs. Serving-host producer counts remain separate acceptance
+      work because a client diagnostic graph does not contain those actions.
 - [x] **C4 — Restore reactive lunch-poll rows.** Direct reactive option and
       voter maps use the scoped callback-child repair. Repository acceptance
       includes 93 assertions, unchanged A4 budgets at all three sizes, and

--- a/packages/patterns/integration/reactive-vote-rows.test.ts
+++ b/packages/patterns/integration/reactive-vote-rows.test.ts
@@ -4,12 +4,31 @@
  * These assertions cover row data. Browser-rendered content is a separate check.
  */
 
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
+import {
+  experimentalOptionsFromEnv,
+  type SchedulerGraphSnapshot,
+} from "@commonfabric/runner";
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { MultiRuntimeHarness } from "./multi-runtime-harness.ts";
 
 const rootPath = join(import.meta.dirname!, "..");
+const serverExecution =
+  experimentalOptionsFromEnv(Deno.env.get).serverExecution ??
+    SERVER_EXECUTION_DEFAULT_ENABLED;
+
+function rowProducer(graph: SchedulerGraphSnapshot, outputId: string) {
+  const matches = graph.nodes.filter((node) =>
+    node.type === "computation" &&
+    node.writes?.some((write) => write.includes(outputId))
+  );
+  expect(matches).toHaveLength(1);
+  const node = matches[0];
+  expect(node.stats?.runCount).toBeGreaterThan(0);
+  return { id: node.id, runs: node.stats!.runCount };
+}
 
 describe("reactive vote rows across replicas", () => {
   it("includes remotely created vote entities in a nested row filter", async () => {
@@ -86,5 +105,73 @@ describe("reactive vote rows across replicas", () => {
     } finally {
       await harness.dispose();
     }
+  });
+
+  it({
+    name:
+      "preserves client row producers and skips untouched rows after remote edits",
+    // Serving-host actions are outside a client worker's diagnostic graph.
+    ignore: serverExecution,
+    fn: async () => {
+      const harness = await MultiRuntimeHarness.create({
+        rootPath,
+        programPath: join(
+          import.meta.dirname!,
+          "fixtures/reactive-vote-rows/mapped.tsx",
+        ),
+        sessions: ["writer", "reader"],
+        diagnostics: true,
+      });
+      try {
+        const writer = harness.session("writer");
+        const reader = harness.session("reader");
+        await writer.send("cast", {
+          key: "alice",
+          optionId: "one",
+          color: "green",
+        });
+        await writer.send("cast", {
+          key: "bob",
+          optionId: "two",
+          color: "yellow",
+        });
+        await harness.settle();
+        expect(await reader.read(["rows"])).toEqual([
+          { id: "one", color: "green", names: "alice" },
+          { id: "two", color: "yellow", names: "bob" },
+        ]);
+        const links = await Promise.all(
+          [0, 1].map((index) => reader.link(["rows", index, "color"])),
+        );
+        let graph = (await reader.diagnostics()).graph;
+        let producers = links.map((link) => rowProducer(graph, link.id));
+        for (const edited of [0, 1]) {
+          await writer.send("cast", {
+            key: edited === 0 ? "alice" : "bob",
+            optionId: edited === 0 ? "one" : "two",
+            color: "red",
+          });
+          await harness.settle();
+          expect(await reader.read(["rows"])).toEqual([
+            { id: "one", color: "red", names: "alice" },
+            { id: "two", color: edited === 0 ? "yellow" : "red", names: "bob" },
+          ]);
+          const nextLinks = await Promise.all(
+            [0, 1].map((index) => reader.link(["rows", index, "color"])),
+          );
+          expect(nextLinks).toEqual(links);
+          graph = (await reader.diagnostics()).graph;
+          const next = links.map((link) => rowProducer(graph, link.id));
+          expect(next.map((producer) => producer.id)).toEqual(
+            producers.map((producer) => producer.id),
+          );
+          expect(next[edited].runs).toBeGreaterThan(producers[edited].runs);
+          expect(next[1 - edited].runs).toBe(producers[1 - edited].runs);
+          producers = next;
+        }
+      } finally {
+        await harness.dispose();
+      }
+    },
   });
 });

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T12:06:03.522064+00:00",
+  "updated": "2026-09-11T12:15:16.961452+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -23,7 +23,8 @@
     "#7282 main integration: all six functional assertions and declared budgets, 413 authoritative pattern checks, full pattern package including browser tests, and all 46 type groups pass.",
     "#7304 merged as c0454ab24e after all 69 exact-head checks, zero issues in the full nine-file Cubic rereview, and clean antagonistic review.",
     "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean.",
-    "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass."
+    "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass.",
+    "#7327 merged as b135f7f067ca8112ac7bf6f638b9511b26361944: all current-head CI gates succeeded or were skipped; Cubic run 103250197793 reported zero issues on dae8319a23; antagonistic review was clean. All nine measurement cases and the forced-disposal cleanup control passed."
   ],
   "stages": [
     {

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T04:49:55.656447+00:00",
+  "updated": "2026-09-11T11:58:48.810157+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -102,7 +102,7 @@
       "id": "C3",
       "title": "Remote row invalidation",
       "status": "active",
-      "detail": "Inline-element dependency fix landed in #7265 with four browser cases and narrow invalidation tests. Remaining acceptance checks and production workaround removal stay open."
+      "detail": "Remote client-execution acceptance passes: editing either of two rows preserves normalized output links and producer identities, reruns the edited producer, and leaves the untouched producer idle. Serving-host producer counts remain open. Live poll changes require coordination."
     },
     {
       "id": "C4",


### PR DESCRIPTION
## Why

A remotely edited row can display the right value while needlessly rebuilding or rerunning neighboring row producers. The existing cross-replica value checks do not distinguish those behaviors. This adds the remaining client-execution identity and narrow-invalidation acceptance for design #7155, following the repair in #7265.

## What Changed

The two-worker integration test identifies each color producer through its normalized output link. It edits each of two rows from the other replica, verifies both output links and producer identities remain stable, requires the edited producer to run, and requires the untouched producer to stay idle. The tracker and dashboard record this evidence and leave serving-host producer counts open: those actions are absent from a client worker's diagnostic graph.

## Test plan

- Client-execution reactive-row integration: all three cases pass.
- Patterns package task: 63 unit tests / 246 steps, source-coverage test, and browser test pass.
- Repository formatting, lint, type checks, and documentation examples.

No live poll is involved.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

