### PR TITLE
docs: align collection guidance with measured lazy reads

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -40,7 +40,8 @@ on the Common Fabric runtime.
 
 - [concepts/pattern.md](concepts/pattern.md) — what a pattern is; inputs, outputs, `[UI]`, `[NAME]`
 - [concepts/reactivity.md](concepts/reactivity.md) — the cell system, read/write access, reactive mental model
-- [concepts/computed/computed.md](concepts/computed/computed.md) — `computed()`, `lift()`, derived values
+- [concepts/computed/computed.md](concepts/computed/computed.md) — `computed()`, `lift()`, derived values, and measured collection-loop cost
+- [../features/collection-aggregates.md](../features/collection-aggregates.md) — named aggregates, numeric contracts, and collection computation costs
 - [concepts/action.md](concepts/action.md) — handling events with `action()`
 - [concepts/handler.md](concepts/handler.md) — reusable parameterized handlers with `handler()`
 - [concepts/identity.md](concepts/identity.md) — object identity, `equals()`, why `===` fails across cells

--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -148,11 +148,16 @@ for why.
 
 ### Reading a Value Narrowly and Handing It Back Whole
 
-A `lift()`'s declared parameter is what it reads, and reading is what it becomes
-reactive to — so declaring the few fields the body touches is how a derivation
-over a large collection stays cheap. Often the body then hands an element
-straight back, and the caller wants the whole element, not the sliver that was
-read.
+A `lift()`'s parameter schema describes the view its body can read. With lazy
+materialization enabled by default, accessing that view records dependencies
+on the paths the body touches. A narrower declaration documents the required
+input, but does not by itself make a collection scan incremental: the
+[measured collection loops](#collection-loop-cost) read the same amount under
+broad and narrow declarations. A body that visits every row still visits every
+row when a used field changes.
+
+A derivation can read a few fields and return the original element, preserving
+the caller's access to its other fields.
 
 Declare that with a type parameter. The result type is the element type, so the
 caller gets back exactly what it passed in:
@@ -172,7 +177,8 @@ const kept = nonEmpty({ rows });
 ```
 
 The schema generated for the lift comes from the constraint, argument and result
-alike, so `nonEmpty` reads `{ key: string }` and nothing more. The elements
+alike. Here the predicate accesses `key`; it does not inspect each element's
+payload. The elements
 survive because a value forwarded out of a derivation is written as a reference,
 and a reference resolves to its whole document however little the derivation
 declared.

--- a/docs/features/collection-aggregates.md
+++ b/docs/features/collection-aggregates.md
@@ -60,6 +60,29 @@ source as an empty collection: predicate count yields `0`, and the By forms
 yield `undefined`. Numeric aggregates require numbers, and score callbacks
 require numeric results.
 
+## Choosing a collection computation
+
+Use `computed` for an inline derivation or module-level `lift` to reuse one.
+Moving the same loop between them does not make it incremental. The
+[collection-loop measurements](../history/development/performance/2026-09-11-computed-lift-collection-loops.md)
+compared computed, broad lift, and narrow lift on 32, 128, and 512 linked rows.
+All three skipped an unread-field edit and scanned the collection for an edit
+to the summed field. At 512 rows that update performed 1,025 proxy reads and
+515 link hops in completed action bodies. These counters exclude setup,
+network traffic, and other runtime work; they do not establish equal latency.
+
+For an operation in the table above, compare its contract with the computation
+you need. In particular, `sum` rounds an exact accumulated total once, so it
+can differ from an ordered JavaScript reduction. Use an explicit cell receiver;
+`rows.map(score).sum()` is not an available replacement.
+
+A captured collection scanned separately for each row can multiply work by
+both collection sizes. Move work shared by all rows outside the row callback
+when that preserves dependencies and output identity. Measure the demanded
+result, including initialization, membership changes, and committed updates
+through settlement. A named aggregate whose callback reads a shared collection
+can still invalidate every callback.
+
 ## Work and ownership
 
 The runtime sorts element identity keys and builds a balanced tree with at most

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -239,8 +239,8 @@ passed before merge, with clean Cubic and antagonistic reviews.
   profiles. Ordinary memory queries wait for session restoration before
   constructing their requests. This guards the handshake-to-session interval;
   a subsequent disconnect during request issue remains a separate boundary.
-  These synthetic probes do not authorize removing the lunch-poll workaround or
-  accessing the live poll.
+  These synthetic probes cover repository behavior. Live poll changes require
+  coordination with Mike.
 
   C3's landed fix records the mutable inline element used when resolving a
   nested array to a content-addressed snapshot. The
@@ -406,7 +406,7 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 
 ## Next task
 
-Complete C3's remaining acceptance checks. C4's repository migration is
+Finish review and publication of C3 acceptance, then continue the collection-operator work. C4's repository migration is
 implemented and validated; updating any deployed poll requires coordination
 with Mike. The first-materialization cases in
 [PR #7302](https://github.com/commontoolsinc/labs/pull/7302) pass all four

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -342,9 +342,14 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
       [reproducible comparison](../history/development/performance/2026-09-11-computed-lift-collection-loops.md)
       validates three forms at 32, 128, and 512 linked rows, including unread-field
       edits. The dashboard tracks publication and review status.
-- [ ] **E2 — Publish the measured advice** where pattern authors encounter
+- [x] **E2 — Publish the measured advice** where pattern authors encounter
       collections, `computed`, and `lift`. Explain nested-scan cost and use only
-      available operators in replacement examples.
+      available operators in replacement examples. The
+      [computed/lift guide](../common/concepts/computed/computed.md#collection-loop-cost)
+      and [collection guide](../features/collection-aggregates.md#choosing-a-collection-computation)
+      explain lazy read width, repeated scans, explicit cell receivers, numeric
+      contract differences, and measurement limits. The author index links both;
+      dashboard publication status remains separate.
 - [ ] **E3 — Add a transformer warning** through the existing diagnostic
       collector. Test recognizable nested reactive scans and negative cases
       involving plain arrays and unrelated scopes; inspect warning volume across

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,10 +1,10 @@
 {
-  "updated": "2026-09-11T12:51:46.919867+00:00",
+  "updated": "2026-09-11T12:59:52.897720+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
-  "pr": "https://github.com/commontoolsinc/labs/pull/7307",
-  "activity": "D3 validation passes. Cubic identified two dashboard ledger inconsistencies; both are repaired for a fresh review.",
-  "review": "Antagonistic D3 review is clean after correcting status wording and verifying reentry of both metadata scopes. The D3 PR requires its own CI and Cubic review before landing.",
+  "pr": "https://github.com/commontoolsinc/labs/pull/7331",
+  "activity": "Finish review of the validated compiler guidance and remote-row acceptance while advancing the remaining collection operators. Live poll changes require coordination.",
+  "review": "Each slice requires clean current-head CI, actual Cubic review, and antagonistic review before landing. The checks ledger records completed merges.",
   "checks": [
     "#7241: all 69 CI gates passed; latest Cubic run reported zero issues; merged as e70704f206.",
     "#7256: all 69 CI gates passed with clean Cubic/antagonistic reviews; merged as 8d3c7dbc3c.",
@@ -25,8 +25,8 @@
     "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean.",
     "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass.",
     "#7327 merged as b135f7f067ca8112ac7bf6f638b9511b26361944: all current-head CI gates succeeded or were skipped; Cubic run 103250197793 reported zero issues on dae8319a23; antagonistic review was clean. All nine measurement cases and the forced-disposal cleanup control passed.",
-    "#7308 merged as e435590cf4c94c91a32260315efe1eedc5e66a7b: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
-    "#7312 merged as c00a2581f13b3183986f4d30c6d4ad86e28a34ab: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
+    "#7308 merged as e435590cf4c94c91a32260315efe1eedc5e66a7b: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. Memory queries wait for session restoration before issuing requests.",
+    "#7312 merged as c00a2581f13b3183986f4d30c6d4ad86e28a34ab: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. Rendered row acceptance covers storage outages, catch-up, and subsequent updates.",
     "#7329 merged as 593c341b27a8baff681374bd01b3125a70ffeca8: all 69 exact-head checks succeeded or were skipped; Cubic run 103258387302 reported zero issues on 9e28f27015; antagonistic review was clean. Client remote-row identity and narrow-invalidation acceptance is landed."
   ],
   "stages": [
@@ -99,8 +99,8 @@
     {
       "id": "C2",
       "title": "Partial materialization correctness",
-      "status": "todo",
-      "detail": "Repair only after C1 establishes the failure."
+      "status": "review",
+      "detail": "Cold first-demand, remote membership, and reconnect acceptance are validated. Session-restoration repair #7308 and rendered reconnect acceptance #7312 are merged. Tracker reconciliation is in review in #7332; C3 producer checks are separate."
     },
     {
       "id": "C3",

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T12:29:23.951704+00:00",
+  "updated": "2026-09-11T12:43:53.407507+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -25,6 +25,8 @@
     "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean.",
     "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass.",
     "#7327 merged as b135f7f067ca8112ac7bf6f638b9511b26361944: all current-head CI gates succeeded or were skipped; Cubic run 103250197793 reported zero issues on dae8319a23; antagonistic review was clean. All nine measurement cases and the forced-disposal cleanup control passed.",
+    "#7308 merged as e435590cf4c94c91a32260315efe1eedc5e66a7b: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
+    "#7312 merged as c00a2581f13b3183986f4d30c6d4ad86e28a34ab: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
     "#7329 merged as 593c341b27a8baff681374bd01b3125a70ffeca8: all 69 exact-head checks succeeded or were skipped; Cubic run 103258387302 reported zero issues on 9e28f27015; antagonistic review was clean. Client remote-row identity and narrow-invalidation acceptance is landed."
   ],
   "stages": [

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T11:41:56.081484+00:00",
+  "updated": "2026-09-11T12:15:16.962534+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -23,7 +23,8 @@
     "#7282 main integration: all six functional assertions and declared budgets, 413 authoritative pattern checks, full pattern package including browser tests, and all 46 type groups pass.",
     "#7304 merged as c0454ab24e after all 69 exact-head checks, zero issues in the full nine-file Cubic rereview, and clean antagonistic review.",
     "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean.",
-    "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass."
+    "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass.",
+    "#7327 merged as b135f7f067ca8112ac7bf6f638b9511b26361944: all current-head CI gates succeeded or were skipped; Cubic run 103250197793 reported zero issues on dae8319a23; antagonistic review was clean. All nine measurement cases and the forced-disposal cleanup control passed."
   ],
   "stages": [
     {
@@ -143,14 +144,14 @@
     {
       "id": "E1",
       "title": "Computed versus lift measurements",
-      "status": "review",
-      "detail": "PR #7327 implements and validates the computed/broad-lift/narrow-lift comparison at 32/128/512 linked rows. The report and reproduction command are linked from the implementation tracker. CI and Cubic review govern landing."
+      "status": "done",
+      "detail": "Merged #7327: validated computed/broad-lift/narrow-lift measurements at 32/128/512 linked rows, with unread-field edits and a reproducible command."
     },
     {
       "id": "E2",
       "title": "Author guidance",
-      "status": "todo",
-      "detail": "Publish measured advice using shipped operators."
+      "status": "review",
+      "detail": "Measured advice is implemented in the computed/lift and collection guides, linked from the author index. Documentation validation and PR review govern landing."
     },
     {
       "id": "E3",

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T12:43:53.407507+00:00",
+  "updated": "2026-09-11T12:51:46.919867+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -69,8 +69,8 @@
     {
       "id": "C1",
       "title": "Multi-replica reproductions",
-      "status": "active",
-      "detail": "Remote edits, removal, and restoration landed in #7285; first-browser-materialization acceptance landed in #7302. Four nested/mapped \u00d7 same/cross-space cases pass, with local demos. Reconnect remains pending."
+      "status": "done",
+      "detail": "Remote edits, removal/restoration, and cold first-browser materialization are validated in nested/mapped and same/cross-space fixtures. Session-restoration repair #7308 and rendered reconnect acceptance #7312 are merged; local recordings remain available."
     },
     {
       "id": "B1",
@@ -105,8 +105,8 @@
     {
       "id": "C3",
       "title": "Remote row invalidation",
-      "status": "active",
-      "detail": "Client identity and narrow-invalidation acceptance is in PR #7329: edits to either row preserve both normalized output links and producer IDs, rerun the edited producer, and leave the untouched producer idle. Serving-host producer counts remain separate acceptance work."
+      "status": "review",
+      "detail": "Client acceptance landed in #7329. Serving-host acceptance is in review in #7331: correct values, stable full output links/producer identities, and untouched-row inactivity in both edit directions. Full runner validation and all 27 final serving-loop cases pass. Publication completes when #7331 lands."
     },
     {
       "id": "C4",
@@ -221,7 +221,7 @@
     {
       "title": "See remote updates",
       "state": "Available \u00b7 C1/C3",
-      "detail": "The row demo shows remote membership, colors, ranking, cross-space profiles, and first browser materialization. Reconnect acceptance remains pending."
+      "detail": "The row demo shows remote membership, colors, ranking, cross-space profiles, and cold first browser materialization. Rendered reconnect acceptance is validated and merged in #7312."
     },
     {
       "title": "Compare optimized vote updates",


### PR DESCRIPTION
## Why

The lift guide says the declared parameter determines every read, which conflicts with default lazy materialization and the measured comparison in #7327. Pattern authors could narrow a type or replace computed with lift and expect a scan to become incremental.

## What Changed

Explain that schemas define readable views while accessed paths establish lazy dependencies. Link the measured comparison from the author index and collection guide, explain repeated-scan cost, and direct replacements toward shipped explicit-cell aggregates with their numeric and membership-cost limits. Mark E2 implemented in the tracker and in review on the dashboard; retain E1's verified merge evidence.

## Test plan

All 599 documentation examples pass. Repository formatting and lint pass. No executable code or examples were changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

