### PR TITLE
test: verify serving-host row identity and narrow invalidation

### DIFF
--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -419,7 +419,8 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 
 ## Next task
 
-Finish review and publication of C3 acceptance, then continue the collection-operator work. C4's repository migration is
+Continue the collection-operator implementation and its measured acceptance.
+C4's repository migration is
 implemented and validated; updating any deployed poll requires coordination
 with Mike. The first-materialization cases in
 [PR #7302](https://github.com/commontoolsinc/labs/pull/7302) pass all four

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -274,7 +274,7 @@ passed before merge, with clean Cubic and antagonistic reviews.
       [serving-loop case](../../packages/runner/test/executor-serving-loop.test.ts)
       observes the actual serving runtime and waits for the authored input
       watermark; a client diagnostic graph does not contain those actions.
-      The dashboard records publication of the serving acceptance in #7331.
+      The dashboard records serving acceptance as in review until #7331 lands.
 - [x] **C4 — Restore reactive lunch-poll rows.** Direct reactive option and
       voter maps use the scoped callback-child repair. Repository acceptance
       includes 93 assertions, unchanged A4 budgets at all three sizes, and

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -267,6 +267,13 @@ passed before merge, with clean Cubic and antagonistic reviews.
       reads, remote inserts/removals, and reconnect where relevant.
 - [ ] **C3 — Repair remote row invalidation.** Verify affected rows update,
       stable element identities survive, and untouched rows do not rerun.
+      Client-execution acceptance is in PR #7329. The
+      [serving-loop acceptance](../../packages/runner/test/executor-serving-loop.test.ts)
+      separately checks correct derived values, stable normalized output links
+      and producer identities, and affected-only producer execution for edits
+      to each of two linked rows. It observes the actual serving runtime and
+      waits for the authored input watermark. Both acceptance slices must land
+      before this item closes.
 - [x] **C4 — Restore reactive lunch-poll rows.** Direct reactive option and
       voter maps use the scoped callback-child repair. Repository acceptance
       includes 93 assertions, unchanged A4 budgets at all three sizes, and

--- a/docs/plans/pattern-computation-cost-implementation.md
+++ b/docs/plans/pattern-computation-cost-implementation.md
@@ -10,8 +10,8 @@ repair landed in #7265; removal/restoration acceptance landed in #7285 and
 first-browser-materialization acceptance landed in #7302. Reconnect repair
 landed in #7308 and rendered reconnect acceptance in #7312. C4's repository-only
 reactive row migration is implemented and validated on the scoped-child and
-bounded-render repairs in #7313 and #7315. Remaining row-invalidation acceptance
-stays open. B1/B2's contract landed in
+bounded-render repairs in #7313 and #7315. Row-invalidation implementation and validation are complete;
+serving-host acceptance is in review in #7331. B1/B2's contract landed in
 #7294 and its typed lookup foundation landed in #7304. Producer lowering,
 bucket maintenance, and joins remain pending.
 
@@ -239,8 +239,8 @@ passed before merge, with clean Cubic and antagonistic reviews.
   profiles. Ordinary memory queries wait for session restoration before
   constructing their requests. This guards the handshake-to-session interval;
   a subsequent disconnect during request issue remains a separate boundary.
-  These synthetic probes do not authorize removing the lunch-poll workaround or
-  accessing the live poll.
+  These synthetic probes cover repository behavior. Live poll changes require
+  coordination with Mike.
 
   C3's landed fix records the mutable inline element used when resolving a
   nested array to a content-addressed snapshot. The
@@ -403,7 +403,7 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 
 ## Next task
 
-Complete C3's remaining acceptance checks. C4's repository migration is
+Finish review and publication of C3 acceptance, then continue the collection-operator work. C4's repository migration is
 implemented and validated; updating any deployed poll requires coordination
 with Mike. The first-materialization cases in
 [PR #7302](https://github.com/commontoolsinc/labs/pull/7302) pass all four

--- a/packages/runner/test/executor-serving-loop.test.ts
+++ b/packages/runner/test/executor-serving-loop.test.ts
@@ -35,6 +35,7 @@ import { decodeMemoryBoundary, resolveScopeKey } from "@commonfabric/memory/v2";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { NormalizedFullLink } from "../src/link-utils.ts";
 import type { MemorySpace } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import {
@@ -183,6 +184,117 @@ describe("stage F serving loop", () => {
       storageManager: clientManager,
     });
   };
+
+  it("preserves serving row producers and skips untouched rows after client edits", async () => {
+    type Row = { key: string; value: number };
+    const ready = Promise.withResolvers<void>();
+    let cancel: (() => void) | undefined;
+    let readRows: (() => Row[]) | undefined;
+    let inspect:
+      | (() => { link: NormalizedFullLink; id: string; runs: number }[])
+      | undefined;
+    onServingRuntime = async (runtime) => {
+      try {
+        runtime.scheduler.enableSettleStats();
+        const compiled = await runtime.patternManager.compilePattern({
+          main: "/main.tsx",
+          files: [{
+            name: "/main.tsx",
+            contents: `
+            import { computed, pattern } from "commonfabric";
+            export default pattern<{rows:{key:string;value:number}[]}>(({rows})=>({
+              rows:rows.map(row=>({key:row.key,value:computed(()=>row.value*2)})),
+            }));
+          `,
+          }],
+        }, { space });
+        const argument = runtime.getCell<{ rows: unknown[] }>(space, "row-arg");
+        const result = runtime.getCell<{ rows: Row[] }>(
+          space,
+          "row-result",
+          compiled.resultSchema,
+        );
+        const inputs = [0, 1].map((index) =>
+          runtime.getCell<Row>(space, `row-input-${index}`)
+        );
+        const tx = runtime.edit();
+        inputs.forEach((cell, index) =>
+          cell.withTx(tx).set({ key: String(index), value: index + 1 })
+        );
+        argument.withTx(tx).set({ rows: inputs });
+        runtime.run(tx, compiled, argument, result);
+        expect((await tx.commit()).error).toBeUndefined();
+        cancel = result.sink(() => {});
+        await runtime.idle();
+        readRows = () => result.get().rows;
+        inspect = () => {
+          const graph = runtime.scheduler.getGraphSnapshot();
+          return [0, 1].map((index) => {
+            const link = result.key("rows").key(index).key("value")
+              .resolveAsCell().getAsNormalizedFullLink();
+            const producers = graph.nodes.filter((node) =>
+              node.type === "computation" &&
+              node.writes?.some((write) => write.includes(link.id))
+            );
+            expect(producers).toHaveLength(1);
+            expect(producers[0].stats?.runCount).toBeGreaterThan(0);
+            return {
+              link,
+              id: producers[0].id,
+              runs: producers[0].stats!.runCount,
+            };
+          });
+        };
+        ready.resolve();
+      } catch (error) {
+        ready.reject(error);
+        throw error;
+      }
+    };
+    host = newHost();
+    openClient();
+    try {
+      const clientResult = clientRuntime.getCell<{ rows: Row[] }>(
+        space,
+        "row-result",
+      );
+      await clientResult.sync();
+      await ready.promise;
+      expect(readRows!()).toEqual([{ key: "0", value: 2 }, {
+        key: "1",
+        value: 4,
+      }]);
+      let before = inspect!();
+      const engine = await server.engineForSpace(space);
+      for (const edited of [0, 1]) {
+        const input = clientRuntime.getCell<Row>(space, `row-input-${edited}`);
+        await input.sync();
+        const tx = clientRuntime.edit();
+        input.withTx(tx).key("value").set(10 + edited);
+        expect((await tx.commit()).error).toBeUndefined();
+        // The serving wave can advance the head beyond its authored input.
+        const authored = engine.database.prepare(
+          `SELECT MAX(seq) AS seq FROM "commit" WHERE class = 'authored'`,
+        ).get() as { seq: number };
+        expect(authored.seq).toBeGreaterThan(0);
+        await waitForSettled(clientRuntime, space, authored.seq);
+        await servingRuntime!.idle();
+        expect(readRows!()).toEqual([{ key: "0", value: 20 }, {
+          key: "1",
+          value: edited === 0 ? 4 : 22,
+        }]);
+        const after = inspect!();
+        expect(after.map(({ link, id }) => ({ link, id }))).toEqual(
+          before.map(({ link, id }) => ({ link, id })),
+        );
+        expect(after[edited].runs).toBeGreaterThan(before[edited].runs);
+        expect(after[1 - edited].runs).toBe(before[1 - edited].runs);
+        before = after;
+      }
+    } finally {
+      cancel?.();
+    }
+  });
 
   it("serves a demanded derivation: authored commit → wave → ONE derived commit with watermark; the client settles via waitForSettled", async () => {
     host = newHost({ flushDeadlineMs: 5_000, idleParkMs: 600_000 });

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,10 +1,10 @@
 {
-  "updated": "2026-09-11T12:51:46.919867+00:00",
+  "updated": "2026-09-11T12:59:52.897720+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
-  "pr": "https://github.com/commontoolsinc/labs/pull/7307",
-  "activity": "D3 validation passes. Cubic identified two dashboard ledger inconsistencies; both are repaired for a fresh review.",
-  "review": "Antagonistic D3 review is clean after correcting status wording and verifying reentry of both metadata scopes. The D3 PR requires its own CI and Cubic review before landing.",
+  "pr": "https://github.com/commontoolsinc/labs/pull/7331",
+  "activity": "Finish review of the validated compiler guidance and remote-row acceptance while advancing the remaining collection operators. Live poll changes require coordination.",
+  "review": "Each slice requires clean current-head CI, actual Cubic review, and antagonistic review before landing. The checks ledger records completed merges.",
   "checks": [
     "#7241: all 69 CI gates passed; latest Cubic run reported zero issues; merged as e70704f206.",
     "#7256: all 69 CI gates passed with clean Cubic/antagonistic reviews; merged as 8d3c7dbc3c.",
@@ -25,8 +25,8 @@
     "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean.",
     "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass.",
     "#7327 merged as b135f7f067ca8112ac7bf6f638b9511b26361944: all current-head CI gates succeeded or were skipped; Cubic run 103250197793 reported zero issues on dae8319a23; antagonistic review was clean. All nine measurement cases and the forced-disposal cleanup control passed.",
-    "#7308 merged as e435590cf4c94c91a32260315efe1eedc5e66a7b: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
-    "#7312 merged as c00a2581f13b3183986f4d30c6d4ad86e28a34ab: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
+    "#7308 merged as e435590cf4c94c91a32260315efe1eedc5e66a7b: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. Memory queries wait for session restoration before issuing requests.",
+    "#7312 merged as c00a2581f13b3183986f4d30c6d4ad86e28a34ab: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. Rendered row acceptance covers storage outages, catch-up, and subsequent updates.",
     "#7329 merged as 593c341b27a8baff681374bd01b3125a70ffeca8: all 69 exact-head checks succeeded or were skipped; Cubic run 103258387302 reported zero issues on 9e28f27015; antagonistic review was clean. Client remote-row identity and narrow-invalidation acceptance is landed."
   ],
   "stages": [
@@ -99,8 +99,8 @@
     {
       "id": "C2",
       "title": "Partial materialization correctness",
-      "status": "todo",
-      "detail": "Repair only after C1 establishes the failure."
+      "status": "review",
+      "detail": "Cold first-demand, remote membership, and reconnect acceptance are validated. Session-restoration repair #7308 and rendered reconnect acceptance #7312 are merged. Tracker reconciliation is in review in #7332; C3 producer checks are separate."
     },
     {
       "id": "C3",

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -229,9 +229,9 @@
       "detail": "Compare the same interaction before and after migration, with read work and measured time."
     }
   ],
-  "validatedRevision": "4f2057b0d64c95e35558ff224786f4b7712fa173",
+  "validatedRevision": "6f5a2b23307cc8fdf4716ef6be94f87e0596779b",
   "validationProvenance": {
-    "revisionUrl": "https://github.com/commontoolsinc/labs/commit/4f2057b0d64c95e35558ff224786f4b7712fa173",
-    "scope": "D3 tests, benchmark, and documentation checkpoint. Full runner and final focused snapshot tests pass; this revision does not identify separately recorded browser captures."
+    "revisionUrl": "https://github.com/commontoolsinc/labs/commit/6f5a2b23307cc8fdf4716ef6be94f87e0596779b",
+    "scope": "Serving-host acceptance: full runner suite passed (1,437 tests / 8,960 steps); final serving-loop file passed all 27 cases after the authored-watermark correction. All 46 type groups and 599 documentation blocks passed. CI and Cubic review are tracked separately before landing."
   }
 }

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T12:29:32.578203+00:00",
+  "updated": "2026-09-11T12:43:53.407507+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -25,6 +25,8 @@
     "D3 local validation: 1,431 runner tests / 8,923 steps; 46 type groups; 599 documentation blocks; history index, formatting, lint, and six exact reuse/control benchmark counts pass. Antagonistic review is clean.",
     "#7282 merged as be92af0510 after all 69 exact-head checks, zero-issue Cubic review, and clean antagonistic review; all six scale assertions pass.",
     "#7327 merged as b135f7f067ca8112ac7bf6f638b9511b26361944: all current-head CI gates succeeded or were skipped; Cubic run 103250197793 reported zero issues on dae8319a23; antagonistic review was clean. All nine measurement cases and the forced-disposal cleanup control passed.",
+    "#7308 merged as e435590cf4c94c91a32260315efe1eedc5e66a7b: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
+    "#7312 merged as c00a2581f13b3183986f4d30c6d4ad86e28a34ab: all 69 reviewed-head checks succeeded or were skipped, with clean Cubic and antagonistic review. C2 uses its session-restoration/reconnect acceptance evidence.",
     "#7329 merged as 593c341b27a8baff681374bd01b3125a70ffeca8: all 69 exact-head checks succeeded or were skipped; Cubic run 103258387302 reported zero issues on 9e28f27015; antagonistic review was clean. Client remote-row identity and narrow-invalidation acceptance is landed."
   ],
   "stages": [

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T11:41:56.081484+00:00",
+  "updated": "2026-09-11T12:21:13.942025+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -102,7 +102,7 @@
       "id": "C3",
       "title": "Remote row invalidation",
       "status": "active",
-      "detail": "Inline-element dependency fix landed in #7265 with four browser cases and narrow invalidation tests. Remaining acceptance checks and production workaround removal stay open."
+      "detail": "Client acceptance is in #7329. Serving-host acceptance now passes correct values, full normalized-link and producer-identity stability, and edited-only execution in both directions. Full runner task: 1,437 tests / 8,960 steps; final serving-loop file: 27 cases. C3 closes after both reviewed slices land."
     },
     {
       "id": "C4",

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -30,7 +30,10 @@
     "#7329 merged as 593c341b27a8baff681374bd01b3125a70ffeca8: all 69 exact-head checks succeeded or were skipped; Cubic run 103258387302 reported zero issues on 9e28f27015; antagonistic review was clean. Client remote-row identity and narrow-invalidation acceptance is landed.",
     "#7328 merged as 26de7f96079d1b4c87eaa44296cc9a453f5f2b9d: all 69 exact-head checks succeeded or were skipped; Cubic 103273903333 reported zero issues on c003f349e8; antagonistic review was clean.",
     "#7330 merged as 06942589ab4825d260e5d8acf64219bdb5d48854: all 69 exact-head gates passed or skipped; Cubic 103278783473 reviewed all five files with zero issues on fe53a2d97d; antagonistic review clean.",
-    "#7332 merged as 881bda4ba1c0805ca88c3e5d2046cfefbcba5e4a: all 69 exact-head gates passed or skipped; Cubic 103278889723 reviewed both files with zero issues on db78661841; antagonistic review clean. C2 acceptance reconciliation is complete."
+    "#7332 merged as 881bda4ba1c0805ca88c3e5d2046cfefbcba5e4a: all 69 exact-head gates passed or skipped; Cubic 103278889723 reviewed both files with zero issues on db78661841; antagonistic review clean. C2 acceptance reconciliation is complete.",
+    "#7317 merged as 3e55b4e42dfd70fef3bd1cf4346fa706c4f2d87c: Restore reactive lunch-poll option and voter rows. All 69 exact-head gates passed or skipped on c2e63c1306da1723547b72d98e7c78fc16b878e5; clean Cubic and antagonistic reviews preceded merge.",
+    "#7320 merged as 3f2401638594bdca616906816a6c06011a39b643: Separate list coordinator state across serving principals and sessions. All 69 exact-head gates passed or skipped on d843b3be374d9b999f3cbd4975ae9f75d4f5e9c1; clean Cubic and antagonistic reviews preceded merge.",
+    "#7321 merged as 2fda18e1acc435f0c6642ff93809d14cd1ecc543: Index pending schema policies to bound document lookup work. All 69 exact-head gates passed or skipped on 8d9937f7192f16fc70cc01641bcae8b24ad83551; clean Cubic and antagonistic reviews preceded merge."
   ],
   "stages": [
     {

--- a/tools/implementation-progress/status.json
+++ b/tools/implementation-progress/status.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-09-11T12:43:53.407507+00:00",
+  "updated": "2026-09-11T12:51:46.919867+00:00",
   "title": "Pattern computation cost",
   "design": "https://github.com/commontoolsinc/labs/pull/7155",
   "pr": "https://github.com/commontoolsinc/labs/pull/7307",
@@ -69,8 +69,8 @@
     {
       "id": "C1",
       "title": "Multi-replica reproductions",
-      "status": "active",
-      "detail": "Remote edits, removal, and restoration landed in #7285; first-browser-materialization acceptance landed in #7302. Four nested/mapped \u00d7 same/cross-space cases pass, with local demos. Reconnect remains pending."
+      "status": "done",
+      "detail": "Remote edits, removal/restoration, and cold first-browser materialization are validated in nested/mapped and same/cross-space fixtures. Session-restoration repair #7308 and rendered reconnect acceptance #7312 are merged; local recordings remain available."
     },
     {
       "id": "B1",
@@ -106,7 +106,7 @@
       "id": "C3",
       "title": "Remote row invalidation",
       "status": "review",
-      "detail": "Client acceptance merged as #7329. Serving acceptance #7331 passes correct values, stable full links/producer identities, and untouched-row inactivity in both directions. Full runner task: 1,437 tests / 8,960 steps; final serving-loop file: 27 cases. C3 publication completes when #7331 lands."
+      "detail": "Client acceptance landed in #7329. Serving-host acceptance is in review in #7331: correct values, stable full output links/producer identities, and untouched-row inactivity in both edit directions. Full runner validation and all 27 final serving-loop cases pass. Publication completes when #7331 lands."
     },
     {
       "id": "C4",
@@ -221,7 +221,7 @@
     {
       "title": "See remote updates",
       "state": "Available \u00b7 C1/C3",
-      "detail": "The row demo shows remote membership, colors, ranking, cross-space profiles, and first browser materialization. Reconnect acceptance remains pending."
+      "detail": "The row demo shows remote membership, colors, ranking, cross-space profiles, and cold first browser materialization. Rendered reconnect acceptance is validated and merged in #7312."
     },
     {
       "title": "Compare optimized vote updates",


### PR DESCRIPTION
## Why

Client diagnostic graphs cannot establish whether the serving host reuses row producers or reruns unaffected neighbors. This completes the serving-host acceptance counterpart to #7329 for design #7155.

## What Changed

A real ExecutorHost serves a pattern over two independently linked rows. A separate client edits each input. The test checks correct derived values, stable full normalized output links and producer identities, an increased run count for the edited row, and an unchanged count for its neighbor. Settlement targets the authored input sequence so a later derived commit cannot move the wait target.

The tracker records C3 implementation and validation; the dashboard tracks landing this final acceptance slice. All data is synthetic; no live poll is involved.

## Test plan

- Full runner task: 1,437 tests / 8,960 steps pass.
- Final serving-loop file after the watermark correction: all 27 cases pass, with type checking.
- All 46 repository type-check groups pass; formatting and lint pass.
- Documentation examples pass.
- A recorded local demo shows cumulative producer counts 1/1 → 2/1 → 2/2 and correct values; browser verification matches the recording.
