### PR TITLE
Fix lunch poll benchmark row matching through render wrappers

### DIFF
--- a/packages/patterns/integration/lunch-poll-read-scale.bench.ts
+++ b/packages/patterns/integration/lunch-poll-read-scale.bench.ts
@@ -195,12 +195,18 @@ async function vote(page: Page, color: "green" | "yellow"): Promise<void> {
       probe.collect(
         `[data-option-title="Lunch 0"] cf-button[data-vote="${expected}"]`,
       ).some((button) => getComputedStyle(button).fontWeight === "700") &&
-      probe.collect('[data-vote-swatch-name="Voter 0"]').some((swatch) =>
-        getComputedStyle(swatch).backgroundColor ===
-          (expected === "green" ? "rgb(47, 138, 100)" : "rgb(212, 168, 47)") &&
-        swatch.parentElement?.parentElement?.firstElementChild?.textContent
-            ?.trim() === "Lunch 0"
-      ),
+      probe.collect('[data-vote-swatch-name="Voter 0"]').some((swatch) => {
+        if (
+          getComputedStyle(swatch).backgroundColor !==
+            (expected === "green" ? "rgb(47, 138, 100)" : "rgb(212, 168, 47)")
+        ) return false;
+        for (let row = swatch.parentElement; row; row = row.parentElement) {
+          if (row.firstElementChild?.textContent?.trim() === "Lunch 0") {
+            return true;
+          }
+        }
+        return false;
+      }),
     { args: [color] },
   );
   await settleView(page);


### PR DESCRIPTION
## Why

The lunch-poll read benchmark can wait indefinitely for an already-rendered vote when reactive rendering inserts a wrapper between a voter swatch and its summary row. This blocks measurement of the collection work in #7155.

## What Changed

Locate the swatch’s summary row through its ancestors instead of assuming exactly two DOM parents. The benchmark still requires the expected swatch color, the Lunch 0 title, and the selected Lunch 0 vote button.

## Test plan

- Real 74-vote browser benchmark: all three measured samples completed (149.5–182.1 ms), with two event commits and zero event commit errors in each diagnostic sample. This validates the benchmark; it is not a migration speedup claim.
- Pattern package: 63 tests / 246 steps, source-coverage test, and browser test passed.
- Repository formatting, lint, and all 46 type-check groups.

Browser validation used isolated synthetic data on the local development server with server execution disabled. The server checkout includes experimental local collection work; the benchmark’s authored pattern is from this branch.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

