### PR TITLE
Reuse pending dependency keys within commit read compaction

### DIFF
--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -756,6 +756,15 @@ const compactCommitReads = <
   space: MemorySpace,
   reads: Read[],
 ): Read[] => {
+  const dependencyKeys = new Map<number | number[], string>();
+  const dependencyKeyFor = (localSeq: number | number[]): string => {
+    let key = dependencyKeys.get(localSeq);
+    if (key === undefined) {
+      key = localSeqKey(localSeq);
+      dependencyKeys.set(localSeq, key);
+    }
+    return key;
+  };
   const sorted = [...reads].sort((left, right) => {
     const leftScope = normalizeCellScope(left.scope);
     const rightScope = normalizeCellScope(right.scope);
@@ -772,8 +781,8 @@ const compactCommitReads = <
     }
 
     if ("localSeq" in left && "localSeq" in right) {
-      const leftKey = localSeqKey(left.localSeq);
-      const rightKey = localSeqKey(right.localSeq);
+      const leftKey = dependencyKeyFor(left.localSeq);
+      const rightKey = dependencyKeyFor(right.localSeq);
       if (leftKey !== rightKey) {
         return leftKey < rightKey ? -1 : 1;
       }
@@ -801,7 +810,7 @@ const compactCommitReads = <
         normalizeCellScope(candidate.scope)
       }:${candidate.id}:${candidate.seq}`
       : `pending:${normalizeCellScope(candidate.scope)}:${candidate.id}:${
-        localSeqKey(candidate.localSeq)
+        dependencyKeyFor(candidate.localSeq)
       }:${candidate.basisSeq}`;
     let group = grouped.get(dependencyKey);
     if (!group) {
@@ -859,8 +868,8 @@ const compactCommitReads = <
     }
 
     if ("localSeq" in left && "localSeq" in right) {
-      const leftKey = localSeqKey(left.localSeq);
-      const rightKey = localSeqKey(right.localSeq);
+      const leftKey = dependencyKeyFor(left.localSeq);
+      const rightKey = dependencyKeyFor(right.localSeq);
       if (leftKey !== rightKey) {
         return leftKey < rightKey ? -1 : 1;
       }


### PR DESCRIPTION
## Why

Compacting commit reads repeatedly joins the same pending-layer array during sorting and grouping. Wide reads over a deep pending stack allocate the same dependency string hundreds or thousands of times. This follows the per-document read-basis reuse in #7324 and was found while validating #7155 locally.

## What Changed

Cache the canonical dependency key per number or array identity within one synchronous compaction call. The canonical key format, comparison order, grouping fields, and returned reads stay unchanged. The cache is discarded when that call returns.

## Test plan

- All 86 stacked-commit cases passed, including divergent read bases and dependency lifetimes.
- Full runner package suite, all 46 type-check groups, repository formatting and lint.
- Bounded allocation probe using the unchanged and changed compactor: 32 / 128 / 512 sibling reads sharing a 512-layer array required 432 / 1,284 / 4,644 joins before, and one join each after; full output values matched. This is an allocation-count result, not a statistical latency claim.

This reduces a measured allocation source. It does not resolve the experimental 1,184-vote poll’s heap exhaustion, and this PR contains no experimental collection producer or poll migration.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

