### PR TITLE
Measure lazy scalar reads separately from full collection scans

### DIFF
--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -4,6 +4,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Audits and reports
 
+- [Lazy scalar read width](development/performance/2026-09-11-lazy-scalar-read-width.md) — D2 eager/lazy one-scalar and all-row baseline at 74, 296, and 1,184 inline rows, with journal counts and timing limits.
+
 - [2026-09-11-nested-collection-scan-diagnostic.md](development/performance/2026-09-11-nested-collection-scan-diagnostic.md) — E3 warning acceptance across 413 pattern entries and 1,731 modules: seven occurrences at five source sites, guarded-UI limits, and callback-local exclusions.
 - [2026-09-11-computed-lift-collection-loops.md](development/performance/2026-09-11-computed-lift-collection-loops.md) — E1 compiled computed/broad-lift/narrow-lift comparison at 32/128/512 linked rows, identical default-posture read counts, and unread-field invalidation controls.
 

--- a/docs/history/development/performance/2026-09-11-lazy-scalar-read-width.md
+++ b/docs/history/development/performance/2026-09-11-lazy-scalar-read-width.md
@@ -1,0 +1,62 @@
+---
+status: historical
+created: 2026-09-11
+archived: 2026-09-11
+reason: "D2 eager/lazy scalar and all-row baseline at three collection sizes."
+---
+
+# Lazy scalar read width
+
+Runtime revision `2e5f76ebfc` on an Apple M5, using Deno 2.9.4
+(aarch64-apple-darwin), was measured with
+`packages/runner/test/cell-schema-read-width.bench.ts`. This supplies the
+one-scalar comparison requested by the lazy-materialization plan. It does not
+change runtime behavior or complete that plan's handler or flag-removal stages.
+
+## Reproduction and boundaries
+
+From the repository root:
+
+```sh
+deno bench -A packages/runner/test/cell-schema-read-width.bench.ts
+```
+
+Each sample creates an isolated runtime, seeds one document containing an inline
+array, and reads through a fresh transaction. Both modes use the same fully
+declared item schema: amount, title, and nested category/tags. The transaction's
+lazy-materialization mark selects the read path explicitly. The timed interval
+includes `get()` and either the first row's amount or the sum of every row's
+amount. It excludes setup, checksum validation, journal inspection, and cleanup.
+Every result is checked against its expected value, and every sample must
+register reads. No linked-row or cross-space workload is represented here.
+
+The benchmark requests `n: 5` and `warmup: 1`; the final JSON reporter recorded
+six samples for every variant.
+Journal counts are reported from the first invocation of each variant; every
+subsequent sample validates the result and nonzero activity.
+Concurrent local validation ran during this measurement. The means below are
+observations, not stable latency thresholds. Journal activities are obtained
+from `getTransactionReadActivities`; they are not proxy-access counts and must
+not be compared directly with the action-body counters from Track A.
+
+## Observations
+
+| Rows | Reader | Eager activities | Lazy activities | Eager mean (p75), ms | Lazy mean (p75), ms |
+| --- | --- | --- | --- | --- | --- |
+| 74 | One scalar | 894 | 17 | 1.199 (1.371) | 0.685 (0.752) |
+| 296 | One scalar | 3,558 | 17 | 6.192 (7.483) | 0.762 (1.453) |
+| 1,184 | One scalar | 14,214 | 17 | 10.891 (15.274) | 0.505 (0.828) |
+| 74 | All row amounts | 894 | 893 | 2.795 (5.738) | 5.556 (6.710) |
+| 296 | All row amounts | 3,558 | 3,557 | 3.200 (3.306) | 8.198 (9.961) |
+| 1,184 | All row amounts | 14,214 | 14,213 | 13.235 (19.958) | 67.135 (79.975) |
+
+The lazy one-scalar reader's recorded work stayed fixed as the array grew.
+Both all-row readers retained linear journal volume, and the lazy all-row
+reader took longer in this run. The measurement supports narrowing what a
+consumer reads; it does not support treating lazy materialization as a universal
+speedup for full scans. Array ownership, linked rows, reactive scheduling, and
+producer maintenance need their own measurements.
+
+For D2, rerun this comparison and the Track A workload after changes to the
+per-access implementation. Record counts and timings separately so a smaller
+read set is not mistaken for a cheaper access.

--- a/docs/plans/lazy-cell-materialization.md
+++ b/docs/plans/lazy-cell-materialization.md
@@ -285,9 +285,13 @@ so read registration is not where the time goes. The permissive object schema
 costing four times the fully declared one is worth its own look: a schema that
 declares less should not traverse more.
 
-- [ ] Add the one-scalar arm once a lazy view exists to read through. Until then
-      it measures nothing new — eager materialization does the same work either
-      way, and the table above is already that number.
+- [x] The one-scalar and all-row comparison is available in
+      `test/cell-schema-read-width.bench.ts`. It uses fresh transactions and the
+      same declared schema in both eager and lazy modes, verifies every result,
+      and reports journal activity separately from timing. The
+      [baseline report](../history/development/performance/2026-09-11-lazy-scalar-read-width.md)
+      records the measured workload and its limits. Re-run it after per-access
+      implementation changes.
 
 ### Stage 1 — Split the standing handle from the pinned view
 

--- a/packages/runner/test/cell-schema-read-width.bench.ts
+++ b/packages/runner/test/cell-schema-read-width.bench.ts
@@ -1,0 +1,102 @@
+/**
+ * Compares eager and lazy reads of one scalar or one field from every row.
+ * Each sample uses a fresh transaction over the same fully declared schema.
+ * Seeding, validation, journal inspection, and disposal are outside the timed
+ * interval. Journal activity counts describe storage reads, not proxy accesses.
+ */
+
+import { Identity } from "@commonfabric/identity";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { getTransactionReadActivities } from "../src/storage/transaction-inspection.ts";
+import { benchDiagnostic } from "./bench-diagnostics.ts";
+
+const identity = await Identity.fromPassphrase("schema read width benchmark");
+const schema = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: {
+      amount: { type: "number" },
+      title: { type: "string" },
+      metadata: {
+        type: "object",
+        properties: {
+          category: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+        },
+      },
+    },
+  },
+} as const satisfies JSONSchema;
+
+for (const size of [74, 296, 1184]) {
+  const rows = Array.from({ length: size }, (_, index) => ({
+    amount: index + 1,
+    title: `Row ${index}`,
+    metadata: { category: "example", tags: ["first", "second"] },
+  }));
+  for (const width of ["one scalar", "all rows"]) {
+    for (const lazy of [false, true]) {
+      let reported = false;
+      Deno.bench({
+        name: `${lazy ? "lazy" : "eager"} ${width} (${size} rows)`,
+        group: `schema-read-width-${size}-${width}`,
+        baseline: !lazy,
+        n: 5,
+        warmup: 1,
+        async fn(b) {
+          await using cleanup = new AsyncDisposableStack();
+          const storage = StorageManager.emulate({ as: identity });
+          cleanup.defer(() => storage.close());
+          const runtime = new Runtime({
+            apiUrl: new URL(import.meta.url),
+            storageManager: storage,
+          });
+          cleanup.defer(() => runtime.dispose({ closeStorage: false }));
+          const seed = runtime.edit();
+          cleanup.defer(() => {
+            if (seed.status().status === "ready") seed.abort();
+          });
+          runtime.getCell(identity.did(), "rows", undefined, seed).set(rows);
+          const committed = await seed.commit();
+          if (committed.error) throw new Error("Benchmark seeding failed");
+          const tx = runtime.edit();
+          cleanup.defer(() => {
+            if (tx.status().status === "ready") tx.abort();
+          });
+          tx.markLazyMaterialize(lazy);
+          const cell = runtime.getCell<typeof rows>(
+            identity.did(),
+            "rows",
+            schema,
+            tx,
+          );
+          b.start();
+          const value = cell.get();
+          const total = width === "one scalar"
+            ? value[0].amount
+            : value.reduce((sum, row) => sum + row.amount, 0);
+          b.end();
+          const expected = width === "one scalar" ? 1 : size * (size + 1) / 2;
+          if (total !== expected) {
+            throw new Error(`Expected ${expected}, received ${total}`);
+          }
+          const activities =
+            Array.from(getTransactionReadActivities(tx)).length;
+          if (activities === 0) {
+            throw new Error("The read registered no activity");
+          }
+          if (!reported) {
+            benchDiagnostic(
+              JSON.stringify({ size, width, lazy, total, activities }),
+            );
+            reported = true;
+          }
+        },
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Why

The lazy-materialization plan still lacks its requested one-scalar baseline. Without it, fewer reads and cheaper reads are easy to confuse when assessing #7155's collection changes. This adds the missing comparison under the owning plan and records both narrow-read savings and full-scan costs.

## What changed

Add an eager/lazy benchmark for one scalar and all row amounts at 74, 296, and 1,184 inline rows. Both modes use identical data and a fully declared schema; each sample uses a fresh transaction, verifies its result, and releases its runtime/storage. Timing excludes setup and journal inspection. Diagnostics use the shared stderr helper so `deno bench --json` remains usable.

Update the owning plan's scalar-baseline checkbox and add a historical report with CPU/runtime identity, observed sample counts, journal volume, means, p75, and measurement limits. Handler semantics and flag removal remain separate work.

## Test plan

All 12 final benchmark cases pass with valid JSON and no errors; diagnostics survive on stderr. An intentionally wrong expected checksum fails. Full runner: 1,437 tests / 8,960 steps. All 46 type groups, final benchmark type check, 599 documentation blocks, history index, formatting, lint, and conflict-marker checks pass. Antagonistic cf-review is clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

