### PR TITLE
fix(piece): an input write defers the stored links it cannot read

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -475,8 +475,12 @@ An input-cell write is currently sharper:
 `cf cell set --piece <id> --input
 <path>` resolves that path through the piece's
 input contract and revalidates the complete input document. It can therefore be
-refused over an unrelated allocated field. Addressing the raw argument cell by
-id avoids that whole-document check, but it is an unsafe recovery tool: it can
+refused over an unrelated allocated field whose value is readable and violates
+the schema. A field the write leaves untouched whose stored value is a link this
+replica cannot read — a per-user instance another principal owns, a document not
+replicated here — is not judged: its value is owned elsewhere and is checked
+when a reactive read materializes it. Addressing the raw argument cell by id
+avoids that whole-document check, but it is an unsafe recovery tool: it can
 erase link-bearing data that a later `cf cell set` will refuse to restore
 because the serialized link has no durable source contract. The superseded
 `cf set` spelling mounts this same command and has identical validation

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -476,15 +476,16 @@ An input-cell write is currently sharper:
 <path>` resolves that path through the piece's
 input contract and revalidates the complete input document. It can therefore be
 refused over an unrelated allocated field whose value is readable and violates
-the schema. A field the write leaves untouched whose stored value is a link this
-replica cannot read — a per-user instance another principal owns, a document not
-replicated here — is not judged: its value is owned elsewhere and is checked
-when a reactive read materializes it. Addressing the raw argument cell by id
-avoids that whole-document check, but it is an unsafe recovery tool: it can
-erase link-bearing data that a later `cf cell set` will refuse to restore
-because the serialized link has no durable source contract. The superseded
-`cf set` spelling mounts this same command and has identical validation
-behavior.
+the schema. A field whose stored or supplied value is a link this replica cannot
+read — a per-user instance another principal owns, a document not replicated
+here — is not judged by that check: its value is owned elsewhere and is checked
+when a reactive read materializes it. A write that itself resolves through a
+link is also checked against its destination's contract, which still refuses a
+required field it cannot reach. Addressing the raw argument cell by id avoids
+that whole-document check, but it is an unsafe recovery tool: it can erase
+link-bearing data that a later `cf cell set` will refuse to restore because the
+serialized link has no durable source contract. The superseded `cf set` spelling
+mounts this same command and has identical validation behavior.
 
 ## Linking piece inputs
 

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -3383,8 +3383,10 @@ class PiecePropIo implements PieceCellIo {
         // elsewhere. Such slots are staged as the unresolved-link placeholder
         // and accepted opaquely; their schema check happens when a reactive
         // read materializes them, the rule stored-argument validation
-        // applies. The written slot is never deferred: its counterpart in the
-        // raw tree below is the value being written, not a link.
+        // applies. The written slot, and every slot above it, is judged as
+        // written: in the raw tree below, the write path holds the value being
+        // written rather than a link, so a write below a stored link answers
+        // for the required fields it would leave absent at its destination.
         const judgedRoot = overlayUnreadableLinkPlaceholders(
           tx,
           targetCell.getAsNormalizedFullLink(),

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -3,6 +3,7 @@ import { fabricAwareEqual, taggedHashStringOf } from "@commonfabric/data-model";
 import { schemaWithProperties } from "@commonfabric/data-model-schema";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
+  acceptsOpaqueCellOrUnresolvedLink,
   applyPieceSourceTransition,
   Cell,
   type CellPath,
@@ -28,6 +29,7 @@ import {
   mergeSchemaDefaults,
   NAME,
   type NormalizedLink,
+  overlayUnreadableLinkPlaceholders,
   parseFabricRef,
   parseLinkOrThrow,
   type Pattern,
@@ -3374,6 +3376,25 @@ class PiecePropIo implements PieceCellIo {
           writePath,
           materializedValue,
         );
+        // A slot the write leaves untouched whose stored value routes through
+        // a link this replica cannot read — another principal's per-user
+        // instance, a document not replicated here — materializes as absent,
+        // and judged as it stands would refuse the write for a value owned
+        // elsewhere. Such slots are staged as the unresolved-link placeholder
+        // and accepted opaquely; their schema check happens when a reactive
+        // read materializes them, the rule stored-argument validation
+        // applies. The written slot is never deferred: its counterpart in the
+        // raw tree below is the value being written, not a link.
+        const judgedRoot = overlayUnreadableLinkPlaceholders(
+          tx,
+          targetCell.getAsNormalizedFullLink(),
+          replaceMaterializedValueAtPath(
+            targetCell.withTx(tx).getRaw(),
+            writePath,
+            materializedValue,
+          ),
+          stagedRoot,
+        );
         const mergedRoot = mergeSchemaDefaults(
           stagedRoot,
           extractDefaultValues(schema),
@@ -3400,12 +3421,12 @@ class PiecePropIo implements PieceCellIo {
                 validateSchemaValue(
                   schema,
                   replaceMaterializedValueAtPath(
-                    stagedRoot,
+                    judgedRoot,
                     writePath,
                     candidate,
                   ),
                   schema,
-                  { acceptOpaqueValue: schemaAcceptsOpaqueCellValue },
+                  { acceptOpaqueValue: acceptsOpaqueCellOrUnresolvedLink },
                 ) === undefined,
             },
           );
@@ -3413,7 +3434,7 @@ class PiecePropIo implements PieceCellIo {
         const validationRoot = writePath.length === 0
           ? nextValue
           : replaceMaterializedValueAtPath(
-            stagedRoot,
+            judgedRoot,
             writePath,
             nextValue,
           );
@@ -3421,7 +3442,7 @@ class PiecePropIo implements PieceCellIo {
           schema,
           validationRoot,
           schema,
-          { acceptOpaqueValue: schemaAcceptsOpaqueCellValue },
+          { acceptOpaqueValue: acceptsOpaqueCellOrUnresolvedLink },
         );
         if (issue !== undefined) {
           throw new Error(`updated input does not match its schema: ${issue}`);

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -275,9 +275,10 @@ function writePathCrossesLink(
   path: readonly (string | number)[],
 ): boolean {
   let current = raw;
-  for (let index = 0; index + 1 < path.length; index++) {
-    if (current === null || typeof current !== "object") return false;
-    current = (current as Record<PropertyKey, unknown>)[path[index]];
+  for (const segment of path.slice(0, -1)) {
+    current = current !== null && typeof current === "object"
+      ? (current as Record<PropertyKey, unknown>)[segment]
+      : undefined;
     if (isLink(current)) return true;
   }
   return false;

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -266,6 +266,23 @@ function replaceMaterializedValueAtPath(
   return clone;
 }
 
+/**
+ * Whether a proper prefix of `path` holds a link in `raw`, so that a write at
+ * `path` resolves through that link into another document.
+ */
+function writePathCrossesLink(
+  raw: unknown,
+  path: readonly (string | number)[],
+): boolean {
+  let current = raw;
+  for (let index = 0; index + 1 < path.length; index++) {
+    if (current === null || typeof current !== "object") return false;
+    current = (current as Record<PropertyKey, unknown>)[path[index]];
+    if (isLink(current)) return true;
+  }
+  return false;
+}
+
 /** Replace a schema-aware snapshot path, reading through Cell ancestors. */
 function replaceMaterializedCellValueAtPath(
   current: unknown,
@@ -3376,27 +3393,45 @@ class PiecePropIo implements PieceCellIo {
           writePath,
           materializedValue,
         );
-        // A slot the write leaves untouched whose stored value routes through
-        // a link this replica cannot read — another principal's per-user
-        // instance, a document not replicated here — materializes as absent,
-        // and judged as it stands would refuse the write for a value owned
-        // elsewhere. Such slots are staged as the unresolved-link placeholder
-        // and accepted opaquely; their schema check happens when a reactive
-        // read materializes them, the rule stored-argument validation
-        // applies. The written slot, and every slot above it, is judged as
-        // written: in the raw tree below, the write path holds the value being
-        // written rather than a link, so a write below a stored link answers
-        // for the required fields it would leave absent at its destination.
-        const judgedRoot = overlayUnreadableLinkPlaceholders(
-          tx,
-          targetCell.getAsNormalizedFullLink(),
-          replaceMaterializedValueAtPath(
-            targetCell.withTx(tx).getRaw(),
-            writePath,
-            materializedValue,
-          ),
-          stagedRoot,
-        );
+        // A slot whose stored value routes through a link this replica cannot
+        // read — another principal's per-user instance, a document not
+        // replicated here — materializes as absent, and judged as it stands
+        // would refuse the write for a value owned elsewhere. Such a slot is
+        // staged as the unresolved-link placeholder and accepted opaquely;
+        // its schema check happens when a reactive read materializes it, the
+        // rule stored-argument validation applies. A link the caller supplies
+        // defers on the same terms — the caller vouches for the link, not for
+        // its target being replicated here — so the raw tree the overlay
+        // walks holds the caller's value, links and all, at the write path,
+        // and a scalar or `undefined` written there is judged as written.
+        // Where the write path crosses a stored link the raw tree stays as
+        // stored, so the overlay can follow that link to the fields around
+        // the written one. The overlay only ever turns an absence into an
+        // accepted opaque, so a candidate is judged against the staged root
+        // first and the overlay is consulted only when that fails.
+        const rawRoot = targetCell.withTx(tx).getRaw();
+        const rawForOverlay = writePathCrossesLink(rawRoot, writePath)
+          ? rawRoot
+          : replaceMaterializedValueAtPath(rawRoot, writePath, value);
+        const argumentLink = targetCell.getAsNormalizedFullLink();
+        const inputIssue = (candidate: unknown): string | undefined => {
+          const options = {
+            acceptOpaqueValue: acceptsOpaqueCellOrUnresolvedLink,
+          };
+          const issue = validateSchemaValue(schema, candidate, schema, options);
+          if (issue === undefined) return undefined;
+          return validateSchemaValue(
+            schema,
+            overlayUnreadableLinkPlaceholders(
+              tx,
+              argumentLink,
+              rawForOverlay,
+              candidate,
+            ),
+            schema,
+            options,
+          );
+        };
         const mergedRoot = mergeSchemaDefaults(
           stagedRoot,
           extractDefaultValues(schema),
@@ -3420,15 +3455,12 @@ class PiecePropIo implements PieceCellIo {
               mergeMaterializedLinks: true,
               acceptOpaqueValue: schemaAcceptsOpaqueCellValue,
               acceptUnionCandidate: (candidate) =>
-                validateSchemaValue(
-                  schema,
+                inputIssue(
                   replaceMaterializedValueAtPath(
-                    judgedRoot,
+                    stagedRoot,
                     writePath,
                     candidate,
                   ),
-                  schema,
-                  { acceptOpaqueValue: acceptsOpaqueCellOrUnresolvedLink },
                 ) === undefined,
             },
           );
@@ -3436,16 +3468,11 @@ class PiecePropIo implements PieceCellIo {
         const validationRoot = writePath.length === 0
           ? nextValue
           : replaceMaterializedValueAtPath(
-            judgedRoot,
+            stagedRoot,
             writePath,
             nextValue,
           );
-        const issue = validateSchemaValue(
-          schema,
-          validationRoot,
-          schema,
-          { acceptOpaqueValue: acceptsOpaqueCellOrUnresolvedLink },
-        );
+        const issue = inputIssue(validationRoot);
         if (issue !== undefined) {
           throw new Error(`updated input does not match its schema: ${issue}`);
         }

--- a/packages/piece/test/ops/piece-input-scoped-links.test.ts
+++ b/packages/piece/test/ops/piece-input-scoped-links.test.ts
@@ -1,0 +1,120 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { createSession, Identity } from "@commonfabric/identity";
+import { type JSONSchema, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { PieceController } from "../../src/ops/piece-controller.ts";
+import { PiecesController } from "../../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("piece input scoped links");
+
+/** The stored form of a per-user slot: a redirect into the user instance. */
+const userRedirect = (path: string[]) => ({
+  "/": { "link@1": { overwrite: "redirect", path, scope: "user" } },
+});
+
+const schema: JSONSchema = {
+  type: "object",
+  properties: {
+    myName: { type: "string" },
+    title: { type: "string" },
+  },
+  required: ["myName", "title"],
+};
+
+describe("piece-controller", () => {
+  describe("input writes over stored links", () => {
+    let storage: ReturnType<typeof StorageManager.emulate>;
+    let runtime: Runtime;
+    let session: Awaited<ReturnType<typeof createSession>>;
+    let pieces: PiecesController;
+
+    beforeEach(async () => {
+      storage = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL("http://localhost:9999"),
+        storageManager: storage,
+      });
+      session = await createSession({
+        identity: signer,
+        spaceName: crypto.randomUUID(),
+      });
+      pieces = new PiecesController(session, runtime);
+      await pieces.synced();
+    });
+
+    afterEach(async () => {
+      await runtime.dispose();
+      await storage.close();
+    });
+
+    /** Installs the schema fixture through the normal persistent-piece setup. */
+    async function create(input: unknown): Promise<PieceController> {
+      const pattern = runtime.unsafeTrustPattern({
+        argumentSchema: schema,
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }, { reason: "stored link input fixture" });
+      return new PieceController(
+        pieces,
+        await pieces.runPersistent(pattern, input, undefined, { start: true }),
+      );
+    }
+
+    it("writes a sibling of a per-user slot this principal has not written", async () => {
+      const piece = await create({
+        myName: userRedirect(["myName"]),
+        title: "before",
+      });
+
+      await piece.input.set("after", ["title"]);
+
+      expect(await piece.input.get(["title"])).toBe("after");
+    });
+
+    it("writes the per-user slot itself through its redirect", async () => {
+      const piece = await create({
+        myName: userRedirect(["myName"]),
+        title: "before",
+      });
+
+      await piece.input.set("me", ["myName"]);
+
+      expect(await piece.input.get(["myName"])).toBe("me");
+    });
+
+    it("still refuses a sibling write when a linked slot holds a readable wrong-typed value", async () => {
+      const tx = runtime.edit();
+      const other = runtime.getCell(
+        session.space,
+        "wrong-typed-name",
+        { type: "object", properties: { n: { type: "number" } } },
+        tx,
+      );
+      other.set({ n: 42 });
+      await tx.commit();
+      const piece = await create({
+        myName: other.key("n").getAsLink(),
+        title: "before",
+      });
+
+      await expect(piece.input.set("after", ["title"])).rejects.toThrow(
+        /myName: value does not match type string/,
+      );
+    });
+
+    it("still refuses an explicit `undefined` written at a required slot", async () => {
+      const piece = await create({
+        myName: userRedirect(["myName"]),
+        title: "before",
+      });
+
+      await expect(piece.input.set(undefined, ["title"])).rejects.toThrow(
+        /title/,
+      );
+    });
+  });
+});

--- a/packages/piece/test/ops/piece-input-scoped-links.test.ts
+++ b/packages/piece/test/ops/piece-input-scoped-links.test.ts
@@ -50,10 +50,13 @@ describe("piece-controller", () => {
       await storage.close();
     });
 
-    /** Installs the schema fixture through the normal persistent-piece setup. */
-    async function create(input: unknown): Promise<PieceController> {
+    /** Installs a schema fixture through the normal persistent-piece setup. */
+    async function createWith(
+      argumentSchema: JSONSchema,
+      input: unknown,
+    ): Promise<PieceController> {
       const pattern = runtime.unsafeTrustPattern({
-        argumentSchema: schema,
+        argumentSchema,
         resultSchema: { type: "object", properties: {} },
         result: {},
         nodes: [],
@@ -63,6 +66,9 @@ describe("piece-controller", () => {
         await pieces.runPersistent(pattern, input, undefined, { start: true }),
       );
     }
+
+    /** Installs the `myName`/`title` fixture. */
+    const create = (input: unknown) => createWith(schema, input);
 
     /** The argument document as stored, links unresolved. */
     const rawArgument = (piece: PieceController) =>
@@ -116,6 +122,27 @@ describe("piece-controller", () => {
       await piece.input.set(userRedirect(["myName"]), ["myName"]);
 
       expect(rawArgument(piece).myName).toEqual(userRedirect(["myName"]));
+    });
+
+    it("writes below a readable link into the slot it points at", async () => {
+      const pair: JSONSchema = {
+        type: "object",
+        properties: { b: { type: "string" }, c: { type: "string" } },
+        required: ["b", "c"],
+      };
+      // `obj` aliases `inner` within the same document, so a write below
+      // `obj` lands in `inner`.
+      const alias = { "/": { "link@1": { path: ["inner"] } } };
+      const piece = await createWith({
+        type: "object",
+        properties: { obj: pair, inner: pair },
+        required: ["obj", "inner"],
+      }, { obj: alias, inner: { b: "before", c: "x" } });
+
+      await piece.input.set("after", ["obj", "b"]);
+
+      expect(await piece.input.get(["inner"])).toEqual({ b: "after", c: "x" });
+      expect(rawArgument(piece).obj).toEqual(alias);
     });
 
     it("throws on `myName` when a linked slot holds a readable wrong-typed value", async () => {

--- a/packages/piece/test/ops/piece-input-scoped-links.test.ts
+++ b/packages/piece/test/ops/piece-input-scoped-links.test.ts
@@ -64,6 +64,10 @@ describe("piece-controller", () => {
       );
     }
 
+    /** The argument document as stored, links unresolved. */
+    const rawArgument = (piece: PieceController) =>
+      pieces.getArgument(piece.getCell()).getRaw() as Record<string, unknown>;
+
     it("writes a sibling of a per-user slot this principal has not written", async () => {
       const piece = await create({
         myName: userRedirect(["myName"]),
@@ -84,9 +88,37 @@ describe("piece-controller", () => {
       await piece.input.set("me", ["myName"]);
 
       expect(await piece.input.get(["myName"])).toBe("me");
+      // The redirect is what the shared document keeps; the name went to
+      // this principal's instance behind it.
+      expect(rawArgument(piece).myName).toEqual(userRedirect(["myName"]));
     });
 
-    it("still refuses a sibling write when a linked slot holds a readable wrong-typed value", async () => {
+    it("writes a root value that re-supplies the stored redirect unchanged", async () => {
+      const piece = await create({
+        myName: userRedirect(["myName"]),
+        title: "before",
+      });
+
+      await piece.input.edit((stored) => ({
+        value: { ...(stored as Record<string, unknown>), title: "after" },
+      }));
+
+      expect(await piece.input.get(["title"])).toBe("after");
+      expect(rawArgument(piece).myName).toEqual(userRedirect(["myName"]));
+    });
+
+    it("writes a supplied redirect at the slot it points from", async () => {
+      const piece = await create({
+        myName: userRedirect(["myName"]),
+        title: "before",
+      });
+
+      await piece.input.set(userRedirect(["myName"]), ["myName"]);
+
+      expect(rawArgument(piece).myName).toEqual(userRedirect(["myName"]));
+    });
+
+    it("throws on `myName` when a linked slot holds a readable wrong-typed value", async () => {
       const tx = runtime.edit();
       const other = runtime.getCell(
         session.space,
@@ -106,14 +138,14 @@ describe("piece-controller", () => {
       );
     });
 
-    it("still refuses an explicit `undefined` written at a required slot", async () => {
+    it("throws on `myName` when `undefined` is written at the linked slot", async () => {
       const piece = await create({
         myName: userRedirect(["myName"]),
         title: "before",
       });
 
-      await expect(piece.input.set(undefined, ["title"])).rejects.toThrow(
-        /title/,
+      await expect(piece.input.set(undefined, ["myName"])).rejects.toThrow(
+        /myName/,
       );
     });
   });

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -396,4 +396,8 @@ export {
 } from "./slug-resolution.ts";
 
 export { schemaPathSelection } from "./schema-path.ts";
-export { storedArgumentValidationIssue } from "./stored-argument-validation.ts";
+export {
+  acceptsOpaqueCellOrUnresolvedLink,
+  overlayUnreadableLinkPlaceholders,
+  storedArgumentValidationIssue,
+} from "./stored-argument-validation.ts";

--- a/packages/runner/src/stored-argument-validation.ts
+++ b/packages/runner/src/stored-argument-validation.ts
@@ -29,7 +29,14 @@ const UNRESOLVED_LINK_PLACEHOLDER = Object.freeze({
   "unresolved cell link": true,
 });
 
-const acceptsOpaqueCellOrUnresolvedLink = (
+/**
+ * Whether `value` needs no schema check where it stands: an opaque Cell whose
+ * wrapper the schema declares, or the placeholder
+ * {@link overlayUnreadableLinkPlaceholders} leaves for a stored link this
+ * replica cannot read. The two together are what let a document be judged
+ * here without judging values that are owned elsewhere.
+ */
+export const acceptsOpaqueCellOrUnresolvedLink = (
   value: unknown,
   schema: JSONSchema,
 ): boolean =>

--- a/packages/runner/src/stored-argument-validation.ts
+++ b/packages/runner/src/stored-argument-validation.ts
@@ -193,9 +193,10 @@ export function readStoredLinkChainRaw(
  * local to its descent. Shared acyclic subgraphs avoid repeated expansion,
  * while cyclic graphs retain their path-dependent cutoff behavior.
  *
- * The caller supplies an already-materialized snapshot. Exported from this
- * module for direct cycle tests: eager materialization can reject a cyclic
- * graph before this walk gets to exercise its own termination guards.
+ * The caller supplies an already-materialized snapshot. Exported for the
+ * piece layer's input writes, which stage a document the same way, and for
+ * direct cycle tests: eager materialization can reject a cyclic graph before
+ * this walk gets to exercise its own termination guards.
  */
 export function overlayUnreadableLinkPlaceholders(
   tx: IExtendedStorageTransaction,


### PR DESCRIPTION

### What

`cf cell set --piece <id> --input <path>` (and `PiecePropIo.set` beneath it)
revalidates the complete input document and refused the write whenever an
*untouched* field's stored value was a link this replica cannot read. The
topics board's `myName` — a redirect into each viewer's per-user instance —
made every such write refuse for everyone but the instance's owner:

```
updated input does not match its schema: myName: value does not match type string
```

The same class bit `cf piece rollback` during the 2026-08-28 Stage B
migration (`docs/history/topics-board-migration-2026-08-28.md`, "Reversal is
one-way"). Filed as the board topic "cf set re-validates the whole document
and reads a user-scoped redirect link as its pointed-at type".

### Why this shape

The runner's stored-argument validation solved exactly this for preflight
and setup: `overlayUnreadableLinkPlaceholders` stages an unreadable linked
slot as a placeholder that `acceptsOpaqueCellOrUnresolvedLink` accepts, and
the slot's schema check happens when a reactive read materializes it
(`packages/runner/src/stored-argument-validation.ts`,
`docs/specs/piece-source-lifecycle.md` "Preflight and setup share
stored-argument validation"). The input-write path now applies the same
rule to the slots the write does not touch, keeping the whole-document
input contract (`packages/cli/README.md` documents it as deliberate) while
no longer judging values owned elsewhere.

The overlay runs on the staged root *after* the written value is spliced
in, with the raw tree's slot at the write path replaced by that value, so
the written slot is never a link to the overlay and is judged as written.
The alternative — narrowing input writes to the written subtree, as result
writes were narrowed on 2026-08-07 — is a larger ruling and not taken here.

### Bound

The deferral reaches every slot whose stored or supplied value is a link this
replica cannot read: an untouched stored link at any depth, and a link the
caller supplies (a root write that re-states the stored redirect, as
`bulk-repair` does, or a redirect written at the slot it points from) — the
caller vouches for the link, not for its target being replicated here. A
scalar or `undefined` written at a linked slot is judged as written. The
overlay is consulted only after a check of the staged root fails, so the
happy path pays for no second walk.

A write that itself resolves *through* a link is also checked against its
destination's contract (`validateWriteDestination`), which still refuses a
required field it cannot reach behind an unreached redirect — so a nested
write into an unwritten per-user instance, or into an absent document, still
refuses on the required fields it would leave absent there. That check and
this one now hold an unreadable linked field to opposite rules within the
same write; reconciling them, or documenting why a write through a link is
held to the stricter rule, is a follow-up.

### Tests

`packages/piece/test/ops/piece-input-scoped-links.test.ts`:

- writes a sibling of a per-user slot this principal has not written
  (red before this change, with the message above)
- writes the per-user slot itself through its redirect (the shared document
  keeps the redirect)
- writes a root value that re-supplies the stored redirect unchanged (red
  before the second revision)
- writes a supplied redirect at the slot it points from (likewise)
- throws on `myName` when a linked slot holds a readable wrong-typed value
- throws on `myName` when `undefined` is written at the linked slot

Gates: `deno fmt --check`, `deno lint`, `deno task check`, full `piece` and
`runner` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
