### PR TITLE
Compare same-space and cross-space poll profiles

### DIFF
--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -358,8 +358,10 @@ voters respectively. `CF_READ_SCALE_PROFILE_LOCATION` selects `same-space`
 (the default) or `cross-space` voter profiles. Both variants use separately
 stored profiles with identical names, vote counts, and option counts. The
 cross-space variant seeds profiles in a dedicated space before seeding the
-poll, so no seed transaction writes across spaces. The benchmark verifies the
-first vote's resolved voter space and records the location in its artifacts.
+poll, so no seed transaction writes across spaces. That seed requires existing
+profiles and rejects an unavailable profile instead of creating it. The
+benchmark verifies the first vote's resolved voter space and records the
+location in its artifacts.
 Seeding, navigation, sign-in, viewer selection, warmup, and teardown are outside
 the timed interval. The timer includes click-helper readiness, browser/protocol
 overhead, and a trusted green-vote click through view

--- a/docs/development/BENCHMARKS.md
+++ b/docs/development/BENCHMARKS.md
@@ -354,7 +354,12 @@ also fails a test.
 `packages/patterns/integration/lunch-poll-read-scale.bench.ts` measures a vote
 change with the production lunch poll's cards and summary demanded by a browser.
 Its three series hold 74, 296, and 1184 votes over 14 options, with 8, 24, and 87
-voters respectively. Voter links point to separate entities in the same space.
+voters respectively. `CF_READ_SCALE_PROFILE_LOCATION` selects `same-space`
+(the default) or `cross-space` voter profiles. Both variants use separately
+stored profiles with identical names, vote counts, and option counts. The
+cross-space variant seeds profiles in a dedicated space before seeding the
+poll, so no seed transaction writes across spaces. The benchmark verifies the
+first vote's resolved voter space and records the location in its artifacts.
 Seeding, navigation, sign-in, viewer selection, warmup, and teardown are outside
 the timed interval. The timer includes click-helper readiness, browser/protocol
 overhead, and a trusted green-vote click through view

--- a/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.tsx
+++ b/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.tsx
@@ -29,6 +29,9 @@ interface SeedEvent {
 
   /** Number of rendered options. */
   optionCount: number;
+
+  /** Requires every supplied profile to be readable before seeding. */
+  requireExistingProfiles?: boolean;
 }
 
 /** Observable controls and results shared by CLI and browser fixtures. */
@@ -73,7 +76,7 @@ const seed = handler<
     votes: Writable<Vote[]>;
   }
 >((
-  { voteCount, voterCount, optionCount },
+  { voteCount, voterCount, optionCount, requireExistingProfiles },
   { profiles, users, options, votes },
 ) => {
   if (
@@ -98,6 +101,11 @@ const seed = handler<
     const profile = profiles.elementById(String(index));
     const name = `Voter ${index}`;
     if (profile.get() === undefined) {
+      if (requireExistingProfiles) {
+        throw new Error(
+          "Supplied voter profiles must be available before seeding",
+        );
+      }
       profile.set({ name });
       profiles.addUnique(profile);
     }

--- a/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.tsx
+++ b/packages/patterns/integration/fixtures/lunch-poll-read-scale/main.tsx
@@ -1,12 +1,16 @@
 import {
+  type Default,
   handler,
+  type JSXElement,
   NAME,
   pattern,
+  type PerSpace,
   type Stream,
   UI,
   Writable,
 } from "commonfabric";
 import LunchPoll, {
+  type CozyPollOutput,
   type LunchProfile,
   type Option,
   type User,
@@ -15,8 +19,53 @@ import LunchPoll, {
   voteKeyFor,
 } from "../../../lunch-poll/main.tsx";
 
+/** Dimensions of one synthetic poll. */
+interface SeedEvent {
+  /** Number of independently linked votes. */
+  voteCount: number;
+
+  /** Number of separately stored voter profiles. */
+  voterCount: number;
+
+  /** Number of rendered options. */
+  optionCount: number;
+}
+
+/** Observable controls and results shared by CLI and browser fixtures. */
+interface Output {
+  /** Fixture title. */
+  [NAME]: string;
+
+  /** Production poll with a synthetic viewer control. */
+  [UI]: JSXElement;
+
+  /** Initializes a fresh fixture. */
+  seed: Stream<SeedEvent>;
+
+  /** Selects the first synthetic voter. */
+  claim: Stream<Record<string, unknown>>;
+
+  /** Production vote handler. */
+  castVote: CozyPollOutput["castVote"];
+
+  /** Number of stored votes. */
+  voteCount: number;
+
+  /** Number of rendered options. */
+  optionCount: number;
+
+  /** Number of roster members. */
+  userCount: number;
+
+  /** Whether the synthetic viewer belongs to the roster. */
+  isJoined: boolean;
+
+  /** Stored vote links used by functional assertions. */
+  votes: readonly Vote[];
+}
+
 const seed = handler<
-  { voteCount: number; voterCount: number; optionCount: number },
+  SeedEvent,
   {
     profiles: Writable<LunchProfile[]>;
     users: Writable<User[]>;
@@ -48,8 +97,10 @@ const seed = handler<
   users.set(Array.from({ length: voterCount }, (_, index) => {
     const profile = profiles.elementById(String(index));
     const name = `Voter ${index}`;
-    profile.set({ name });
-    profiles.addUnique(profile);
+    if (profile.get() === undefined) {
+      profile.set({ name });
+      profiles.addUnique(profile);
+    }
     return { name, profile, color: "#2f6f4e" };
   }));
   const seededVotes: Writable<Vote>[] = [];
@@ -72,8 +123,9 @@ const claim = handler<Record<string, unknown>, {
   overrideViewer.send({ profile: profiles.elementById("0"), name: "Voter 0" });
 });
 
-export default pattern(() => {
-  const profiles = new Writable.perSpace<LunchProfile[]>([]);
+export default pattern<{
+  profiles?: PerSpace<Default<LunchProfile[], []>>;
+}, Output>(({ profiles }) => {
   const users = new Writable.perSpace<User[]>([]);
   const options = new Writable.perSpace<Option[]>([]);
   const votes = new Writable.perSpace<Vote[]>([]);

--- a/packages/patterns/integration/fixtures/lunch-poll-read-scale/preseeded-profiles.test.tsx
+++ b/packages/patterns/integration/fixtures/lunch-poll-read-scale/preseeded-profiles.test.tsx
@@ -6,6 +6,7 @@ export default pattern(() => {
   const profiles = new Writable.perSpace<LunchProfile[]>([]);
   const poll = Poll({ profiles });
   return {
+    expectRuntimeErrors: 1,
     [TESTS]: [
       {
         action: action(() => {
@@ -13,6 +14,24 @@ export default pattern(() => {
           first.set({ name: "Existing profile", avatar: "existing-avatar" });
           profiles.addUnique(first);
         }),
+      },
+      {
+        action: action(() =>
+          poll.seed.send({
+            voteCount: 3,
+            voterCount: 2,
+            optionCount: 2,
+            requireExistingProfiles: true,
+          })
+        ),
+      },
+      {
+        assertion: assert(() =>
+          profiles.elementById("0").get().name === "Existing profile" &&
+          profiles.elementById("1").get() === undefined &&
+          profiles.get().length === 1 && poll.voteCount === 0 &&
+          poll.optionCount === 0 && poll.userCount === 0
+        ),
       },
       {
         action: action(() =>

--- a/packages/patterns/integration/fixtures/lunch-poll-read-scale/preseeded-profiles.test.tsx
+++ b/packages/patterns/integration/fixtures/lunch-poll-read-scale/preseeded-profiles.test.tsx
@@ -1,0 +1,41 @@
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
+import type { LunchProfile } from "../../../lunch-poll/main.tsx";
+import Poll from "./main.tsx";
+
+export default pattern(() => {
+  const profiles = new Writable.perSpace<LunchProfile[]>([]);
+  const poll = Poll({ profiles });
+  return {
+    [TESTS]: [
+      {
+        action: action(() => {
+          const first = profiles.elementById("0");
+          first.set({ name: "Existing profile", avatar: "existing-avatar" });
+          profiles.addUnique(first);
+        }),
+      },
+      {
+        action: action(() =>
+          poll.seed.send({ voteCount: 3, voterCount: 2, optionCount: 2 })
+        ),
+      },
+      {
+        assertion: assert(() =>
+          profiles.elementById("0").get().name === "Existing profile" &&
+          profiles.elementById("0").get().avatar === "existing-avatar" &&
+          profiles.elementById("1").get().name === "Voter 1" &&
+          profiles.get().length === 2
+        ),
+      },
+      { action: action(() => poll.claim.send({ type: "click" })) },
+      {
+        assertion: assert(() =>
+          poll.voteCount === 3 && poll.userCount === 2 && poll.isJoined &&
+          poll.votes.some((vote) =>
+            vote.voter?.equals(profiles.elementById("0"))
+          )
+        ),
+      },
+    ],
+  };
+});

--- a/packages/patterns/integration/lunch-poll-read-scale.bench.ts
+++ b/packages/patterns/integration/lunch-poll-read-scale.bench.ts
@@ -13,6 +13,7 @@ import {
   waitForCondition,
 } from "@commonfabric/integration";
 import { login } from "@commonfabric/integration/shell-utils";
+import type { Cell } from "@commonfabric/runner";
 import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
 import type { RuntimeClient } from "@commonfabric/runtime-client";
 import { join } from "@std/path";
@@ -26,6 +27,13 @@ import { waitForPieceView } from "./topics-navigation-helpers.ts";
 
 const SIZES = [74, 296, 1184];
 const OPTIONS = 14;
+const profileLocation = Deno.env.get("CF_READ_SCALE_PROFILE_LOCATION") ??
+  "same-space";
+if (profileLocation !== "same-space" && profileLocation !== "cross-space") {
+  throw new Error(
+    "`CF_READ_SCALE_PROFILE_LOCATION` must be `same-space` or `cross-space`",
+  );
+}
 const identity = await Identity.fromPassphrase(
   "lunch poll read scale benchmark",
   { implementation: "noble" },
@@ -102,7 +110,12 @@ async function verifyPosture(): Promise<void> {
 
 const fixtures = new Map<
   number,
-  Promise<{ spaceName: string; pieceId: string }>
+  Promise<{
+    spaceName: string;
+    pieceId: string;
+    profileLocation: string;
+    profileSpace: string;
+  }>
 >();
 /** Seeds one dedicated space per size and releases the seeding runtime. */
 function fixture(voteCount: number) {
@@ -110,7 +123,8 @@ function fixture(voteCount: number) {
   if (!created) {
     created = (async () => {
       await verifyPosture();
-      const spaceName = `${env.SPACE_NAME}-read-${voteCount}`;
+      const spaceName =
+        `${env.SPACE_NAME}-${profileLocation}-read-${voteCount}`;
       const cc = await initializePiecesController({
         space: spaceName,
         apiUrl: new URL(env.API_URL),
@@ -118,6 +132,37 @@ function fixture(voteCount: number) {
       });
       try {
         await cc.ensureDefaultPattern();
+        const voterCount = Math.ceil(voteCount / OPTIONS) + 2;
+        let profileSpace = cc.getSpace();
+        let input: { profiles: Cell<{ name: string }[]> } | undefined;
+        if (profileLocation === "cross-space") {
+          const profileController = await initializePiecesController({
+            space: `${spaceName}-profiles`,
+            apiUrl: new URL(env.API_URL),
+            identity,
+          });
+          try {
+            profileSpace = profileController.getSpace();
+            const profiles = cc.runtime.getCell<{ name: string }[]>(
+              profileSpace,
+              "benchmark-voter-profiles",
+            );
+            const initialized = await cc.runtime.editWithRetry((tx) => {
+              const writable = profiles.withTx(tx);
+              writable.set([]);
+              for (let index = 0; index < voterCount; index++) {
+                const profile = writable.elementById(String(index));
+                profile.set({ name: `Voter ${index}` });
+                writable.addUnique(profile);
+              }
+            });
+            if (initialized.error) throw new Error(initialized.error.message);
+            await cc.synced();
+            input = { profiles };
+          } finally {
+            await profileController.dispose();
+          }
+        }
         const root = join(import.meta.dirname!, "..");
         const program = await resolveLocalProgram(
           (resolver) => cc.runtime.harness.resolve(resolver),
@@ -137,15 +182,17 @@ function fixture(voteCount: number) {
         );
         const piece = await cc.create<
           {
+            votes: { voter: unknown }[];
             seed: {
               voteCount: number;
               voterCount: number;
               optionCount: number;
             };
           }
-        >(program, { start: true });
+        >(program, { start: true, input });
         const result = cc.getResult<
           {
+            votes: { voter: unknown }[];
             seed: {
               voteCount: number;
               voterCount: number;
@@ -155,7 +202,6 @@ function fixture(voteCount: number) {
         >(piece.getCell());
         const stop = result.sink(() => {});
         try {
-          const voterCount = Math.ceil(voteCount / OPTIONS) + 2;
           const sent = await cc.runtime.editWithRetry((tx) =>
             result.key("seed").withTx(tx).send({
               voteCount,
@@ -166,13 +212,21 @@ function fixture(voteCount: number) {
           if (sent.error) throw new Error(sent.error.message);
           await cc.runtime.settled(Infinity);
           await cc.synced();
+          const voterSpace = result.key("votes").key(0).key("voter")
+            .resolveAsCell().space;
+          if (voterSpace !== profileSpace) {
+            throw new Error("Seeded vote does not reference the profile space");
+          }
+          note(
+            `[lunch-read-scale] verified ${profileLocation} voter links: ${profileSpace}`,
+          );
           note(
             `[lunch-read-scale] seeded ${voteCount} votes, ${voterCount} voters, ${OPTIONS} options`,
           );
         } finally {
           stop();
         }
-        return { spaceName, pieceId: piece.id };
+        return { spaceName, pieceId: piece.id, profileLocation, profileSpace };
       } finally {
         await cc.dispose();
       }

--- a/packages/patterns/integration/lunch-poll-read-scale.bench.ts
+++ b/packages/patterns/integration/lunch-poll-read-scale.bench.ts
@@ -187,6 +187,7 @@ function fixture(voteCount: number) {
               voteCount: number;
               voterCount: number;
               optionCount: number;
+              requireExistingProfiles?: boolean;
             };
           }
         >(program, { start: true, input });
@@ -197,6 +198,7 @@ function fixture(voteCount: number) {
               voteCount: number;
               voterCount: number;
               optionCount: number;
+              requireExistingProfiles?: boolean;
             };
           }
         >(piece.getCell());
@@ -207,6 +209,7 @@ function fixture(voteCount: number) {
               voteCount,
               voterCount,
               optionCount: OPTIONS,
+              requireExistingProfiles: profileLocation === "cross-space",
             })
           );
           if (sent.error) throw new Error(sent.error.message);


### PR DESCRIPTION
## Why

A5 of #7155 needs a controlled comparison between local and cross-space voter links before B6 can make a broader savings claim. The rendered poll benchmark currently fixes all profiles in the poll space. This fixture can run independently of the maintained-group migration in #7336 and keeps the live poll untouched.

## What changed

Add `CF_READ_SCALE_PROFILE_LOCATION=same-space|cross-space`, with same-space as the default. The cross-space variant seeds matching profiles in a dedicated space before the poll seed transaction, verifies the first vote's resolved profile space, and records the location and profile DID in artifacts.

Let the fixture receive preseeded profiles while preserving their contents and identity. Cross-space seeding requires every profile to be available and rejects missing profiles without creating them. Keep its JSX output schema aligned with the authored result. Add a regression for preserved profiles and document the benchmark option.

## Test plan

- All nine CLI assertions pass: unchanged read budgets at 74, 296, and 1,184 votes, plus preservation of supplied profiles, voter identity links, and rollback when a required profile is unavailable.
- Fresh 74-vote browser acceptance passes in both locations through cleanup. Each records 134 completed reactive runs, 1,016 proxy accesses, 896 link hops, 2 successful event commits, and 0 errors. These are single acceptance runs, not a latency comparison.
- Full patterns package, all 413 authoritative pattern checks, all 46 workspace type groups, 599 checked documentation blocks, formatting, and lint pass.
- Antagonistic self-review covers emitted schemas, transaction boundaries, cross-space setup/teardown, and assertion coverage. Cubic and final CI review remain required before merge.

This PR targets main independently of #7323 and #7336. Synthetic spaces only; no deployed poll update.
