### PR TITLE
feat(runner,piece,cli): setup receipts name the store seq they committed at

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -553,6 +553,12 @@ That status means “source changed, running deploy unverified,” not rollback:
 `piece render`, `piece inspect`, and `piece getsrc` to determine the live state.
 A receipt alone is never proof that the updated piece starts.
 
+In either case the receipt names the committed pattern ref, the source revision,
+and the seq at which the space's commit log accepted the update. That seq is
+what `cf inspect value-at --seq` and `diff --from` take, so the piece can be
+read at exactly the commit that applied the update, or diffed against what has
+landed since.
+
 ## Where a piece is created
 
 Against a deployment that runs the serving loop — one whose published posture

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -215,7 +215,7 @@ export function setsrcSuccessLine(
 ): string {
   return `Committed source update for piece ${config.piece} (Pattern Ref: ${
     formatPatternIdentity(update.ref)
-  }, Revision: ${update.revisionId})`;
+  }, Revision: ${update.revisionId}, Seq: ${update.seq})`;
 }
 
 /** A warning for work which failed after storage accepted the source update. */
@@ -225,7 +225,7 @@ export function setsrcRefreshWarning(
   return update.refresh.status === "failed"
     ? `Source revision ${update.revisionId} committed as ${
       formatPatternIdentity(update.ref)
-    }, but refreshing the running piece failed: ${update.refresh.warning}`
+    } at seq ${update.seq}, but refreshing the running piece failed: ${update.refresh.warning}`
     : undefined;
 }
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -77,7 +77,8 @@ const ID = "~/.my.key";
 // The 43-character id length matches the entity ids the runtime mints, and
 // clears the runner parser's handle-length threshold.
 const LLM_HANDLE = `of:fid1:${"baedreiabcdefghijklmnopqrstuvwxyz0123456789"}`;
-const SPACE_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+const SPACE_DID =
+  "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK" as const;
 const OTHER_SPACE_DID =
   "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z";
 const FULL_URL = `${API_URL}/${SPACE}/${PIECE}`;
@@ -2726,6 +2727,8 @@ describe("cli piece parsing", () => {
       ref: { identity: "B".repeat(43), symbol: "default" },
       revisionId: "revision-2",
       detachedOrigin: null,
+      space: SPACE_DID,
+      seq: 12,
       refresh: { status: "completed" as const },
     };
     const { config, update } = await setPieceSourceFromCommand(
@@ -2782,12 +2785,14 @@ describe("cli piece parsing", () => {
         ref: { identity: "B".repeat(43), symbol: "default" },
         revisionId: "revision-2",
         detachedOrigin: null,
+        space: SPACE_DID,
+        seq: 12,
         refresh: { status: "completed" },
       },
     )).toBe(
       `Committed source update for piece ${PIECE} ` +
         `(Pattern Ref: cf:module/${"B".repeat(43)}#default, ` +
-        `Revision: revision-2)`,
+        `Revision: revision-2, Seq: 12)`,
     );
   });
 
@@ -2797,6 +2802,8 @@ describe("cli piece parsing", () => {
       ref: { identity: "B".repeat(43), symbol: "default" },
       revisionId: "revision-2",
       detachedOrigin: null,
+      space: SPACE_DID,
+      seq: 12,
       refresh: { status: "completed" as const },
     };
     const rendered: string[] = [];
@@ -2830,7 +2837,7 @@ describe("cli piece parsing", () => {
     expect(rendered).toEqual([
       `Committed source update for piece ${PIECE} ` +
       `(Pattern Ref: cf:module/${"B".repeat(43)}#default, ` +
-      `Revision: revision-2)`,
+      `Revision: revision-2, Seq: 12)`,
     ]);
     expect(warned).toEqual([]);
     expect(exitCodes).toEqual([]);
@@ -2848,6 +2855,8 @@ describe("cli piece parsing", () => {
       ref: { identity: "B".repeat(43), symbol: "default" },
       revisionId: "revision-2",
       detachedOrigin: null,
+      space: SPACE_DID,
+      seq: 12,
       refresh: {
         status: "failed" as const,
         warning: "dependency unavailable",
@@ -2887,11 +2896,12 @@ describe("cli piece parsing", () => {
     expect(rendered).toEqual([
       `Committed source update for piece ${PIECE} ` +
       `(Pattern Ref: cf:module/${"B".repeat(43)}#default, ` +
-      `Revision: revision-2)`,
+      `Revision: revision-2, Seq: 12)`,
     ]);
     expect(warned).toEqual([
       `Source revision revision-2 committed as ` +
-      `cf:module/${"B".repeat(43)}#default, but refreshing the running ` +
+      `cf:module/${"B".repeat(43)}#default at seq 12, but refreshing the ` +
+      `running ` +
       `piece failed: dependency unavailable`,
     ]);
     expect(hinted).toHaveLength(1);
@@ -2936,6 +2946,8 @@ describe("cli piece parsing", () => {
                 ref: { identity: "B".repeat(43), symbol: "default" },
                 revisionId: "revision-2",
                 detachedOrigin: null,
+                space: SPACE_DID,
+                seq: 12,
                 refresh: {
                   status: "failed" as const,
                   warning: "dependency unavailable",
@@ -4678,6 +4690,8 @@ describe("cli piece parsing", () => {
                   },
                   revisionId: "revision-2",
                   detachedOrigin: null,
+                  space: SPACE_DID,
+                  seq: 12,
                   refresh: { status: "completed" as const },
                 });
               },

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -2819,6 +2819,8 @@ describe("cell-bridge", () => {
             ref: { identity: "A".repeat(43), symbol: "default" },
             revisionId: "revision-2",
             detachedOrigin: null,
+            space: "did:key:test" as const,
+            seq: 12,
             refresh: {
               status: "failed" as const,
               warning: "dependency unavailable",
@@ -5877,6 +5879,8 @@ describe("cell-bridge", () => {
         ref: { identity: "A".repeat(43), symbol: "default" },
         revisionId: "revision-2",
         detachedOrigin: null,
+        space: "did:key:test",
+        seq: 12,
         refresh: { status: "failed", warning: "dependency unavailable" },
       })).toBe(
         `Source revision revision-2 committed as cf:module/${
@@ -5891,6 +5895,8 @@ describe("cell-bridge", () => {
         ref: { identity: "A".repeat(43), symbol: "default" },
         revisionId: "revision-2",
         detachedOrigin: null,
+        space: "did:key:test",
+        seq: 12,
         refresh: { status: "completed" },
       })).toBeUndefined();
       // A finalize with no receipt — a metadata write, which updated no source.

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -219,6 +219,8 @@ Deno.test("source projection failures after commit become warnings, not rejected
     ref: { identity: "A".repeat(43), symbol: "default" },
     revisionId: "revision-committed-before-finalize",
     detachedOrigin: null,
+    space: "did:key:test" as const,
+    seq: 12,
     refresh: { status: "completed" as const },
   };
   const failure = new Error("projection rebuild failed");

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -25,6 +25,7 @@ import {
   isStream,
   type JSONSchema,
   KeepAsCell,
+  type MemorySpace,
   mergeSchemaDefaults,
   NAME,
   type NormalizedLink,
@@ -521,6 +522,13 @@ export interface PatternUpdateReceipt extends PieceSourceSetResult {
   status: "committed";
   /** Content-addressed pattern pointer written by the transaction. */
   ref: { identity: string; symbol: string };
+  /** The space whose commit log accepted the setup transaction. */
+  space: MemorySpace;
+  /**
+   * Position in `space`'s commit log at which the transaction was accepted:
+   * the seq `cf inspect value-at --seq` and `diff --from/--to` read.
+   */
+  seq: number;
   /** Source-history revision written atomically with `.ref`. */
   revisionId: string;
   /** Outcome of work which refreshes the running piece after commit. */
@@ -4643,7 +4651,7 @@ export class PieceController<T = unknown> {
   ): Promise<PatternUpdateReceipt> {
     const mutationVersion = ++this.#mutationVersion;
     let transition: PieceSourceTransition | undefined;
-    let committedRef: { identity: string; symbol: string } | undefined;
+    let commit: PatternSetupCommitReceipt | undefined;
     try {
       await this.#runMutation(mutationVersion, async () => {
         // A piece whose current pattern cannot load is exactly the piece a
@@ -4764,17 +4772,17 @@ export class PieceController<T = unknown> {
               sourceTransition: transition,
             },
           );
-          committedRef = result.commit.pattern;
+          commit = result.commit;
           return result.cell as Cell<T>;
         } catch (error) {
           if (error instanceof PatternSetupPostCommitError) {
-            committedRef = error.commit.pattern;
+            commit = error.commit;
           }
           throw error;
         }
       });
     } catch (error) {
-      if (transition !== undefined && committedRef !== undefined) {
+      if (transition !== undefined && commit !== undefined) {
         // The wrapper says only that post-commit work failed, which this line
         // already says; what a reader needs is which work and why. Log the
         // cause, the same failure `refresh.warning` reports, so the console
@@ -4791,7 +4799,9 @@ export class PieceController<T = unknown> {
         // named, whatever happened to the refresh afterwards.
         return {
           status: "committed",
-          ref: committedRef,
+          ref: commit.pattern,
+          space: commit.space,
+          seq: commit.seq,
           revisionId: transition.revisionId,
           detachedOrigin: transition.expected.origin,
           refresh: { status: "failed", warning },
@@ -4800,13 +4810,15 @@ export class PieceController<T = unknown> {
       throw pinnedSourceMoved(error, options?.expectedPattern);
     }
     // The mutation assigns `transition` before the write it belongs to, and
-    // sets `committedRef` from the accepted transaction's receipt; every
-    // earlier exit from it throws — so a mutation that resolved has both, and
-    // a mutation that did not took the catch above. Asserted rather than
-    // guarded because a guard here could never fire.
+    // holds the accepted transaction's receipt in `commit`; every earlier exit
+    // from it throws — so a mutation that resolved has both, and a mutation
+    // that did not took the catch above. Asserted rather than guarded because
+    // a guard here could never fire.
     return {
       status: "committed",
-      ref: committedRef!,
+      ref: commit!.pattern,
+      space: commit!.space,
+      seq: commit!.seq,
       revisionId: transition!.revisionId,
       detachedOrigin: transition!.expected.origin,
       refresh: { status: "completed" },

--- a/packages/piece/test/setsrc-commit-receipt.test.ts
+++ b/packages/piece/test/setsrc-commit-receipt.test.ts
@@ -71,18 +71,37 @@ describe("setsrc commit receipt", () => {
 
     const durable = getPatternIdentityRef(piece.getCell());
     const revision = getPieceSourceRevisions(piece.getCell()).at(-1);
-    expect(receipt).toEqual({
+    const { seq, ...named } = receipt;
+    expect(named).toEqual({
       status: "committed",
       ref: durable,
       revisionId: revision?.revisionId,
       detachedOrigin: null,
+      space: pieces.getSpace(),
       refresh: { status: "completed" },
     });
+    expect(Number.isInteger(seq)).toBe(true);
+    expect(seq).toBeGreaterThan(0);
     expect(receipt.ref.identity).not.toBe(before?.identity);
     expect(revision?.pattern).toEqual(receipt.ref);
     expect(
       (piece.getCell().getAsQueryResult() as { marker?: string }).marker,
     ).toBe("v2");
+  });
+
+  it("orders two updates by the seq their space accepted them at", async () => {
+    // The seq is the receipt's own position in the space's commit log, so
+    // two receipts for one piece order each other without reading the piece.
+
+    const piece = await pieces.create(markedProgram("v1"), { input: {} });
+    await runtime.idle();
+
+    const first = await piece.setPattern(markedProgram("v2"));
+    const second = await piece.setPattern(markedProgram("v3"));
+
+    expect(second.space).toBe(first.space);
+    expect(second.seq).toBeGreaterThan(first.seq);
+    expect(getPatternIdentityRef(piece.getCell())).toEqual(second.ref);
   });
 
   it("performs no additional cell synchronization after the update operation returns its receipt", async () => {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1117,6 +1117,15 @@ type SetupResult<R> = {
 export interface PatternSetupCommitReceipt {
   /** Content-addressed pattern pointer written by the transaction. */
   pattern: { identity: string; symbol: string };
+  /** The space whose commit log accepted the transaction. */
+  space: MemorySpace;
+  /**
+   * Position in `space`'s commit log at which storage accepted the
+   * transaction. With `space` it is the coordinate `cf inspect value-at --seq`
+   * and `diff --from/--to` read, and it orders this receipt against every
+   * other commit to the space.
+   */
+  seq: number;
 }
 
 /** Result of running a pattern through an owned setup transaction. */
@@ -6844,6 +6853,7 @@ export class Runner {
     const givenTx = resultCell.tx?.status().status === "ready" && resultCell.tx;
     let setupRes: SetupResult<any> | undefined;
     let commit: PatternSetupCommitReceipt | undefined;
+    let committedTx: IExtendedStorageTransaction | undefined;
     const assertExpectedPatternIdentity = (
       cell: Cell<any>,
     ): void => {
@@ -6887,6 +6897,9 @@ export class Runner {
     } else {
       const outcome = await this.#runtime.editWithRetry(
         (tx) => {
+          // The attempt that commits is the last one this callback sees, so
+          // the receipt below names the commit it produced.
+          committedTx = tx;
           // Receipts and source-update authority require this transaction's
           // durable acceptance. Check each attempt because a seal destination
           // can be installed during synchronization or between retries.
@@ -6971,7 +6984,17 @@ export class Runner {
             );
           }
           // deno-coverage-ignore-stop
-          commit = { pattern: patternRef };
+          // Recorded on the transaction at its verdict, before the commit
+          // promise resolved, so a resolved commit carries it; like the
+          // pointer above, a missing seq is the type's edge and fails loudly
+          // rather than minting a receipt that names no commit.
+          const seq = committedTx?.committedSeq?.(resultCell.space);
+          if (seq === undefined) {
+            throw new Error(
+              "the pattern setup committed without recording its store seq",
+            );
+          }
+          commit = { pattern: patternRef, space: resultCell.space, seq };
         }
       }
     }

--- a/packages/runner/src/storage/commit-identity.ts
+++ b/packages/runner/src/storage/commit-identity.ts
@@ -1,3 +1,11 @@
+/**
+ * What a source transaction's commits are known by after the fact: the
+ * per-space client commit sequence each was built with, and the store seq the
+ * space accepted each at. The replica records both as they become known and
+ * the transaction reads them back, so a caller holding the transaction can
+ * name its commit after the replica's bounded ack record has forgotten it.
+ */
+
 import type { IStorageTransaction, MemorySpace } from "./interface.ts";
 
 // Per-space client commit sequence numbers recorded for a source
@@ -6,23 +14,67 @@ import type { IStorageTransaction, MemorySpace } from "./interface.ts";
 // precondition for follow-up work.
 const localSeqBySource = new WeakMap<object, Map<MemorySpace, number>>();
 
+// Per-space store sequence numbers recorded for a source transaction when
+// its commit's verdict arrives (storage/v2.ts): the position in the space's
+// commit log the writes landed at. Read back through the transaction's
+// `committedSeq()`.
+const seqBySource = new WeakMap<object, Map<MemorySpace, number>>();
+
+function recordBySpace(
+  table: WeakMap<object, Map<MemorySpace, number>>,
+  source: IStorageTransaction,
+  space: MemorySpace,
+  value: number,
+): void {
+  let bySpace = table.get(source);
+  if (!bySpace) {
+    bySpace = new Map();
+    table.set(source, bySpace);
+  }
+  bySpace.set(space, value);
+}
+
+/**
+ * Records the client commit sequence `source`'s commit to `space` was built
+ * with.
+ */
 export function recordCommitLocalSeq(
   source: IStorageTransaction,
   space: MemorySpace,
   localSeq: number,
 ): void {
-  let bySpace = localSeqBySource.get(source);
-  if (!bySpace) {
-    bySpace = new Map();
-    localSeqBySource.set(source, bySpace);
-  }
-  bySpace.set(space, localSeq);
+  recordBySpace(localSeqBySource, source, space, localSeq);
 }
 
+/**
+ * The client commit sequence `source`'s commit to `space` was built with, if
+ * one was recorded.
+ */
 export function getCommitLocalSeq(
   source: IStorageTransaction | undefined,
   space: MemorySpace,
 ): number | undefined {
   if (!source) return undefined;
   return localSeqBySource.get(source)?.get(space);
+}
+
+/** Records the store seq `space` accepted `source`'s commit at. */
+export function recordCommitSeq(
+  source: IStorageTransaction,
+  space: MemorySpace,
+  seq: number,
+): void {
+  recordBySpace(seqBySource, source, space, seq);
+}
+
+/**
+ * The store seq `space` accepted `source`'s commit at, once its verdict has
+ * arrived.
+ */
+export function getCommitSeq(
+  source: IStorageTransaction | undefined,
+  space: MemorySpace,
+): number | undefined {
+  if (!source) return undefined;
+  return seqBySource.get(source)?.get(space);
 }

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -4004,6 +4004,10 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     return this.#wrapped.status();
   }
 
+  committedSeq(space: MemorySpace): number | undefined {
+    return this.#wrapped.committedSeq?.(space);
+  }
+
   #transformReadOptions(options?: IReadOptions): IReadOptions {
     if (!this.#options.nonReactive) {
       return options ?? {};

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -2865,6 +2865,10 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     return this.tx.status();
   }
 
+  committedSeq(space: MemorySpace): number | undefined {
+    return this.tx.committedSeq?.(space);
+  }
+
   read(
     address: IMemorySpaceAddress,
     options?: IReadOptions,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1424,6 +1424,16 @@ export interface IStorageTransaction {
   status(): StorageTransactionStatus;
 
   /**
+   * The store seq `space` accepted this transaction's commit at: the position
+   * in that space's commit log the writes landed at, which
+   * `cf inspect value-at --seq` and `diff --from/--to` read. Known once the
+   * commit's verdict arrives; undefined before it, for a commit the space
+   * rejected, and for a space this transaction wrote nothing to. Optional the
+   * same way as the read hooks above; absent means unknown.
+   */
+  committedSeq?(space: MemorySpace): number | undefined;
+
+  /**
    * Reads a value from a (local) memory address and captures corresponding
    * `Read` in the transaction invariants. If value was written in read memory
    * address in this transaction read will return value that was written as

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -34,6 +34,7 @@ import {
 } from "../../../memory/v2/path.ts";
 import type { CellScope } from "../builder/types.ts";
 import { normalizeCellScope } from "../scope.ts";
+import { getCommitSeq } from "./commit-identity.ts";
 import type {
   Activity,
   ChangeGroup,
@@ -1134,6 +1135,10 @@ export class V2StorageTransaction implements IStorageTransaction {
       return { status: "pending", journal: this.journal };
     }
     return { status: "ready", journal: this.journal };
+  }
+
+  committedSeq(space: MemorySpace): number | undefined {
+    return getCommitSeq(this, space);
   }
 
   getReadActivities(): readonly IReadActivity[] {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -94,7 +94,7 @@ import { entityKey } from "../scheduler/keys.ts";
 import { isCellScope, normalizeCellScope } from "../scope.ts";
 import { normalizeSpaceHost, SpaceHostValidationError } from "../space-host.ts";
 import type { RuntimeTelemetryMarker } from "../telemetry.ts";
-import { recordCommitLocalSeq } from "./commit-identity.ts";
+import { recordCommitLocalSeq, recordCommitSeq } from "./commit-identity.ts";
 import * as Differential from "./differential.ts";
 import {
   IMemoryAddress,
@@ -5356,6 +5356,9 @@ export class SpaceReplica
       // The cover class: a sealed native commit is the co-hosted
       // executor's wave commit (speculative seals resolve withdrawn and
       // never reach here) — the wave admission class, derived.
+      if (source !== undefined) {
+        recordCommitSeq(source, this.#space, v.committed.seq);
+      }
       this.#confirmPending(
         localSeq,
         operations,
@@ -6133,6 +6136,7 @@ export class SpaceReplica
             operations,
             applied,
             resolveAtVerdict,
+            source,
           );
           // Tx-sourced commits ALWAYS record the coverage wait: the inner
           // settlement promise carries commit callbacks and the
@@ -6187,6 +6191,7 @@ export class SpaceReplica
           operations,
           outcome.applied,
           resolveAtVerdict,
+          source,
         );
         // Same rule as the direct-await branch above: tx-sourced commits
         // always record; only the direct path honors the verdict opt-out.
@@ -7807,11 +7812,17 @@ export class SpaceReplica
     operations: NativeCommitOperation[],
     applied: AppliedCommit,
     resolveAtVerdict = false,
+    source?: IStorageTransaction,
   ): Promise<void> {
     // The retirement floor's ack record (speculation.md §4): known at
     // VERDICT time, before any parking — a parked promotion changes when
     // the value becomes visible, not that the origin acked.
     this.#ackedSeqsByLocalSeq.set(localSeq, applied.seq);
+    // The same seq, on the transaction that produced the commit: its caller
+    // can name the commit after the bounded record above has forgotten it.
+    if (source !== undefined) {
+      recordCommitSeq(source, this.#space, applied.seq);
+    }
     if (
       this.#ackedSeqsByLocalSeq.size > SpaceReplica.#MAX_RETAINED_ACK_SEQS
     ) {

--- a/packages/runner/test/commit-identity.test.ts
+++ b/packages/runner/test/commit-identity.test.ts
@@ -1,7 +1,9 @@
 import { expect } from "@std/expect";
 import {
   getCommitLocalSeq,
+  getCommitSeq,
   recordCommitLocalSeq,
+  recordCommitSeq,
 } from "../src/storage/commit-identity.ts";
 import type { IStorageTransaction } from "../src/storage/interface.ts";
 
@@ -16,4 +18,18 @@ Deno.test("commit local sequence records values per source and space", () => {
 
   expect(getCommitLocalSeq(tx, "did:key:space")).toBe(7);
   expect(getCommitLocalSeq(tx, "did:key:other")).toBeUndefined();
+});
+
+Deno.test("commit store sequence lookup is empty without a source transaction", () => {
+  expect(getCommitSeq(undefined, "did:key:space")).toBeUndefined();
+});
+
+Deno.test("commit store sequence records values per source and space", () => {
+  const tx = {} as IStorageTransaction;
+
+  recordCommitSeq(tx, "did:key:space", 42);
+
+  expect(getCommitSeq(tx, "did:key:space")).toBe(42);
+  expect(getCommitSeq(tx, "did:key:other")).toBeUndefined();
+  expect(getCommitLocalSeq(tx, "did:key:space")).toBeUndefined();
 });

--- a/packages/runner/test/extended-storage-transaction.test.ts
+++ b/packages/runner/test/extended-storage-transaction.test.ts
@@ -763,4 +763,24 @@ describe("extended-storage-transaction", () => {
       }
     });
   });
+
+  it("reports a committed seq through the sample wrapper", async () => {
+    // `Cell.sample()` and `Cell.sink()` hand out this wrapper, and the
+    // accessor is optional on the interface, so a wrapper that dropped it
+    // would compile and answer undefined for a commit the wrapped
+    // transaction knows the seq of.
+
+    const tx = runtime.edit();
+    runtime.getCell(space, "wrapped committed seq", undefined, tx).set({
+      title: "after",
+    });
+    const wrapper = createNonReactiveTransaction(tx);
+    expect(wrapper.committedSeq?.(space)).toBeUndefined();
+
+    await tx.commit();
+
+    const seq = tx.committedSeq?.(space);
+    expect(seq).toBeGreaterThan(0);
+    expect(wrapper.committedSeq?.(space)).toBe(seq);
+  });
 });

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -5,6 +5,8 @@ import { stub } from "@std/testing/mock";
 import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import type { Server as MemoryV2Server } from "@commonfabric/memory/v2/server";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import {
@@ -18,6 +20,8 @@ import { Runtime } from "../src/runtime.ts";
 import { entityKey } from "../src/scheduler/keys.ts";
 import { validateSchemaValue } from "../src/cfc/mod.ts";
 import { resolvedSchema } from "./schema-ref-helpers.ts";
+import { testSessionOpenAuthFactory } from "./memory-v2-test-utils.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
 import { resultSchemaMetaSpelling } from "../src/result-schema-meta.ts";
 import {
   areNormalizedLinksSame,
@@ -82,6 +86,28 @@ function setupTrusted(
     argument as never,
     resultCell as never,
   );
+}
+
+/**
+ * A second session on the fixture's loopback server: it reads the space as
+ * storage holds it, not as this runtime's replica does.
+ */
+async function openRemoteSession(
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+): Promise<
+  { client: MemoryV2Client.Client; session: MemoryV2Client.SpaceSession }
+> {
+  const candidate = storageManager as unknown as {
+    server?: () => MemoryV2Server;
+  };
+  if (typeof candidate.server !== "function") {
+    throw new Error("the receipt fixture needs an emulated storage manager");
+  }
+  const client = await MemoryV2Client.connect({
+    transport: MemoryV2Client.loopback(candidate.server()),
+  });
+  const session = await client.mount(space, {}, testSessionOpenAuthFactory);
+  return { client, session };
 }
 
 async function compileReceiptPattern(
@@ -1919,6 +1945,26 @@ describe("setup/start", () => {
       receiptSourceSnapshot(runtime, resultCell).pattern,
     );
     expect(result.cell.get()).toEqual({ marker: "v2" });
+
+    // The seq is the commit's own position in the space's log: read there,
+    // the document already carries the receipt's pointer, and read one seq
+    // earlier it still carries the pointer the setup replaced.
+    expect(result.commit.space).toBe(space);
+    const remote = await openRemoteSession(storageManager);
+    try {
+      const id = resultCell.getAsNormalizedFullLink().id;
+      const pointerAt = async (seq: number) =>
+        (await remote.session.queryGraph({
+          roots: [{ id, selector: { path: [], schema: false } }],
+          atSeq: seq,
+        }))
+          .entities.find((entity) => entity.id === id)?.document
+          ?.patternIdentity;
+      expect(await pointerAt(result.commit.seq)).toEqual(result.commit.pattern);
+      expect(await pointerAt(result.commit.seq - 1)).toEqual(previous);
+    } finally {
+      await remote.client.close();
+    }
   });
 
   it("runSyncedWithCommit carries its receipt through post-commit failures", async () => {
@@ -1971,8 +2017,41 @@ describe("setup/start", () => {
       expect(failure.commit.pattern).toEqual(
         receiptSourceSnapshot(runtime, resultCell).pattern,
       );
+      expect(failure.commit.space).toBe(space);
+      expect(failure.commit.seq).toBeGreaterThan(0);
     } finally {
       runtime.runner.accessForTestingOnly.dependencySyncer = undefined;
+    }
+  });
+
+  it("runSyncedWithCommit refuses a receipt when the accepted commit reports no seq", async () => {
+    // The seq is recorded at the verdict, so a resolved commit without one is
+    // the type's edge — and a receipt that names no commit is refused loudly
+    // there rather than issued.
+
+    const resultCell = runtime.getCell(space, "runSynced receipt without seq");
+    const initialPattern = await compileReceiptPattern(runtime, "v1");
+    const nextPattern = await compileReceiptPattern(runtime, "v2");
+    await runtime.runSynced(resultCell, initialPattern, {});
+    const previous = receiptSourceSnapshot(runtime, resultCell).pattern;
+    const pieceSourceTransition = await receiptSourceTransition(
+      runtime,
+      resultCell,
+    );
+    const committedSeq = ExtendedStorageTransaction.prototype.committedSeq;
+    ExtendedStorageTransaction.prototype.committedSeq = () => undefined;
+
+    try {
+      await expect(runtime.runSyncedWithCommit(
+        resultCell,
+        nextPattern,
+        {},
+        { expectedPatternIdentity: previous, pieceSourceTransition },
+      )).rejects.toThrow(
+        "the pattern setup committed without recording its store seq",
+      );
+    } finally {
+      ExtendedStorageTransaction.prototype.committedSeq = committedSeq;
     }
   });
 

--- a/packages/runner/test/v2-transaction-committed-seq.test.ts
+++ b/packages/runner/test/v2-transaction-committed-seq.test.ts
@@ -1,0 +1,95 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import type { Server as MemoryV2Server } from "@commonfabric/memory/v2/server";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { testSessionOpenAuthFactory } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("v2-transaction committed seq");
+const space = signer.did();
+const otherSpace = (await Identity.fromPassphrase("another space")).did();
+
+describe("v2-transaction", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let remoteClient: MemoryV2Client.Client;
+  let remoteSession: MemoryV2Client.SpaceSession;
+
+  // A second session on the loopback server reads the space as storage holds
+  // it, not as the runtime's own replica does.
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const candidate = storageManager as unknown as {
+      server?: () => MemoryV2Server;
+    };
+    if (typeof candidate.server !== "function") {
+      throw new Error("the fixture needs an emulated storage manager");
+    }
+    remoteClient = await MemoryV2Client.connect({
+      transport: MemoryV2Client.loopback(candidate.server()),
+    });
+    remoteSession = await remoteClient.mount(
+      space,
+      {},
+      testSessionOpenAuthFactory,
+    );
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await remoteClient.close();
+    await storageManager.close();
+  });
+
+  it("reports the store seq its space accepted the commit at", async () => {
+    // Known only once the verdict arrives, and then exactly the commit's
+    // position in the space's log: read there, another session sees the
+    // write; read one seq earlier, it sees nothing of it.
+
+    const tx = runtime.edit();
+    const cell = runtime.getCell(space, "committed seq", undefined, tx);
+    cell.set({ title: "after" });
+    expect(tx.committedSeq?.(space)).toBeUndefined();
+
+    const committed = await tx.commit();
+    expect(committed.error).toBeUndefined();
+    const seq = tx.committedSeq?.(space);
+    if (seq === undefined) {
+      throw new Error("the accepted commit reported no seq");
+    }
+
+    const id = cell.getAsNormalizedFullLink().id;
+    const valueAt = async (atSeq: number) =>
+      (await remoteSession.queryGraph({
+        roots: [{ id, selector: { path: [], schema: false } }],
+        atSeq,
+      }))
+        .entities.find((entity) => entity.id === id)?.document?.value;
+    expect(await valueAt(seq)).toEqual({ title: "after" });
+    expect(await valueAt(seq - 1)).toBeUndefined();
+    expect(tx.committedSeq?.(otherSpace)).toBeUndefined();
+  });
+
+  it("reports no seq for a commit its space refused", async () => {
+    const { replica } = storageManager.open(space);
+    replica.commitNative = (() =>
+      Promise.reject(
+        new Error("simulated storage crash"),
+      )) as NonNullable<typeof replica.commitNative>;
+
+    const tx = runtime.edit();
+    runtime.getCell(space, "refused seq", undefined, tx).set({
+      title: "never",
+    });
+    const committed = await tx.commit();
+
+    expect(committed.error).toBeDefined();
+    expect(tx.committedSeq?.(space)).toBeUndefined();
+  });
+});

--- a/packages/runner/test/v2-transaction-committed-seq.test.ts
+++ b/packages/runner/test/v2-transaction-committed-seq.test.ts
@@ -1,3 +1,10 @@
+/**
+ * The seq a committed transaction reports is verified against storage rather
+ * than against the code that recorded it: a second session reads the document
+ * at that seq and one seq earlier, so the number has to be the commit's real
+ * position in the space's log, not merely a number the replica remembered.
+ */
+
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";


### PR DESCRIPTION
## What

A `PatternSetupCommitReceipt` proved that storage accepted a setup transaction but named no commit: nothing in it could be looked up in the store, ordered against another receipt, or read back at the point it landed. The store has that identity — every accepted commit gets a position in its space's commit log, the `seq` the durable `commit` table is keyed by and the coordinate `cf inspect value-at --seq`, `diff --from/--to`, and `history` read — and the runner learns it at the verdict. It just never reached the caller: `commit()` resolves `Result<Unit>`, `editWithRetry` returns only the callback's value, and the seq stayed in the replica's bounded ack record.

## How

- The replica records the accepted seq on the transaction that produced the commit, next to the existing per-space local-seq record in `storage/commit-identity.ts`, at the moment the verdict arrives (`#settleAccept`, and the sealed path's `committed` verdict). Keyed by the transaction rather than kept in the bounded `#ackedSeqsByLocalSeq` map, so the answer lasts as long as the caller holds the transaction.
- `IStorageTransaction.committedSeq?(space)` reads it back: the store seq the space accepted the commit at, undefined before the verdict, for a rejected commit, and for a space the transaction wrote nothing to. `V2StorageTransaction` implements it; `ExtendedStorageTransaction` forwards it.
- `runSyncedWithCommit` mints the receipt from the transaction that committed (captured in the `editWithRetry` callback — the attempt that commits is the last one it sees), so `PatternSetupCommitReceipt` now carries `space` and `seq`. A resolved commit always has the seq recorded; a missing one is the type's edge and fails loudly like the missing-pointer guard beside it, rather than minting a receipt that names no commit.
- `PatternUpdateReceipt` carries both fields through `setPattern`, and `cf piece setsrc` prints the seq in its success line and refresh warning. `packages/cli/README.md` says what the receipt names and what to do with the seq.

`PieceSourceActionResult` (the `changeSource` verdict that crosses the shell RPC) is unchanged; a seq there is a separate decision, since detach and the adopt-already-current arm have no setup transaction to name.

## Tests

- `v2-transaction-committed-seq.test.ts`: a committed transaction reports the seq at which a second session on the loopback server sees the write when reading the document `atSeq` — and sees nothing of it one seq earlier — so the seq is verified as the commit boundary by storage itself, not by the code under test; undefined before commit, for an unwritten space, and for a commit the replica refused. Validated as an instrument: recording the seq off by one fails it.
- `runner.test.ts`: `runSyncedWithCommit`'s receipt names its space, and read at its seq the piece document carries the receipt's pointer while one seq earlier it carries the pointer the setup replaced; the post-commit-failure receipt carries both fields; and a resolved commit that reports no seq is refused rather than receipted.
- `commit-identity.test.ts`: the record is per source and space, independent of the local-seq record.
- `setsrc-commit-receipt.test.ts`: the receipt's shape, and two updates to one piece order by seq without a read of the piece.
- CLI and fuse fixtures gain the fields; the CLI's printed lines pin the seq.

Local: runner, piece, cli, and fuse suites; repo-wide fmt, lint, `deno task check`, `check-docs`, `check-package-cycles`, `check-skill-facts`, `check-command-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

