### PR TITLE
fix(integration): own browser process groups during teardown

### DIFF
--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -97,16 +97,18 @@ ephemeral test profile cannot start maintenance of the installed browser.
 Detached updater crash handlers can inherit Chrome's stderr and keep it open
 after the browser exits. Chrome's own crash reporting remains enabled.
 
-`BrowserProcess.close()` sends `SIGKILL` to the browser and waits for its exit
-status and both output streams to reach EOF before profile removal. Test
-callers dispose their page runtimes and collect coverage before closing the
+Each browser launches in its own Unix process group. `BrowserProcess.close()`
+sends `SIGKILL` to that group, including renderers that outlive the root, and
+waits for root exit and both output streams to reach EOF before profile removal.
+Test callers dispose their page runtimes and collect coverage before closing the
 browser. Process termination does not wait for the browser's event loop to
 handle a signal. An output reader failure is propagated after the browser
 process has been reaped. A browser's exit and its output reaching EOF are
 separate events: inherited descriptors can outlive the process that opened
-them. When investigating a teardown stall,
-capture every holder of the pipe, including detached updater processes, and
-record assertion completion separately from suite and process completion.
+them. Detached crash handlers can outlive the group and remain covered by the
+EOF wait. When investigating a teardown stall, capture every holder of the
+pipe, including renderers and detached updater processes, and record assertion
+completion separately from suite and process completion.
 
 ### Focused browser regressions
 

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -88,6 +88,22 @@ If a browser command did run inside the agent sandbox, disregard its
 browser-startup failure and rerun it outside the sandbox before interpreting
 the test result.
 
+### Browser process cleanup
+
+The integration browser launcher uses the installed Chrome selected by
+`packages/integration/astral-adapter.ts`; `ASTRAL_BIN_PATH` overrides that
+selection. Chrome launches include `--disable-updater-scheduler` so an
+ephemeral test profile cannot start maintenance of the installed browser.
+Detached updater crash handlers can inherit Chrome's stderr and keep it open
+after the browser exits. Chrome's own crash reporting remains enabled.
+
+`BrowserProcess.close()` signals the browser and waits for its exit status
+and both output streams to reach EOF before profile removal. A browser's exit
+and its output reaching EOF are separate events: inherited descriptors can
+outlive the process that opened them. When investigating a teardown stall,
+capture every holder of the pipe, including detached updater processes, and
+record assertion completion separately from suite and process completion.
+
 ### Focused browser regressions
 
 A package can reserve a `*.browser.test.ts` file for DOM behavior that needs a

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -97,10 +97,14 @@ ephemeral test profile cannot start maintenance of the installed browser.
 Detached updater crash handlers can inherit Chrome's stderr and keep it open
 after the browser exits. Chrome's own crash reporting remains enabled.
 
-`BrowserProcess.close()` signals the browser and waits for its exit status
-and both output streams to reach EOF before profile removal. A browser's exit
-and its output reaching EOF are separate events: inherited descriptors can
-outlive the process that opened them. When investigating a teardown stall,
+`BrowserProcess.close()` sends `SIGKILL` to the browser and waits for its exit
+status and both output streams to reach EOF before profile removal. Test
+callers dispose their page runtimes and collect coverage before closing the
+browser. Process termination does not wait for the browser's event loop to
+handle a signal. An output reader failure is propagated after the browser
+process has been reaped. A browser's exit and its output reaching EOF are
+separate events: inherited descriptors can outlive the process that opened
+them. When investigating a teardown stall,
 capture every holder of the pipe, including detached updater processes, and
 record assertion completion separately from suite and process completion.
 

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -110,6 +110,9 @@ EOF wait. When investigating a teardown stall, capture every holder of the
 pipe, including renderers and detached updater processes, and record assertion
 completion separately from suite and process completion.
 
+Browser tests require macOS or Linux. The launcher rejects other platforms
+before it starts a browser.
+
 ### Focused browser regressions
 
 A package can reserve a `*.browser.test.ts` file for DOM behavior that needs a

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -156,6 +156,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Investigations, journals, and working notes
 
+- [Browser process-group teardown follow-up, 2026-09-11](development/browser-process-group-teardown-2026-09-11.md) — Orphan renderers retaining browser pipes, explicit process-group ownership, and cleanup regression validation.
+
 - [Browser teardown investigation, 2026-09-11](development/browser-teardown-investigation-2026-09-11.md) — Current Chrome, detached Crashpad/updater pipe holders, controlled descriptor reproduction, and ON/OFF prototype validation.
 
 - [Scoped snapshot memo verification](development/performance/2026-09-10-scoped-snapshot-memo.md) — D3 metadata/epoch isolation regressions and exact label-view reuse counts at three sizes.

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -156,6 +156,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Investigations, journals, and working notes
 
+- [Browser teardown investigation, 2026-09-11](development/browser-teardown-investigation-2026-09-11.md) — Current Chrome, detached Crashpad/updater pipe holders, controlled descriptor reproduction, and ON/OFF prototype validation.
+
 - [Scoped snapshot memo verification](development/performance/2026-09-10-scoped-snapshot-memo.md) — D3 metadata/epoch isolation regressions and exact label-view reuse counts at three sizes.
 
 - [Pattern read accounting: first-batch baseline](development/performance/2026-09-pattern-read-accounting.md) — 2026-09-10: transaction-scoped read counters, generic reduction update costs, headless lunch-poll attribution, and instrumentation overhead measurements.

--- a/docs/history/development/browser-process-group-teardown-2026-09-11.md
+++ b/docs/history/development/browser-process-group-teardown-2026-09-11.md
@@ -1,0 +1,88 @@
+---
+status: historical
+created: 2026-09-11
+archived: 2026-09-11
+reason: "Follow-up capture of orphan renderer pipe retention and process-group cleanup validation."
+---
+
+# Browser process-group teardown follow-up, 2026-09-11
+
+A follow-up to the [initial investigation](browser-teardown-investigation-2026-09-11.md)
+found an additional reason root-only termination is insufficient. This work is
+part of [PR 7342](https://github.com/commontoolsinc/labs/pull/7342), based on
+`be73306e5ee16d0e5a26fd8c6c9d1e29c6c5c19d`. The initial investigation's base and
+failed attempts remain in its frozen report.
+
+## Renderer retention after root exit
+
+The uninstrumented `full-on-clean-02` run used commit
+`18ddc617d7d894c0cf9504e30d6427e5e9f18192`, which suppressed Chrome's updater
+scheduler and killed the browser root with `SIGKILL`. Its voting assertion
+passed, but lunch-poll teardown remained pending. The root Chrome had exited.
+At the September 11, 17:44:50 UTC capture:
+
+- Deno PID 74564 still held stdout and stderr read ends.
+- Orphan renderer PIDs 83859 and 85470, both reparented to PID 1, retained both
+  write ends. Both were in the investigation test's process group 74564 and
+  named its private `integration-browser-64b0a27b514abba4` profile.
+- Chrome Crashpad PID 83801 retained the same stderr write end.
+- The stdout pair was `0x911612f9c213bdd6` / `0xcb0a8cf60333a5ad`; the stderr
+  pair was `0x10a5463b40b14ef` / `0xa1bf753e98f6310d`.
+
+The helpers subsequently exited without intervention. Sampling raced that exit
+and provides no explanation of their internal delay. The suite then completed
+naturally: six tests and 25 steps, including group-chat. No process was signaled
+and no test was interrupted in this run. This proves a remaining dependency on
+surviving renderers, not an infinite native deadlock or a measured latency
+regression. Machine load was high and variable; no benchmark claim is made.
+
+## Process ownership and correction
+
+Each browser now launches with Deno's `detached: true`, creating a separate Unix
+process group on the supported macOS and Linux platforms. Cleanup sends
+`SIGKILL` to that owned group, including surviving renderers, while keeping the
+test runner and other browsers outside the target group. It still awaits the
+root status and both output streams. Detached crash handlers remain covered by
+the EOF wait. Updater scheduling remains disabled for ephemeral Chrome launches.
+
+Deno reports an absent group as `Deno.errors.NotFound` (`ESRCH`), rather than
+the terminated-child `TypeError` from `ChildProcess.kill()`. Cleanup recognizes
+only that absent-group case and propagates other signal failures. An output
+reader failure still waits for root reaping before it propagates.
+
+The regression suite establishes a distinct browser group, terminates a child
+that survives root exit, and separately verifies that an inherited stderr held
+outside the group keeps cleanup pending until stdin EOF releases the holder.
+The detached helper uses the current Deno binary with `--no-config --no-lock`
+and no imports. A suspended-root case guards against cooperative termination.
+An actual installed-Chrome diagnostic suspended the entire owned group and
+then completed browser close, output cleanup, and profile removal.
+
+## Validation and evidence
+
+The integration package passed 61 tests and 79 steps; deno-web-test passed 38
+tests and 20 steps. The focused browser-process suite passed 23 steps. Repository
+formatting, lint, type checks, and all 599 checked documentation examples passed.
+
+Current Chrome remained 153.0.8010.36, selected normally with `ASTRAL_BIN_PATH`
+unset. Deno remained 2.9.4. The fresh ON integration run of the full affected
+five-file workload completed naturally with six tests and 25 steps. The matching
+OFF run also completed naturally with six tests and 25 steps. Per-arm
+servers used fresh stores and matching server, client, and baked-shell execution
+posture. The server binaries retained the same underlying runtime code as the
+PR base; the process-group change is in the test launcher.
+
+Evidence is retained under
+`/Users/berni/.codex/artifacts/browser-teardown-pr-2026-09-11`: exact run commands,
+manifests, output logs, patches, process snapshots, load, server posture, binary
+hashes, `metadata/renderer-retention.json`, and both capture directories named
+there. The initial failed group prototype exposed the distinct ESRCH error and
+is retained alongside the corrected run. A diagnostic invocation missing its
+workspace config failed before launching Chrome and is retained separately.
+The original investigation and supplied prior reports were not edited.
+
+The correction does not supervise arbitrary processes that create independent
+groups and redirect their output. It preserves the output barrier for detached
+helpers, and the native reason the observed renderers delayed exit remains
+unresolved. Chrome and its updater should also isolate descriptors belonging to
+detached maintenance services, as described in the initial investigation.

--- a/docs/history/development/browser-teardown-investigation-2026-09-11.md
+++ b/docs/history/development/browser-teardown-investigation-2026-09-11.md
@@ -1,0 +1,252 @@
+---
+status: historical
+created: 2026-09-11
+archived: 2026-09-11
+reason: "Investigation snapshot of current-Chrome teardown, descriptor retention, and updater-isolation validation."
+---
+
+# Browser teardown investigation, 2026-09-11
+
+The inherited-stderr mechanism reproduced on fresh main with the installed
+Chrome. It involved **both Chrome Crashpad and GoogleUpdater crash handlers**.
+The narrow prototype prevents Chrome test launches from scheduling installed
+browser maintenance. It does not replace lifecycle waits with a timer and does
+not establish that all current-browser teardown failures are fixed.
+
+## Provenance and environment
+
+- Base: `263057f5deb76c93def7fa89ad9ffd386bb40d66`, fetched from
+  `commontoolsinc/labs` origin/main on September 11.
+- Baseline branch: `codex/browser-teardown-investigation`, worktree
+  `/Users/berni/.codex/worktrees/browser-teardown-investigation/labs`.
+- Prototype branch: `codex/browser-teardown-updater-isolation`, worktree
+  `/Users/berni/.codex/worktrees/browser-teardown-fix/labs`, same base.
+- `/Users/berni/src/labs` was left on its existing checkout. Other worktrees,
+  production data, execution defaults, thresholds, and enabled lanes were not
+  changed. Signals were limited to captured investigation processes.
+- macOS 26.4.1 (25E253), ARM64; Deno pin and actual fresh-login resolution:
+  2.9.4 through `/opt/homebrew/bin/deno`; V8 15.0.245.2-rusty, TypeScript 6.0.3.
+- Astral: pinned JSR `@astral/astral` 0.5.6.
+- Browser: `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`,
+  **153.0.8010.36**. Normal adapter selection, `ASTRAL_BIN_PATH` unset for
+  baseline and validation runs. No Chrome 125 run was used.
+- Executable SHA256:
+  `fe21b4086d7f035b17ce4c8ff9d1ceef88eb9510252a5b311d7a5aa48c352b32`.
+  Framework SHA256:
+  `8d46f03a86ab51c8a329dd6d106bb5275d28d4c3a8da77f120c6ddfb968577b0`.
+- Crashpad executable SHA256:
+  `ad0dc3566ba0eb1e56ba4e253052a24abe85edda4de4149a32462276a13bbc05`.
+  The full executable paths are in `metadata/binary-hashes.json`.
+  Installed GoogleUpdater was 152.0.7933.0, hash in that same file.
+- Machine load was high and variable, including a one-minute load near 198.
+  Every run records load and process snapshots. Repository benchmark isolation
+  was not established; durations are observations of lifecycle completion,
+  **not latency comparisons or performance claims**. One failed ON run overlapped
+  our repository type check, in addition to unrelated machine work.
+
+Evidence root: `/Users/berni/.codex/artifacts/browser-teardown-2026-09-11`.
+Paths below are relative to that root unless explicitly repository paths.
+
+## Blocking chain on current main
+
+The repository, not Astral's `Browser.close()`, owns the relevant process wait.
+`packages/integration/browser-process.ts` launches `Deno.Command` with stdout
+and stderr piped. It reads the DevTools endpoint from stderr, then continuously
+drains both streams. `stopBrowserProcess()` signals the root Chrome, awaits
+both drains, and then awaits `child.status`. It suppresses only recognized
+already-exited errors. `BrowserProcess.close()` finally disconnects Astral;
+`Browser.close()` subsequently removes the private profile directory.
+
+Astral 0.5.6's own close asks CDP to close the browser and has a timed process
+fallback; Labs bypasses that method. Labs still uses Astral's page close and
+websocket disconnect. Page close uses the DevTools HTTP close-target endpoint.
+The repository holds the process and pipe handles; readers own their stream
+locks, and there is no cancellation of an inherited pipe during normal close.
+
+`ShellIntegration` cleanup is sequential: presentation cleanup, page runtime
+coverage/disposal, page close, browser close. Lunch-poll registers host cleanup,
+guest cleanup, then sink cancellation and controller disposal. The pinned BDD
+runner invokes registered afterAll functions in registration order. Thus a
+browser wait blocks subsequent controller `Runtime.dispose()` and outer test
+runner cleanup. The page's own runtime disposal precedes browser close; it is
+incorrect to say no runtime disposal can have occurred.
+
+Controller disposal awaits runner/storage/scheduler work through
+`Runtime.dispose()`. On the reproduced pipe stall, the blocked browser wait
+precedes that work; there is no evidence that storage initiated that stall.
+The outer normal integration runner eventually shut down its isolated toolshed
+and shell after the diagnostic intervention released the test.
+
+### Natural reproduction and causal intervention
+
+`normal-on-01` started through `deno task integration patterns lunch-poll-vote`
+with server execution explicitly ON and a fresh store. The voting assertion
+passed. The suite did not complete. The root Chrome processes had exited.
+Deno PID 58885 fd 42 still read pipe `0x417d3396fba64a54`; Chrome Crashpad PID
+61099 held its peer `0x64eba47afca46442` on fd 2.
+
+After ps/lsof and native sampling, terminating that descriptor-proven Crashpad
+**did not unblock cleanup**. A system-wide lsof found the same write endpoint
+in GoogleUpdater crash-handler PIDs 62414 and 62418. Both started during this
+run, were absent from the before snapshot, and had the investigation's
+`packages/patterns` as cwd. Terminating these two proven holders released the
+pipe, allowed suite completion, and allowed server cleanup. Exit code zero
+therefore describes **intervention-assisted completion**, not a passing run.
+
+Captures: `captures/normal-on-01-active/`, `captures/normal-on-01-stall/`.
+Signal records, samples, pipe endpoints, updater logs, and pre-intervention
+server logs are retained. Pipe addresses can be reused after closure; matches
+across non-overlapping snapshots do not establish ownership.
+
+### Controlled descriptor reproduction
+
+`controlled-descriptor-01` uses the actual installed Chrome through an explicit
+**diagnostic-only** `ASTRAL_BIN_PATH` wrapper. The wrapper forks a detached
+helper that redirects stdin/stdout, inherits stderr, and waits on a FIFO. The
+parent execs Chrome. The wrapper is not used for integration validation.
+
+The trace establishes: page close completed; browser close began; Chrome PID
+24260 exited successfully and stdout reached EOF at 16:47:39.186Z; stderr and
+browser close remained pending. Detached helper PID 24289 held the matching
+stderr descriptor. Releasing its FIFO at 16:48:58Z closed the final write end;
+stderr EOF and BrowserProcess.close completion followed at 16:48:58.989Z, then
+profile cleanup completed. No timeout declares this success, and no helper is
+left running. See the run log, `runs/controlled-descriptor-control/`, and
+`captures/controlled-descriptor-01-held-after-exit/`.
+
+This independently proves the lifecycle dependency. It does not establish why
+Chrome's native crash handler retained every Mach right in the natural case.
+
+## Attribution and intermittency
+
+The mechanism is high-confidence: detached helper descriptor retention blocks
+the repository's EOF-based cleanup. Attribution is an interaction between
+Chrome/updater subprocess inheritance and Labs' choice of pipe EOF as a proxy
+for profile-writer completion. It is not an Astral BrowserProcess.close defect
+on this base: that class and wait are repository code.
+
+Exact Chrome-tag sources independently support the updater path:
+
+- [Browser startup checks the updater-scheduler switch](https://chromium.googlesource.com/chromium/src/+/refs/tags/153.0.8010.36/chrome/browser/chrome_browser_main.cc).
+- [The scheduler posts its initial work after 19 seconds](https://chromium.googlesource.com/chromium/src/+/refs/tags/153.0.8010.36/chrome/browser/updater/scheduler.cc).
+- [The Mac updater scheduler launches maintenance in a new process group](https://chromium.googlesource.com/chromium/src/+/refs/tags/153.0.8010.36/chrome/browser/updater/scheduler_impl.cc).
+
+Downloaded source and retrieval metadata are in `metadata/upstream/`. Crashpad
+main-branch sources show macOS subprocess launch preserving descriptors 0–2 and
+double-forking; those sources are **not proven to be the exact bundled revision**.
+Native Crashpad sampling found Mach-message/semaphore waits, not an active
+upload. Whether inherited Mach exception rights in updater processes extend
+Chrome Crashpad's lifetime remains unresolved.
+
+A short browser-only baseline run completed naturally. A held baseline browser
+also completed naturally, with stderr EOF later than root exit/stdout EOF.
+The equivalent baseline ON two-suite run completed naturally after long teardown
+intervals; updater lifecycle logs showed handlers ending at different times.
+The OFF equivalent also completed. Launch duration, whether maintenance starts,
+and when detached holders release descriptors explain the observed possibility
+of success without establishing a frequency or complete causal model of native
+helper exit. These results do not show server execution causes the browser bug.
+
+## Prototype and regression
+
+The only executable production change adds `--disable-updater-scheduler` to
+Chrome launches in `spawnBrowser()`, preserving caller arguments. Firefox is
+unchanged. Current installed Chrome and its own crash reporting stay enabled.
+The prototype retains stream draining, actual child status, error propagation,
+and profile cleanup order. It adds no sleep, retry, timeout, discarded stream,
+or success-on-interruption behavior.
+
+The launch-policy regression fails on base and passes with the switch. The
+existing real subprocess descriptor test is strengthened to establish root
+exit and stdout EOF while stderr remains held, then release the holder through
+stdin and observe close completion. Fake-launch failures continue to propagate;
+a Firefox case checks that the Chrome-specific switch is absent. The complete
+integration package passed: 61 tests, 75 steps. Repository fmt, lint, and type
+checking passed. A held real-Chrome prototype diagnostic also completed with
+both streams and status accounted for.
+
+This is a narrow mitigation and an appropriate upstreamable launch policy,
+not a general solution to unmanaged subprocess lifetime. Upstream Chrome/
+GoogleUpdater should explicitly redirect detached maintenance-service standard
+descriptors and investigate inherited Mach exception rights. A broader Labs
+change needs explicit ownership/reaping of all profile writers before releasing
+streams or removing the profile. Cancelling stderr or timing out the wait alone
+would hide ownership failures. No such broad change is claimed here.
+
+## Validation and limitations
+
+| Run | Arm / scope | Outcome |
+| --- | --- | --- |
+| normal-on-01 | Base ON, normal lunch-poll lane | Assertion pass, pipe stall; intervention-assisted exit 0, not a pass |
+| baseline-off-01 | Base OFF, lunch-poll + group-chat | 2 tests / 2 steps passed; natural completion |
+| baseline-on-02 | Base ON, same two files | 2 tests / 2 steps passed; natural completion after long teardown intervals |
+| fixed-on-01 | Prototype ON | Missing prior-only file; no tests ran |
+| fixed-on-02 | Prototype ON, full affected workload | Lunch assertion failure, live-Chrome delay, intervention and interruption; not a pass |
+| fixed-off-01 | Prototype OFF, full affected workload | 6 tests / 25 steps passed; natural completion |
+| fixed-on-diagnostic-03 | Prototype ON, same workload with preload | 6 tests / 25 steps passed; all disposal phases completed; diagnostic only |
+| fixed-on-04 | Prototype ON, same workload without preload | 6 tests / 25 steps passed; natural completion |
+
+The final uninstrumented ON and OFF runs used current Chrome with no browser
+override. Their servers also shut down with exit zero. Binary hashes were
+rechecked unchanged after validation. This is one successful uninstrumented
+prototype run per arm, not a measured flake-rate reduction or proof that the
+earlier assertion failure and live-Chrome delay are fixed. A separate
+instrumented ON run completed page/runtime/process/stream cleanup in order.
+All shorter controls, regressions, builds, static checks, server runs, failures,
+and interventions remain in `run-ledger.json`.
+
+A self-review through `cf-review` found the executable change confined to
+Chrome launch policy, with caller arguments, Firefox, stream waits, child
+status, and errors preserved. It corrected misleading comments that equated
+pipe EOF with all descendant processes exiting. The unresolved validation
+failure above is a limitation of the recommendation, not a reason to discard
+that run. No upstream issue, PR, merge, deployment, or production change was
+made.
+
+The first attempted five-suite prototype invocation accidentally named the
+prior campaign's `topic-board-seed.test.ts`, absent on this base; import failure
+occurred before tests. It remains in the ledger as `fixed-on-01`. The actual
+current workload names topic-board-fixture, topic-board-child-contract,
+topic-create-onscreen, lunch-poll-vote, and cfc-group-chat-demo-two-browsers.
+These five files contain six top-level tests. This is the full affected
+workload, not a claim to have run every unrelated pattern integration test.
+
+The unsuccessful `fixed-on-02` ON run must remain visible: lunch-poll failed
+after host profile-name fill, with a policy-rejected write, before voting.
+During subsequent teardown Chrome PID 18605 was still alive, unlike the
+original exited-root pipe stall. Its native sample included a worker waiting
+in `SecItemCopyMatching`/securityd IPC. That stack does not prove the main
+shutdown dependency or identify its cause. The root was force-stopped after
+captures, which let the suite advance; the test process was later interrupted
+while group-chat was pending. It is neither a successful run nor proof that the
+updater flag fixes the separate live-Chrome failure. The uninstrumented capture
+cannot determine every pending JS cleanup phase in that attempt.
+
+## Reproduction commands and retained evidence
+
+Every execution attempt, including failures and interventions, has
+`runs/<name>/manifest.json`, exact argv, selected environment, source head,
+diff summary, start/end load, process snapshots, and `output.log`. The
+machine-readable ledger links these runs and separately classifies outcomes.
+Full patches, selected exact base sources and hashes, installed binary hashes,
+compiled per-arm toolshed binaries, upstream source snapshots, native samples,
+pipe captures, and diagnostic scripts are retained.
+
+`build-on` and `build-off` compile toolshed and its baked shell with explicit
+matching execution values and the exact base SHA. Each test arm uses a new
+store and a private port. Saved `/api/meta` verifies SHA, server flag, and
+`shellServerExecutionDefine`; health stats verify presence/absence of serving
+execution. Client test processes carry the same explicit flag. The OFF health
+response omits `servingLoop`; the diagnostic posture script was corrected to
+accept that documented representation, without changing the server or tests.
+
+The diagnostic scripts contain instrumentation outside the repository. Normal
+runs use no preload or browser override. Run manifests are authoritative for
+which is which. No older-browser control is counted as validation.
+
+The supplied prior reports were opened only after writing
+`metadata/independent-explanation-01.md`. They support an earlier exited-Chrome,
+Crashpad-held-pipe observation; this investigation adds updater holders and
+causal release. Their original bytes were preserved; hashes are retained in
+`metadata/prior-hashes.json`. The prior campaign's six-file workload
+included a seed test not present on this main SHA.

--- a/packages/deno-web-test/README.md
+++ b/packages/deno-web-test/README.md
@@ -100,14 +100,16 @@ disables Chrome's updater scheduler so detached maintenance services cannot
 inherit the test browser's output pipes. Chrome's own crash reporting remains
 enabled.
 
-Closing the browser sends `SIGKILL` to its root process and waits for its exit
-status and both output pipes to reach end of file. A child that inherits a pipe
-holds its write end until it exits or closes that descriptor; EOF establishes
-that those descriptors are closed, not that every descendant has exited. Both
-pipes are drained continuously because an unread pipe can fill and block its
-writer. Profile removal follows the process and output waits. The spawning and
-the waits belong to [`BrowserProcess`](../integration/browser-process.ts), which
-the browser integration tests also use.
+Each browser launches in its own Unix process group. Closing it sends `SIGKILL`
+to that group and waits for the root's exit status and both output pipes to
+reach end of file. This also stops renderers that outlive the root. A child that
+inherits a pipe holds its write end until it exits or closes that descriptor;
+EOF establishes that those descriptors are closed, not that every descendant has
+exited. Both pipes are drained continuously because an unread pipe can fill and
+block its writer. Profile removal follows the process and output waits. The
+spawning and the waits belong to
+[`BrowserProcess`](../integration/browser-process.ts), which the browser
+integration tests also use.
 
 ## Support
 

--- a/packages/deno-web-test/README.md
+++ b/packages/deno-web-test/README.md
@@ -95,19 +95,19 @@ names, every missing parent included, whenever it writes into it, so the removal
 has to follow the last of Chrome's processes rather than the browser process,
 which the crash handler and the rendering processes outlive.
 
-The harness spawns Chrome itself and attaches astral to the running browser with
-`connect()`. Every process Chrome starts inherits the two pipes the browser was
-spawned with, and holds a pipe until it exits or closes that pipe, so spawning
-the browser here is what keeps those pipes in reach. The wait is for the read
-ends of both to reach end of file, which is once the last process holding either
-of them has gone, whichever of the two it held. Piping standard output as well
-keeps what the browser writes out of the harness's own output, which a spawn
-leaves inherited for any stream it asks no pipe for. Both pipes are read to the
-end rather than left alone, because a pipe nobody reads fills up and stops the
-process writing into it, and what a browser writes says nothing the run acts on.
-Closing the browser returns on that end of file, and the removal follows. The
-spawning and the wait are [`BrowserProcess`](../integration/browser-process.ts),
-which the browser integration tests use for the same reason.
+The harness spawns Chrome itself and attaches astral with `connect()`. It
+disables Chrome's updater scheduler so detached maintenance services cannot
+inherit the test browser's output pipes. Chrome's own crash reporting remains
+enabled.
+
+Closing the browser sends `SIGKILL` to its root process and waits for its exit
+status and both output pipes to reach end of file. A child that inherits a pipe
+holds its write end until it exits or closes that descriptor; EOF establishes
+that those descriptors are closed, not that every descendant has exited. Both
+pipes are drained continuously because an unread pipe can fill and block its
+writer. Profile removal follows the process and output waits. The spawning and
+the waits belong to [`BrowserProcess`](../integration/browser-process.ts), which
+the browser integration tests also use.
 
 ## Support
 

--- a/packages/deno-web-test/test/temporary-directories.test.ts
+++ b/packages/deno-web-test/test/temporary-directories.test.ts
@@ -10,10 +10,9 @@
  * that a run making no such directory would fail there rather than pass
  * silently here.
  *
- * `BrowserProcess.close()` returns once every process holding the browser's
- * output pipes has gone, and the run closes the browser before it returns.
- * Nothing the run started is writing into the directory while it is read
- * below.
+ * The run closes the browser before it returns. `BrowserProcess.close()`
+ * waits for the browser's exit and the closure of inherited output pipes;
+ * profile removal follows those waits.
  */
 
 import { describe, it } from "@std/testing/bdd";

--- a/packages/integration/browser-process.ts
+++ b/packages/integration/browser-process.ts
@@ -290,6 +290,11 @@ export class BrowserProcess {
    * that starts and then fails to connect is stopped before this throws.
    */
   static async start(options: LaunchOptions): Promise<BrowserProcess> {
+    if (Deno.build.os !== "darwin" && Deno.build.os !== "linux") {
+      throw new Error(
+        `Browser tests require macOS or Linux; received ${Deno.build.os}.`,
+      );
+    }
     const spawned = await spawnBrowser(options);
     try {
       const browser = await connectToBrowser(

--- a/packages/integration/browser-process.ts
+++ b/packages/integration/browser-process.ts
@@ -3,17 +3,16 @@
  * way the caller can wait out.
  *
  * Chrome recreates the directory `--user-data-dir` names, every missing parent
- * included, whenever it writes into it, and the crash handler and rendering
- * processes it starts outlive the browser process. Removing the profile
- * directory while one of those is alive puts the directory back, so the
- * removal has to follow the last process in the tree, and
- * `Deno.ChildProcess.status` covers one process.
+ * included, whenever it writes into it. Its rendering and utility processes
+ * can keep writing after the browser process exits, so removing the profile
+ * must wait for those writers too. `Deno.ChildProcess.status` covers one
+ * process.
  *
- * Every process in the tree inherits the two pipes the browser was spawned
- * with, and holds a pipe until it exits or closes that pipe. Both read ends
- * are waited for, so the wait ends once the last process holding either of
- * them has gone. Piping both also keeps the browser's output out of the
- * caller's own, which a spawn leaves inherited for any stream it asks no pipe
+ * Both output pipes are drained until their inherited write ends close.
+ * Chrome's installed updater is excluded from these launches: its detached
+ * services can retain the pipes independently of the browser's profile.
+ * Piping both also keeps the browser's output out of the caller's own,
+ * which a spawn leaves inherited for any stream it asks no pipe
  * for. The browser is spawned here and astral attached to the running browser,
  * which is what keeps those pipes in reach.
  */
@@ -41,7 +40,7 @@ import { isChildProcessGone } from "./astral-adapter.ts";
  */
 export const BOOT_FAILURE_MESSAGE = "Your binary refused to boot";
 
-/** A browser that has started, and how to reach and wait out its tree. */
+/** A browser that has started, its endpoint, and its output completion. */
 type SpawnedBrowser = {
   /** The browser process. */
   child: Deno.ChildProcess;
@@ -58,8 +57,8 @@ type SpawnedBrowser = {
  * read from it.
  *
  * A process that inherits a pipe holds its write end open until it exits or
- * closes the descriptor, and a browser closes neither, so for a browser and
- * everything it starts this is the point at which the last of them has gone.
+ * closes the descriptor. EOF establishes that no writer holds this pipe;
+ * it does not establish the exit of processes that redirected their output.
  * What is read is discarded rather than left unread because a full pipe blocks
  * the process writing into it.
  */
@@ -72,7 +71,7 @@ export async function readToEnd(
 }
 
 /**
- * Kills `child` and returns once every process in its tree has exited.
+ * Kills `child` and waits for its output to close and its exit status to settle.
  *
  * `closed` is what `readBrowserOutput()` reported for the same child. A
  * browser asked to close over the protocol is usually still shutting down when
@@ -98,9 +97,9 @@ export async function stopBrowserProcess(
  * Reads the browser's standard output and standard error to the end of both,
  * and reports the developer-tools endpoint named in the latter.
  *
- * The endpoint is reported while the reads carry on, because the pipes are
- * what say when the browser's processes have gone and a pipe nobody reads
- * fills up and stops the process writing into it. Output that ends without
+ * The endpoint is reported while the reads carry on, because a pipe nobody
+ * reads fills up and stops the process writing into it. The reads finish once
+ * all inherited write ends close. Output that ends without
  * naming an endpoint is a browser that never started: it is written out, and
  * the endpoint fails.
  */
@@ -161,7 +160,11 @@ async function spawnBrowser(options: LaunchOptions): Promise<SpawnedBrowser> {
     await getBinary(product, { cache: options.cache });
   const args = generateBinArgs(product, {
     launchPresets: options.launchPresets,
-    args: options.args,
+    // An ephemeral test browser must not start maintenance of the installed
+    // browser. Updater crash handlers can retain stderr after Chrome exits.
+    args: product === "chrome"
+      ? ["--disable-updater-scheduler", ...(options.args ?? [])]
+      : options.args,
     headless: options.headless,
   });
 
@@ -224,7 +227,7 @@ async function connectToBrowser(
   });
 }
 
-/** A running browser, and the process tree the run can wait out. */
+/** A running browser with an owned process, connection, and output streams. */
 export class BrowserProcess {
   #child: Deno.ChildProcess;
   #outputClosed: Promise<void>;
@@ -262,8 +265,8 @@ export class BrowserProcess {
   }
 
   /**
-   * Closes the browser and returns once every process holding the browser's
-   * output has closed it, which is once the last of them has exited.
+   * Closes the browser and waits for its process to exit and both output
+   * streams to reach EOF.
    *
    * The browser is stopped by the signal rather than by astral's `close()`,
    * which asks over the browser's connection and waits for an answer. A

--- a/packages/integration/browser-process.ts
+++ b/packages/integration/browser-process.ts
@@ -71,26 +71,29 @@ export async function readToEnd(
 }
 
 /**
- * Kills `child` and waits for its output to close and its exit status to settle.
+ * Kills `child` with `SIGKILL` and waits for its output and exit status.
  *
- * `closed` is what `readBrowserOutput()` reported for the same child. A
- * browser asked to close over the protocol is usually still shutting down when
- * the kill lands, and is occasionally gone already, which throws rather than
- * doing nothing.
+ * `closed` is what `readBrowserOutput()` reported for the same child. Process
+ * termination must complete without cooperation from the browser's event
+ * loop. Output remains drained while the browser's children shut down, and an
+ * output failure is reported only after the root process has been reaped.
  */
 export async function stopBrowserProcess(
   child: Pick<Deno.ChildProcess, "kill" | "status">,
   closed: Promise<void>,
 ): Promise<void> {
   try {
-    child.kill();
+    child.kill("SIGKILL");
   } catch (error) {
     if (!isChildProcessGone(error)) {
       throw error;
     }
   }
-  await closed;
-  await child.status;
+  try {
+    await closed;
+  } finally {
+    await child.status;
+  }
 }
 
 /**

--- a/packages/integration/browser-process.ts
+++ b/packages/integration/browser-process.ts
@@ -31,8 +31,6 @@ import {
   websocketReady,
 } from "@astral/astral";
 
-import { isChildProcessGone } from "./astral-adapter.ts";
-
 /**
  * The message a launch throws when the browser exited without naming an
  * endpoint. Exported so that whoever decides what to do about such a launch
@@ -71,21 +69,23 @@ export async function readToEnd(
 }
 
 /**
- * Kills `child` with `SIGKILL` and waits for its output and exit status.
+ * Kills the process group led by `child` and waits for output and root status.
  *
- * `closed` is what `readBrowserOutput()` reported for the same child. Process
- * termination must complete without cooperation from the browser's event
- * loop. Output remains drained while the browser's children shut down, and an
- * output failure is reported only after the root process has been reaped.
+ * `closed` is what `readBrowserOutput()` reported for the same child.
+ * The child must have been spawned with `detached: true`, which creates its
+ * own process group on the supported Unix platforms. Killing that group also
+ * stops renderers that outlive the root, without signaling the test runner.
+ * Output remains drained until detached helpers release their descriptors.
+ * An output failure is reported only after the root has been reaped.
  */
 export async function stopBrowserProcess(
-  child: Pick<Deno.ChildProcess, "kill" | "status">,
+  child: Pick<Deno.ChildProcess, "pid" | "status">,
   closed: Promise<void>,
 ): Promise<void> {
   try {
-    child.kill("SIGKILL");
+    Deno.kill(-child.pid, "SIGKILL");
   } catch (error) {
-    if (!isChildProcessGone(error)) {
+    if (!(error instanceof Deno.errors.NotFound)) {
       throw error;
     }
   }
@@ -181,6 +181,7 @@ async function spawnBrowser(options: LaunchOptions): Promise<SpawnedBrowser> {
 
   const child = new Deno.Command(binary, {
     args,
+    detached: true,
     stdout: "piped",
     stderr: "piped",
   }).spawn();

--- a/packages/integration/browser.ts
+++ b/packages/integration/browser.ts
@@ -22,7 +22,7 @@ export const PROFILE_DIRECTORY_PREFIX = "integration-browser-";
 // Wrapper around `@astral/astral`'s `Browser`.
 //
 // Each browser keeps its profile in a temporary directory of its own, which
-// `close()` removes once the browser and everything it started has exited. A
+// `close()` removes after the browser exits and its output streams end. A
 // browser nothing closes leaves that directory behind, so a caller holds one
 // for as long as it holds the browser.
 export class Browser {
@@ -123,8 +123,8 @@ export class Browser {
       });
       return new Browser(process, profileDir, { timeout });
     } catch (error) {
-      // A launch that threw has stopped whatever it started, and hands back no
-      // browser for anyone to close the directory with. The launch failure is
+      // A failed launch completes its process and output cleanup, and hands
+      // back no browser for anyone to close the directory with. The failure is
       // the diagnosis, so a removal that fails as well is carried alongside it
       // rather than in its place.
       try {

--- a/packages/integration/test/browser-process.test.ts
+++ b/packages/integration/test/browser-process.test.ts
@@ -130,12 +130,52 @@ describe("browser-process", () => {
   });
 
   describe("stopBrowserProcess()", () => {
-    it("ends a running process with `SIGTERM`", async () => {
+    it("ends a running process with `SIGKILL`", async () => {
       const child = shell("read line", { stdin: "piped" });
 
       await stopBrowserProcess(child, readToEnd(child.stderr));
 
-      expect((await child.status).signal).toBe("SIGTERM");
+      expect((await child.status).signal).toBe("SIGKILL");
+    });
+
+    it("ends a suspended process without resuming its event loop", async () => {
+      const child = shell("read line", { stdin: "piped" });
+      child.kill("SIGSTOP");
+
+      try {
+        await stopBrowserProcess(child, readToEnd(child.stderr));
+
+        expect((await child.status).signal).toBe("SIGKILL");
+      } finally {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // A completed stop has already reaped this process.
+        }
+        await child.status;
+      }
+    });
+
+    it("reaps the browser before reporting an output reader failure", async () => {
+      const child = shell("read line", { stdin: "piped" });
+      const readFailure = new Error("Could not read browser output");
+      let exited = false;
+      const status = child.status.then((status) => {
+        exited = true;
+        return status;
+      });
+
+      try {
+        await expect(stopBrowserProcess({
+          kill: (signal) => child.kill(signal),
+          status,
+        }, Promise.reject(readFailure))).rejects.toBe(readFailure);
+
+        expect(exited).toBe(true);
+      } finally {
+        await status;
+        await readToEnd(child.stderr);
+      }
     });
 
     it("returns for a process that has already exited, leaving its exit status intact", async () => {
@@ -221,7 +261,7 @@ describe("browser-process", () => {
             .close();
 
           expect(disconnected).toBe(true);
-          expect((await child.status).signal).toBe("SIGTERM");
+          expect((await child.status).signal).toBe("SIGKILL");
         });
       });
     });

--- a/packages/integration/test/browser-process.test.ts
+++ b/packages/integration/test/browser-process.test.ts
@@ -310,6 +310,19 @@ describe("browser-process", () => {
 
     describe("static members", () => {
       describe("start()", () => {
+        it("rejects an unsupported platform before launching a browser", async () => {
+          const build = Deno.build;
+          Object.defineProperty(Deno, "build", {
+            value: { ...build, os: "windows" },
+          });
+          try {
+            await expect(BrowserProcess.start({ path: "unused-browser" }))
+              .rejects.toThrow("Browser tests require macOS or Linux");
+          } finally {
+            Object.defineProperty(Deno, "build", { value: build });
+          }
+        });
+
         it("gives each browser its own process group", async () => {
           const options = await fakeBrowser(
             "no endpoint",

--- a/packages/integration/test/browser-process.test.ts
+++ b/packages/integration/test/browser-process.test.ts
@@ -175,7 +175,7 @@ describe("browser-process", () => {
       const started = await stdout.read();
       expect(new TextDecoder().decode(started.value)).toBe("started\n");
 
-      // Each of the three events reaches the list from the event loop, so a
+      // Each event reaches the list from the event loop, so a
       // stop that returned on the shell's exit alone would record itself
       // between the other two rather than after them.
       const events: string[] = [];
@@ -184,11 +184,19 @@ describe("browser-process", () => {
       });
       await child.status;
       events.push("shell exited");
+      expect((await stdout.read()).done).toBe(true);
+      events.push("stdout ended");
+      expect(events).toEqual(["shell exited", "stdout ended"]);
       await child.stdin.close();
       events.push("released");
       await stopping;
 
-      expect(events).toEqual(["shell exited", "released", "stopped"]);
+      expect(events).toEqual([
+        "shell exited",
+        "stdout ended",
+        "released",
+        "stopped",
+      ]);
     });
   });
 
@@ -220,6 +228,38 @@ describe("browser-process", () => {
 
     describe("static members", () => {
       describe("start()", () => {
+        it("keeps Chrome launches from scheduling the installed updater", async () => {
+          const options = await fakeBrowser(
+            "no endpoint",
+            1,
+            'printf \'%s\\n\' "$@" > "$0.args"',
+          );
+
+          await expect(BrowserProcess.start(options)).rejects.toThrow(
+            BOOT_FAILURE_MESSAGE,
+          );
+
+          const args = (await Deno.readTextFile(`${options.path}.args`))
+            .trim().split("\n");
+          expect(args).toContain("--disable-updater-scheduler");
+          expect(args).toContain(options.args[0]);
+        });
+
+        it("leaves Firefox launches free of Chrome updater switches", async () => {
+          const options = await fakeBrowser(
+            "no endpoint",
+            1,
+            'printf \'%s\\n\' "$@" > "$0.args"',
+          );
+
+          await expect(BrowserProcess.start({ ...options, product: "firefox" }))
+            .rejects.toThrow(BOOT_FAILURE_MESSAGE);
+
+          const args = (await Deno.readTextFile(`${options.path}.args`))
+            .trim().split("\n");
+          expect(args).not.toContain("--disable-updater-scheduler");
+        });
+
         it("throws when the browser exits without naming an endpoint", async () => {
           const options = await fakeBrowser("no endpoint", 1);
 

--- a/packages/integration/test/browser-process.test.ts
+++ b/packages/integration/test/browser-process.test.ts
@@ -12,6 +12,7 @@
 import type { Browser as AstralBrowser } from "@astral/astral";
 import { expect } from "@std/expect";
 import { afterEach, describe, it } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
 
 import {
   BOOT_FAILURE_MESSAGE,
@@ -26,31 +27,30 @@ import {
 // listening socket, or a process from outliving a failure.
 const madeByTest: (() => Promise<void>)[] = [];
 
-// A shell that starts `cat` in the background, says so on its standard output,
-// and then waits. `cat` inherits the standard error the shell was spawned with
-// and holds it until its own standard input reaches end of file, which the
-// test brings about by closing the shell's standard input. The redirection
+// A shell that starts `cat` in the background, announces it, and exits. `cat`
+// retains stderr until it is killed or its stdin reaches EOF. The redirection
 // through file descriptor 3 is what gets that pipe to `cat`: a background
 // job's standard input is /dev/null unless it is redirected explicitly.
-const HOLDS_STANDARD_ERROR =
-  "exec 3<&0; cat <&3 >/dev/null & echo started; wait";
+const HOLDS_STANDARD_ERROR = "exec 3<&0; cat <&3 >/dev/null & echo started";
 
-// Spawns `script` under `sh` with its standard error piped, and registers the
-// kill and the closing of its standard input.
-function shell(
-  script: string,
+// Spawns a command in its own process group with stderr piped, and registers
+// group termination and the closing of its standard input.
+function spawn(
+  binary: string,
+  args: string[],
   streams: { stdin?: "piped" | "null"; stdout?: "piped" | "null" } = {},
 ): Deno.ChildProcess {
   const stdin = streams.stdin ?? "null";
-  const child = new Deno.Command("sh", {
-    args: ["-c", script],
+  const child = new Deno.Command(binary, {
+    args,
+    detached: true,
     stdin,
     stdout: streams.stdout ?? "null",
     stderr: "piped",
   }).spawn();
   madeByTest.push(async () => {
     try {
-      child.kill();
+      Deno.kill(-child.pid, "SIGKILL");
     } catch {
       // Already gone, which is where most of these tests leave it.
     }
@@ -60,6 +60,13 @@ function shell(
     await child.status;
   });
   return child;
+}
+
+function shell(
+  script: string,
+  streams: { stdin?: "piped" | "null"; stdout?: "piped" | "null" } = {},
+): Deno.ChildProcess {
+  return spawn("sh", ["-c", script], streams);
 }
 
 // More than a pipe holds, so a stand-in that writes this much to its standard
@@ -167,7 +174,7 @@ describe("browser-process", () => {
 
       try {
         await expect(stopBrowserProcess({
-          kill: (signal) => child.kill(signal),
+          pid: child.pid,
           status,
         }, Promise.reject(readFailure))).rejects.toBe(readFailure);
 
@@ -189,50 +196,85 @@ describe("browser-process", () => {
     });
 
     it("rethrows a kill failure that is not the process having gone", async () => {
+      const child = shell("read line", { stdin: "piped" });
       const refused = new Error("Operation not permitted (os error 1)");
-      const child = {
-        kill: () => {
-          throw refused;
-        },
-        status: Promise.resolve({ success: false, code: 1, signal: null }),
-      };
-
+      using _kill = stub(Deno, "kill", () => {
+        throw refused;
+      });
       await expect(stopBrowserProcess(child, Promise.resolve())).rejects
         .toThrow("Operation not permitted");
     });
 
-    it("returns after a process that outlived the one it was given has exited", async () => {
+    it("stops descendants in the owned group after the root has exited", async () => {
       const child = shell(HOLDS_STANDARD_ERROR, {
         stdin: "piped",
         stdout: "piped",
       });
+      const stdout = child.stdout.getReader();
+      madeByTest.push(() => stdout.cancel());
+      expect(new TextDecoder().decode((await stdout.read()).value)).toBe(
+        "started\n",
+      );
+      expect((await child.status).code).toBe(0);
+
+      await stopBrowserProcess(child, readToEnd(child.stderr));
+
+      expect((await stdout.read()).done).toBe(true);
+      expect((await child.status).code).toBe(0);
+    });
+
+    it("waits for inherited output held outside the owned process group", async () => {
+      // This helper has no imports or workspace dependencies. Its separate
+      // group models Crashpad's detached launch, and stdin EOF releases it.
+      const child = spawn(Deno.execPath(), [
+        "eval",
+        "--no-config",
+        "--no-lock",
+        `const child = new Deno.Command(Deno.execPath(), {
+          args: ["eval", "--no-config", "--no-lock",
+            "await Deno.stdin.readable.pipeTo(new WritableStream());"],
+          detached: true,
+          stdin: "inherit",
+          stdout: "null",
+          stderr: "inherit",
+        }).spawn();
+        console.log(child.pid);
+        await child.status;`,
+      ], { stdin: "piped", stdout: "piped" });
       const closed = readToEnd(child.stderr);
 
-      // `cat` is running by the time the shell has said so, so the kill below
-      // takes the shell without taking the holder of the pipe with it.
       const stdout = child.stdout.getReader();
       madeByTest.push(() => stdout.cancel());
       const started = await stdout.read();
-      expect(new TextDecoder().decode(started.value)).toBe("started\n");
+      const helperPid = Number(new TextDecoder().decode(started.value).trim());
+      expect(Number.isSafeInteger(helperPid) && helperPid > 0).toBe(true);
+      madeByTest.push(() => {
+        try {
+          Deno.kill(helperPid, "SIGKILL");
+        } catch {
+          // EOF has already released the detached helper on success.
+        }
+        return Promise.resolve();
+      });
 
       // Each event reaches the list from the event loop, so a
-      // stop that returned on the shell's exit alone would record itself
+      // stop that returned on the root's exit alone would record itself
       // between the other two rather than after them.
       const events: string[] = [];
       const stopping = stopBrowserProcess(child, closed).then(() => {
         events.push("stopped");
       });
       await child.status;
-      events.push("shell exited");
+      events.push("root exited");
       expect((await stdout.read()).done).toBe(true);
       events.push("stdout ended");
-      expect(events).toEqual(["shell exited", "stdout ended"]);
+      expect(events).toEqual(["root exited", "stdout ended"]);
       await child.stdin.close();
       events.push("released");
       await stopping;
 
       expect(events).toEqual([
-        "shell exited",
+        "root exited",
         "stdout ended",
         "released",
         "stopped",
@@ -268,6 +310,25 @@ describe("browser-process", () => {
 
     describe("static members", () => {
       describe("start()", () => {
+        it("gives each browser its own process group", async () => {
+          const options = await fakeBrowser(
+            "no endpoint",
+            1,
+            'printf \'%s\\n\' "$$" > "$0.pid"; ps -p "$$" -o pgid= > "$0.group"',
+          );
+
+          await expect(BrowserProcess.start(options)).rejects.toThrow(
+            BOOT_FAILURE_MESSAGE,
+          );
+
+          const pid = Number(await Deno.readTextFile(`${options.path}.pid`));
+          const group = Number(
+            await Deno.readTextFile(`${options.path}.group`),
+          );
+          expect(pid).toBeGreaterThan(0);
+          expect(group).toBe(pid);
+        });
+
         it("keeps Chrome launches from scheduling the installed updater", async () => {
           const options = await fakeBrowser(
             "no endpoint",

--- a/packages/runner/test/engine-read-through.test.ts
+++ b/packages/runner/test/engine-read-through.test.ts
@@ -241,7 +241,12 @@ describe("engine-read-through", () => {
     const tx = clientRuntime.edit();
     clientArg.withTx(tx).set({ n });
     expect((await tx.commit()).error).toBeUndefined();
-    const authoredSeq = Engine.serverSeq(engine);
+    // Only the authored input is the settlement target; the store head can
+    // already include a serving wave that followed it.
+    const authoredSeq = Engine.readState(engine, {
+      id: clientArg.getAsNormalizedFullLink().id,
+    })!.seq;
+    expect(Engine.commitClassOfSeq(engine, authoredSeq)).toBe("authored");
     await waitUntil(
       () => readWatermarkSeq(engine) >= authoredSeq,
       "watermark to reach the authored commit",
@@ -673,9 +678,27 @@ describe("engine-read-through", () => {
     });
     const creating = clientRuntime.edit();
     cell.withTx(creating).set({ made: true });
-    expect((await creating.commit()).error).toBeUndefined();
-    const authoredSeq = Engine.serverSeq(engine);
     const refreshesBefore = host.stats().storeRefreshes;
+    // Observe completion after a serving wave has landed, so the store head
+    // includes derived work as well as the authored creation.
+    const covered = Promise.withResolvers<void>();
+    const noteExecutorCommit = server.noteExecutorCommit.bind(server);
+    server.noteExecutorCommit = (notice) => {
+      noteExecutorCommit(notice);
+      const created = Engine.readState(engine, { id });
+      if (created && readWatermarkSeq(engine) >= created.seq) {
+        covered.resolve();
+      }
+    };
+    try {
+      expect((await creating.commit()).error).toBeUndefined();
+      await covered.promise;
+    } finally {
+      server.noteExecutorCommit = noteExecutorCommit;
+    }
+    const authoredSeq = Engine.readState(engine, { id })!.seq;
+    expect(Engine.commitClassOfSeq(engine, authoredSeq)).toBe("authored");
+    expect(Engine.serverSeq(engine)).toBeGreaterThan(authoredSeq);
     await waitUntil(
       () => readWatermarkSeq(engine) >= authoredSeq,
       "the watermark to cover the creating commit",


### PR DESCRIPTION
Browser assertions could pass while `afterAll` remained blocked on inherited output pipes. The investigation reproduced detached GoogleUpdater crash handlers retaining stderr after Chrome exited, then captured orphan Chrome renderers holding both pipes after root-only termination.

Unsupported platforms are rejected before browser launch; the repository targets macOS and Linux. The shared launcher now gives each browser its own Unix process group, stops that group with `SIGKILL`, and awaits root status plus both output streams before profile removal. This stops renderers that outlive the root without signaling the test runner or other browsers. Chrome launches also disable updater scheduling so ephemeral profiles cannot start detached maintenance services. Output-reader failures propagate after root reaping; absent groups are recognized through Deno's ESRCH/NotFound error, while other signal errors propagate.

Regressions cover process-group isolation, descendants surviving root exit, suspended processes, a detached helper retaining stderr outside the group, Chrome/Firefox launch policy, and error-path cleanup. The output barrier remains intact; no sleep, retry, timeout, or early stream cancellation declares teardown successful.

Validation with Deno 2.9.4 and installed Chrome 153.0.8010.36 on macOS 26.4.1, using normal browser selection with `ASTRAL_BIN_PATH` unset:

- Fresh ON and OFF: each completed all 6 tests / 25 steps across the full affected five-file workload, including lunch-poll teardown and subsequent group-chat. Each arm used a fresh store and matching server/client/baked-shell posture.
- Integration package: 61 tests / 80 steps. `deno-web-test`: 38 tests / 20 steps. The lifecycle suite includes the unsupported-platform regression (24 steps).
- Actual-Chrome diagnostic: suspend the entire owned process group, then complete browser close, output cleanup, and profile removal.
- Repository formatting, lint, type checks, all 599 checked documentation examples, and history-index validation pass.

The [initial investigation](docs/history/development/browser-teardown-investigation-2026-09-11.md) and [renderer/process-group follow-up](docs/history/development/browser-process-group-teardown-2026-09-11.md) retain the blocking chains, native attribution limits, and all earlier outcomes. The root-only follow-up eventually completed naturally after the captured renderer delay; intervention-assisted and interrupted initial runs are not counted as passes. This change does not claim to supervise arbitrary independently detached processes. Native reasons for delayed renderer/helper exit remain unresolved, and no latency claim is made under the machine's variable load.

Exact commands, manifests, patches, versions/hashes, logs, captures, and review snapshots are archived in `/Users/berni/.codex/artifacts/browser-teardown-2026-09-11` and `/Users/berni/.codex/artifacts/browser-teardown-pr-2026-09-11`. The original investigation base was `263057f5deb76c93def7fa89ad9ffd386bb40d66`; the PR was rebased and validated on `be73306e5ee16d0e5a26fd8c6c9d1e29c6c5c19d`. Execution defaults, enabled lanes, assertion thresholds, and normal current-browser selection are unchanged.

Two CI attempts on `0ed029c626` and `8f95dc5879` exposed a pre-existing runner test race: `engine-read-through` read the latest store sequence after its authored write, which can already name a derived bookkeeping commit. A controlled reproduction recorded authored sequence 3, derived target 5, and watermark 3; the unchanged wait timed out on the wrong target. The test now reads each authored document's revision, asserts its commit class, and forces observation after a serving wave. Its refresh counter baseline is captured before the write. No runtime behavior, threshold, or lane was changed. Red/green evidence and both failed CI attempts are retained under `ci/runner-7-second` and the run ledger.

The full local runner package invocation was interrupted with exit 143 after 306 module starts and no reported test failure; the corrected suite passed within it. It is retained as interrupted, not a package pass. All eight runner CI shards pass on `fa03ea7d05`; shard 7 completed 180 tests / 1,097 steps, including the corrected regression.

Final status: [CI run 34636521993](https://github.com/commontoolsinc/labs/actions/runs/34636521993) is green at `fa03ea7d05d9f11c7beec233d144140e51ed036e`: 66 successful checks and 3 expected skips, including all eight runner shards and both browser integration arms. Cubic completed review of this head with zero issues; the platform review thread is addressed and resolved. The local current-Chrome ON/OFF confirmations each passed 6 tests / 25 steps at `8f95dc5879`; the final commit changes only the runner test, with no browser or production runtime source difference.
