### PR TITLE
test(runner): waitUntil's deadline comment claims only the window

### DIFF
--- a/packages/runner/test/support/wait-until.ts
+++ b/packages/runner/test/support/wait-until.ts
@@ -5,9 +5,11 @@
  *
  * The deadline is a stuck-condition backstop, not a bound on how long the
  * awaited work may legitimately take, and a caller sizes it for that: crossing
- * it says the state never arrived, never that it arrived slowly. Which suites
- * wait this way rather than on an event, and why, is recorded under "Where the
- * polling `waitFor` stays" in `docs/development/waiting-in-tests.md`.
+ * it proves only that the predicate did not come true within the window — a
+ * fixed bound cannot tell a stuck wait from one delayed past it; the width
+ * just makes the stuck reading the likely one. Which suites wait this way
+ * rather than on an event, and why, is recorded under "Where the polling
+ * `waitFor` stays" in `docs/development/waiting-in-tests.md`.
  */
 export const waitUntil = async (
   predicate: () => boolean | Promise<boolean>,


### PR DESCRIPTION
## What

Comment-only. The doc comment in `packages/runner/test/support/wait-until.ts` claimed that crossing the deadline "says the state never arrived, never that it arrived slowly" — an absolute a fixed bound cannot earn. The sentence now states what a crossing establishes: the predicate did not come true within the window — a fixed bound cannot tell a stuck wait from one delayed past it; the width just makes the stuck reading the likely one. This is the window-relative phrasing `wait-on-delivery.ts` beside it already carries (adapted for a poll: "the predicate did not come true" rather than "no delivery satisfied the predicate"). The rest of the comment — the stuck-condition-backstop framing, the caller-sizes-it guidance, and the pointer to "Where the polling `waitFor` stays" — is unchanged.

## Why

#7272's review flagged this exact claim in the new `wait-on-delivery.ts` helper (https://github.com/commontoolsinc/labs/pull/7272#discussion_r3984225015), and that helper adopted the window-relative guarantee. The identical phrasing predates that PR in `wait-until.ts` (from #6587) and was deliberately left out of its scope, with this follow-up offered in https://github.com/commontoolsinc/labs/pull/7272#discussion_r3984321087.

The `waitUntil` bullet in `docs/development/waiting-in-tests.md` was checked and needs no touch: its "stuck-condition backstop rather than a bound at the call site" framing makes no claim about what a crossing proves, and the corrected epistemics already appear once in that section, in the wait-on-delivery paragraph #7272 added directly beneath it.

## Verification

No behavior or test changes. Repo-wide `deno fmt --check` and `deno lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

