### PR TITLE
feat(topics): version stored state and migrate legacy authors

### DIFF
--- a/packages/patterns/baselines/topics/main.tsx/20260911T180754Z-mcI7bUFztYae79gW.json
+++ b/packages/patterns/baselines/topics/main.tsx/20260911T180754Z-mcI7bUFztYae79gW.json
@@ -1,0 +1,549 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "NamesMap": {
+        "additionalProperties": {
+          "type": "unknown"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key. `\"legacy\"` records a display name\nwhose author kind is unknown.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicDemand": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "The display name, which the board's mention index copies into each\ntopic's row — the label every `@`-mention completion carries. The index\nlift states the same three-string demand for itself; this entry is the\nboard-level record of it.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "mentions": {
+            "default": [],
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "shortName": {
+            "description": "The board's name for the topic, as the topic reads it out of the board's\nnames table. The card renders it as a badge and the mention index copies\nit into the topic's universe row, so `#42` matches without expanding a\ntopic.\n\nOPTIONAL rather than defaulted, which is a fact about the compatibility\nproof: a defaulted property moves the demand's defaults below an array\nconstraint the proof cannot show stable under default insertion, while an\noptional one simply tolerates a topic that publishes none.\n\nA member's open producer contract allows any value at an undeclared\nproperty. Demanding a string there narrows that contract even when the\nproperty is optional, so `setsrc` requires an accepted compatibility\nbreak until the producer guarantees the string type. An optional\n`unknown` demand imposes no such restriction. A topic whose\nlookup has produced no value — one filed a moment ago, or one from before\nthe board numbered anything — is absent here rather than blank, and every\nconsumer treats the two the same.",
+            "tags": [
+              "42"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "mentions",
+          "$NAME",
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "names": {
+        "$ref": "#/$defs/NamesMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "The board's member namespace: each name to the topic it names, held as an\nunread reference. `addTopic` writes one key per create and `backfillNames`\none key per member it names; nothing rewrites the map whole. Reads as empty\non a board from before it numbered anything, in the default form `NamesMap`\nexplains."
+      },
+      "topics": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's durable topic list. `addTopic` appends here; direct writes\nare legitimate but unattributed, and a whole-array write forfeits the\nmergeability the verb's append keeps.",
+        "items": {
+          "$ref": "#/$defs/TopicDemand"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddTopicEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation. The authenticated principal remains the\nhuman whose identity key invoked the stream; this is the agent's explicit\ncontent-level signature under that shared principal.\n\nRequired, for the reason given on `AgentAuthoredEvent`: acceptance widens\ncompatibly and narrows only through a break, so tolerating an unsigned\ncreate is a tolerance that could never be withdrawn.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The topic's initial living-document body. A topic born with a body\nappears with it atomically — no reader observes the title-only halfway\nstate, and no follow-up `setBody` call is needed to finish a create\n(verb contract: the atomic-unit rule).",
+            "type": "string"
+          },
+          "title": {
+            "description": "The topic's title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "BackfillNamesEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent running the backfill, checked as `addTopic` checks it.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "MentionableRow": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "piece": {
+            "type": "unknown"
+          },
+          "shortName": {
+            "default": "",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "shortName",
+          "piece",
+          "$NAME"
+        ],
+        "type": "object"
+      },
+      "NamesMap": {
+        "additionalProperties": {
+          "type": "unknown"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      },
+      "NamingDeclaration": {
+        "properties": {
+          "compact": {
+            "description": "Whether the collection offers the compact spelling that joins its name to\na member's with a hyphen. Only a collection whose member names cannot\ncontain a hyphen may say so.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The collection's own name, which a binding uses to reach it. Absent when\nthe collection makes no claim about what it is bound as.",
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/$defs/NamingPolicy",
+            "description": "The policy the names are held to."
+          }
+        },
+        "required": [
+          "policy",
+          "compact"
+        ],
+        "type": "object"
+      },
+      "NamingPolicy": {
+        "properties": {
+          "allocator": {
+            "description": "What a name is made of: a monotonic sequence, a random code, a string a\nperson chose, or a derivation from the member's own content.",
+            "enum": [
+              "sequence",
+              "random",
+              "human",
+              "derived"
+            ]
+          },
+          "permanent": {
+            "description": "Whether a name, once assigned, is never retired or reassigned.",
+            "type": "boolean"
+          },
+          "reuse": {
+            "description": "Whether a retired name may be given to another member.",
+            "type": "boolean"
+          },
+          "unique": {
+            "description": "Whether a name is unique across the collection's whole history, or only\namong its current members.",
+            "enum": [
+              "history",
+              "current"
+            ]
+          }
+        },
+        "required": [
+          "unique",
+          "permanent",
+          "reuse",
+          "allocator"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key. `\"legacy\"` records a display name\nwhose author kind is unknown.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicCrossrefRow": {
+        "properties": {
+          "mentionedBy": {
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "description": "The topic this row is about. `unknown` because it is written as a\nreference and only ever compared — `equals` takes the raw link. Anything\nwider retrieves the piece instead of pointing at it: declared `object`,\nthis field reads back as the whole expanded topic, `$UI` tree included.",
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "topic",
+          "mentionedBy"
+        ],
+        "type": "object"
+      },
+      "TopicDemand": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "The display name, which the board's mention index copies into each\ntopic's row — the label every `@`-mention completion carries. The index\nlift states the same three-string demand for itself; this entry is the\nboard-level record of it.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "mentions": {
+            "default": [],
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "shortName": {
+            "description": "The board's name for the topic, as the topic reads it out of the board's\nnames table. The card renders it as a badge and the mention index copies\nit into the topic's universe row, so `#42` matches without expanding a\ntopic.\n\nOPTIONAL rather than defaulted, which is a fact about the compatibility\nproof: a defaulted property moves the demand's defaults below an array\nconstraint the proof cannot show stable under default insertion, while an\noptional one simply tolerates a topic that publishes none.\n\nA member's open producer contract allows any value at an undeclared\nproperty. Demanding a string there narrows that contract even when the\nproperty is optional, so `setsrc` requires an accepted compatibility\nbreak until the producer guarantees the string type. An optional\n`unknown` demand imposes no such restriction. A topic whose\nlookup has produced no value — one filed a moment ago, or one from before\nthe board numbered anything — is absent here rather than blank, and every\nconsumer treats the two the same.",
+            "tags": [
+              "42"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "mentions",
+          "$NAME",
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      },
+      "TopicIndexRow": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "description": "Coalesced to 0 for a cold or older topic whose derived path is absent,\nso the row itself never carries the mixed-version undefined.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Who filed the topic. A record without structured authorship materializes\nthe inert `{ kind: \"person\", name: \"\" }` default, which\n`topicAuthorLabel()` renders as `someone`."
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "shortName": {
+            "description": "The board's name for the topic. Optional rather than defaulted, unlike\nthe two above, for the reason `TopicDemand.shortName` states.",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Topics — a tracker over #topic pieces: durable units of shared attention\n(CT-1878). Deliberately minimal: no statuses, labels, or assignees; topics\nsort by last activity. Replaces Linear / GitHub issues / loose process docs\nfor the team; PR workflows stay in GitHub and arrive here as links.\n\nHeadless use: survey the whole board with one bounded read of `index` — a\nrow is its Topic, so select the row's own address alongside `title` and use\nthat canonical address as the piece for the Topic's reads and verbs.\nFile with `addTopic`, title and optional initial body in one call, then work\non the Topic directly: the body is its living document, the thread its\nappend-only deliberation. Sign every authored-content mutation with\n`agentName`; Fabric records the human principal behind the key, and the name\nsays which agent acted under it. Reference-only `mention` and `unmention`\ncalls carry no content signature.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addTopic": {
+        "$ref": "#/$defs/AddTopicEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "File a topic. The atomic unit takes the initial body with the title, so\nno reader observes a title-only halfway state and no follow-up `setBody`\nfinishes a create. Returns the created topic as its survey row — the\nreference plus the write-time facts the pattern resolved."
+      },
+      "backfillNames": {
+        "$ref": "#/$defs/BackfillNamesEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Name every unnamed member in filing order. Idempotent. A member filed\npast `addTopic` also needs a one-time link-bind of `namesTable` onto it\nbefore its row and its universe entry show the name, the same operator\nstep `mentionable` states for itself."
+      },
+      "crossrefs": {
+        "default": [],
+        "description": "The board's mention pivot, one row per topic: the topic, and the topics\nthat mention it. Published so a topic composed outside `addTopic` can be\nwired to the same table the board's own children read — the graph is\nderived once, here, and never per topic.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossrefRow"
+        },
+        "type": "array"
+      },
+      "index": {
+        "default": [],
+        "description": "The full-board survey surface: one bounded row per topic, carrying the\nscalars a survey reads. A row IS its topic, so a row's own address is the\ntopic's — `--select index[].@` reads it, and an index into this array is\nnot a stable address.",
+        "items": {
+          "$ref": "#/$defs/TopicIndexRow"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "default": [],
+        "description": "The board's mention universe, under the name the topic pattern's editor\nautocompletes over — what `addTopic` wires into each child. One derived\ndocument of copies, each holding its topic as an unread reference and\ncarrying the board's name for it, rather than the topics themselves, so a\nreader of the universe expands no topic and `#42` finds a member without\nexpanding one; see `MentionableRow` in\n`../collection-naming/mentionable.ts`.",
+        "items": {
+          "$ref": "#/$defs/MentionableRow"
+        },
+        "tags": [
+          "42"
+        ],
+        "type": "array"
+      },
+      "names": {
+        "$ref": "#/$defs/NamesMap",
+        "default": {},
+        "description": "The namespace itself: each name to the topic it names. A slug pointing\nhere is what makes a member addressable as `<collection>/<name>`.\nPublished under the default its input carries."
+      },
+      "namesTable": {
+        "default": [],
+        "description": "The names table, one row per named member, which every topic the board\ncreates reads its own name from. Published so a topic composed outside\n`addTopic` can be wired to the same table.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "naming": {
+        "$ref": "#/$defs/NamingDeclaration",
+        "description": "What the board declares about its names, for a consumer deciding whether\na name may be held rather than an identity."
+      },
+      "newTitle": {
+        "description": "Session-local draft for the footer composer (exposed for embedding and\nheadless driving, like the chat exemplar's drafts).",
+        "type": "string"
+      },
+      "submitTopic": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Submit the footer composer as the current viewer's canonical Profile.",
+        "tier": "wrapper"
+      },
+      "topicCount": {
+        "description": "How many topics the board holds, nulls included.",
+        "type": "number"
+      },
+      "topics": {
+        "description": "The board's topics, in filing order, through the shape the board demands\nof them: the display scalars and the mention universe, and no verbs. A\ncaller that means to mutate a topic addresses the topic itself, where its\nown schema governs. Survey through `index` instead; read this when you\nalready know which topic you are expanding.",
+        "items": {
+          "$ref": "#/$defs/TopicDemand"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "topics",
+      "mentionable",
+      "names",
+      "namesTable",
+      "naming",
+      "topicCount",
+      "crossrefs",
+      "index",
+      "addTopic",
+      "backfillNames",
+      "submitTopic",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/topic.tsx/20260911T180754Z-lFOGw2meRUFdE9q6.json
+++ b/packages/patterns/baselines/topics/topic.tsx/20260911T180754Z-lFOGw2meRUFdE9q6.json
@@ -1,0 +1,1053 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      },
+      "StoredTopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "authorName": {
+            "description": "Display name recorded without an author kind.",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key. `\"legacy\"` records a display name\nwhose author kind is unknown.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicCrossrefRow": {
+        "properties": {
+          "mentionedBy": {
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "description": "The topic this row is about. `unknown` because it is written as a\nreference and only ever compared — `equals` takes the raw link. Anything\nwider retrieves the piece instead of pointing at it: declared `object`,\nthis field reads back as the whole expanded topic, `$UI` tree included.",
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "topic",
+          "mentionedBy"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicMentionable": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "authorFieldsMigratedV1": {
+        "asCell": [
+          "cell"
+        ],
+        "default": false,
+        "description": "Completion of the per-topic migration from display names to authors.",
+        "type": "boolean"
+      },
+      "boardCrossrefs": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's mention pivot, one row per topic. A topic reads its own row\nout of it and nothing else; see `backlinksOf`. Absent, a topic simply shows\nno inbound references.\n\nReadable, not writable: the pivot is the board's derivation, and a topic\nhas no business writing into it. Declaring the narrower cell says so where\na reader can see it, rather than leaving it to convention.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossrefRow"
+        },
+        "type": "array"
+      },
+      "boardNames": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's names table, one row per named topic. The topic reads its own\nrow out of it and nothing else; absent, the topic shows no number.\n\nReadable, not writable, for the reason `boardCrossrefs` states: the table\nis the board's derivation, and a topic has no business writing into it.\nWired at creation by the board's create, and rewired onto a topic filed\nbefore the namespace as a one-time link-bind — the same operator step\n`mentionable` states for itself.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The topic's living document: durable conclusions get folded up into the\nbody; the comment thread below holds the deliberation.",
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "bodyUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "comments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/StoredTopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "createdBy": {
+        "$ref": "#/$defs/TopicAuthor"
+      },
+      "createdByName": {
+        "description": "Creator display name recorded without an author kind.",
+        "type": "string"
+      },
+      "links": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's mention universe — what the body editor autocompletes\nover. Wired at creation to the board's mention index (one derived\ndocument of copies; `MentionableRow` in\n`../collection-naming/mentionable.ts`), and rewired onto a piece from\nbefore the index as a one-time link-bind. A plain list of the pieces\nthemselves also satisfies the demand — a board not yet rewired, or a\ncomposer without a board. Absent, the editor simply offers no\ncompletions.\n\nDeclared readable, which is what settles the retained link's proof. A\nwritable handle adds a write-back leg to that proof, asking this\nthree-field projection to accept every field the board's row publishes,\nand the row carries a required `piece` this projection deliberately omits\n— so a topic wired to a board is refused even the source it is running.\nThe declaration is not a runtime gate: a write through the handle is\nrefused by nothing, and where the universe is a plain list of pieces the\neditor's name write-back reaches a member's own title through it.",
+        "items": {
+          "$ref": "#/$defs/TopicMentionable"
+        },
+        "type": "array"
+      },
+      "mentioned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "Pieces this topic references outside its prose — what `mention` records.\n\nIts own list rather than an entry in `references`, because that map belongs\nto the body editor: the editor mints its keys, rewrites its labels, and\ncollects entries whose token has left the document. A verb writing there\nwould be writing into somebody else's bookkeeping. Here there is nothing to\nkey by, because there is nothing to point back at from the prose — a\nreference outside a sentence is just a link in a list.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point, keyed by the token that\nappears in the body. The editor owns the contents; this pattern owns the\ncell, which is what makes a mention durable and — because each entry holds\nthe destination as a REFERENCE — what makes the reference graph a question\nabout cell identity rather than about text.\n\nThe default has to match the one `TopicOutput` publishes. A map published\nunder a different default than its input carries cannot be materialized."
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "titleUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        },
+        "description": "Attribution of the last rename, stamped by `setTitle` — the same pair\nthe body keeps, because a title is the other editable scalar."
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/topic.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The comment text, appended verbatim after trimming. Must be non-empty:\nan empty body rejects rather than recording a blank thread entry.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "What the link points at — a rendering hint, not a behavior switch.\nOptional because the handler defaults it to `\"web\"`, and a caller should\nnot be made to supply a field the verb never needed.",
+            "type": "string"
+          },
+          "label": {
+            "description": "Display label. Optional, and a blank one falls back to the URL.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The link target. Must be http(s): anything else rejects, because a\nuser-supplied scheme on a shared surface is script execution in every\nviewer's session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "EditCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement text, trimmed. Must be non-empty: emptying a\ncomment is a retraction, and `removeComment` is what says so.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to revise, named and checked as in `RemoveCommentEvent`,\nand additionally naming `body`, which this verb writes.",
+            "properties": {
+              "body": {
+                "default": "",
+                "type": "string"
+              },
+              "editedAt": {
+                "type": "number"
+              },
+              "removedAt": {
+                "type": "number"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt",
+              "body"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "MentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "The piece to reference — the piece itself, not an address. Identity here\nis the cell, so this is what a caller passes and what gets stored.\n\nDeclared through the one field every Topic has rather than `unknown`. The\ncell declaration marks this as a reference position, so the CLI resolves a\ncanonical `/of:...` value from an inline JSON event into the live piece\nlink. It also bounds the validation read: `topic.get()` is `undefined` for\na value that is not a reference and an object for any piece, and `mention`\nchecks it before storing anything.\n\n`title` is also the most this can safely name: this schema reaches every\ntopic in `mentionable`, so a property without a default would be demanded\nof topics written before it existed and refuse their update. `title`\ncarries one, and that default does double duty — it is also why the check\nadmits a piece that is not a topic at all, which reads back `{ title: \"\" }`\nrather than `undefined`. `deno task pattern-vintage` proves the update side\nby replaying a real board.\n\nNothing reads THROUGH it beyond that one field — the value is stored and\ncompared.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "RemoveCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to retract — the stored element, not a copy of its fields.\nNames only what this verb reads and writes, for the reason\n`MentionEvent.topic` names only `title`: the declaration bounds the\nvalidation read, and a payload that is not a reference reads back\n`undefined` and is refused rather than silently matching nothing.\n`sentAt` carries a default, so it is what makes a real element read back\nas an object; the stamp fields are optional, which is what lets this\nschema reach comments written before they existed.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "RemoveLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "link": {
+            "description": "The stored link element. What a reader passes, from the row it renders.\nNamed as in `RemoveCommentEvent`, with `url` playing the defaulted-field\nrole `sentAt` plays there.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "url": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "url": {
+            "description": "The link's URL, for a caller that cannot pass a reference. Retracts the\nmost recently added link still present with this URL, so retracting twice\nretracts two rather than re-stamping one.\n\nSequentially. Two concurrent retractions naming the same URL both resolve\nthe same newest-present element and merge into one stamped record, so\nthey retract one link between them rather than two. Naming the link by\nreference is what makes a caller's target unambiguous under concurrency;\nthis spelling trades that for being reachable at all.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement body, persisted verbatim — no trimming, so\nwhitespace-sensitive Markdown survives. An empty body is legal: clearing\na living document is an edit, not an error.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetTitleEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation, stored as structured attribution beside\nthe write time. Required so every successful rename is attributed.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The new title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key. `\"legacy\"` records a display name\nwhose author kind is unknown.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicSummary": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      },
+      "UnmentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "Declared and checked exactly as `MentionEvent.topic` is, and for the same\nreason: a payload that is not a reference matches no stored entry, so\nwithout the check it would remove nothing and report success.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A #topic — one durable unit of shared attention: a title, a living body\ndocument, a flat chronological comment thread, typed links out to other\ncore objects (PRs, agent sessions, web pages), and the references it makes\nto sibling pieces.\n\nDurable conclusions get folded up into the body — revise it whole with\n`setBody`; the thread holds the deliberation as point-in-time `addComment`\nrecords. The thread only ever grows: `removeComment` and `removeLink` stamp\na record as retracted and leave it where it is, and `editComment` revises a\nbody in place, so what a reader shows is the array filtered rather than the\narray itself. Sign every authored-content mutation with `agentName`:\nFabric records the human principal behind the key; the name says which\nagent acted under it. Reference-only `mention` and `unmention` calls carry\nno content signature. The session-draft cells and `submit*` streams below\nbelong to the rendered page, not the headless contract — they read state\nonly this session holds.",
+    "properties": {
+      "$NAME": {
+        "default": "",
+        "description": "The topic's display name. Like the other derived display fields, a cold\nretained topic may not have produced this path yet; its persisted title\nremains authoritative until it does.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addComment": {
+        "$ref": "#/$defs/AddCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Append to the thread — a point-in-time record of progress or\ndeliberation; durable conclusions belong in the body. Returns the\ncomment as recorded, resolved author and `sentAt` included."
+      },
+      "addLink": {
+        "$ref": "#/$defs/AddLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Attach a typed outbound link — a PR, an agent session, a web page.\nReturns the link as recorded, resolved `addedBy` and `addedAt`\nincluded. Appends merge and nothing dedupes: a repeated URL is two\nentries."
+      },
+      "body": {
+        "default": "",
+        "description": "The living document, verbatim Markdown. `setBody` replaces it whole.",
+        "type": "string"
+      },
+      "bodyDraft": {
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "bodyUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ]
+      },
+      "cancelEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the body editor; the session drafts are the discard.",
+        "tier": "wrapper"
+      },
+      "cancelEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the rename editor; the session draft is the discard.",
+        "tier": "wrapper"
+      },
+      "commentCount": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "commentDraft": {
+        "description": "Session-local composer/edit state. These controls belong to a direct Topic\ninstance, not the shared TopicPiece projection used by the tracker's list.",
+        "type": "string"
+      },
+      "comments": {
+        "description": "The thread, in arrival order, each record carrying its author snapshot\nand `sentAt`.\n\nMEMBERSHIP is append-only; a record is not. Nothing is ever removed from\nthis array — `removeComment` stamps `removedAt` and leaves the record in\nplace, and `editComment` revises a body and stamps `editedAt` — so a\nreader that wants the live thread filters on `removedAt` rather than\ntaking the array as it stands. `commentCount` is that filtered count.",
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+        "type": "number"
+      },
+      "createdBy": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "editComment": {
+        "$ref": "#/$defs/EditCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Revise a comment's body in place, naming it by reference. Stamps\n`editedAt` and leaves `author` and `sentAt` as they were. Outside the\nprojection for the reason `removeComment` states."
+      },
+      "editingBody": {
+        "description": "Whether the body editor is open.\n\nA bare session-scoped value rather than a cell-wrapped one, and that\nspelling costs a capability worth knowing about before reaching for it: a\nverb cannot take a whole Topic as captured state while any required\nproperty is published this way. The piece does not materialize through the\nverb's state schema, so the argument arrives undefined and the runtime\ndeclines to run the verb at all — \"stream action argument is undefined\n(potential schema mismatch)\", logged rather than thrown, with the write\nsilently absent.\n\nNothing needs that today. A board names a member by writing the piece into\nits namespace, and every path that does so builds the piece inside the\nverb (`addTopic`, the browser composer) or resolves it out of the board's\nown list (`backfillNames`); none of them takes a Topic as an argument, so\nnone reads one through a state schema. Cell-wrapping these two would buy\nthe capability at the cost of a `scope changed` break on every deployed\nTopic, so it waits for a verb that needs it.",
+        "scope": "session",
+        "type": "boolean"
+      },
+      "editingTitle": {
+        "description": "Whether the rename editor is open. Bare for the reason `editingBody`\nstates, and the constraint is per property: cell-wrapping one and not the\nother buys nothing.",
+        "scope": "session",
+        "type": "boolean"
+      },
+      "lastActivityAt": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "linkKindDraft": {
+        "type": "string"
+      },
+      "linkLabelDraft": {
+        "type": "string"
+      },
+      "linkUrlDraft": {
+        "type": "string"
+      },
+      "links": {
+        "description": "Typed outbound links, in arrival order, each carrying its author snapshot\nand `addedAt`. Append-only in membership on the same terms as `comments`:\n`removeLink` stamps rather than removes, and a stamped link additionally\nstops resolving into `mentions`.",
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mention": {
+        "$ref": "#/$defs/MentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Reference another piece from this topic — the payload is the piece\nitself, stored as a reference. Takes no `agentName` and returns no value;\nFabric retains the authenticated principal behind the edge."
+      },
+      "mentioned": {
+        "default": [],
+        "description": "Pieces referenced outside the prose, recorded by `mention`.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "mentions": {
+        "default": [],
+        "description": "Every piece this topic's prose and links point at, as references.\n\nThe board's pivot is declared over this and nothing else, so what one topic\ncosts a full-board scan is exactly this list of identities. Declared\n`unknown[]` because these are references, and comparing them never reads\nwhat is behind them.\n\nThe cell annotation that makes them comparable belongs to the READER, not\nhere: the pivot declares its own view of this list as\n`TopicMentionSource.mentions: ComparableCell<unknown>[]`, and that is what\nmakes its graph settle rather than depend on load order. A published\n`unknown[]` is what each reader annotates for itself.\n\nThe default stands alone: a declared default and `| undefined` collide,\nand the default is what a topic deployed before this path existed\nmaterializes against.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "referencedBy": {
+        "default": [],
+        "description": "The topics that mention this one, read out of the board's pivot.\n\nDeclared through `TopicSummary` rather than `TopicPiece`, and that is\nload-bearing rather than stingy: a topic whose backlinks were topics would\nbe a type that contains itself, and resolving one from a list would walk\nthe graph. The summary carries no reference of its own, so it terminates.\nA reader that wants more follows the link, which resolves whole.",
+        "items": {
+          "$ref": "#/$defs/TopicSummary"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point. Durable content, like\n`links`. The body editor works on a session copy of this map, which a save\npublishes here whole, beside the prose whose tokens name its entries."
+      },
+      "referencesDraft": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "description": "The body draft's mention map, staged so Cancel can discard it.\n\n`cf-code-editor` writes an entry the moment a mention is inserted and\ndrops one the moment its token leaves the document, neither of them\nwaiting for Save. Pointed at the durable map while `$value` holds a\nsession draft, those writes would outlive a discarded edit: a canceled\ninsertion would leave an edge no token names, and a canceled deletion\nwould strip the destination from a token the durable body still carries.\nThe editor's own ordering assumes its two bindings share a lifetime, so\nthis gives them one."
+      },
+      "removeComment": {
+        "$ref": "#/$defs/RemoveCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a comment, naming it by reference. The record is stamped rather\nthan deleted, so the thread keeps its evidence while a reader stops\nshowing it and `commentCount` stops counting it.\n\nHere rather than on `TopicPiece`, for the reason `setTitle` is: boards\nstore that projection, so it is a demand on every topic they already\nhold, and a required verb added to it would refuse every one deployed\nbefore the verb existed. A verb has no default to be rescued by, so there\nis no compatible way to demand a new one. Addressing the topic directly\nreaches all three of these."
+      },
+      "removeLink": {
+        "$ref": "#/$defs/RemoveLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a link, by reference or by `url`. Stamped like a comment, and a\nretracted link stops resolving into `mentions`. The url spelling exists\nbecause a link record carries no fid for a CLI caller to name. Outside\nthe projection for the reason `removeComment` states."
+      },
+      "saveBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: publish the session body and mention-map drafts whole,\nattributed to the viewer's Profile — the contract verb is `setBody`.",
+        "tier": "wrapper"
+      },
+      "saveTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: save the session title draft under the viewer's Profile —\nthe contract verb is `setTitle`, and both land through the same core, so\na browser rename stamps the same attribution and moves the same activity\nclock.",
+        "tier": "wrapper"
+      },
+      "setBody": {
+        "$ref": "#/$defs/SetBodyEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Replace the living document whole — read it, revise it, write it back\ncomplete; the body is one value with whole-value conflict semantics.\nRequires `agentName` and returns the persisted body with its attribution."
+      },
+      "setTitle": {
+        "$ref": "#/$defs/SetTitleEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Rename the topic. Requires `agentName` and returns the persisted title\nwith its attribution. This direct-address verb stays outside the board's\nnarrow `TopicPiece` demand."
+      },
+      "shortName": {
+        "description": "The name the board calls this topic by, read out of the board's names\ntable by identity. The display name stays the title — this rides beside\nit, under the name a mention pill reads it by (`Mentionable.shortName` in\n`packages/ui/src/v2/core/mentionable.ts`), so a mention of this topic\nelsewhere gains the number as soon as the board names it.\n\nAbsent for a topic no board has named, or one wired to no board: the\nlookup produces nothing and the property is simply not there. Every\nconsumer treats that as no name — the badge renders nothing, a universe\nrow matches no `#42` query, and a mention pill shows no number\n(`_trackRefShortName` in\n`packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts` reads an\nabsent name exactly as it reads a blank one).\n\nOptional rather than defaulted, and the difference is the compatibility\nproof's: this is what a board's stored list is validated against, and a\ndefaulted property there moves the demand's defaults below an array\nconstraint the proof cannot show stable under default insertion. It is not\nwhat lets the projection apply over a board whose members predate the\nproperty, and nothing is; `TopicDemand.shortName` in `./main.tsx` states\nwhy.",
+        "tags": [
+          "42"
+        ],
+        "type": "string"
+      },
+      "startEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the body editor, seeding the session drafts from the\ndurable body and mention map.",
+        "tier": "wrapper"
+      },
+      "startEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the rename editor, seeding the session draft from the\ndurable title.",
+        "tier": "wrapper"
+      },
+      "submitComment": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session comment draft under the viewer's\nProfile. Reads session-local state, so it is a silent no-op headless —\nthe contract verb is `addComment`.",
+        "tier": "wrapper"
+      },
+      "submitLink": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session link drafts under the viewer's Profile —\nthe contract verb is `addLink`.",
+        "tier": "wrapper"
+      },
+      "title": {
+        "default": "",
+        "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+        "type": "string"
+      },
+      "titleDraft": {
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "titleUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ],
+        "description": "Attribution of the last rename; unset until the first `setTitle`.\nBeside `setTitle` rather than on the projection, for the same reason."
+      },
+      "unmention": {
+        "$ref": "#/$defs/UnmentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Stop referencing a piece: removes every `mention`-made entry naming it.\nReferences made in the prose are retracted by editing the prose, not by\nthis. Takes no `agentName` and returns no value."
+      }
+    },
+    "required": [
+      "commentDraft",
+      "bodyDraft",
+      "editingBody",
+      "titleDraft",
+      "editingTitle",
+      "linkUrlDraft",
+      "linkLabelDraft",
+      "linkKindDraft",
+      "referencesDraft",
+      "setTitle",
+      "removeComment",
+      "editComment",
+      "removeLink",
+      "startEditTitle",
+      "saveTitle",
+      "cancelEditTitle",
+      "submitComment",
+      "startEditBody",
+      "saveBody",
+      "cancelEditBody",
+      "submitLink",
+      "$UI",
+      "body",
+      "comments",
+      "links",
+      "mentions",
+      "references",
+      "mentioned",
+      "referencedBy",
+      "addComment",
+      "addLink",
+      "setBody",
+      "mention",
+      "unmention",
+      "$NAME",
+      "title",
+      "createdAt",
+      "commentCount",
+      "lastActivityAt"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/topic.tsx/20260911T185348Z-TLZ8gBXbqm4PebTM.json
+++ b/packages/patterns/baselines/topics/topic.tsx/20260911T185348Z-TLZ8gBXbqm4PebTM.json
@@ -1,0 +1,1053 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      },
+      "StoredTopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "authorName": {
+            "description": "Unrestricted legacy storage; only nonblank strings supply a name.",
+            "type": "unknown"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key. `\"legacy\"` records a display name\nwhose author kind is unknown.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicCrossrefRow": {
+        "properties": {
+          "mentionedBy": {
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "description": "The topic this row is about. `unknown` because it is written as a\nreference and only ever compared — `equals` takes the raw link. Anything\nwider retrieves the piece instead of pointing at it: declared `object`,\nthis field reads back as the whole expanded topic, `$UI` tree included.",
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "topic",
+          "mentionedBy"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicMentionable": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "authorFieldsMigratedV1": {
+        "asCell": [
+          "cell"
+        ],
+        "default": false,
+        "description": "Completion of the per-topic migration from display names to authors.",
+        "type": "boolean"
+      },
+      "boardCrossrefs": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's mention pivot, one row per topic. A topic reads its own row\nout of it and nothing else; see `backlinksOf`. Absent, a topic simply shows\nno inbound references.\n\nReadable, not writable: the pivot is the board's derivation, and a topic\nhas no business writing into it. Declaring the narrower cell says so where\na reader can see it, rather than leaving it to convention.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossrefRow"
+        },
+        "type": "array"
+      },
+      "boardNames": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's names table, one row per named topic. The topic reads its own\nrow out of it and nothing else; absent, the topic shows no number.\n\nReadable, not writable, for the reason `boardCrossrefs` states: the table\nis the board's derivation, and a topic has no business writing into it.\nWired at creation by the board's create, and rewired onto a topic filed\nbefore the namespace as a one-time link-bind — the same operator step\n`mentionable` states for itself.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The topic's living document: durable conclusions get folded up into the\nbody; the comment thread below holds the deliberation.",
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "bodyUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "comments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/StoredTopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "createdBy": {
+        "$ref": "#/$defs/TopicAuthor"
+      },
+      "createdByName": {
+        "description": "Creator display name recorded without an author kind.",
+        "type": "unknown"
+      },
+      "links": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's mention universe — what the body editor autocompletes\nover. Wired at creation to the board's mention index (one derived\ndocument of copies; `MentionableRow` in\n`../collection-naming/mentionable.ts`), and rewired onto a piece from\nbefore the index as a one-time link-bind. A plain list of the pieces\nthemselves also satisfies the demand — a board not yet rewired, or a\ncomposer without a board. Absent, the editor simply offers no\ncompletions.\n\nDeclared readable, which is what settles the retained link's proof. A\nwritable handle adds a write-back leg to that proof, asking this\nthree-field projection to accept every field the board's row publishes,\nand the row carries a required `piece` this projection deliberately omits\n— so a topic wired to a board is refused even the source it is running.\nThe declaration is not a runtime gate: a write through the handle is\nrefused by nothing, and where the universe is a plain list of pieces the\neditor's name write-back reaches a member's own title through it.",
+        "items": {
+          "$ref": "#/$defs/TopicMentionable"
+        },
+        "type": "array"
+      },
+      "mentioned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "Pieces this topic references outside its prose — what `mention` records.\n\nIts own list rather than an entry in `references`, because that map belongs\nto the body editor: the editor mints its keys, rewrites its labels, and\ncollects entries whose token has left the document. A verb writing there\nwould be writing into somebody else's bookkeeping. Here there is nothing to\nkey by, because there is nothing to point back at from the prose — a\nreference outside a sentence is just a link in a list.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point, keyed by the token that\nappears in the body. The editor owns the contents; this pattern owns the\ncell, which is what makes a mention durable and — because each entry holds\nthe destination as a REFERENCE — what makes the reference graph a question\nabout cell identity rather than about text.\n\nThe default has to match the one `TopicOutput` publishes. A map published\nunder a different default than its input carries cannot be materialized."
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "titleUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        },
+        "description": "Attribution of the last rename, stamped by `setTitle` — the same pair\nthe body keeps, because a title is the other editable scalar."
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/topic.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The comment text, appended verbatim after trimming. Must be non-empty:\nan empty body rejects rather than recording a blank thread entry.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "What the link points at — a rendering hint, not a behavior switch.\nOptional because the handler defaults it to `\"web\"`, and a caller should\nnot be made to supply a field the verb never needed.",
+            "type": "string"
+          },
+          "label": {
+            "description": "Display label. Optional, and a blank one falls back to the URL.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The link target. Must be http(s): anything else rejects, because a\nuser-supplied scheme on a shared surface is script execution in every\nviewer's session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "EditCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement text, trimmed. Must be non-empty: emptying a\ncomment is a retraction, and `removeComment` is what says so.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to revise, named and checked as in `RemoveCommentEvent`,\nand additionally naming `body`, which this verb writes.",
+            "properties": {
+              "body": {
+                "default": "",
+                "type": "string"
+              },
+              "editedAt": {
+                "type": "number"
+              },
+              "removedAt": {
+                "type": "number"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt",
+              "body"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "MentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "The piece to reference — the piece itself, not an address. Identity here\nis the cell, so this is what a caller passes and what gets stored.\n\nDeclared through the one field every Topic has rather than `unknown`. The\ncell declaration marks this as a reference position, so the CLI resolves a\ncanonical `/of:...` value from an inline JSON event into the live piece\nlink. It also bounds the validation read: `topic.get()` is `undefined` for\na value that is not a reference and an object for any piece, and `mention`\nchecks it before storing anything.\n\n`title` is also the most this can safely name: this schema reaches every\ntopic in `mentionable`, so a property without a default would be demanded\nof topics written before it existed and refuse their update. `title`\ncarries one, and that default does double duty — it is also why the check\nadmits a piece that is not a topic at all, which reads back `{ title: \"\" }`\nrather than `undefined`. `deno task pattern-vintage` proves the update side\nby replaying a real board.\n\nNothing reads THROUGH it beyond that one field — the value is stored and\ncompared.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "RemoveCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to retract — the stored element, not a copy of its fields.\nNames only what this verb reads and writes, for the reason\n`MentionEvent.topic` names only `title`: the declaration bounds the\nvalidation read, and a payload that is not a reference reads back\n`undefined` and is refused rather than silently matching nothing.\n`sentAt` carries a default, so it is what makes a real element read back\nas an object; the stamp fields are optional, which is what lets this\nschema reach comments written before they existed.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "RemoveLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "link": {
+            "description": "The stored link element. What a reader passes, from the row it renders.\nNamed as in `RemoveCommentEvent`, with `url` playing the defaulted-field\nrole `sentAt` plays there.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "url": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "url": {
+            "description": "The link's URL, for a caller that cannot pass a reference. Retracts the\nmost recently added link still present with this URL, so retracting twice\nretracts two rather than re-stamping one.\n\nSequentially. Two concurrent retractions naming the same URL both resolve\nthe same newest-present element and merge into one stamped record, so\nthey retract one link between them rather than two. Naming the link by\nreference is what makes a caller's target unambiguous under concurrency;\nthis spelling trades that for being reachable at all.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement body, persisted verbatim — no trimming, so\nwhitespace-sensitive Markdown survives. An empty body is legal: clearing\na living document is an edit, not an error.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetTitleEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation, stored as structured attribution beside\nthe write time. Required so every successful rename is attributed.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The new title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key. `\"legacy\"` records a display name\nwhose author kind is unknown.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicSummary": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      },
+      "UnmentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "Declared and checked exactly as `MentionEvent.topic` is, and for the same\nreason: a payload that is not a reference matches no stored entry, so\nwithout the check it would remove nothing and report success.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A #topic — one durable unit of shared attention: a title, a living body\ndocument, a flat chronological comment thread, typed links out to other\ncore objects (PRs, agent sessions, web pages), and the references it makes\nto sibling pieces.\n\nDurable conclusions get folded up into the body — revise it whole with\n`setBody`; the thread holds the deliberation as point-in-time `addComment`\nrecords. The thread only ever grows: `removeComment` and `removeLink` stamp\na record as retracted and leave it where it is, and `editComment` revises a\nbody in place, so what a reader shows is the array filtered rather than the\narray itself. Sign every authored-content mutation with `agentName`:\nFabric records the human principal behind the key; the name says which\nagent acted under it. Reference-only `mention` and `unmention` calls carry\nno content signature. The session-draft cells and `submit*` streams below\nbelong to the rendered page, not the headless contract — they read state\nonly this session holds.",
+    "properties": {
+      "$NAME": {
+        "default": "",
+        "description": "The topic's display name. Like the other derived display fields, a cold\nretained topic may not have produced this path yet; its persisted title\nremains authoritative until it does.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addComment": {
+        "$ref": "#/$defs/AddCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Append to the thread — a point-in-time record of progress or\ndeliberation; durable conclusions belong in the body. Returns the\ncomment as recorded, resolved author and `sentAt` included."
+      },
+      "addLink": {
+        "$ref": "#/$defs/AddLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Attach a typed outbound link — a PR, an agent session, a web page.\nReturns the link as recorded, resolved `addedBy` and `addedAt`\nincluded. Appends merge and nothing dedupes: a repeated URL is two\nentries."
+      },
+      "body": {
+        "default": "",
+        "description": "The living document, verbatim Markdown. `setBody` replaces it whole.",
+        "type": "string"
+      },
+      "bodyDraft": {
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "bodyUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ]
+      },
+      "cancelEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the body editor; the session drafts are the discard.",
+        "tier": "wrapper"
+      },
+      "cancelEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the rename editor; the session draft is the discard.",
+        "tier": "wrapper"
+      },
+      "commentCount": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "commentDraft": {
+        "description": "Session-local composer/edit state. These controls belong to a direct Topic\ninstance, not the shared TopicPiece projection used by the tracker's list.",
+        "type": "string"
+      },
+      "comments": {
+        "description": "The thread, in arrival order, each record carrying its author snapshot\nand `sentAt`.\n\nMEMBERSHIP is append-only; a record is not. Nothing is ever removed from\nthis array — `removeComment` stamps `removedAt` and leaves the record in\nplace, and `editComment` revises a body and stamps `editedAt` — so a\nreader that wants the live thread filters on `removedAt` rather than\ntaking the array as it stands. `commentCount` is that filtered count.",
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+        "type": "number"
+      },
+      "createdBy": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "editComment": {
+        "$ref": "#/$defs/EditCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Revise a comment's body in place, naming it by reference. Stamps\n`editedAt` and leaves `author` and `sentAt` as they were. Outside the\nprojection for the reason `removeComment` states."
+      },
+      "editingBody": {
+        "description": "Whether the body editor is open.\n\nA bare session-scoped value rather than a cell-wrapped one, and that\nspelling costs a capability worth knowing about before reaching for it: a\nverb cannot take a whole Topic as captured state while any required\nproperty is published this way. The piece does not materialize through the\nverb's state schema, so the argument arrives undefined and the runtime\ndeclines to run the verb at all — \"stream action argument is undefined\n(potential schema mismatch)\", logged rather than thrown, with the write\nsilently absent.\n\nNothing needs that today. A board names a member by writing the piece into\nits namespace, and every path that does so builds the piece inside the\nverb (`addTopic`, the browser composer) or resolves it out of the board's\nown list (`backfillNames`); none of them takes a Topic as an argument, so\nnone reads one through a state schema. Cell-wrapping these two would buy\nthe capability at the cost of a `scope changed` break on every deployed\nTopic, so it waits for a verb that needs it.",
+        "scope": "session",
+        "type": "boolean"
+      },
+      "editingTitle": {
+        "description": "Whether the rename editor is open. Bare for the reason `editingBody`\nstates, and the constraint is per property: cell-wrapping one and not the\nother buys nothing.",
+        "scope": "session",
+        "type": "boolean"
+      },
+      "lastActivityAt": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "linkKindDraft": {
+        "type": "string"
+      },
+      "linkLabelDraft": {
+        "type": "string"
+      },
+      "linkUrlDraft": {
+        "type": "string"
+      },
+      "links": {
+        "description": "Typed outbound links, in arrival order, each carrying its author snapshot\nand `addedAt`. Append-only in membership on the same terms as `comments`:\n`removeLink` stamps rather than removes, and a stamped link additionally\nstops resolving into `mentions`.",
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mention": {
+        "$ref": "#/$defs/MentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Reference another piece from this topic — the payload is the piece\nitself, stored as a reference. Takes no `agentName` and returns no value;\nFabric retains the authenticated principal behind the edge."
+      },
+      "mentioned": {
+        "default": [],
+        "description": "Pieces referenced outside the prose, recorded by `mention`.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "mentions": {
+        "default": [],
+        "description": "Every piece this topic's prose and links point at, as references.\n\nThe board's pivot is declared over this and nothing else, so what one topic\ncosts a full-board scan is exactly this list of identities. Declared\n`unknown[]` because these are references, and comparing them never reads\nwhat is behind them.\n\nThe cell annotation that makes them comparable belongs to the READER, not\nhere: the pivot declares its own view of this list as\n`TopicMentionSource.mentions: ComparableCell<unknown>[]`, and that is what\nmakes its graph settle rather than depend on load order. A published\n`unknown[]` is what each reader annotates for itself.\n\nThe default stands alone: a declared default and `| undefined` collide,\nand the default is what a topic deployed before this path existed\nmaterializes against.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "referencedBy": {
+        "default": [],
+        "description": "The topics that mention this one, read out of the board's pivot.\n\nDeclared through `TopicSummary` rather than `TopicPiece`, and that is\nload-bearing rather than stingy: a topic whose backlinks were topics would\nbe a type that contains itself, and resolving one from a list would walk\nthe graph. The summary carries no reference of its own, so it terminates.\nA reader that wants more follows the link, which resolves whole.",
+        "items": {
+          "$ref": "#/$defs/TopicSummary"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point. Durable content, like\n`links`. The body editor works on a session copy of this map, which a save\npublishes here whole, beside the prose whose tokens name its entries."
+      },
+      "referencesDraft": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "description": "The body draft's mention map, staged so Cancel can discard it.\n\n`cf-code-editor` writes an entry the moment a mention is inserted and\ndrops one the moment its token leaves the document, neither of them\nwaiting for Save. Pointed at the durable map while `$value` holds a\nsession draft, those writes would outlive a discarded edit: a canceled\ninsertion would leave an edge no token names, and a canceled deletion\nwould strip the destination from a token the durable body still carries.\nThe editor's own ordering assumes its two bindings share a lifetime, so\nthis gives them one."
+      },
+      "removeComment": {
+        "$ref": "#/$defs/RemoveCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a comment, naming it by reference. The record is stamped rather\nthan deleted, so the thread keeps its evidence while a reader stops\nshowing it and `commentCount` stops counting it.\n\nHere rather than on `TopicPiece`, for the reason `setTitle` is: boards\nstore that projection, so it is a demand on every topic they already\nhold, and a required verb added to it would refuse every one deployed\nbefore the verb existed. A verb has no default to be rescued by, so there\nis no compatible way to demand a new one. Addressing the topic directly\nreaches all three of these."
+      },
+      "removeLink": {
+        "$ref": "#/$defs/RemoveLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a link, by reference or by `url`. Stamped like a comment, and a\nretracted link stops resolving into `mentions`. The url spelling exists\nbecause a link record carries no fid for a CLI caller to name. Outside\nthe projection for the reason `removeComment` states."
+      },
+      "saveBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: publish the session body and mention-map drafts whole,\nattributed to the viewer's Profile — the contract verb is `setBody`.",
+        "tier": "wrapper"
+      },
+      "saveTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: save the session title draft under the viewer's Profile —\nthe contract verb is `setTitle`, and both land through the same core, so\na browser rename stamps the same attribution and moves the same activity\nclock.",
+        "tier": "wrapper"
+      },
+      "setBody": {
+        "$ref": "#/$defs/SetBodyEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Replace the living document whole — read it, revise it, write it back\ncomplete; the body is one value with whole-value conflict semantics.\nRequires `agentName` and returns the persisted body with its attribution."
+      },
+      "setTitle": {
+        "$ref": "#/$defs/SetTitleEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Rename the topic. Requires `agentName` and returns the persisted title\nwith its attribution. This direct-address verb stays outside the board's\nnarrow `TopicPiece` demand."
+      },
+      "shortName": {
+        "description": "The name the board calls this topic by, read out of the board's names\ntable by identity. The display name stays the title — this rides beside\nit, under the name a mention pill reads it by (`Mentionable.shortName` in\n`packages/ui/src/v2/core/mentionable.ts`), so a mention of this topic\nelsewhere gains the number as soon as the board names it.\n\nAbsent for a topic no board has named, or one wired to no board: the\nlookup produces nothing and the property is simply not there. Every\nconsumer treats that as no name — the badge renders nothing, a universe\nrow matches no `#42` query, and a mention pill shows no number\n(`_trackRefShortName` in\n`packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts` reads an\nabsent name exactly as it reads a blank one).\n\nOptional rather than defaulted, and the difference is the compatibility\nproof's: this is what a board's stored list is validated against, and a\ndefaulted property there moves the demand's defaults below an array\nconstraint the proof cannot show stable under default insertion. It is not\nwhat lets the projection apply over a board whose members predate the\nproperty, and nothing is; `TopicDemand.shortName` in `./main.tsx` states\nwhy.",
+        "tags": [
+          "42"
+        ],
+        "type": "string"
+      },
+      "startEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the body editor, seeding the session drafts from the\ndurable body and mention map.",
+        "tier": "wrapper"
+      },
+      "startEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the rename editor, seeding the session draft from the\ndurable title.",
+        "tier": "wrapper"
+      },
+      "submitComment": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session comment draft under the viewer's\nProfile. Reads session-local state, so it is a silent no-op headless —\nthe contract verb is `addComment`.",
+        "tier": "wrapper"
+      },
+      "submitLink": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session link drafts under the viewer's Profile —\nthe contract verb is `addLink`.",
+        "tier": "wrapper"
+      },
+      "title": {
+        "default": "",
+        "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+        "type": "string"
+      },
+      "titleDraft": {
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "titleUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ],
+        "description": "Attribution of the last rename; unset until the first `setTitle`.\nBeside `setTitle` rather than on the projection, for the same reason."
+      },
+      "unmention": {
+        "$ref": "#/$defs/UnmentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Stop referencing a piece: removes every `mention`-made entry naming it.\nReferences made in the prose are retracted by editing the prose, not by\nthis. Takes no `agentName` and returns no value."
+      }
+    },
+    "required": [
+      "commentDraft",
+      "bodyDraft",
+      "editingBody",
+      "titleDraft",
+      "editingTitle",
+      "linkUrlDraft",
+      "linkLabelDraft",
+      "linkKindDraft",
+      "referencesDraft",
+      "setTitle",
+      "removeComment",
+      "editComment",
+      "removeLink",
+      "startEditTitle",
+      "saveTitle",
+      "cancelEditTitle",
+      "submitComment",
+      "startEditBody",
+      "saveBody",
+      "cancelEditBody",
+      "submitLink",
+      "$UI",
+      "body",
+      "comments",
+      "links",
+      "mentions",
+      "references",
+      "mentioned",
+      "referencedBy",
+      "addComment",
+      "addLink",
+      "setBody",
+      "mention",
+      "unmention",
+      "$NAME",
+      "title",
+      "createdAt",
+      "commentCount",
+      "lastActivityAt"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/topic.tsx/20260911T230650Z-jpIt_H74ytb3FdPd.json
+++ b/packages/patterns/baselines/topics/topic.tsx/20260911T230650Z-jpIt_H74ytb3FdPd.json
@@ -1,0 +1,1053 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "NamesTableRow": {
+        "properties": {
+          "member": {
+            "description": "The member. `unknown` because it is written as a reference and only ever\ncompared; anything wider would read the member back whole.",
+            "type": "unknown"
+          },
+          "name": {
+            "description": "The member's name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "member",
+          "name"
+        ],
+        "type": "object"
+      },
+      "StoredTopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "authorName": {
+            "description": "Unrestricted legacy storage; only nonblank strings supply a name.",
+            "type": "unknown"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key. `\"legacy\"` records a display name\nwhose author kind is unknown.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicCrossrefRow": {
+        "properties": {
+          "mentionedBy": {
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "description": "The topic this row is about. `unknown` because it is written as a\nreference and only ever compared — `equals` takes the raw link. Anything\nwider retrieves the piece instead of pointing at it: declared `object`,\nthis field reads back as the whole expanded topic, `$UI` tree included.",
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "topic",
+          "mentionedBy"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicMentionable": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "boardCrossrefs": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's mention pivot, one row per topic. A topic reads its own row\nout of it and nothing else; see `backlinksOf`. Absent, a topic simply shows\nno inbound references.\n\nReadable, not writable: the pivot is the board's derivation, and a topic\nhas no business writing into it. Declaring the narrower cell says so where\na reader can see it, rather than leaving it to convention.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossrefRow"
+        },
+        "type": "array"
+      },
+      "boardNames": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's names table, one row per named topic. The topic reads its own\nrow out of it and nothing else; absent, the topic shows no number.\n\nReadable, not writable, for the reason `boardCrossrefs` states: the table\nis the board's derivation, and a topic has no business writing into it.\nWired at creation by the board's create, and rewired onto a topic filed\nbefore the namespace as a one-time link-bind — the same operator step\n`mentionable` states for itself.",
+        "items": {
+          "$ref": "#/$defs/NamesTableRow"
+        },
+        "type": "array"
+      },
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The topic's living document: durable conclusions get folded up into the\nbody; the comment thread below holds the deliberation.",
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "bodyUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "comments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/StoredTopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "createdBy": {
+        "$ref": "#/$defs/TopicAuthor"
+      },
+      "createdByName": {
+        "description": "Creator display name recorded without an author kind.",
+        "type": "unknown"
+      },
+      "links": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's mention universe — what the body editor autocompletes\nover. Wired at creation to the board's mention index (one derived\ndocument of copies; `MentionableRow` in\n`../collection-naming/mentionable.ts`), and rewired onto a piece from\nbefore the index as a one-time link-bind. A plain list of the pieces\nthemselves also satisfies the demand — a board not yet rewired, or a\ncomposer without a board. Absent, the editor simply offers no\ncompletions.\n\nDeclared readable, which is what settles the retained link's proof. A\nwritable handle adds a write-back leg to that proof, asking this\nthree-field projection to accept every field the board's row publishes,\nand the row carries a required `piece` this projection deliberately omits\n— so a topic wired to a board is refused even the source it is running.\nThe declaration is not a runtime gate: a write through the handle is\nrefused by nothing, and where the universe is a plain list of pieces the\neditor's name write-back reaches a member's own title through it.",
+        "items": {
+          "$ref": "#/$defs/TopicMentionable"
+        },
+        "type": "array"
+      },
+      "mentioned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "Pieces this topic references outside its prose — what `mention` records.\n\nIts own list rather than an entry in `references`, because that map belongs\nto the body editor: the editor mints its keys, rewrites its labels, and\ncollects entries whose token has left the document. A verb writing there\nwould be writing into somebody else's bookkeeping. Here there is nothing to\nkey by, because there is nothing to point back at from the prose — a\nreference outside a sentence is just a link in a list.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point, keyed by the token that\nappears in the body. The editor owns the contents; this pattern owns the\ncell, which is what makes a mention durable and — because each entry holds\nthe destination as a REFERENCE — what makes the reference graph a question\nabout cell identity rather than about text.\n\nThe default has to match the one `TopicOutput` publishes. A map published\nunder a different default than its input carries cannot be materialized."
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "titleUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        },
+        "description": "Attribution of the last rename, stamped by `setTitle` — the same pair\nthe body keeps, because a title is the other editable scalar."
+      },
+      "topicStateVersion": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "description": "Number of ordered state upgrades completed by this topic.",
+        "type": "number"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/topic.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The comment text, appended verbatim after trimming. Must be non-empty:\nan empty body rejects rather than recording a blank thread entry.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "What the link points at — a rendering hint, not a behavior switch.\nOptional because the handler defaults it to `\"web\"`, and a caller should\nnot be made to supply a field the verb never needed.",
+            "type": "string"
+          },
+          "label": {
+            "description": "Display label. Optional, and a blank one falls back to the URL.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The link target. Must be http(s): anything else rejects, because a\nuser-supplied scheme on a shared surface is script execution in every\nviewer's session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "EditCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement text, trimmed. Must be non-empty: emptying a\ncomment is a retraction, and `removeComment` is what says so.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to revise, named and checked as in `RemoveCommentEvent`,\nand additionally naming `body`, which this verb writes.",
+            "properties": {
+              "body": {
+                "default": "",
+                "type": "string"
+              },
+              "editedAt": {
+                "type": "number"
+              },
+              "removedAt": {
+                "type": "number"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt",
+              "body"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "MentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "The piece to reference — the piece itself, not an address. Identity here\nis the cell, so this is what a caller passes and what gets stored.\n\nDeclared through the one field every Topic has rather than `unknown`. The\ncell declaration marks this as a reference position, so the CLI resolves a\ncanonical `/of:...` value from an inline JSON event into the live piece\nlink. It also bounds the validation read: `topic.get()` is `undefined` for\na value that is not a reference and an object for any piece, and `mention`\nchecks it before storing anything.\n\n`title` is also the most this can safely name: this schema reaches every\ntopic in `mentionable`, so a property without a default would be demanded\nof topics written before it existed and refuse their update. `title`\ncarries one, and that default does double duty — it is also why the check\nadmits a piece that is not a topic at all, which reads back `{ title: \"\" }`\nrather than `undefined`. `deno task pattern-vintage` proves the update side\nby replaying a real board.\n\nNothing reads THROUGH it beyond that one field — the value is stored and\ncompared.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "RemoveCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to retract — the stored element, not a copy of its fields.\nNames only what this verb reads and writes, for the reason\n`MentionEvent.topic` names only `title`: the declaration bounds the\nvalidation read, and a payload that is not a reference reads back\n`undefined` and is refused rather than silently matching nothing.\n`sentAt` carries a default, so it is what makes a real element read back\nas an object; the stamp fields are optional, which is what lets this\nschema reach comments written before they existed.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "RemoveLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "link": {
+            "description": "The stored link element. What a reader passes, from the row it renders.\nNamed as in `RemoveCommentEvent`, with `url` playing the defaulted-field\nrole `sentAt` plays there.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "url": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "url": {
+            "description": "The link's URL, for a caller that cannot pass a reference. Retracts the\nmost recently added link still present with this URL, so retracting twice\nretracts two rather than re-stamping one.\n\nSequentially. Two concurrent retractions naming the same URL both resolve\nthe same newest-present element and merge into one stamped record, so\nthey retract one link between them rather than two. Naming the link by\nreference is what makes a caller's target unambiguous under concurrency;\nthis spelling trades that for being reachable at all.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement body, persisted verbatim — no trimming, so\nwhitespace-sensitive Markdown survives. An empty body is legal: clearing\na living document is an edit, not an error.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetTitleEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation, stored as structured attribution beside\nthe write time. Required so every successful rename is attributed.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The new title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key. `\"legacy\"` records a display name\nwhose author kind is unknown.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicSummary": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      },
+      "UnmentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "Declared and checked exactly as `MentionEvent.topic` is, and for the same\nreason: a payload that is not a reference matches no stored entry, so\nwithout the check it would remove nothing and report success.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A #topic — one durable unit of shared attention: a title, a living body\ndocument, a flat chronological comment thread, typed links out to other\ncore objects (PRs, agent sessions, web pages), and the references it makes\nto sibling pieces.\n\nDurable conclusions get folded up into the body — revise it whole with\n`setBody`; the thread holds the deliberation as point-in-time `addComment`\nrecords. The thread only ever grows: `removeComment` and `removeLink` stamp\na record as retracted and leave it where it is, and `editComment` revises a\nbody in place, so what a reader shows is the array filtered rather than the\narray itself. Sign every authored-content mutation with `agentName`:\nFabric records the human principal behind the key; the name says which\nagent acted under it. Reference-only `mention` and `unmention` calls carry\nno content signature. The session-draft cells and `submit*` streams below\nbelong to the rendered page, not the headless contract — they read state\nonly this session holds.",
+    "properties": {
+      "$NAME": {
+        "default": "",
+        "description": "The topic's display name. Like the other derived display fields, a cold\nretained topic may not have produced this path yet; its persisted title\nremains authoritative until it does.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addComment": {
+        "$ref": "#/$defs/AddCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Append to the thread — a point-in-time record of progress or\ndeliberation; durable conclusions belong in the body. Returns the\ncomment as recorded, resolved author and `sentAt` included."
+      },
+      "addLink": {
+        "$ref": "#/$defs/AddLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Attach a typed outbound link — a PR, an agent session, a web page.\nReturns the link as recorded, resolved `addedBy` and `addedAt`\nincluded. Appends merge and nothing dedupes: a repeated URL is two\nentries."
+      },
+      "body": {
+        "default": "",
+        "description": "The living document, verbatim Markdown. `setBody` replaces it whole.",
+        "type": "string"
+      },
+      "bodyDraft": {
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "bodyUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ]
+      },
+      "cancelEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the body editor; the session drafts are the discard.",
+        "tier": "wrapper"
+      },
+      "cancelEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the rename editor; the session draft is the discard.",
+        "tier": "wrapper"
+      },
+      "commentCount": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "commentDraft": {
+        "description": "Session-local composer/edit state. These controls belong to a direct Topic\ninstance, not the shared TopicPiece projection used by the tracker's list.",
+        "type": "string"
+      },
+      "comments": {
+        "description": "The thread, in arrival order, each record carrying its author snapshot\nand `sentAt`.\n\nMEMBERSHIP is append-only; a record is not. Nothing is ever removed from\nthis array — `removeComment` stamps `removedAt` and leaves the record in\nplace, and `editComment` revises a body and stamps `editedAt` — so a\nreader that wants the live thread filters on `removedAt` rather than\ntaking the array as it stands. `commentCount` is that filtered count.",
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+        "type": "number"
+      },
+      "createdBy": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "editComment": {
+        "$ref": "#/$defs/EditCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Revise a comment's body in place, naming it by reference. Stamps\n`editedAt` and leaves `author` and `sentAt` as they were. Outside the\nprojection for the reason `removeComment` states."
+      },
+      "editingBody": {
+        "description": "Whether the body editor is open.\n\nA bare session-scoped value rather than a cell-wrapped one, and that\nspelling costs a capability worth knowing about before reaching for it: a\nverb cannot take a whole Topic as captured state while any required\nproperty is published this way. The piece does not materialize through the\nverb's state schema, so the argument arrives undefined and the runtime\ndeclines to run the verb at all — \"stream action argument is undefined\n(potential schema mismatch)\", logged rather than thrown, with the write\nsilently absent.\n\nNothing needs that today. A board names a member by writing the piece into\nits namespace, and every path that does so builds the piece inside the\nverb (`addTopic`, the browser composer) or resolves it out of the board's\nown list (`backfillNames`); none of them takes a Topic as an argument, so\nnone reads one through a state schema. Cell-wrapping these two would buy\nthe capability at the cost of a `scope changed` break on every deployed\nTopic, so it waits for a verb that needs it.",
+        "scope": "session",
+        "type": "boolean"
+      },
+      "editingTitle": {
+        "description": "Whether the rename editor is open. Bare for the reason `editingBody`\nstates, and the constraint is per property: cell-wrapping one and not the\nother buys nothing.",
+        "scope": "session",
+        "type": "boolean"
+      },
+      "lastActivityAt": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "linkKindDraft": {
+        "type": "string"
+      },
+      "linkLabelDraft": {
+        "type": "string"
+      },
+      "linkUrlDraft": {
+        "type": "string"
+      },
+      "links": {
+        "description": "Typed outbound links, in arrival order, each carrying its author snapshot\nand `addedAt`. Append-only in membership on the same terms as `comments`:\n`removeLink` stamps rather than removes, and a stamped link additionally\nstops resolving into `mentions`.",
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mention": {
+        "$ref": "#/$defs/MentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Reference another piece from this topic — the payload is the piece\nitself, stored as a reference. Takes no `agentName` and returns no value;\nFabric retains the authenticated principal behind the edge."
+      },
+      "mentioned": {
+        "default": [],
+        "description": "Pieces referenced outside the prose, recorded by `mention`.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "mentions": {
+        "default": [],
+        "description": "Every piece this topic's prose and links point at, as references.\n\nThe board's pivot is declared over this and nothing else, so what one topic\ncosts a full-board scan is exactly this list of identities. Declared\n`unknown[]` because these are references, and comparing them never reads\nwhat is behind them.\n\nThe cell annotation that makes them comparable belongs to the READER, not\nhere: the pivot declares its own view of this list as\n`TopicMentionSource.mentions: ComparableCell<unknown>[]`, and that is what\nmakes its graph settle rather than depend on load order. A published\n`unknown[]` is what each reader annotates for itself.\n\nThe default stands alone: a declared default and `| undefined` collide,\nand the default is what a topic deployed before this path existed\nmaterializes against.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "referencedBy": {
+        "default": [],
+        "description": "The topics that mention this one, read out of the board's pivot.\n\nDeclared through `TopicSummary` rather than `TopicPiece`, and that is\nload-bearing rather than stingy: a topic whose backlinks were topics would\nbe a type that contains itself, and resolving one from a list would walk\nthe graph. The summary carries no reference of its own, so it terminates.\nA reader that wants more follows the link, which resolves whole.",
+        "items": {
+          "$ref": "#/$defs/TopicSummary"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point. Durable content, like\n`links`. The body editor works on a session copy of this map, which a save\npublishes here whole, beside the prose whose tokens name its entries."
+      },
+      "referencesDraft": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "description": "The body draft's mention map, staged so Cancel can discard it.\n\n`cf-code-editor` writes an entry the moment a mention is inserted and\ndrops one the moment its token leaves the document, neither of them\nwaiting for Save. Pointed at the durable map while `$value` holds a\nsession draft, those writes would outlive a discarded edit: a canceled\ninsertion would leave an edge no token names, and a canceled deletion\nwould strip the destination from a token the durable body still carries.\nThe editor's own ordering assumes its two bindings share a lifetime, so\nthis gives them one."
+      },
+      "removeComment": {
+        "$ref": "#/$defs/RemoveCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a comment, naming it by reference. The record is stamped rather\nthan deleted, so the thread keeps its evidence while a reader stops\nshowing it and `commentCount` stops counting it.\n\nHere rather than on `TopicPiece`, for the reason `setTitle` is: boards\nstore that projection, so it is a demand on every topic they already\nhold, and a required verb added to it would refuse every one deployed\nbefore the verb existed. A verb has no default to be rescued by, so there\nis no compatible way to demand a new one. Addressing the topic directly\nreaches all three of these."
+      },
+      "removeLink": {
+        "$ref": "#/$defs/RemoveLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a link, by reference or by `url`. Stamped like a comment, and a\nretracted link stops resolving into `mentions`. The url spelling exists\nbecause a link record carries no fid for a CLI caller to name. Outside\nthe projection for the reason `removeComment` states."
+      },
+      "saveBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: publish the session body and mention-map drafts whole,\nattributed to the viewer's Profile — the contract verb is `setBody`.",
+        "tier": "wrapper"
+      },
+      "saveTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: save the session title draft under the viewer's Profile —\nthe contract verb is `setTitle`, and both land through the same core, so\na browser rename stamps the same attribution and moves the same activity\nclock.",
+        "tier": "wrapper"
+      },
+      "setBody": {
+        "$ref": "#/$defs/SetBodyEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Replace the living document whole — read it, revise it, write it back\ncomplete; the body is one value with whole-value conflict semantics.\nRequires `agentName` and returns the persisted body with its attribution."
+      },
+      "setTitle": {
+        "$ref": "#/$defs/SetTitleEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Rename the topic. Requires `agentName` and returns the persisted title\nwith its attribution. This direct-address verb stays outside the board's\nnarrow `TopicPiece` demand."
+      },
+      "shortName": {
+        "description": "The name the board calls this topic by, read out of the board's names\ntable by identity. The display name stays the title — this rides beside\nit, under the name a mention pill reads it by (`Mentionable.shortName` in\n`packages/ui/src/v2/core/mentionable.ts`), so a mention of this topic\nelsewhere gains the number as soon as the board names it.\n\nAbsent for a topic no board has named, or one wired to no board: the\nlookup produces nothing and the property is simply not there. Every\nconsumer treats that as no name — the badge renders nothing, a universe\nrow matches no `#42` query, and a mention pill shows no number\n(`_trackRefShortName` in\n`packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts` reads an\nabsent name exactly as it reads a blank one).\n\nOptional rather than defaulted, and the difference is the compatibility\nproof's: this is what a board's stored list is validated against, and a\ndefaulted property there moves the demand's defaults below an array\nconstraint the proof cannot show stable under default insertion. It is not\nwhat lets the projection apply over a board whose members predate the\nproperty, and nothing is; `TopicDemand.shortName` in `./main.tsx` states\nwhy.",
+        "tags": [
+          "42"
+        ],
+        "type": "string"
+      },
+      "startEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the body editor, seeding the session drafts from the\ndurable body and mention map.",
+        "tier": "wrapper"
+      },
+      "startEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the rename editor, seeding the session draft from the\ndurable title.",
+        "tier": "wrapper"
+      },
+      "submitComment": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session comment draft under the viewer's\nProfile. Reads session-local state, so it is a silent no-op headless —\nthe contract verb is `addComment`.",
+        "tier": "wrapper"
+      },
+      "submitLink": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session link drafts under the viewer's Profile —\nthe contract verb is `addLink`.",
+        "tier": "wrapper"
+      },
+      "title": {
+        "default": "",
+        "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+        "type": "string"
+      },
+      "titleDraft": {
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "titleUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ],
+        "description": "Attribution of the last rename; unset until the first `setTitle`.\nBeside `setTitle` rather than on the projection, for the same reason."
+      },
+      "unmention": {
+        "$ref": "#/$defs/UnmentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Stop referencing a piece: removes every `mention`-made entry naming it.\nReferences made in the prose are retracted by editing the prose, not by\nthis. Takes no `agentName` and returns no value."
+      }
+    },
+    "required": [
+      "commentDraft",
+      "bodyDraft",
+      "editingBody",
+      "titleDraft",
+      "editingTitle",
+      "linkUrlDraft",
+      "linkLabelDraft",
+      "linkKindDraft",
+      "referencesDraft",
+      "setTitle",
+      "removeComment",
+      "editComment",
+      "removeLink",
+      "startEditTitle",
+      "saveTitle",
+      "cancelEditTitle",
+      "submitComment",
+      "startEditBody",
+      "saveBody",
+      "cancelEditBody",
+      "submitLink",
+      "$UI",
+      "body",
+      "comments",
+      "links",
+      "mentions",
+      "references",
+      "mentioned",
+      "referencedBy",
+      "addComment",
+      "addLink",
+      "setBody",
+      "mention",
+      "unmention",
+      "$NAME",
+      "title",
+      "createdAt",
+      "commentCount",
+      "lastActivityAt"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/integration/topic-author-migration.test.ts
+++ b/packages/patterns/integration/topic-author-migration.test.ts
@@ -197,4 +197,89 @@ describe("topic-author-migration", () => {
       cancel();
     }
   });
+
+  it("preserves non-string legacy values without manufacturing authors", async () => {
+    const names = [42, false, null, ["not a name"], {
+      displayName: "not a name",
+    }];
+    const { argument, result, originalComments } = await start({
+      createdByName: { displayName: "not a creator name" },
+      comments: names.map((authorName, index) => ({
+        authorName,
+        body: "No usable name",
+        sentAt: index,
+      })),
+    });
+    expect(await result.key("createdBy").pull()).toEqual({
+      name: "",
+      kind: "person",
+    });
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(true);
+    expect(argument.key("createdBy").getRaw()).toBeUndefined();
+    expect(argument.key("createdByName").getRaw()).toEqual({
+      displayName: "not a creator name",
+    });
+    expect(fabricAwareEqual(
+      argument.key("comments").getRaw({ lastNode: "value" }),
+      originalComments,
+    )).toBe(true);
+    for (const [index, name] of names.entries()) {
+      const comment = argument.key("comments").key(index);
+      expect(comment.key("author").getRaw()).toBeUndefined();
+      expect(comment.key("authorName").getRaw()).toEqual(name);
+    }
+    expect(errors).toEqual([]);
+  });
+
+  for (const field of ["creator", "comment"] as const) {
+    it(`waits for a linked ${field} name before completing any author writes`, async () => {
+      const pendingName = runtime.getCell<string>(space, "pending-name");
+      const { argument, result } = await start({
+        createdByName: field === "creator" ? pendingName : "Creator",
+        authorFieldsMigratedV1: false,
+        comments: [
+          { authorName: "First author", body: "First", sentAt: 1 },
+          {
+            authorName: field === "comment" ? pendingName : "Second author",
+            body: "Second",
+            sentAt: 2,
+          },
+        ],
+      });
+      const cancel = result.key("createdBy").sink(() => {});
+      try {
+        await runtime.idle();
+        await runtime.storageManager.synced();
+        expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(false);
+        expect(argument.key("createdBy").getRaw()).toBeUndefined();
+        expect(argument.key("comments").key(0).key("author").getRaw())
+          .toBeUndefined();
+
+        const arrival = runtime.edit();
+        pendingName.withTx(arrival).set("  Delayed name  ");
+        expect((await arrival.commit()).error).toBeUndefined();
+        expect(await result.key("createdBy").pull()).toEqual({
+          name: field === "creator" ? "  Delayed name  " : "Creator",
+          kind: "legacy",
+        });
+        await runtime.idle();
+        await runtime.storageManager.synced();
+        expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(true);
+        expect(
+          argument.key("comments").key(1).key("author").getRaw({
+            lastNode: "value",
+          }),
+        ).toEqual({
+          name: field === "comment" ? "  Delayed name  " : "Second author",
+          kind: "legacy",
+        });
+        expect(pendingName.getRaw()).toBe("  Delayed name  ");
+        expect(errors).toEqual([]);
+      } finally {
+        cancel();
+      }
+    });
+  }
 });

--- a/packages/patterns/integration/topic-author-migration.test.ts
+++ b/packages/patterns/integration/topic-author-migration.test.ts
@@ -78,6 +78,71 @@ describe("topic-author-migration", () => {
     return { argument, result, originalComments };
   };
 
+  it("upgrades version zero to the current version without any result read", async () => {
+    const { argument } = await start({
+      createdByName: "Creator",
+      comments: [{ authorName: "Commenter", body: "First", sentAt: 1 }],
+    });
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    expect(argument.key("topicStateVersion").getRaw()).toBe(1);
+    expect(argument.key("createdBy").getRaw({ lastNode: "value" })).toEqual({
+      name: "Creator",
+      kind: "legacy",
+    });
+    expect(
+      argument.key("comments").key(0).key("author").getRaw({
+        lastNode: "value",
+      }),
+    ).toEqual({ name: "Commenter", kind: "legacy" });
+    expect(errors).toEqual([]);
+  });
+
+  for (
+    const comments of [[], [{
+      authorName: "Commenter",
+      body: "First",
+      sentAt: 1,
+    }]]
+  ) {
+    it(`upgrades without a stored creator name and with ${comments.length} comments`, async () => {
+      const { argument } = await start({ comments });
+      await runtime.idle();
+      await runtime.storageManager.synced();
+      expect(argument.key("topicStateVersion").getRaw()).toBe(1);
+      expect(argument.key("createdBy").getRaw()).toBeUndefined();
+      expect(argument.key("createdByName").getRaw()).toBeUndefined();
+      if (comments.length) {
+        expect(
+          argument.key("comments").key(0).key("author").getRaw({
+            lastNode: "value",
+          }),
+        ).toEqual({ name: "Commenter", kind: "legacy" });
+      }
+      expect(errors).toEqual([]);
+    });
+  }
+
+  for (const placeholder of ["someone", "  someone  "]) {
+    it(`keeps the legacy placeholder ${JSON.stringify(placeholder)} unattributed`, async () => {
+      const { argument } = await start({
+        createdByName: placeholder,
+        comments: [{ authorName: placeholder, body: "First", sentAt: 1 }],
+      });
+      await runtime.idle();
+      await runtime.storageManager.synced();
+      expect(argument.key("topicStateVersion").getRaw()).toBe(1);
+      expect(argument.key("createdBy").getRaw()).toBeUndefined();
+      expect(argument.key("comments").key(0).key("author").getRaw())
+        .toBeUndefined();
+      expect(argument.key("createdByName").getRaw()).toBe(placeholder);
+      expect(argument.key("comments").key(0).key("authorName").getRaw()).toBe(
+        placeholder,
+      );
+      expect(errors).toEqual([]);
+    });
+  }
+
   it("preserves comment links and completion after reopening from stored source", async () => {
     const { argument, result, originalComments } = await start({
       createdByName: "Fable",
@@ -92,7 +157,7 @@ describe("topic-author-migration", () => {
     });
     await runtime.idle();
     await runtime.storageManager.synced();
-    expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(true);
+    expect(argument.key("topicStateVersion").getRaw()).toBe(1);
     expect(fabricAwareEqual(
       argument.key("comments").getRaw({ lastNode: "value" }),
       originalComments,
@@ -148,7 +213,7 @@ describe("topic-author-migration", () => {
     expect(reopenedArgument.key("createdByName").getRaw()).toBe(
       "Changed legacy name",
     );
-    expect(reopenedArgument.key("authorFieldsMigratedV1").getRaw()).toBe(true);
+    expect(reopenedArgument.key("topicStateVersion").getRaw()).toBe(1);
     expect(errors).toEqual([]);
   });
 
@@ -159,7 +224,7 @@ describe("topic-author-migration", () => {
     );
     const { argument, result } = await start({
       createdByName: "Creator",
-      authorFieldsMigratedV1: false,
+      topicStateVersion: 0,
       comments: [
         { authorName: "First author", body: "First", sentAt: 1 },
         pending,
@@ -169,7 +234,7 @@ describe("topic-author-migration", () => {
     try {
       await runtime.idle();
       await runtime.storageManager.synced();
-      expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(false);
+      expect(argument.key("topicStateVersion").getRaw()).toBe(0);
       expect(argument.key("createdBy").getRaw()).toBeUndefined();
       expect(argument.key("comments").key(0).key("author").getRaw())
         .toBeUndefined();
@@ -187,7 +252,7 @@ describe("topic-author-migration", () => {
       });
       await runtime.idle();
       await runtime.storageManager.synced();
-      expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(true);
+      expect(argument.key("topicStateVersion").getRaw()).toBe(1);
       expect(pending.key("author").getRaw({ lastNode: "value" })).toEqual({
         name: "Delayed author",
         kind: "legacy",
@@ -216,7 +281,7 @@ describe("topic-author-migration", () => {
     });
     await runtime.idle();
     await runtime.storageManager.synced();
-    expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(true);
+    expect(argument.key("topicStateVersion").getRaw()).toBe(1);
     expect(argument.key("createdBy").getRaw()).toBeUndefined();
     expect(argument.key("createdByName").getRaw()).toEqual({
       displayName: "not a creator name",
@@ -238,7 +303,7 @@ describe("topic-author-migration", () => {
       const pendingName = runtime.getCell<string>(space, "pending-name");
       const { argument, result } = await start({
         createdByName: field === "creator" ? pendingName : "Creator",
-        authorFieldsMigratedV1: false,
+        topicStateVersion: 0,
         comments: [
           { authorName: "First author", body: "First", sentAt: 1 },
           {
@@ -252,7 +317,7 @@ describe("topic-author-migration", () => {
       try {
         await runtime.idle();
         await runtime.storageManager.synced();
-        expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(false);
+        expect(argument.key("topicStateVersion").getRaw()).toBe(0);
         expect(argument.key("createdBy").getRaw()).toBeUndefined();
         expect(argument.key("comments").key(0).key("author").getRaw())
           .toBeUndefined();
@@ -266,7 +331,7 @@ describe("topic-author-migration", () => {
         });
         await runtime.idle();
         await runtime.storageManager.synced();
-        expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(true);
+        expect(argument.key("topicStateVersion").getRaw()).toBe(1);
         expect(
           argument.key("comments").key(1).key("author").getRaw({
             lastNode: "value",

--- a/packages/patterns/integration/topic-author-migration.test.ts
+++ b/packages/patterns/integration/topic-author-migration.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Runs the Topic source against isolated in-process storage to check durable
+ * migration, linked comment identity, and incomplete-input recovery.
+ */
+
+import { expect } from "@std/expect";
+import { fromFileUrl } from "@std/path";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { fabricAwareEqual } from "@commonfabric/data-model";
+import { Identity } from "@commonfabric/identity";
+import { getPatternIdentityRef, Runtime } from "@commonfabric/runner";
+import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
+import {
+  EmulatedStorageManager,
+  newLoopbackServer,
+} from "@commonfabric/runner/storage/cache.deno";
+
+const PATTERN_PATH = fromFileUrl(
+  new URL("../topics/topic.tsx", import.meta.url),
+);
+const ROOT_PATH = fromFileUrl(new URL("..", import.meta.url));
+const signer = await Identity.fromPassphrase("topic author migration fixture");
+const space = signer.did();
+
+describe("topic-author-migration", () => {
+  let server: ReturnType<typeof newLoopbackServer>;
+  let runtime: Runtime;
+  let errors: string[];
+
+  /** Opens a fresh client replica against this test's durable storage. */
+  const open = () =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: EmulatedStorageManager.connectTo(server, { as: signer }),
+      experimental: { lazyMaterialization: true, serverExecution: false },
+      errorHandlers: [(error) => errors.push(String(error))],
+    });
+
+  beforeEach(() => {
+    server = newLoopbackServer({ subscriptionRefreshDelayMs: 0 });
+    errors = [];
+    runtime = open();
+  });
+  afterEach(async () => {
+    await runtime.dispose();
+    await server.close();
+  });
+
+  /** Seeds storage, then starts the actual Topic source over those inputs. */
+  const start = async (input: Record<string, unknown>) => {
+    const program = await resolveLocalProgram(
+      (resolver) => runtime.harness.resolve(resolver),
+      { main: PATTERN_PATH, root: ROOT_PATH },
+    );
+    const compiled = await runtime.patternManager.compilePattern(program, {
+      space,
+    });
+    const argument = runtime.getCell<Record<string, unknown>>(
+      space,
+      "argument",
+    );
+    const result = runtime.getCell<Record<string, unknown>>(
+      space,
+      "result",
+      compiled.resultSchema,
+    );
+    const seed = runtime.edit();
+    argument.withTx(seed).set(input);
+    expect((await seed.commit()).error).toBeUndefined();
+    const originalComments = argument.key("comments").getRaw({
+      lastNode: "value",
+    });
+    const tx = runtime.edit();
+    runtime.run(tx, compiled, argument, result);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    return { argument, result, originalComments };
+  };
+
+  it("preserves comment links and completion after reopening from stored source", async () => {
+    const { argument, result, originalComments } = await start({
+      createdByName: "Fable",
+      comments: [
+        { authorName: "Fable", body: "First", sentAt: 1, extra: "keep" },
+        { authorName: "Gideon", body: "Reply", sentAt: 2 },
+      ],
+    });
+    expect(await result.key("createdBy").pull()).toEqual({
+      kind: "legacy",
+      name: "Fable",
+    });
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(true);
+    expect(fabricAwareEqual(
+      argument.key("comments").getRaw({ lastNode: "value" }),
+      originalComments,
+    )).toBe(true);
+    expect(argument.key("comments").key(0).key("extra").getRaw()).toBe("keep");
+    expect(argument.key("comments").key(0).key("authorName").getRaw()).toBe(
+      "Fable",
+    );
+    expect(
+      argument.key("comments").key(1).key("author").getRaw({
+        lastNode: "value",
+      }),
+    ).toEqual({ name: "Gideon", kind: "legacy" });
+    const identity = getPatternIdentityRef(result);
+    expect(identity).toBeDefined();
+    if (!identity) throw new Error("Topic has no retained source identity.");
+
+    const edit = runtime.edit();
+    argument.withTx(edit).key("createdByName").set("Changed legacy name");
+    expect((await edit.commit()).error).toBeUndefined();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await runtime.dispose();
+    runtime = open();
+
+    const loaded = await runtime.patternManager.loadPatternByIdentity(
+      identity.identity,
+      identity.symbol,
+      space,
+      { repairCache: false },
+    );
+    expect(loaded).toBeDefined();
+    if (!loaded) throw new Error("Stored Topic source did not load.");
+    const reopenedArgument = runtime.getCell<Record<string, unknown>>(
+      space,
+      "argument",
+    );
+    const reopenedResult = runtime.getCell<Record<string, unknown>>(
+      space,
+      "result",
+      loaded.resultSchema,
+    );
+    await reopenedArgument.sync();
+    await reopenedResult.sync();
+    const tx = runtime.edit();
+    runtime.run(tx, loaded, reopenedArgument, reopenedResult);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    expect(await reopenedResult.key("createdBy").pull()).toEqual({
+      kind: "legacy",
+      name: "Fable",
+    });
+    expect(reopenedArgument.key("createdByName").getRaw()).toBe(
+      "Changed legacy name",
+    );
+    expect(reopenedArgument.key("authorFieldsMigratedV1").getRaw()).toBe(true);
+    expect(errors).toEqual([]);
+  });
+
+  it("leaves completion and author fields untouched until a linked comment arrives", async () => {
+    const pending = runtime.getCell<Record<string, unknown>>(
+      space,
+      "pending-comment",
+    );
+    const { argument, result } = await start({
+      createdByName: "Creator",
+      authorFieldsMigratedV1: false,
+      comments: [
+        { authorName: "First author", body: "First", sentAt: 1 },
+        pending,
+      ],
+    });
+    const cancel = result.key("createdBy").sink(() => {});
+    try {
+      await runtime.idle();
+      await runtime.storageManager.synced();
+      expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(false);
+      expect(argument.key("createdBy").getRaw()).toBeUndefined();
+      expect(argument.key("comments").key(0).key("author").getRaw())
+        .toBeUndefined();
+
+      const arrival = runtime.edit();
+      pending.withTx(arrival).set({
+        authorName: "Delayed author",
+        body: "Arrived",
+        sentAt: 2,
+      });
+      expect((await arrival.commit()).error).toBeUndefined();
+      expect(await result.key("createdBy").pull()).toEqual({
+        name: "Creator",
+        kind: "legacy",
+      });
+      await runtime.idle();
+      await runtime.storageManager.synced();
+      expect(argument.key("authorFieldsMigratedV1").getRaw()).toBe(true);
+      expect(pending.key("author").getRaw({ lastNode: "value" })).toEqual({
+        name: "Delayed author",
+        kind: "legacy",
+      });
+      expect(errors).toEqual([]);
+    } finally {
+      cancel();
+    }
+  });
+});

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -65,22 +65,27 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   current authored-content verb writes structured attribution; the public result
   and mutation contracts contain no mutable "current author" state or
   display-name mirrors.
-- **Legacy display names migrate once per topic.** Reading a topic's author data
-  runs a lift that fills missing structured names from `createdByName` and
-  comment `authorName` fields. It preserves nonblank structured names, existing
-  kinds and avatars, the legacy fields, and comment identity. A name with no
-  known kind receives `kind: "legacy"`, which renders as the name without a
-  person or agent classification. The stored input flag `authorFieldsMigratedV1`
-  defaults to false and becomes true in the same transaction as the copies. All
-  relevant author fields are read through cell handles before writing; an
-  unresolved linked comment or name leaves completion pending. Legacy-name
-  inputs stay `unknown` to accept the full stored domain. The lift's explicit
-  schema reads strings while keeping other values opaque; only nonblank strings
-  are copied. Non-string values remain stored unchanged and do not prevent
-  completion. The flag is shared per topic and survives reopening and source
-  updates. This migration covers the records present when it completes; legacy
-  writers must be retired before rollout, because later legacy-shaped records
-  are outside that completed pass.
+- **Topic state upgrades run in order.** Running a Topic runs an upgrade lift,
+  even without a consumer reading its result. The input `topicStateVersion`
+  defaults to zero; pending steps run in order, and each records its new version
+  after its writes in the same transaction. Every durable mutation uses the same
+  upgrade function before writing. Both board creation paths stamp the current
+  version. A stored future or invalid version makes the lift inert and durable
+  mutations reject; session editor controls remain available.
+- **The first upgrade preserves legacy attribution.** It fills missing
+  structured names from `createdByName` and comment `authorName`, retaining
+  nonblank structured names, kinds, avatars, legacy fields, and comment
+  identity. Names without a known kind receive `kind: "legacy"`. Blank strings
+  and the trimmed placeholder `"someone"` supply no attribution. Legacy inputs
+  stay `unknown`; explicit reader schemas materialize strings and keep other
+  values opaque and unchanged. Every source and destination is read through
+  handles before the first write, so an unresolved linked comment or name leaves
+  this step pending. Once complete, later legacy writes are outside this pass.
+
+  [State upgrade design](state-upgrades.md) describes the sequence, mutation
+  boundary, schema bindings, tests, and rollback limits. Legacy writers must be
+  retired before rollout. Source rollback preserves stored data; only code that
+  implements the version guard can refuse writes to a newer state version.
 - **The board names its members, and every reader reaches a name the same way.**
   `addTopic` allocates the next name in the same transaction as the append, so
   no reader observes a topic without its name and two concurrent creates

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -65,6 +65,18 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   current authored-content verb writes structured attribution; the public result
   and mutation contracts contain no mutable "current author" state or
   display-name mirrors.
+- **Legacy display names migrate once per topic.** Reading a topic's author data
+  runs a lift that fills missing structured names from `createdByName` and
+  comment `authorName` fields. It preserves nonblank structured names, existing
+  kinds and avatars, the legacy fields, and comment identity. A name with no
+  known kind receives `kind: "legacy"`, which renders as the name without a
+  person or agent classification. The stored input flag `authorFieldsMigratedV1`
+  defaults to false and becomes true in the same transaction as the copies. All
+  source records are read before writing; an unresolved linked comment leaves
+  completion pending. The flag is shared per topic and survives reopening and
+  source updates. This migration covers the records present when it completes;
+  legacy writers must be retired before rollout, because later legacy-shaped
+  records are outside that completed pass.
 - **The board names its members, and every reader reaches a name the same way.**
   `addTopic` allocates the next name in the same transaction as the append, so
   no reader observes a topic without its name and two concurrent creates

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -72,11 +72,15 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   known kind receives `kind: "legacy"`, which renders as the name without a
   person or agent classification. The stored input flag `authorFieldsMigratedV1`
   defaults to false and becomes true in the same transaction as the copies. All
-  source records are read before writing; an unresolved linked comment leaves
-  completion pending. The flag is shared per topic and survives reopening and
-  source updates. This migration covers the records present when it completes;
-  legacy writers must be retired before rollout, because later legacy-shaped
-  records are outside that completed pass.
+  relevant author fields are read through cell handles before writing; an
+  unresolved linked comment or name leaves completion pending. Legacy-name
+  inputs stay `unknown` to accept the full stored domain. The lift's explicit
+  schema reads strings while keeping other values opaque; only nonblank strings
+  are copied. Non-string values remain stored unchanged and do not prevent
+  completion. The flag is shared per topic and survives reopening and source
+  updates. This migration covers the records present when it completes; legacy
+  writers must be retired before rollout, because later legacy-shaped records
+  are outside that completed pass.
 - **The board names its members, and every reader reaches a name the same way.**
   `addTopic` allocates the next name in the same transaction as the append, so
   no reader observes a topic without its name and two concurrent creates

--- a/packages/patterns/topics/author-migration-multi-user.test.tsx
+++ b/packages/patterns/topics/author-migration-multi-user.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Exercises one shared migration with two open runtimes and concurrent comment
- * appends. The initial completed flag lets both readers open the legacy data
+ * appends. The initial current version lets both readers open the legacy data
  * before an action enables migration.
  */
 
@@ -14,21 +14,21 @@ import {
 } from "commonfabric";
 import Topic, { type TopicOutput } from "./topic.tsx";
 
-/** Shared topic and its stored migration flag. */
+/** Shared topic and its stored state version. */
 interface Setup {
   /** Topic both participants keep open. */
   topic: TopicOutput;
 
   /** Test control for enabling migration after both readers are ready. */
-  migrated: Writable<boolean>;
+  migrated: Writable<number>;
 }
 
 /** Creates shared legacy records with migration initially disabled. */
 export const setup = pattern(() => {
-  const migrated = new Writable(true);
+  const migrated = new Writable(1);
   const topic = Topic({
     createdByName: "Legacy creator",
-    authorFieldsMigratedV1: migrated,
+    topicStateVersion: migrated,
     comments: [
       { authorName: "Fable", body: "Legacy comment", sentAt: 1 },
       {
@@ -44,7 +44,7 @@ export const setup = pattern(() => {
 
 /** Enables migration with both readers open, then appends a comment. */
 export const first = pattern<{ setup: Setup }>(({ setup }) => {
-  const action_enable_migration = action(() => setup.migrated.set(false));
+  const action_enable_migration = action(() => setup.migrated.set(0));
   const action_append = action(() =>
     setup.topic.addComment.send({
       agentName: "First writer",
@@ -60,7 +60,7 @@ export const first = pattern<{ setup: Setup }>(({ setup }) => {
     setup.topic.comments[0].author?.name === "Fable" &&
     setup.topic.comments[0].author?.kind === "legacy" &&
     setup.topic.comments[1].author?.name === "Current author" &&
-    setup.migrated.get() === true
+    setup.migrated.get() === 1
   );
   const assert_both_appends = assert(() =>
     setup.topic.comments.length === 4 &&
@@ -109,7 +109,7 @@ export const second = pattern<{ setup: Setup }>(({ setup }) => {
     setup.topic.comments[0].author?.name === "Fable" &&
     setup.topic.comments[0].author?.kind === "legacy" &&
     setup.topic.comments[1].author?.name === "Current author" &&
-    setup.migrated.get() === true
+    setup.migrated.get() === 1
   );
   const assert_both_appends = assert(() =>
     setup.topic.comments.length === 4 &&

--- a/packages/patterns/topics/author-migration-multi-user.test.tsx
+++ b/packages/patterns/topics/author-migration-multi-user.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Exercises one shared migration with two open runtimes and concurrent comment
+ * appends. The initial completed flag lets both readers open the legacy data
+ * before an action enables migration.
+ */
+
+import {
+  action,
+  assert,
+  multiUserTest,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
+import Topic, { type TopicOutput } from "./topic.tsx";
+
+/** Shared topic and its stored migration flag. */
+interface Setup {
+  /** Topic both participants keep open. */
+  topic: TopicOutput;
+
+  /** Test control for enabling migration after both readers are ready. */
+  migrated: Writable<boolean>;
+}
+
+/** Creates shared legacy records with migration initially disabled. */
+export const setup = pattern(() => {
+  const migrated = new Writable(true);
+  const topic = Topic({
+    createdByName: "Legacy creator",
+    authorFieldsMigratedV1: migrated,
+    comments: [
+      { authorName: "Fable", body: "Legacy comment", sentAt: 1 },
+      {
+        authorName: "Old display name",
+        author: { kind: "agent", name: "Current author" },
+        body: "Structured comment",
+        sentAt: 2,
+      },
+    ],
+  });
+  return { topic, migrated };
+});
+
+/** Enables migration with both readers open, then appends a comment. */
+export const first = pattern<{ setup: Setup }>(({ setup }) => {
+  const action_enable_migration = action(() => setup.migrated.set(false));
+  const action_append = action(() =>
+    setup.topic.addComment.send({
+      agentName: "First writer",
+      body: "First concurrent comment",
+    })
+  );
+  const assert_legacy_is_visible = assert(() =>
+    setup.topic.comments[0].body === "Legacy comment" &&
+    setup.topic.comments[0].author === undefined
+  );
+  const assert_migrated = assert(() =>
+    setup.topic.createdBy?.name === "Legacy creator" &&
+    setup.topic.comments[0].author?.name === "Fable" &&
+    setup.topic.comments[0].author?.kind === "legacy" &&
+    setup.topic.comments[1].author?.name === "Current author" &&
+    setup.migrated.get() === true
+  );
+  const assert_both_appends = assert(() =>
+    setup.topic.comments[2].author?.kind === "agent" &&
+    setup.topic.comments[3].author?.kind === "agent" &&
+    setup.topic.comments[2].author?.name !==
+      setup.topic.comments[3].author?.name &&
+    setup.topic.comments[0].author?.name === "Fable"
+  );
+  return {
+    [TESTS]: [
+      { assertion: assert_legacy_is_visible },
+      { label: "first-open" },
+      { await: "second-open" },
+      { action: action_enable_migration },
+      { assertion: assert_migrated },
+      { label: "migration-enabled" },
+      { action: action_append },
+      { label: "first-appended" },
+      { await: "second-appended" },
+      { assertion: assert_both_appends },
+    ],
+  };
+});
+
+/** Observes migration from another runtime and appends a comment. */
+export const second = pattern<{ setup: Setup }>(({ setup }) => {
+  const action_append = action(() =>
+    setup.topic.addComment.send({
+      agentName: "Second writer",
+      body: "Second concurrent comment",
+    })
+  );
+  const assert_legacy_is_visible = assert(() =>
+    setup.topic.comments[0].body === "Legacy comment" &&
+    setup.topic.comments[0].author === undefined
+  );
+  const assert_migrated = assert(() =>
+    setup.topic.createdBy?.name === "Legacy creator" &&
+    setup.topic.comments[0].author?.name === "Fable" &&
+    setup.topic.comments[0].author?.kind === "legacy" &&
+    setup.topic.comments[1].author?.name === "Current author" &&
+    setup.migrated.get() === true
+  );
+  return {
+    [TESTS]: [
+      { assertion: assert_legacy_is_visible },
+      { label: "second-open" },
+      { await: "first-open" },
+      { await: "migration-enabled" },
+      { assertion: assert_migrated },
+      { action: action_append },
+      { label: "second-appended" },
+      { await: "first-appended" },
+      { assertion: assert_migrated },
+    ],
+  };
+});
+
+export default multiUserTest({ setup, participants: { first, second } });

--- a/packages/patterns/topics/author-migration-multi-user.test.tsx
+++ b/packages/patterns/topics/author-migration-multi-user.test.tsx
@@ -63,10 +63,17 @@ export const first = pattern<{ setup: Setup }>(({ setup }) => {
     setup.migrated.get() === true
   );
   const assert_both_appends = assert(() =>
+    setup.topic.comments.length === 4 &&
     setup.topic.comments[2].author?.kind === "agent" &&
     setup.topic.comments[3].author?.kind === "agent" &&
-    setup.topic.comments[2].author?.name !==
-      setup.topic.comments[3].author?.name &&
+    ((setup.topic.comments[2].author?.name === "First writer" &&
+      setup.topic.comments[2].body === "First concurrent comment" &&
+      setup.topic.comments[3].author?.name === "Second writer" &&
+      setup.topic.comments[3].body === "Second concurrent comment") ||
+      (setup.topic.comments[2].author?.name === "Second writer" &&
+        setup.topic.comments[2].body === "Second concurrent comment" &&
+        setup.topic.comments[3].author?.name === "First writer" &&
+        setup.topic.comments[3].body === "First concurrent comment")) &&
     setup.topic.comments[0].author?.name === "Fable"
   );
   return {
@@ -104,6 +111,20 @@ export const second = pattern<{ setup: Setup }>(({ setup }) => {
     setup.topic.comments[1].author?.name === "Current author" &&
     setup.migrated.get() === true
   );
+  const assert_both_appends = assert(() =>
+    setup.topic.comments.length === 4 &&
+    setup.topic.comments[2].author?.kind === "agent" &&
+    setup.topic.comments[3].author?.kind === "agent" &&
+    ((setup.topic.comments[2].author?.name === "First writer" &&
+      setup.topic.comments[2].body === "First concurrent comment" &&
+      setup.topic.comments[3].author?.name === "Second writer" &&
+      setup.topic.comments[3].body === "Second concurrent comment") ||
+      (setup.topic.comments[2].author?.name === "Second writer" &&
+        setup.topic.comments[2].body === "Second concurrent comment" &&
+        setup.topic.comments[3].author?.name === "First writer" &&
+        setup.topic.comments[3].body === "First concurrent comment")) &&
+    setup.topic.comments[0].author?.name === "Fable"
+  );
   return {
     [TESTS]: [
       { assertion: assert_legacy_is_visible },
@@ -114,7 +135,7 @@ export const second = pattern<{ setup: Setup }>(({ setup }) => {
       { action: action_append },
       { label: "second-appended" },
       { await: "first-appended" },
-      { assertion: assert_migrated },
+      { assertion: assert_both_appends },
     ],
   };
 });

--- a/packages/patterns/topics/author-migration.test.tsx
+++ b/packages/patterns/topics/author-migration.test.tsx
@@ -64,6 +64,12 @@ export default pattern(() => {
     createdByName: "Legacy creator",
     createdBy: { kind: "agent", name: "Current creator", avatar: "keep.png" },
   });
+  const unusableMigrated = new Writable(false);
+  const unusable = Topic({
+    createdByName: 42,
+    comments: [{ authorName: false, body: "No usable name", sentAt: 1 }],
+    authorFieldsMigratedV1: unusableMigrated,
+  });
   const completed = Topic({
     createdByName: "Must stay legacy",
     comments: [{
@@ -123,6 +129,11 @@ export default pattern(() => {
     completed.createdBy?.name === "" &&
     completed.comments[0].author === undefined
   );
+  const assert_nonstring_names_complete_without_authors = assert(() =>
+    unusable.createdBy?.name === "" &&
+    unusable.comments[0].author === undefined &&
+    unusableMigrated.get() === true
+  );
   const action_change_legacy_names = action(() => {
     legacyCreator.set("Changed legacy creator");
     comments.key(0).key("authorName").set("Changed legacy commenter");
@@ -156,6 +167,7 @@ export default pattern(() => {
       { assertion: assert_original_data_preserved },
       { assertion: assert_missing_flag_defaults_false },
       { assertion: assert_completed_flag_skips },
+      { assertion: assert_nonstring_names_complete_without_authors },
       { action: action_change_legacy_names },
       { assertion: assert_completed_migration_stays_inert },
       { action: action_replay_migration },

--- a/packages/patterns/topics/author-migration.test.tsx
+++ b/packages/patterns/topics/author-migration.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Exercises legacy author migration through ordinary Topic reads and mutations.
+ * Exercises legacy author migration when Topics run and mutate.
  * Shared input cells expose durable fields and comment identity to assertions.
  */
 
@@ -48,7 +48,7 @@ export default pattern(() => {
   ]);
   const creator = new Writable<TopicAuthor | undefined>();
   const legacyCreator = new Writable("Fable");
-  const migrated = new Writable(false);
+  const migrated = new Writable(0);
   const firstComment = comments.key(0);
   const subject = Topic({
     title: "Topics v0 smoke — hello from the fabric",
@@ -56,19 +56,19 @@ export default pattern(() => {
     comments,
     createdBy: creator,
     createdByName: legacyCreator,
-    authorFieldsMigratedV1: migrated,
+    topicStateVersion: migrated,
     createdAt: 1783615093992,
   });
-  const defaulted = Topic({ createdByName: "Default flag" });
+  const defaulted = Topic({ createdByName: "Default version" });
   const structured = Topic({
     createdByName: "Legacy creator",
     createdBy: { kind: "agent", name: "Current creator", avatar: "keep.png" },
   });
-  const unusableMigrated = new Writable(false);
+  const unusableMigrated = new Writable(0);
   const unusable = Topic({
     createdByName: 42,
     comments: [{ authorName: false, body: "No usable name", sentAt: 1 }],
-    authorFieldsMigratedV1: unusableMigrated,
+    topicStateVersion: unusableMigrated,
   });
   const completed = Topic({
     createdByName: "Must stay legacy",
@@ -77,20 +77,20 @@ export default pattern(() => {
       body: "Untouched",
       sentAt: 1,
     }],
-    authorFieldsMigratedV1: true,
+    topicStateVersion: 1,
   });
 
-  const assert_creator_migrated_on_read = assert(() =>
+  const assert_creator_migrated_on_run = assert(() =>
     subject.createdBy?.name === "Fable" &&
     subject.createdBy?.kind === "legacy"
   );
-  const assert_comments_migrated_on_read = assert(() =>
+  const assert_comments_migrated_on_run = assert(() =>
     subject.comments[0].author?.name === "Fable" &&
     subject.comments[0].author?.kind === "legacy" &&
     subject.comments[1].author?.name === "Gideon" &&
     subject.comments[1].author?.kind === "legacy"
   );
-  const assert_completed_durably = assert(() => migrated.get() === true);
+  const assert_completed_durably = assert(() => migrated.get() === 1);
   const assert_existing_author_wins = assert(() =>
     subject.comments[2].author?.name === "Current name" &&
     subject.comments[2].author?.kind === "agent" &&
@@ -121,29 +121,34 @@ export default pattern(() => {
     legacyCreator.get() === "Fable" &&
     comments.get().length === 6
   );
-  const assert_missing_flag_defaults_false = assert(() =>
-    defaulted.createdBy?.name === "Default flag" &&
+  const assert_missing_version_defaults_zero = assert(() =>
+    defaulted.createdBy?.name === "Default version" &&
     defaulted.createdBy?.kind === "legacy"
   );
-  const assert_completed_flag_skips = assert(() =>
+  const assert_current_version_skips = assert(() =>
     completed.createdBy?.name === "" &&
     completed.comments[0].author === undefined
   );
   const assert_nonstring_names_complete_without_authors = assert(() =>
     unusable.createdBy?.name === "" &&
     unusable.comments[0].author === undefined &&
-    unusableMigrated.get() === true
+    unusableMigrated.get() === 1
   );
   const action_change_legacy_names = action(() => {
     legacyCreator.set("Changed legacy creator");
+    creator.key("name").set("");
     comments.key(0).key("authorName").set("Changed legacy commenter");
   });
   const assert_completed_migration_stays_inert = assert(() =>
-    creator.get()?.name === "Fable" &&
+    creator.get()?.name === "" &&
     subject.comments[0].author?.name === "Fable" &&
-    migrated.get() === true
+    migrated.get() === 1
   );
-  const action_replay_migration = action(() => migrated.set(false));
+  const action_replay_migration = action(() => migrated.set(0));
+  const assert_replay_fills_only_missing_author = assert(() =>
+    creator.get()?.name === "Changed legacy creator" &&
+    subject.comments[0].author?.name === "Fable" && migrated.get() === 1
+  );
   const action_edit_migrated_comment = action(() => {
     subject.editComment.send({
       comment: firstComment,
@@ -158,20 +163,20 @@ export default pattern(() => {
 
   return {
     [TESTS]: [
-      { assertion: assert_creator_migrated_on_read },
-      { assertion: assert_comments_migrated_on_read },
+      { assertion: assert_creator_migrated_on_run },
+      { assertion: assert_comments_migrated_on_run },
       { assertion: assert_completed_durably },
       { assertion: assert_existing_author_wins },
       { assertion: assert_partial_author_keeps_metadata },
       { assertion: assert_blank_names_stay_absent },
       { assertion: assert_original_data_preserved },
-      { assertion: assert_missing_flag_defaults_false },
-      { assertion: assert_completed_flag_skips },
+      { assertion: assert_missing_version_defaults_zero },
+      { assertion: assert_current_version_skips },
       { assertion: assert_nonstring_names_complete_without_authors },
       { action: action_change_legacy_names },
       { assertion: assert_completed_migration_stays_inert },
       { action: action_replay_migration },
-      { assertion: assert_completed_migration_stays_inert },
+      { assertion: assert_replay_fills_only_missing_author },
       { action: action_edit_migrated_comment },
       { assertion: assert_original_reference_remains_editable },
     ],

--- a/packages/patterns/topics/author-migration.test.tsx
+++ b/packages/patterns/topics/author-migration.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Exercises legacy author migration through ordinary Topic reads and mutations.
+ * Shared input cells expose durable fields and comment identity to assertions.
+ */
+
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
+import Topic, { type TopicAuthor, type TopicComment } from "./topic.tsx";
+
+/** Comment storage visible to the fixture's data-preservation assertions. */
+interface StoredComment extends TopicComment {
+  /** Name written by a legacy client. */
+  authorName?: string;
+
+  /** Extra stored content that the migration must preserve. */
+  extra?: string;
+}
+
+export default pattern(() => {
+  const comments = new Writable<StoredComment[]>([
+    {
+      authorName: "Fable",
+      body: "First comment — written headlessly by Fable over the cf CLI.",
+      sentAt: 1783615357000,
+      extra: "keep this",
+    },
+    {
+      authorName: "Gideon",
+      body: "And my first reply from the UI!",
+      sentAt: 1783615484455,
+    },
+    {
+      authorName: "Old name",
+      author: { kind: "agent", name: "Current name", avatar: "avatar.png" },
+      body: "Already structured",
+      sentAt: 3,
+    },
+    {
+      authorName: "Preserved person",
+      author: { kind: "person", name: "  ", avatar: "person.png" },
+      body: "Missing structured name",
+      sentAt: 4,
+      editedAt: 5,
+      removedAt: 6,
+      removedBy: { kind: "agent", name: "Moderator" },
+    },
+    { authorName: "  ", body: "No usable name", sentAt: 7 },
+    { body: "No attribution", sentAt: 8 },
+  ]);
+  const creator = new Writable<TopicAuthor | undefined>();
+  const legacyCreator = new Writable("Fable");
+  const migrated = new Writable(false);
+  const firstComment = comments.key(0);
+  const subject = Topic({
+    title: "Topics v0 smoke — hello from the fabric",
+    body: "I'm adding a body",
+    comments,
+    createdBy: creator,
+    createdByName: legacyCreator,
+    authorFieldsMigratedV1: migrated,
+    createdAt: 1783615093992,
+  });
+  const defaulted = Topic({ createdByName: "Default flag" });
+  const structured = Topic({
+    createdByName: "Legacy creator",
+    createdBy: { kind: "agent", name: "Current creator", avatar: "keep.png" },
+  });
+  const completed = Topic({
+    createdByName: "Must stay legacy",
+    comments: [{
+      authorName: "Must stay legacy",
+      body: "Untouched",
+      sentAt: 1,
+    }],
+    authorFieldsMigratedV1: true,
+  });
+
+  const assert_creator_migrated_on_read = assert(() =>
+    subject.createdBy?.name === "Fable" &&
+    subject.createdBy?.kind === "legacy"
+  );
+  const assert_comments_migrated_on_read = assert(() =>
+    subject.comments[0].author?.name === "Fable" &&
+    subject.comments[0].author?.kind === "legacy" &&
+    subject.comments[1].author?.name === "Gideon" &&
+    subject.comments[1].author?.kind === "legacy"
+  );
+  const assert_completed_durably = assert(() => migrated.get() === true);
+  const assert_existing_author_wins = assert(() =>
+    subject.comments[2].author?.name === "Current name" &&
+    subject.comments[2].author?.kind === "agent" &&
+    subject.comments[2].author?.avatar === "avatar.png" &&
+    structured.createdBy?.name === "Current creator" &&
+    structured.createdBy?.kind === "agent" &&
+    structured.createdBy?.avatar === "keep.png"
+  );
+  const assert_partial_author_keeps_metadata = assert(() =>
+    subject.comments[3].author?.name === "Preserved person" &&
+    subject.comments[3].author?.kind === "person" &&
+    subject.comments[3].author?.avatar === "person.png" &&
+    subject.comments[3].editedAt === 5 &&
+    subject.comments[3].removedAt === 6 &&
+    subject.comments[3].removedBy?.name === "Moderator"
+  );
+  const assert_blank_names_stay_absent = assert(() =>
+    subject.comments[4].author === undefined &&
+    subject.comments[5].author === undefined
+  );
+  const assert_original_data_preserved = assert(() =>
+    subject.body === "I'm adding a body" &&
+    subject.createdAt === 1783615093992 &&
+    subject.comments[0].sentAt === 1783615357000 &&
+    subject.comments[1].body === "And my first reply from the UI!" &&
+    comments.get()[0].authorName === "Fable" &&
+    comments.get()[0].extra === "keep this" &&
+    legacyCreator.get() === "Fable" &&
+    comments.get().length === 6
+  );
+  const assert_missing_flag_defaults_false = assert(() =>
+    defaulted.createdBy?.name === "Default flag" &&
+    defaulted.createdBy?.kind === "legacy"
+  );
+  const assert_completed_flag_skips = assert(() =>
+    completed.createdBy?.name === "" &&
+    completed.comments[0].author === undefined
+  );
+  const action_change_legacy_names = action(() => {
+    legacyCreator.set("Changed legacy creator");
+    comments.key(0).key("authorName").set("Changed legacy commenter");
+  });
+  const assert_completed_migration_stays_inert = assert(() =>
+    creator.get()?.name === "Fable" &&
+    subject.comments[0].author?.name === "Fable" &&
+    migrated.get() === true
+  );
+  const action_replay_migration = action(() => migrated.set(false));
+  const action_edit_migrated_comment = action(() => {
+    subject.editComment.send({
+      comment: firstComment,
+      body: "Edited through the original reference",
+      agentName: "Test editor",
+    });
+  });
+  const assert_original_reference_remains_editable = assert(() =>
+    subject.comments[0].body === "Edited through the original reference" &&
+    subject.comments[0].author?.name === "Fable"
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_creator_migrated_on_read },
+      { assertion: assert_comments_migrated_on_read },
+      { assertion: assert_completed_durably },
+      { assertion: assert_existing_author_wins },
+      { assertion: assert_partial_author_keeps_metadata },
+      { assertion: assert_blank_names_stay_absent },
+      { assertion: assert_original_data_preserved },
+      { assertion: assert_missing_flag_defaults_false },
+      { assertion: assert_completed_flag_skips },
+      { action: action_change_legacy_names },
+      { assertion: assert_completed_migration_stays_inert },
+      { action: action_replay_migration },
+      { assertion: assert_completed_migration_stays_inert },
+      { action: action_edit_migrated_comment },
+      { assertion: assert_original_reference_remains_editable },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -31,6 +31,7 @@ import {
 import Topic, {
   rejectMutation,
   snippet,
+  TOPIC_STATE_VERSION,
   type TopicAuthor,
   topicAuthorFromAgent,
   topicAuthorFromPerson,
@@ -510,6 +511,7 @@ export const submitProfileTopic = handler<void, {
   const author = topicAuthorFromPerson(profileName, profileAvatar);
   if (!trimmed || !author) return;
   const piece = Topic({
+    topicStateVersion: TOPIC_STATE_VERSION,
     title: trimmed,
     createdAt: Date.now(),
     createdBy: author,
@@ -575,6 +577,7 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, names }) => {
       rejectMutation("addTopic", "agentName must be non-blank");
     if (!trimmed) rejectMutation("addTopic", "title must be non-empty");
     const piece = Topic({
+      topicStateVersion: TOPIC_STATE_VERSION,
       title: trimmed,
       // Body at create is part of the create's atomic unit; created-with is
       // not an update, so bodyUpdatedBy/At stay unset (createdBy covers it).

--- a/packages/patterns/topics/state-upgrades.md
+++ b/packages/patterns/topics/state-upgrades.md
@@ -1,0 +1,126 @@
+# Topic state upgrades
+
+Topics owns its durable state format. `topic.tsx` declares an ordered list of
+upgrade identifiers, the functions implementing those steps, and a shared
+`upgradeTopicState` runner. This is pattern code using ordinary cell reads and
+writes; the runtime does not choose or interpret Topic versions.
+
+## Version and sequence
+
+`topicStateVersion` is an optional stored input with a default of zero. Version
+zero is the shape accepted before any listed upgrade has completed. A version of
+N means the first N steps have completed. `TOPIC_STATE_VERSION` is the list's
+length, so the board's browser composer and `addTopic` stamp the same current
+version when creating a Topic.
+
+The list contains stable string identifiers. Its order defines the sequence;
+append steps and retain the existing positions. A switch dispatches identifiers
+to their implementations, with an exhaustive check when adding a step. This
+keeps module-scope data serializable in the pattern sandbox. A single version
+represents progress through a prefix of the sequence, which makes prerequisites
+explicit without independent completion flags or arbitrary flag combinations.
+
+The shared runner validates the stored version as a nonnegative safe integer. A
+current version is a no-op. An older version runs its remaining steps in order.
+A future or invalid version is left unchanged by the lift and rejected by a
+durable mutation, with the verb name in the error.
+
+## Execution and mutation boundary
+
+Running a Topic runs the upgrade lift. No consumer has to read the result or
+open the author UI for the lift to write. Each headless content verb and browser
+handler also calls the shared runner after validating the request and before its
+first durable write. A handler therefore works on upgraded state even when it
+runs before the lift.
+
+The guarded entry points include comment creation, editing and retraction; link
+creation and retraction; title and body saves; and adding or removing mentions.
+Module-scope browser handlers carry the same upgrade binding as the headless
+handlers. Local draft edits, opening editors, and canceling editors operate on
+session state and do not require an upgrade.
+
+A handler may finish an upgrade and then encounter an unresolved input needed
+for its own mutation. In that case the completed upgrade can commit while the
+requested mutation remains pending. Upgrade progress is independent of whether
+that later mutation completes.
+
+## Step contract
+
+Each step reads every source and destination it needs before making its first
+write. It uses cell handles for those reads: an absent optional field is a valid
+input, while an unresolved link must leave the step pending. Optional property
+reads can conflate those cases.
+
+After the step returns, the runner writes the next version in the same
+transaction. A transaction can commit writes made before a later unresolved
+read, so reading first is part of correctness. If a later step is blocked,
+earlier completed steps and their version can remain committed. Implementations
+must be deterministic, read no clock, and tolerate an already-upgraded target
+shape. Fabric handles transaction conflicts; the pattern adds no locking or
+revision protocol.
+
+A step's legacy field names are permanent storage identifiers. Keep their
+spellings and interpretation fixed when renaming current fields or changing
+current authoring conventions. Evolve subsequent shapes with new steps.
+
+## Version zero to one: legacy author names
+
+The first step copies useful `createdByName` and comment `authorName` values
+into missing structured author names. A useful value is a nonblank string whose
+trimmed value is not the exact placeholder `"someone"`. The stored name is
+copied verbatim; trimming only decides whether it supplies attribution.
+
+A nonblank structured name wins. Existing kinds and avatars are preserved; a
+copied name with no kind receives `"legacy"`, which expresses that the author
+classification is unknown. The step leaves source fields, comment identities,
+and unrelated content unchanged. It does not rewrite already-structured
+`"someone"` names or infer identities from profiles.
+
+The public input fields retain their broad legacy domains. The upgrade reader
+uses the explicit schema type union `["string", "unknown"]`: strings are read as
+values, while non-string legacy data stays opaque. TypeScript's
+`string | unknown` alone collapses to opaque `unknown` and cannot express that
+reader. Both the lift and mutation bindings use the same explicit schema.
+
+Mutations carry a cell containing the upgrade handles. The cell keeps the nested
+read-only source handle intact through handler state typing; reading the binding
+yields handles, and the runner reads the version before following the legacy
+data. Other handler fields retain their generated contracts. The structured
+creator remains plain in the outer Topic input; the internal upgrade binding
+supplies its writable destination.
+
+## Rollout and rollback
+
+Retire legacy writers before applying the update. The first step covers the
+records present when it completes; a legacy client writing another old-style
+comment afterward does not reset the version or rerun that step.
+
+Restoring source does not undo data writes. A version-aware older implementation
+can render supported portions of newer state while refusing its durable
+mutations. This is a write guard, not a guarantee that every future format will
+render correctly in old code. It cannot constrain code that predates the guard,
+already-running legacy clients, or writes made directly to stored cells.
+
+Use the space-clone rehearsal procedure before applying source to real data.
+Admission checks, tests of the exact packaged source, and observation of actual
+migration writes establish different things; a successful source compatibility
+check alone does not establish successful migration execution.
+
+## Tests and extension
+
+Each step needs coverage starting from the shape immediately before that step,
+including already-upgraded targets and unresolved input recovery. Keep a
+version-zero-to-current test alongside those per-step cases as the list grows.
+The first step is both the individual zero-to-one case and the full sequence.
+
+The Topics suite covers execution without a result read, absent creator names,
+placeholders, opaque values, preservation of comment links, reopening from
+stored source, replay without overwriting structured names, and two clients
+sharing progress. The inertness test clears a structured name after completion
+so that ignoring the version would cause an observable unwanted copy.
+
+The version tests exercise all durable entry points against future state and
+check both rejection and unchanged data. They also cover invalid versions and a
+standalone browser handler upgrading version-zero state before appending,
+without a Topic lift to do the work for it. New entry points must receive the
+upgrade binding and join this coverage.

--- a/packages/patterns/topics/state-version.test.tsx
+++ b/packages/patterns/topics/state-version.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * Exercises future-version refusal across every durable Topic entry point and
+ * a browser mutation that upgrades old state without a running Topic lift.
+ */
+
+import {
+  action,
+  assert,
+  Default,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
+import Topic, {
+  dropMention,
+  retractProfileComment,
+  retractProfileLink,
+  saveProfileBody,
+  saveProfileTitle,
+  submitProfileComment,
+  submitProfileLink,
+  TOPIC_STATE_VERSION,
+  type TopicAuthor,
+  type TopicComment,
+  type TopicLink,
+  type TopicMentionRefMap,
+} from "./topic.tsx";
+
+/** Stored comment with the immutable version-zero author key. */
+interface LegacyComment extends TopicComment {
+  /** Legacy name read by the first upgrade step. */
+  authorName?: string;
+}
+
+export default pattern(() => {
+  const version = new Writable<number>(TOPIC_STATE_VERSION + 1);
+  const creator = new Writable<TopicAuthor | undefined>();
+  const comments = new Writable<LegacyComment[]>([
+    { authorName: "Legacy commenter", body: "Original comment", sentAt: 1 },
+  ]);
+  const links = new Writable<TopicLink[]>([
+    {
+      kind: "web",
+      url: "https://example.com",
+      label: "Original link",
+      addedAt: 2,
+    },
+  ]);
+  const title = new Writable("Original title");
+  const body = new Writable("Original body");
+  const mentioned = new Writable<unknown[]>([]);
+  const references = new Writable<TopicMentionRefMap>({});
+  const updatedBy = new Writable<TopicAuthor>({ kind: "person", name: "" });
+  const updatedAt = new Writable(0);
+  const upgrade = {
+    topicStateVersion: version,
+    createdByName: "Legacy creator",
+    createdBy: creator,
+    comments,
+  };
+  const subject = Topic({
+    ...upgrade,
+    title,
+    body,
+    links,
+    mentioned,
+    references,
+    titleUpdatedBy: updatedBy,
+    titleUpdatedAt: updatedAt,
+    bodyUpdatedBy: updatedBy,
+    bodyUpdatedAt: updatedAt,
+  });
+  const targetA = new Writable({ title: "A" });
+  const targetB = new Writable({ title: "B" });
+  const action_seed_mention = action(() => mentioned.push(targetA));
+
+  const browserState = {
+    upgrade,
+    title,
+    body,
+    comments,
+    comment: comments.key(0),
+    links,
+    link: links.key(0),
+    mentioned,
+    topic: targetA,
+    references,
+    titleUpdatedBy: updatedBy,
+    titleUpdatedAt: updatedAt,
+    bodyUpdatedBy: updatedBy,
+    bodyUpdatedAt: updatedAt,
+    titleDraft: new Writable("Changed title"),
+    bodyDraft: new Writable("Changed body"),
+    commentDraft: new Writable("New comment"),
+    linkUrlDraft: new Writable("https://example.org"),
+    linkLabelDraft: new Writable("New link"),
+    linkKindDraft: new Writable("web"),
+    referencesDraft: new Writable<TopicMentionRefMap>({}),
+    editingTitle: new Writable(true),
+    editingBody: new Writable(true),
+    profileName: "Test person",
+    profileAvatar: "",
+  };
+  const browserAddComment = submitProfileComment(browserState);
+  const browserRemoveComment = retractProfileComment(browserState);
+  const browserAddLink = submitProfileLink(browserState);
+  const browserRemoveLink = retractProfileLink(browserState);
+  const browserSetTitle = saveProfileTitle(browserState);
+  const browserSetBody = saveProfileBody(browserState);
+  const browserUnmention = dropMention(browserState);
+
+  const action_add_comment = action(() =>
+    subject.addComment.send({ body: "New", agentName: "Test agent" })
+  );
+  const action_edit_comment = action(() =>
+    subject.editComment.send({
+      comment: comments.key(0),
+      body: "Changed",
+      agentName: "Test agent",
+    })
+  );
+  const action_remove_comment = action(() =>
+    subject.removeComment.send({
+      comment: comments.key(0),
+      agentName: "Test agent",
+    })
+  );
+  const action_add_link = action(() =>
+    subject.addLink.send({
+      url: "https://example.org",
+      agentName: "Test agent",
+    })
+  );
+  const action_remove_link = action(() =>
+    subject.removeLink.send({ link: links.key(0), agentName: "Test agent" })
+  );
+  const action_set_title = action(() =>
+    subject.setTitle.send({ title: "Changed", agentName: "Test agent" })
+  );
+  const action_set_body = action(() =>
+    subject.setBody.send({ body: "Changed", agentName: "Test agent" })
+  );
+  const action_mention = action(() => subject.mention.send({ topic: targetB }));
+  const action_unmention = action(() =>
+    subject.unmention.send({ topic: targetA })
+  );
+  const action_browser_add_comment = action(() => browserAddComment.send());
+  const action_browser_remove_comment = action(() =>
+    browserRemoveComment.send()
+  );
+  const action_browser_add_link = action(() => browserAddLink.send());
+  const action_browser_remove_link = action(() => browserRemoveLink.send());
+  const action_browser_set_title = action(() => browserSetTitle.send());
+  const action_browser_set_body = action(() => browserSetBody.send());
+  const action_browser_unmention = action(() => browserUnmention.send());
+
+  const assert_no_durable_writes = assert(() =>
+    title.get() === "Original title" && body.get() === "Original body" &&
+    creator.get() === undefined &&
+    comments.get().length === 1 && comments.get()[0].author === undefined &&
+    comments.get()[0].body === "Original comment" &&
+    comments.get()[0].removedAt === undefined &&
+    comments.get()[0].editedAt === undefined &&
+    links.get().length === 1 && links.get()[0].removedAt === undefined &&
+    mentioned.get().length === 1 &&
+    updatedBy.get().name === "" && updatedAt.get() === 0
+  );
+  const assert_future_version_retained = assert(() =>
+    version.get() === TOPIC_STATE_VERSION + 1
+  );
+  const action_negative_version = action(() => version.set(-1));
+  const action_fractional_version = action(() => version.set(0.5));
+  const action_unsafe_version = action(() =>
+    version.set(Number.MAX_SAFE_INTEGER + 1)
+  );
+  const assert_negative_version_retained = assert(() => version.get() === -1);
+  const assert_fractional_version_retained = assert(() =>
+    version.get() === 0.5
+  );
+  const assert_unsafe_version_retained = assert(() =>
+    version.get() === Number.MAX_SAFE_INTEGER + 1
+  );
+
+  const oldVersion = new Writable(0);
+  const oldCreator = new Writable<TopicAuthor | undefined>();
+  const oldComments = new Writable<LegacyComment[] | Default<[]>>([
+    { authorName: "Old commenter", body: "Old comment", sentAt: 1 },
+  ]);
+  const oldDraft = new Writable("New comment");
+  const upgradeAndSubmit = submitProfileComment({
+    upgrade: {
+      topicStateVersion: oldVersion,
+      createdByName: "Old creator",
+      createdBy: oldCreator,
+      comments: oldComments,
+    },
+    comments: oldComments,
+    commentDraft: oldDraft,
+    profileName: "Current person",
+    profileAvatar: "",
+  });
+  const assert_upgrade_waits_for_handler = assert(() =>
+    oldVersion.get() === 0 && oldCreator.get() === undefined &&
+    oldComments.get()[0].author === undefined
+  );
+  const action_upgrade_and_submit = action(() => upgradeAndSubmit.send());
+  const assert_handler_upgraded_before_appending = assert(() =>
+    oldVersion.get() === TOPIC_STATE_VERSION &&
+    oldCreator.get()?.name === "Old creator" &&
+    oldComments.get().length === 2 &&
+    oldComments.get()[0].author?.name === "Old commenter" &&
+    oldComments.get()[1].author?.name === "Current person" &&
+    oldDraft.get() === ""
+  );
+
+  return {
+    expectRuntimeErrors: 19,
+    [TESTS]: [
+      { action: action_seed_mention },
+      { assertion: assert_no_durable_writes },
+      { action: action_add_comment },
+      { assertion: assert_no_durable_writes },
+      { action: action_edit_comment },
+      { assertion: assert_no_durable_writes },
+      { action: action_remove_comment },
+      { assertion: assert_no_durable_writes },
+      { action: action_add_link },
+      { assertion: assert_no_durable_writes },
+      { action: action_remove_link },
+      { assertion: assert_no_durable_writes },
+      { action: action_set_title },
+      { assertion: assert_no_durable_writes },
+      { action: action_set_body },
+      { assertion: assert_no_durable_writes },
+      { action: action_mention },
+      { assertion: assert_no_durable_writes },
+      { action: action_unmention },
+      { assertion: assert_no_durable_writes },
+      { action: action_browser_add_comment },
+      { assertion: assert_no_durable_writes },
+      { action: action_browser_remove_comment },
+      { assertion: assert_no_durable_writes },
+      { action: action_browser_add_link },
+      { assertion: assert_no_durable_writes },
+      { action: action_browser_remove_link },
+      { assertion: assert_no_durable_writes },
+      { action: action_browser_set_title },
+      { assertion: assert_no_durable_writes },
+      { action: action_browser_set_body },
+      { assertion: assert_no_durable_writes },
+      { action: action_browser_unmention },
+      { assertion: assert_no_durable_writes },
+      { assertion: assert_future_version_retained },
+      { action: action_negative_version },
+      { action: action_set_title },
+      { assertion: assert_no_durable_writes },
+      { assertion: assert_negative_version_retained },
+      { action: action_fractional_version },
+      { action: action_set_title },
+      { assertion: assert_no_durable_writes },
+      { assertion: assert_fractional_version_retained },
+      { action: action_unsafe_version },
+      { action: action_set_title },
+      { assertion: assert_no_durable_writes },
+      { assertion: assert_unsafe_version_retained },
+      { assertion: assert_upgrade_waits_for_handler },
+      { action: action_upgrade_and_submit },
+      { assertion: assert_handler_upgraded_before_appending },
+    ],
+  };
+});

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -6,6 +6,7 @@ import {
   Default,
   equals,
   handler,
+  type JSONSchema,
   lift,
   NAME,
   pattern,
@@ -380,8 +381,8 @@ export interface TopicInput {
   /** Creator display name recorded without an author kind. */
   createdByName?: unknown;
 
-  /** Completion of the per-topic migration from display names to authors. */
-  authorFieldsMigratedV1?: Writable<boolean | Default<false>>;
+  /** Number of ordered state upgrades completed by this topic. */
+  topicStateVersion?: Writable<number | Default<0>>;
 
   bodyUpdatedBy?: Writable<
     TopicAuthor | Default<{ kind: "person"; name: "" }>
@@ -1008,21 +1009,275 @@ export const appendLink = (
   return link;
 };
 
+/** Handles shared by ordered Topic upgrades and every durable mutation. */
+interface TopicUpgradeState {
+  /** Number of steps already committed for this topic. */
+  topicStateVersion: Writable<number>;
+
+  /** Legacy storage key; its spelling remains fixed for version-zero inputs. */
+  createdByName: ReadonlyCell<unknown>;
+
+  /** Structured creator destination under its existing declared shape. */
+  createdBy: Writable<TopicAuthor | undefined>;
+
+  /** Original comment identities, including the fixed legacy `authorName` key. */
+  comments: Writable<Pick<StoredTopicComment, "author" | "authorName">[]>;
+}
+
+/** Reader contract that materializes strings while retaining opaque legacy data. */
+const TOPIC_UPGRADE_SCHEMA = {
+  type: "object",
+  properties: {
+    topicStateVersion: toSchema<Writable<number>>(),
+    createdBy: toSchema<Writable<TopicAuthor | undefined>>(),
+    // Concrete strings are read; every other legacy value stays opaque.
+    // A TypeScript `string | unknown` collapses to opaque-only `unknown`.
+    createdByName: {
+      type: ["string", "unknown"],
+      asCell: ["readonly"],
+    },
+    comments: {
+      type: "array",
+      asCell: ["cell"],
+      items: {
+        type: "object",
+        properties: {
+          author: toSchema<TopicAuthor>(),
+          authorName: { type: ["string", "unknown"] },
+        },
+      },
+    },
+  },
+  required: [
+    "topicStateVersion",
+    "createdByName",
+    "createdBy",
+    "comments",
+  ],
+} as const;
+
+/** Durable fields and upgrade handles bound to a Topic mutation. */
+type TopicWriteState<K extends keyof TopicInput = never> =
+  & Required<Pick<TopicInput, K>>
+  & {
+    /** Shared state checked before the mutation's first durable write. */
+    upgrade: Writable<TopicUpgradeState>;
+  };
+
+/**
+ * Upgrades version zero to one by filling missing structured author names.
+ * Legacy key spellings in this step are storage identifiers and remain fixed.
+ * Reads every source and destination before writing, so unresolved links leave
+ * the step pending. Existing structured names, kinds, and avatars take priority.
+ */
+const upgradeLegacyAuthors = (input: TopicUpgradeState): void => {
+  const { createdByName, createdBy, comments } = input;
+
+  const legacyCreatorName = createdByName.get();
+  const creator = createdBy.get();
+  const creatorKind = creator?.kind;
+  const creatorName = !creator?.name.trim() &&
+      typeof legacyCreatorName === "string" && legacyCreatorName.trim() &&
+      legacyCreatorName.trim() !== "someone"
+    ? legacyCreatorName
+    : undefined;
+  // Resolve every source and destination before making the first write. A
+  // missing linked record must leave completion pending. Read through handles:
+  // optional property reads can turn unresolved links into `undefined`.
+  const commentAuthors = comments.get().map((_, index) => {
+    const comment = comments.key(index);
+    const author = comment.key("author").get();
+    const legacyName = comment.key("authorName").get();
+    return {
+      index,
+      name: !author?.name.trim() &&
+          typeof legacyName === "string" && legacyName.trim() &&
+          legacyName.trim() !== "someone"
+        ? legacyName
+        : undefined,
+      kind: author?.kind,
+    };
+  });
+
+  if (creatorName !== undefined) {
+    createdBy.key("name").set(creatorName);
+    if (!creatorKind) createdBy.key("kind").set("legacy");
+  }
+  commentAuthors.forEach(({ index, name, kind }) => {
+    if (name === undefined) return;
+    const author = comments.key(index).key("author");
+    author.key("name").set(name);
+    if (!kind) author.key("kind").set("legacy");
+  });
+};
+
+/** Ordered, append-only steps; entry zero upgrades state version zero to one. */
+const TOPIC_STATE_UPGRADES = ["legacy-authors"] as const;
+
+/** State version stamped by every current Topics board creation path. */
+export const TOPIC_STATE_VERSION = TOPIC_STATE_UPGRADES.length;
+
+/**
+ * Runs pending upgrades in order, recording each version after its step's writes.
+ * With a verb, refuses unsupported versions before a durable mutation; without
+ * one, leaves such state untouched so the running Topic can still render it.
+ */
+const upgradeTopicState = (state: TopicUpgradeState, verb?: string): void => {
+  const version = state.topicStateVersion.get();
+  if (
+    !Number.isSafeInteger(version) || version < 0 ||
+    version > TOPIC_STATE_VERSION
+  ) {
+    if (verb) {
+      rejectMutation(verb, `unsupported topic state version ${version}`);
+    }
+    return;
+  }
+  for (let index = version; index < TOPIC_STATE_VERSION; index++) {
+    const step = TOPIC_STATE_UPGRADES[index];
+    switch (step) {
+      case "legacy-authors":
+        upgradeLegacyAuthors(state);
+        break;
+      default: {
+        const unhandled: never = step;
+        throw new Error(`Unsupported Topic upgrade step ${unhandled}`);
+      }
+    }
+    state.topicStateVersion.set(index + 1);
+  }
+};
+
+/** Runs pending state upgrades whenever the Topic runs, without a result read. */
+const migrateTopicState = lift(
+  (state: TopicUpgradeState): void => upgradeTopicState(state),
+  TOPIC_UPGRADE_SCHEMA,
+  toSchema<void>(),
+);
+
+/** Object schemas whose properties extend generated mutation contracts. */
+type TopicObjectSchema = Exclude<JSONSchema, boolean>;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const SUBMIT_PROFILE_COMMENT_STATE_SCHEMA = toSchema<
+  SubmitProfileCommentState
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const RETRACT_PROFILE_COMMENT_STATE_SCHEMA = toSchema<
+  RetractProfileCommentState
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const SAVE_PROFILE_TITLE_STATE_SCHEMA = toSchema<
+  SaveProfileTitleState
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const SAVE_PROFILE_BODY_STATE_SCHEMA = toSchema<
+  SaveProfileBodyState
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const DROP_MENTION_STATE_SCHEMA = toSchema<
+  DropMentionState
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const RETRACT_PROFILE_LINK_STATE_SCHEMA = toSchema<
+  RetractProfileLinkState
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const SUBMIT_PROFILE_LINK_STATE_SCHEMA = toSchema<
+  SubmitProfileLinkState
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const COMMENTS_WRITE_SCHEMA = toSchema<
+  TopicWriteState<"comments">
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const LINKS_WRITE_SCHEMA = toSchema<
+  TopicWriteState<"links">
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const BODY_WRITE_SCHEMA = toSchema<
+  TopicWriteState<"body" | "bodyUpdatedBy" | "bodyUpdatedAt">
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const TITLE_WRITE_SCHEMA = toSchema<
+  TopicWriteState<"title" | "titleUpdatedBy" | "titleUpdatedAt">
+>() as TopicObjectSchema;
+
+/** Generated object contract extended with the concrete legacy reader. */
+const MENTIONED_WRITE_SCHEMA = toSchema<
+  TopicWriteState<"mentioned">
+>() as TopicObjectSchema;
+
+/** Bound state for `submitProfileComment`. */
+type SubmitProfileCommentState = {
+  /** Shared upgrade handles for this Topic. */
+  upgrade: Writable<TopicUpgradeState>;
+
+  /** Stored thread containing the mutation target. */
+  comments: Writable<TopicComment[] | Default<[]>>;
+
+  /** Session draft cleared after a successful comment submit. */
+  commentDraft: Writable<string>;
+
+  /** Resolved canonical Profile name for attribution. */
+  profileName: string;
+
+  /** Resolved canonical Profile avatar for attribution. */
+  profileAvatar: string;
+};
+
 /** Browser comment submit with Profile fields already resolved by the pattern.
  * Keeping the mutation in a module-scope handler lets tests bind deterministic
  * Profile snapshots while production still sources them only from wishes. */
-export const submitProfileComment = handler<void, {
+export const submitProfileComment = handler<void, SubmitProfileCommentState>(
+  toSchema<void>(),
+  {
+    ...SUBMIT_PROFILE_COMMENT_STATE_SCHEMA,
+    properties: {
+      ...SUBMIT_PROFILE_COMMENT_STATE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  (_, { upgrade, comments, commentDraft, profileName, profileAvatar }) => {
+    const text = commentDraft.get();
+    const author = topicAuthorFromPerson(profileName, profileAvatar);
+    if (!text.trim() || !author) return;
+    upgradeTopicState(upgrade.get(), "submitProfileComment");
+    appendComment(comments, text, author);
+    commentDraft.set("");
+  },
+);
+
+/** Bound state for `retractProfileComment`. */
+type RetractProfileCommentState = {
+  /** Shared upgrade handles for this Topic. */
+  upgrade: Writable<TopicUpgradeState>;
+
+  /** Stored thread containing the mutation target. */
   comments: Writable<TopicComment[] | Default<[]>>;
-  commentDraft: Writable<string>;
+
+  // A CELL, for the reason `dropMention` gives about `topic`: bound as a plain
+  // value it arrives resolved, matches no stored position, and removes
+  // nothing.
+  /** Original comment cell selected for retraction. */
+  comment: Writable<TopicComment>;
+
+  /** Resolved canonical Profile name for attribution. */
   profileName: string;
+
+  /** Resolved canonical Profile avatar for attribution. */
   profileAvatar: string;
-}>((_, { comments, commentDraft, profileName, profileAvatar }) => {
-  const text = commentDraft.get();
-  const author = topicAuthorFromPerson(profileName, profileAvatar);
-  if (!text.trim() || !author) return;
-  appendComment(comments, text, author);
-  commentDraft.set("");
-});
+};
 
 /** Browser comment retraction under the current Profile snapshot.
  *
@@ -1038,23 +1293,26 @@ export const submitProfileComment = handler<void, {
  * regression in that property presents: refused here, a control bound to a
  * copy does nothing, where without it the copy would be stamped and the
  * reader would be shown a thread the topic does not hold. */
-export const retractProfileComment = handler<void, {
-  comments: Writable<TopicComment[] | Default<[]>>;
-  // A CELL, for the reason `dropMention` gives about `topic`: bound as a plain
-  // value it arrives resolved, matches no stored position, and removes
-  // nothing.
-  comment: Writable<TopicComment>;
-  profileName: string;
-  profileAvatar: string;
-}>((_, { comments, comment, profileName, profileAvatar }) => {
-  const author = topicAuthorFromPerson(profileName, profileAvatar);
-  if (!author) return;
-  if (!comment || comment.get() === undefined) return;
-  if (!isElementOf(comments, comment)) return;
-  if (comment.get()?.removedAt !== undefined) return;
-  comment.key("removedAt").set(Date.now());
-  comment.key("removedBy").set(author);
-});
+export const retractProfileComment = handler<void, RetractProfileCommentState>(
+  toSchema<void>(),
+  {
+    ...RETRACT_PROFILE_COMMENT_STATE_SCHEMA,
+    properties: {
+      ...RETRACT_PROFILE_COMMENT_STATE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  (_, { upgrade, comments, comment, profileName, profileAvatar }) => {
+    const author = topicAuthorFromPerson(profileName, profileAvatar);
+    if (!author) return;
+    if (!comment || comment.get() === undefined) return;
+    if (!isElementOf(comments, comment)) return;
+    if (comment.get()?.removedAt !== undefined) return;
+    upgradeTopicState(upgrade.get(), "retractProfileComment");
+    comment.key("removedAt").set(Date.now());
+    comment.key("removedBy").set(author);
+  },
+);
 
 /** The one place a rename lands. The contract verb and the browser save both
  * ride it, so the trim rule, the attribution stamp, and the activity clock
@@ -1079,85 +1337,167 @@ export const persistTitle = (
   return { title: trimmed, titleUpdatedBy: author, titleUpdatedAt: at };
 };
 
+/** Bound state for `saveProfileTitle`. */
+type SaveProfileTitleState = {
+  /** Shared upgrade handles for this Topic. */
+  upgrade: Writable<TopicUpgradeState>;
+
+  /** Durable title saved with its attribution stamps. */
+  title: Writable<string | Default<"">>;
+
+  /** Session title draft awaiting an explicit save. */
+  titleDraft: Writable<string>;
+
+  /** Session editor visibility after a successful save. */
+  editingTitle: Writable<boolean>;
+
+  /** Author snapshot of the latest title save. */
+  titleUpdatedBy: Writable<
+    TopicAuthor | Default<{ kind: "person"; name: "" }>
+  >;
+
+  /** Timestamp of the latest title save. */
+  titleUpdatedAt: Writable<number | Default<0>>;
+
+  /** Resolved canonical Profile name for attribution. */
+  profileName: string;
+
+  /** Resolved canonical Profile avatar for attribution. */
+  profileAvatar: string;
+};
+
 /** Browser title save under the current Profile snapshot. The header binds a
  * session draft, never the durable title: a live-bound shared string would
  * conflict per keystroke, and a title write outside `persistTitle` would
  * leave `titleUpdatedBy` and the activity clock describing an earlier
  * rename. */
-export const saveProfileTitle = handler<void, {
-  title: Writable<string | Default<"">>;
-  titleDraft: Writable<string>;
-  editingTitle: Writable<boolean>;
-  titleUpdatedBy: Writable<
-    TopicAuthor | Default<{ kind: "person"; name: "" }>
-  >;
-  titleUpdatedAt: Writable<number | Default<0>>;
-  profileName: string;
-  profileAvatar: string;
-}>((
-  _,
+export const saveProfileTitle = handler<void, SaveProfileTitleState>(
+  toSchema<void>(),
   {
-    title,
-    titleDraft,
-    editingTitle,
-    titleUpdatedBy,
-    titleUpdatedAt,
-    profileName,
-    profileAvatar,
+    ...SAVE_PROFILE_TITLE_STATE_SCHEMA,
+    properties: {
+      ...SAVE_PROFILE_TITLE_STATE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
   },
-) => {
-  const text = titleDraft.get();
-  const author = topicAuthorFromPerson(profileName, profileAvatar);
-  if (!text.trim() || !author) return;
-  persistTitle(title, titleUpdatedBy, titleUpdatedAt, text, author);
-  editingTitle.set(false);
-});
+  (
+    _,
+    {
+      upgrade,
+      title,
+      titleDraft,
+      editingTitle,
+      titleUpdatedBy,
+      titleUpdatedAt,
+      profileName,
+      profileAvatar,
+    },
+  ) => {
+    const text = titleDraft.get();
+    const author = topicAuthorFromPerson(profileName, profileAvatar);
+    if (!text.trim() || !author) return;
+    upgradeTopicState(upgrade.get(), "saveProfileTitle");
+    persistTitle(title, titleUpdatedBy, titleUpdatedAt, text, author);
+    editingTitle.set(false);
+  },
+);
 
-/** Browser body save under the current Profile snapshot. */
-export const saveProfileBody = handler<void, {
+/** Bound state for `saveProfileBody`. */
+type SaveProfileBodyState = {
+  /** Shared upgrade handles for this Topic. */
+  upgrade: Writable<TopicUpgradeState>;
+
+  /** Durable prose saved with its references and attribution. */
   body: Writable<string | Default<"">>;
+
+  /** Session prose draft awaiting an explicit save. */
   bodyDraft: Writable<string>;
-  // deno-lint-ignore ban-types
-  references: Writable<TopicMentionRefMap | Default<{}>>;
+
+  /** Durable mention map published with the body. */
+  references: Writable<
+    // deno-lint-ignore ban-types
+    TopicMentionRefMap | Default<{}>
+  >;
+
+  /** Session mention map accompanying the body draft. */
   referencesDraft: Writable<TopicMentionRefMap>;
+
+  /** Session editor visibility after a successful save. */
   editingBody: Writable<boolean>;
+
+  /** Author snapshot of the latest body save. */
   bodyUpdatedBy: Writable<
     TopicAuthor | Default<{ kind: "person"; name: "" }>
   >;
+
+  /** Timestamp of the latest body save. */
   bodyUpdatedAt: Writable<number | Default<0>>;
+
+  /** Resolved canonical Profile name for attribution. */
   profileName: string;
+
+  /** Resolved canonical Profile avatar for attribution. */
   profileAvatar: string;
-}>((
-  _,
+};
+
+/** Browser body save under the current Profile snapshot. */
+export const saveProfileBody = handler<void, SaveProfileBodyState>(
+  toSchema<void>(),
   {
-    body,
-    bodyDraft,
-    references,
-    referencesDraft,
-    editingBody,
-    bodyUpdatedBy,
-    bodyUpdatedAt,
-    profileName,
-    profileAvatar,
+    ...SAVE_PROFILE_BODY_STATE_SCHEMA,
+    properties: {
+      ...SAVE_PROFILE_BODY_STATE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
   },
-) => {
-  const author = topicAuthorFromPerson(profileName, profileAvatar);
-  if (!author) return;
-  // One whole-value set per explicit save keeps the conflict window small; a
-  // live-bound textarea on a shared string would conflict per keystroke.
-  body.set(bodyDraft.get());
-  // The map publishes with the prose it describes, in this one transaction:
-  // the tokens and the destinations they name are one document, and a save
-  // that landed only half of it would leave a dead link either way. Whole-map,
-  // for the same reason the body above is whole-value — an entry belongs to
-  // the draft that minted it, and the two conflict as one document or not at
-  // all. `destination` is `unknown`, which is what carries each one across as
-  // a link rather than expanding the piece behind it.
-  references.set(referencesDraft.get());
-  bodyUpdatedBy.set(author);
-  bodyUpdatedAt.set(Date.now());
-  editingBody.set(false);
-});
+  (
+    _,
+    {
+      upgrade,
+      body,
+      bodyDraft,
+      references,
+      referencesDraft,
+      editingBody,
+      bodyUpdatedBy,
+      bodyUpdatedAt,
+      profileName,
+      profileAvatar,
+    },
+  ) => {
+    const author = topicAuthorFromPerson(profileName, profileAvatar);
+    if (!author) return;
+    upgradeTopicState(upgrade.get(), "saveProfileBody");
+    // One whole-value set per explicit save keeps the conflict window small; a
+    // live-bound textarea on a shared string would conflict per keystroke.
+    body.set(bodyDraft.get());
+    // The map publishes with the prose it describes, in this one transaction:
+    // the tokens and the destinations they name are one document, and a save
+    // that landed only half of it would leave a dead link either way. Whole-map,
+    // for the same reason the body above is whole-value — an entry belongs to
+    // the draft that minted it, and the two conflict as one document or not at
+    // all. `destination` is `unknown`, which is what carries each one across as
+    // a link rather than expanding the piece behind it.
+    references.set(referencesDraft.get());
+    bodyUpdatedBy.set(author);
+    bodyUpdatedAt.set(Date.now());
+    editingBody.set(false);
+  },
+);
+
+/** Bound state for `dropMention`. */
+type DropMentionState = {
+  /** Shared upgrade handles for this Topic. */
+  upgrade: Writable<TopicUpgradeState>;
+
+  /** Durable set of verb-made piece references. */
+  mentioned: Writable<unknown[] | Default<[]>>;
+
+  // A CELL, because `removeByValue` matches a cell by its link. Bound as a
+  // plain value it would arrive resolved, match nothing, and remove nothing.
+  /** Original piece cell selected for reference removal. */
+  topic: Writable<unknown>;
+};
 
 /**
  * Drop one verb-made reference from the browser.
@@ -1167,15 +1507,39 @@ export const saveProfileBody = handler<void, {
  * `removeByValue` here for the same reason it is in `unmention`: it resolves
  * against durable state instead of rewriting the list.
  */
-export const dropMention = handler<void, {
-  mentioned: Writable<unknown[] | Default<[]>>;
-  // A CELL, because `removeByValue` matches a cell by its link. Bound as a
-  // plain value it would arrive resolved, match nothing, and remove nothing.
-  topic: Writable<unknown>;
-}>((_, { mentioned, topic }) => {
-  if (!topic) return;
-  mentioned.removeByValue(topic);
-});
+export const dropMention = handler<void, DropMentionState>(
+  toSchema<void>(),
+  {
+    ...DROP_MENTION_STATE_SCHEMA,
+    properties: {
+      ...DROP_MENTION_STATE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  (_, { upgrade, mentioned, topic }) => {
+    if (!topic) return;
+    upgradeTopicState(upgrade.get(), "dropMention");
+    mentioned.removeByValue(topic);
+  },
+);
+
+/** Bound state for `retractProfileLink`. */
+type RetractProfileLinkState = {
+  /** Shared upgrade handles for this Topic. */
+  upgrade: Writable<TopicUpgradeState>;
+
+  /** Stored links containing the mutation target. */
+  links: Writable<TopicLink[] | Default<[]>>;
+
+  /** Original link cell selected for retraction. */
+  link: Writable<TopicLink>;
+
+  /** Resolved canonical Profile name for attribution. */
+  profileName: string;
+
+  /** Resolved canonical Profile avatar for attribution. */
+  profileAvatar: string;
+};
 
 /** Browser link retraction under the current Profile snapshot.
  *
@@ -1183,48 +1547,83 @@ export const dropMention = handler<void, {
  * {@link retractProfileComment} is bound and for the same reasons. A stamped
  * link additionally stops resolving into `mentions`, so this control retracts
  * a reference as well as a row. */
-export const retractProfileLink = handler<void, {
+export const retractProfileLink = handler<void, RetractProfileLinkState>(
+  toSchema<void>(),
+  {
+    ...RETRACT_PROFILE_LINK_STATE_SCHEMA,
+    properties: {
+      ...RETRACT_PROFILE_LINK_STATE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  (_, { upgrade, links, link, profileName, profileAvatar }) => {
+    const author = topicAuthorFromPerson(profileName, profileAvatar);
+    if (!author) return;
+    if (!link || link.get() === undefined) return;
+    if (!isElementOf(links, link)) return;
+    if (link.get()?.removedAt !== undefined) return;
+    upgradeTopicState(upgrade.get(), "retractProfileLink");
+    link.key("removedAt").set(Date.now());
+    link.key("removedBy").set(author);
+  },
+);
+
+/** Bound state for `submitProfileLink`. */
+type SubmitProfileLinkState = {
+  /** Shared upgrade handles for this Topic. */
+  upgrade: Writable<TopicUpgradeState>;
+
+  /** Stored links containing the mutation target. */
   links: Writable<TopicLink[] | Default<[]>>;
-  link: Writable<TopicLink>;
+
+  /** Session URL draft validated before link creation. */
+  linkUrlDraft: Writable<string>;
+
+  /** Session label draft accompanying the URL. */
+  linkLabelDraft: Writable<string>;
+
+  /** Session link category draft. */
+  linkKindDraft: Writable<TopicLinkKind>;
+
+  /** Resolved canonical Profile name for attribution. */
   profileName: string;
+
+  /** Resolved canonical Profile avatar for attribution. */
   profileAvatar: string;
-}>((_, { links, link, profileName, profileAvatar }) => {
-  const author = topicAuthorFromPerson(profileName, profileAvatar);
-  if (!author) return;
-  if (!link || link.get() === undefined) return;
-  if (!isElementOf(links, link)) return;
-  if (link.get()?.removedAt !== undefined) return;
-  link.key("removedAt").set(Date.now());
-  link.key("removedBy").set(author);
-});
+};
 
 /** Browser link submit under the current Profile snapshot. */
-export const submitProfileLink = handler<void, {
-  links: Writable<TopicLink[] | Default<[]>>;
-  linkUrlDraft: Writable<string>;
-  linkLabelDraft: Writable<string>;
-  linkKindDraft: Writable<TopicLinkKind>;
-  profileName: string;
-  profileAvatar: string;
-}>((
-  _,
+export const submitProfileLink = handler<void, SubmitProfileLinkState>(
+  toSchema<void>(),
   {
-    links,
-    linkUrlDraft,
-    linkLabelDraft,
-    linkKindDraft,
-    profileName,
-    profileAvatar,
+    ...SUBMIT_PROFILE_LINK_STATE_SCHEMA,
+    properties: {
+      ...SUBMIT_PROFILE_LINK_STATE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
   },
-) => {
-  const url = linkUrlDraft.get();
-  const author = topicAuthorFromPerson(profileName, profileAvatar);
-  if (!url.trim() || !isSafeLinkUrl(url) || !author) return;
-  appendLink(links, url, linkKindDraft.get(), linkLabelDraft.get(), author);
-  linkUrlDraft.set("");
-  linkLabelDraft.set("");
-  linkKindDraft.set("web");
-});
+  (
+    _,
+    {
+      upgrade,
+      links,
+      linkUrlDraft,
+      linkLabelDraft,
+      linkKindDraft,
+      profileName,
+      profileAvatar,
+    },
+  ) => {
+    const url = linkUrlDraft.get();
+    const author = topicAuthorFromPerson(profileName, profileAvatar);
+    if (!url.trim() || !isSafeLinkUrl(url) || !author) return;
+    upgradeTopicState(upgrade.get(), "submitProfileLink");
+    appendLink(links, url, linkKindDraft.get(), linkLabelDraft.get(), author);
+    linkUrlDraft.set("");
+    linkLabelDraft.set("");
+    linkKindDraft.set("web");
+  },
+);
 
 // ===== Derivations =====
 //
@@ -1352,92 +1751,318 @@ const createdByOf = lift((
   createdBy && createdBy.name.trim() ? createdBy : { kind: "person", name: "" }
 );
 
-/**
- * Copies legacy display names into missing structured author names once per
- * topic. Existing author kinds and avatars remain authoritative; an unknown
- * kind is recorded as `legacy`.
- */
-const migrateAuthorFields = lift(
-  (input: {
-    /** Durable completion shared by every reader of this topic. */
-    authorFieldsMigratedV1: Writable<boolean>;
-    /** Source handle whose read distinguishes an absent name from a pending link. */
-    createdByName: ReadonlyCell<unknown>;
-    /** Structured creator destination under its existing declared shape. */
-    createdBy: Writable<TopicAuthor | undefined>;
-    /** Author fields addressed through the original comment identities. */
-    comments: Writable<Pick<StoredTopicComment, "author" | "authorName">[]>;
-  }): void => {
-    if (input.authorFieldsMigratedV1.get()) return;
-    const { createdByName, createdBy, comments } = input;
-
-    const legacyCreatorName = createdByName.get();
-    const creator = createdBy.get();
-    const creatorKind = creator?.kind;
-    const creatorName = !creator?.name.trim() &&
-        typeof legacyCreatorName === "string" && legacyCreatorName.trim()
-      ? legacyCreatorName
-      : undefined;
-    // Resolve every source and destination before making the first write. A
-    // missing linked record must leave completion pending. Read through handles:
-    // optional property reads can turn unresolved links into `undefined`.
-    const commentAuthors = comments.get().map((_, index) => {
-      const comment = comments.key(index);
-      const author = comment.key("author").get();
-      const legacyName = comment.key("authorName").get();
-      return {
-        index,
-        name: !author?.name.trim() &&
-            typeof legacyName === "string" && legacyName.trim()
-          ? legacyName
-          : undefined,
-        kind: author?.kind,
-      };
-    });
-
-    if (creatorName !== undefined) {
-      createdBy.key("name").set(creatorName);
-      if (!creatorKind) createdBy.key("kind").set("legacy");
-    }
-    commentAuthors.forEach(({ index, name, kind }) => {
-      if (name === undefined) return;
-      const author = comments.key(index).key("author");
-      author.key("name").set(name);
-      if (!kind) author.key("kind").set("legacy");
-    });
-    input.authorFieldsMigratedV1.set(true);
-  },
+/** Handles `addComment` after bringing durable Topic state up to date. */
+const addCommentHandler = handler<
+  AddCommentEvent,
+  TopicWriteState<"comments">,
+  AddCommentResult
+>(
+  toSchema<AddCommentEvent>(),
   {
-    type: "object",
+    ...COMMENTS_WRITE_SCHEMA,
     properties: {
-      authorFieldsMigratedV1: toSchema<Writable<boolean>>(),
-      createdBy: toSchema<Writable<TopicAuthor | undefined>>(),
-      // Concrete strings are read; every other legacy value stays opaque.
-      // A TypeScript `string | unknown` collapses to opaque-only `unknown`.
-      createdByName: {
-        type: ["string", "unknown"],
-        asCell: ["readonly"],
-      },
-      comments: {
-        type: "array",
-        asCell: ["cell"],
-        items: {
-          type: "object",
-          properties: {
-            author: toSchema<TopicAuthor>(),
-            authorName: { type: ["string", "unknown"] },
-          },
-        },
-      },
+      ...COMMENTS_WRITE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
     },
-    required: [
-      "authorFieldsMigratedV1",
-      "createdByName",
-      "createdBy",
-      "comments",
-    ],
-  } as const,
-  toSchema<void>(),
+  },
+  ({ body: text, agentName }, { upgrade, comments }) => {
+    const trimmed = (text ?? "").trim();
+    const author = topicAuthorFromAgent(agentName) ??
+      rejectMutation("addComment", "agentName must be non-blank");
+    if (!trimmed) rejectMutation("addComment", "body must be non-empty");
+    upgradeTopicState(upgrade.get(), "addComment");
+    return { comment: appendComment(comments, trimmed, author) };
+  },
+);
+
+/** Handles `addLink` after bringing durable Topic state up to date. */
+const addLinkHandler = handler<
+  AddLinkEvent,
+  TopicWriteState<"links">,
+  AddLinkResult
+>(
+  toSchema<AddLinkEvent>(),
+  {
+    ...LINKS_WRITE_SCHEMA,
+    properties: {
+      ...LINKS_WRITE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  ({ kind, url, label, agentName }, { upgrade, links }) => {
+    const trimmedUrl = (url ?? "").trim();
+    const author = topicAuthorFromAgent(agentName) ??
+      rejectMutation("addLink", "agentName must be non-blank");
+    if (!trimmedUrl) rejectMutation("addLink", "url must be non-empty");
+    if (!isSafeLinkUrl(trimmedUrl)) {
+      rejectMutation("addLink", "url must be http(s)");
+    }
+    upgradeTopicState(upgrade.get(), "addLink");
+    return { link: appendLink(links, trimmedUrl, kind, label, author) };
+  },
+);
+
+/** Handles `removeComment` after bringing durable Topic state up to date. */
+const removeCommentHandler = handler<
+  RemoveCommentEvent,
+  TopicWriteState<"comments">,
+  RemoveCommentResult
+>(
+  toSchema<RemoveCommentEvent>(),
+  {
+    ...COMMENTS_WRITE_SCHEMA,
+    properties: {
+      ...COMMENTS_WRITE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  ({ comment, agentName }, { upgrade, comments }) => {
+    const author = topicAuthorFromAgent(agentName) ??
+      rejectMutation("removeComment", "agentName must be non-blank");
+    // The same reference check `mention` makes, and it earns its place for
+    // the same reason: a payload that is not a reference has no stored
+    // element behind it, so the writes below would land on nothing and
+    // report success.
+    if (!comment || comment.get() === undefined) {
+      rejectMutation("removeComment", "comment must be a reference");
+    }
+    if (!isElementOf(comments, comment)) {
+      rejectMutation("removeComment", "comment is not on this topic");
+    }
+    if (comment.get()?.removedAt !== undefined) {
+      rejectMutation("removeComment", "comment is already retracted");
+    }
+    upgradeTopicState(upgrade.get(), "removeComment");
+    const removedAt = Date.now();
+    // Two field writes into the element the caller named, not a rewrite of
+    // the array. Concurrent retractions of distinct comments merge, and
+    // every surviving reference stays a reference.
+    comment.key("removedAt").set(removedAt);
+    comment.key("removedBy").set(author);
+    return { removedAt, removedBy: author };
+  },
+);
+
+/** Handles `editComment` after bringing durable Topic state up to date. */
+const editCommentHandler = handler<
+  EditCommentEvent,
+  TopicWriteState<"comments">,
+  EditCommentResult
+>(
+  toSchema<EditCommentEvent>(),
+  {
+    ...COMMENTS_WRITE_SCHEMA,
+    properties: {
+      ...COMMENTS_WRITE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  ({ comment, body: text, agentName }, { upgrade, comments }) => {
+    // Checked, not bound: `editComment` requires a signature like every
+    // other mutation here, and then stores nothing from it. `author` and
+    // `sentAt` stay as the comment was written — an edit changes what was
+    // said, not who said it. Fabric still records the principal behind
+    // the write.
+    if (!topicAuthorFromAgent(agentName)) {
+      rejectMutation("editComment", "agentName must be non-blank");
+    }
+    if (!comment || comment.get() === undefined) {
+      rejectMutation("editComment", "comment must be a reference");
+    }
+    if (!isElementOf(comments, comment)) {
+      rejectMutation("editComment", "comment is not on this topic");
+    }
+    if (comment.get()?.removedAt !== undefined) {
+      rejectMutation("editComment", "comment is retracted");
+    }
+    const trimmed = (text ?? "").trim();
+    if (!trimmed) rejectMutation("editComment", "body must be non-empty");
+    upgradeTopicState(upgrade.get(), "editComment");
+    const editedAt = Date.now();
+    comment.key("body").set(trimmed);
+    comment.key("editedAt").set(editedAt);
+    return { body: trimmed, editedAt };
+  },
+);
+
+/** Handles `removeLink` after bringing durable Topic state up to date. */
+const removeLinkHandler = handler<
+  RemoveLinkEvent,
+  TopicWriteState<"links">,
+  RemoveLinkResult
+>(
+  toSchema<RemoveLinkEvent>(),
+  {
+    ...LINKS_WRITE_SCHEMA,
+    properties: {
+      ...LINKS_WRITE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  ({ link, url, agentName }, { upgrade, links }) => {
+    const author = topicAuthorFromAgent(agentName) ??
+      rejectMutation("removeLink", "agentName must be non-blank");
+    const named = (url ?? "").trim();
+    if (link && named) {
+      rejectMutation("removeLink", "pass link or url, not both");
+    }
+    let target = link;
+    if (!target) {
+      if (!named) {
+        rejectMutation("removeLink", "pass link or url");
+      }
+      // The url spelling resolves to an element the same way the reference
+      // spelling arrives as one, so both paths stamp a stored record.
+      // Newest first, so retracting twice retracts two rather than
+      // re-stamping the one already gone.
+      const stored = links.get();
+      for (let i = stored.length - 1; i >= 0; i--) {
+        const candidate = stored[i];
+        if (candidate?.url === named && isPresent(candidate)) {
+          target = links.key(i) as typeof link;
+          break;
+        }
+      }
+      if (!target) {
+        rejectMutation("removeLink", `no link present with url ${named}`);
+      }
+    } else if (target.get() === undefined) {
+      rejectMutation("removeLink", "link must be a reference");
+    } else if (!isElementOf(links, target)) {
+      rejectMutation("removeLink", "link is not on this topic");
+    } else if (target.get()?.removedAt !== undefined) {
+      rejectMutation("removeLink", "link is already retracted");
+    }
+    upgradeTopicState(upgrade.get(), "removeLink");
+    const removedAt = Date.now();
+    target!.key("removedAt").set(removedAt);
+    target!.key("removedBy").set(author);
+    return {
+      url: target!.get()?.url ?? named,
+      removedAt,
+      removedBy: author,
+    };
+  },
+);
+
+/** Handles `setBody` after bringing durable Topic state up to date. */
+const setBodyHandler = handler<
+  SetBodyEvent,
+  TopicWriteState<"body" | "bodyUpdatedBy" | "bodyUpdatedAt">,
+  SetBodyResult
+>(
+  toSchema<SetBodyEvent>(),
+  {
+    ...BODY_WRITE_SCHEMA,
+    properties: {
+      ...BODY_WRITE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  (
+    { body: text, agentName },
+    { upgrade, body, bodyUpdatedBy, bodyUpdatedAt },
+  ) => {
+    const author = topicAuthorFromAgent(agentName) ??
+      rejectMutation("setBody", "agentName must be non-blank");
+    const persisted = text ?? "";
+    upgradeTopicState(upgrade.get(), "setBody");
+    body.set(persisted);
+    const bodyUpdatedAtValue = Date.now();
+    bodyUpdatedBy.set(author);
+    bodyUpdatedAt.set(bodyUpdatedAtValue);
+    return {
+      body: persisted,
+      bodyUpdatedBy: author,
+      bodyUpdatedAt: bodyUpdatedAtValue,
+    };
+  },
+);
+
+/** Handles `setTitle` after bringing durable Topic state up to date. */
+const setTitleHandler = handler<
+  SetTitleEvent,
+  TopicWriteState<"title" | "titleUpdatedBy" | "titleUpdatedAt">,
+  SetTitleResult
+>(
+  toSchema<SetTitleEvent>(),
+  {
+    ...TITLE_WRITE_SCHEMA,
+    properties: {
+      ...TITLE_WRITE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  (
+    { title: text, agentName },
+    { upgrade, title, titleUpdatedBy, titleUpdatedAt },
+  ) => {
+    const trimmed = (text ?? "").trim();
+    const author = topicAuthorFromAgent(agentName ?? "") ??
+      rejectMutation("setTitle", "agentName must be non-blank");
+    if (!trimmed) rejectMutation("setTitle", "title must be non-empty");
+    upgradeTopicState(upgrade.get(), "setTitle");
+    return persistTitle(
+      title,
+      titleUpdatedBy,
+      titleUpdatedAt,
+      trimmed,
+      author,
+    );
+  },
+);
+
+/** Handles `mention` after bringing durable Topic state up to date. */
+const mentionHandler = handler<MentionEvent, TopicWriteState<"mentioned">>(
+  toSchema<MentionEvent>(),
+  {
+    ...MENTIONED_WRITE_SCHEMA,
+    properties: {
+      ...MENTIONED_WRITE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  ({ topic }, { upgrade, mentioned }) => {
+    // A reference, or a rejection. The schema wraps whatever it is handed as
+    // a cell without looking behind it, so this is the boundary — and the
+    // narrowed payload is what makes it one read of one field: `undefined`
+    // is a value with no document behind it, and any real piece answers with
+    // an object because `title` carries a default.
+    if (!topic || topic.get() === undefined) {
+      rejectMutation("mention", "topic must be a reference");
+    }
+    // A set-add, not an append: referencing the same piece twice is one
+    // reference. Mergeable, so concurrent mentions of distinct pieces all
+    // land and a repeated one is a no-op against durable state.
+    upgradeTopicState(upgrade.get(), "mention");
+    mentioned.addUnique(topic);
+  },
+);
+
+/** Handles `unmention` after bringing durable Topic state up to date. */
+const unmentionHandler = handler<UnmentionEvent, TopicWriteState<"mentioned">>(
+  toSchema<UnmentionEvent>(),
+  {
+    ...MENTIONED_WRITE_SCHEMA,
+    properties: {
+      ...MENTIONED_WRITE_SCHEMA.properties,
+      upgrade: { ...TOPIC_UPGRADE_SCHEMA, asCell: ["cell"] },
+    },
+  },
+  ({ topic }, { upgrade, mentioned }) => {
+    // Same check as `mention`, and it earns its place here too: a payload
+    // that is not a reference matches no stored entry, so the removal below
+    // would quietly do nothing and report success.
+    if (!topic || topic.get() === undefined) {
+      rejectMutation("unmention", "topic must be a reference");
+    }
+    // `removeByValue`, not `remove` or `removeAll`: those two rebuild the
+    // array and set it back, which is both a clobbering write and the shape
+    // that flattens surviving references. This one resolves against durable
+    // state, so concurrent removals of distinct entries merge.
+    upgradeTopicState(upgrade.get(), "unmention");
+    mentioned.removeByValue(topic);
+  },
 );
 
 // ===== The pattern =====
@@ -1452,7 +2077,7 @@ export default pattern<TopicInput, TopicOutput>(
       createdAt,
       createdBy,
       createdByName,
-      authorFieldsMigratedV1,
+      topicStateVersion,
       bodyUpdatedBy,
       bodyUpdatedAt,
       titleUpdatedBy,
@@ -1465,12 +2090,8 @@ export default pattern<TopicInput, TopicOutput>(
       [SELF]: self,
     },
   ) => {
-    migrateAuthorFields({
-      authorFieldsMigratedV1,
-      createdByName,
-      createdBy,
-      comments,
-    });
+    const upgrade = { topicStateVersion, createdByName, createdBy, comments };
+    migrateTopicState(upgrade);
 
     // Session-local UI state (new-tab test: none of this should carry over).
     const commentDraft = new Writable.perSession("");
@@ -1505,162 +2126,29 @@ export default pattern<TopicInput, TopicOutput>(
 
     // --- Streams (external API; also usable headlessly via CLI) ---
 
-    const addComment = action<AddCommentEvent, AddCommentResult>(
-      ({ body: text, agentName }) => {
-        const trimmed = (text ?? "").trim();
-        const author = topicAuthorFromAgent(agentName) ??
-          rejectMutation("addComment", "agentName must be non-blank");
-        if (!trimmed) rejectMutation("addComment", "body must be non-empty");
-        return { comment: appendComment(comments, trimmed, author) };
-      },
-    );
+    const addComment = addCommentHandler({ upgrade, comments });
 
-    const addLink = action<AddLinkEvent, AddLinkResult>(
-      ({ kind, url, label, agentName }) => {
-        const trimmedUrl = (url ?? "").trim();
-        const author = topicAuthorFromAgent(agentName) ??
-          rejectMutation("addLink", "agentName must be non-blank");
-        if (!trimmedUrl) rejectMutation("addLink", "url must be non-empty");
-        if (!isSafeLinkUrl(trimmedUrl)) {
-          rejectMutation("addLink", "url must be http(s)");
-        }
-        return { link: appendLink(links, trimmedUrl, kind, label, author) };
-      },
-    );
+    const addLink = addLinkHandler({ upgrade, links });
 
-    const removeComment = action<RemoveCommentEvent, RemoveCommentResult>(
-      ({ comment, agentName }) => {
-        const author = topicAuthorFromAgent(agentName) ??
-          rejectMutation("removeComment", "agentName must be non-blank");
-        // The same reference check `mention` makes, and it earns its place for
-        // the same reason: a payload that is not a reference has no stored
-        // element behind it, so the writes below would land on nothing and
-        // report success.
-        if (!comment || comment.get() === undefined) {
-          rejectMutation("removeComment", "comment must be a reference");
-        }
-        if (!isElementOf(comments, comment)) {
-          rejectMutation("removeComment", "comment is not on this topic");
-        }
-        if (comment.get()?.removedAt !== undefined) {
-          rejectMutation("removeComment", "comment is already retracted");
-        }
-        const removedAt = Date.now();
-        // Two field writes into the element the caller named, not a rewrite of
-        // the array. Concurrent retractions of distinct comments merge, and
-        // every surviving reference stays a reference.
-        comment.key("removedAt").set(removedAt);
-        comment.key("removedBy").set(author);
-        return { removedAt, removedBy: author };
-      },
-    );
+    const removeComment = removeCommentHandler({ upgrade, comments });
 
-    const editComment = action<EditCommentEvent, EditCommentResult>(
-      ({ comment, body: text, agentName }) => {
-        // Checked, not bound: `editComment` requires a signature like every
-        // other mutation here, and then stores nothing from it. `author` and
-        // `sentAt` stay as the comment was written — an edit changes what was
-        // said, not who said it. Fabric still records the principal behind
-        // the write.
-        if (!topicAuthorFromAgent(agentName)) {
-          rejectMutation("editComment", "agentName must be non-blank");
-        }
-        if (!comment || comment.get() === undefined) {
-          rejectMutation("editComment", "comment must be a reference");
-        }
-        if (!isElementOf(comments, comment)) {
-          rejectMutation("editComment", "comment is not on this topic");
-        }
-        if (comment.get()?.removedAt !== undefined) {
-          rejectMutation("editComment", "comment is retracted");
-        }
-        const trimmed = (text ?? "").trim();
-        if (!trimmed) rejectMutation("editComment", "body must be non-empty");
-        const editedAt = Date.now();
-        comment.key("body").set(trimmed);
-        comment.key("editedAt").set(editedAt);
-        return { body: trimmed, editedAt };
-      },
-    );
+    const editComment = editCommentHandler({ upgrade, comments });
 
-    const removeLink = action<RemoveLinkEvent, RemoveLinkResult>(
-      ({ link, url, agentName }) => {
-        const author = topicAuthorFromAgent(agentName) ??
-          rejectMutation("removeLink", "agentName must be non-blank");
-        const named = (url ?? "").trim();
-        if (link && named) {
-          rejectMutation("removeLink", "pass link or url, not both");
-        }
-        let target = link;
-        if (!target) {
-          if (!named) {
-            rejectMutation("removeLink", "pass link or url");
-          }
-          // The url spelling resolves to an element the same way the reference
-          // spelling arrives as one, so both paths stamp a stored record.
-          // Newest first, so retracting twice retracts two rather than
-          // re-stamping the one already gone.
-          const stored = links.get();
-          for (let i = stored.length - 1; i >= 0; i--) {
-            const candidate = stored[i];
-            if (candidate?.url === named && isPresent(candidate)) {
-              target = links.key(i) as typeof link;
-              break;
-            }
-          }
-          if (!target) {
-            rejectMutation("removeLink", `no link present with url ${named}`);
-          }
-        } else if (target.get() === undefined) {
-          rejectMutation("removeLink", "link must be a reference");
-        } else if (!isElementOf(links, target)) {
-          rejectMutation("removeLink", "link is not on this topic");
-        } else if (target.get()?.removedAt !== undefined) {
-          rejectMutation("removeLink", "link is already retracted");
-        }
-        const removedAt = Date.now();
-        target!.key("removedAt").set(removedAt);
-        target!.key("removedBy").set(author);
-        return {
-          url: target!.get()?.url ?? named,
-          removedAt,
-          removedBy: author,
-        };
-      },
-    );
+    const removeLink = removeLinkHandler({ upgrade, links });
 
-    const setBody = action<SetBodyEvent, SetBodyResult>(
-      ({ body: text, agentName }) => {
-        const author = topicAuthorFromAgent(agentName) ??
-          rejectMutation("setBody", "agentName must be non-blank");
-        const persisted = text ?? "";
-        body.set(persisted);
-        const bodyUpdatedAtValue = Date.now();
-        bodyUpdatedBy.set(author);
-        bodyUpdatedAt.set(bodyUpdatedAtValue);
-        return {
-          body: persisted,
-          bodyUpdatedBy: author,
-          bodyUpdatedAt: bodyUpdatedAtValue,
-        };
-      },
-    );
+    const setBody = setBodyHandler({
+      upgrade,
+      body,
+      bodyUpdatedBy,
+      bodyUpdatedAt,
+    });
 
-    const setTitle = action<SetTitleEvent, SetTitleResult>(
-      ({ title: text, agentName }) => {
-        const trimmed = (text ?? "").trim();
-        const author = topicAuthorFromAgent(agentName ?? "") ??
-          rejectMutation("setTitle", "agentName must be non-blank");
-        if (!trimmed) rejectMutation("setTitle", "title must be non-empty");
-        return persistTitle(
-          title,
-          titleUpdatedBy,
-          titleUpdatedAt,
-          trimmed,
-          author,
-        );
-      },
-    );
+    const setTitle = setTitleHandler({
+      upgrade,
+      title,
+      titleUpdatedBy,
+      titleUpdatedAt,
+    });
 
     /**
      * Record a reference to another piece.
@@ -1675,39 +2163,15 @@ export default pattern<TopicInput, TopicOutput>(
      * only collects keys it saw when the document loaded or minted itself, so a
      * key that arrived from elsewhere is kept.
      */
-    const mention = action<MentionEvent>(({ topic }) => {
-      // A reference, or a rejection. The schema wraps whatever it is handed as
-      // a cell without looking behind it, so this is the boundary — and the
-      // narrowed payload is what makes it one read of one field: `undefined`
-      // is a value with no document behind it, and any real piece answers with
-      // an object because `title` carries a default.
-      if (!topic || topic.get() === undefined) {
-        rejectMutation("mention", "topic must be a reference");
-      }
-      // A set-add, not an append: referencing the same piece twice is one
-      // reference. Mergeable, so concurrent mentions of distinct pieces all
-      // land and a repeated one is a no-op against durable state.
-      mentioned.addUnique(topic);
-    });
+    const mention = mentionHandler({ upgrade, mentioned });
 
     /** Stop referencing a piece — every entry naming it. */
-    const unmention = action<UnmentionEvent>(({ topic }) => {
-      // Same check as `mention`, and it earns its place here too: a payload
-      // that is not a reference matches no stored entry, so the removal below
-      // would quietly do nothing and report success.
-      if (!topic || topic.get() === undefined) {
-        rejectMutation("unmention", "topic must be a reference");
-      }
-      // `removeByValue`, not `remove` or `removeAll`: those two rebuild the
-      // array and set it back, which is both a clobbering write and the shape
-      // that flattens surviving references. This one resolves against durable
-      // state, so concurrent removals of distinct entries merge.
-      mentioned.removeByValue(topic);
-    });
+    const unmention = unmentionHandler({ upgrade, mentioned });
 
     // --- UI-side actions (close over session drafts) ---
 
     const submitComment = submitProfileComment({
+      upgrade,
       comments,
       commentDraft,
       profileName,
@@ -1720,6 +2184,7 @@ export default pattern<TopicInput, TopicOutput>(
     });
 
     const saveTitle = saveProfileTitle({
+      upgrade,
       title,
       titleDraft,
       editingTitle,
@@ -1745,6 +2210,7 @@ export default pattern<TopicInput, TopicOutput>(
     });
 
     const saveBody = saveProfileBody({
+      upgrade,
       body,
       bodyDraft,
       references,
@@ -1763,6 +2229,7 @@ export default pattern<TopicInput, TopicOutput>(
     });
 
     const submitLink = submitProfileLink({
+      upgrade,
       links,
       linkUrlDraft,
       linkLabelDraft,
@@ -2018,6 +2485,7 @@ export default pattern<TopicInput, TopicOutput>(
                             disabled={!hasProfile}
                             data-retract="link"
                             onClick={retractProfileLink({
+                              upgrade,
                               links,
                               link,
                               profileName,
@@ -2116,6 +2584,7 @@ export default pattern<TopicInput, TopicOutput>(
                               disabled={!hasProfile}
                               data-retract="comment"
                               onClick={retractProfileComment({
+                                upgrade,
                                 comments,
                                 comment,
                                 profileName,
@@ -2189,7 +2658,7 @@ export default pattern<TopicInput, TopicOutput>(
                           <cf-cell-link $cell={topic} />
                           <cf-button
                             variant="ghost"
-                            onClick={dropMention({ mentioned, topic })}
+                            onClick={dropMention({ upgrade, mentioned, topic })}
                           >
                             Remove
                           </cf-button>

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -45,7 +45,8 @@ export interface TopicAuthor {
   /** Open for the same reason `TopicLinkKind` is: this is provided data, so a
    * closed set here could never gain `"service"` or whatever acts next.
    * Well-known values are `"person"` and `"agent"`, the latter marking an
-   * agent acting with its human user's key. */
+   * agent acting with its human user's key. `"legacy"` records a display name
+   * whose author kind is unknown. */
   kind: string;
   name: string;
   avatar?: string;
@@ -299,6 +300,12 @@ export interface TopicComment {
   removedBy?: TopicAuthor;
 }
 
+/** Stored comment fields available to the author migration. */
+interface StoredTopicComment extends TopicComment {
+  /** Display name recorded without an author kind. */
+  authorName?: string;
+}
+
 export interface TopicLink {
   kind: TopicLinkKind | Default<"web">;
   url: string | Default<"">;
@@ -363,10 +370,17 @@ export interface TopicInput {
   /** The topic's living document: durable conclusions get folded up into the
    * body; the comment thread below holds the deliberation. */
   body?: Writable<string | Default<"">>;
-  comments?: Writable<TopicComment[] | Default<[]>>;
+  comments?: Writable<StoredTopicComment[] | Default<[]>>;
   links?: Writable<TopicLink[] | Default<[]>>;
   createdAt?: number | Default<0>;
-  createdBy?: TopicAuthor;
+  createdBy?: Writable<TopicAuthor | undefined>;
+
+  /** Creator display name recorded without an author kind. */
+  createdByName?: string;
+
+  /** Completion of the per-topic migration from display names to authors. */
+  authorFieldsMigratedV1?: Writable<boolean | Default<false>>;
+
   bodyUpdatedBy?: Writable<
     TopicAuthor | Default<{ kind: "person"; name: "" }>
   >;
@@ -1336,6 +1350,61 @@ const createdByOf = lift((
   createdBy && createdBy.name.trim() ? createdBy : { kind: "person", name: "" }
 );
 
+/**
+ * Copies legacy display names into missing structured author names once per
+ * topic. Existing author kinds and avatars remain authoritative; an unknown
+ * kind is recorded as `legacy`.
+ */
+const migrateAuthorFields = lift((
+  {
+    authorFieldsMigratedV1,
+    createdByName,
+    createdBy,
+    comments,
+  }: {
+    /** Durable completion flag shared by every reader of this topic. */
+    authorFieldsMigratedV1: Writable<boolean>;
+
+    /** Legacy creator name, retained after migration. */
+    createdByName?: string;
+
+    /** Destination for the creator's structured display snapshot. */
+    createdBy: Writable<TopicAuthor | undefined>;
+
+    /** Stored comments, addressed individually to preserve their identity. */
+    comments: Writable<StoredTopicComment[]>;
+  },
+): void => {
+  if (authorFieldsMigratedV1.get()) return;
+
+  const creator = createdBy.get();
+  const creatorKind = creator?.kind;
+  const creatorName = !creator?.name.trim() && createdByName?.trim()
+    ? createdByName
+    : undefined;
+  // Resolve every source and destination before making the first write. A
+  // missing linked record must leave completion pending.
+  const commentAuthors = comments.get().map((comment, index) => ({
+    index,
+    name: !comment.author?.name.trim() && comment.authorName?.trim()
+      ? comment.authorName
+      : undefined,
+    kind: comment.author?.kind,
+  }));
+
+  if (creatorName !== undefined) {
+    createdBy.key("name").set(creatorName);
+    if (!creatorKind) createdBy.key("kind").set("legacy");
+  }
+  commentAuthors.forEach(({ index, name, kind }) => {
+    if (name === undefined) return;
+    const author = comments.key(index).key("author");
+    author.key("name").set(name);
+    if (!kind) author.key("kind").set("legacy");
+  });
+  authorFieldsMigratedV1.set(true);
+});
+
 // ===== The pattern =====
 
 export default pattern<TopicInput, TopicOutput>(
@@ -1347,6 +1416,8 @@ export default pattern<TopicInput, TopicOutput>(
       links,
       createdAt,
       createdBy,
+      createdByName,
+      authorFieldsMigratedV1,
       bodyUpdatedBy,
       bodyUpdatedAt,
       titleUpdatedBy,
@@ -1359,6 +1430,13 @@ export default pattern<TopicInput, TopicOutput>(
       [SELF]: self,
     },
   ) => {
+    migrateAuthorFields({
+      authorFieldsMigratedV1,
+      createdByName,
+      createdBy,
+      comments,
+    });
+
     // Session-local UI state (new-tab test: none of this should carry over).
     const commentDraft = new Writable.perSession("");
     const editingBody = new Writable.perSession(false);

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -373,7 +373,7 @@ export interface TopicInput {
   comments?: Writable<StoredTopicComment[] | Default<[]>>;
   links?: Writable<TopicLink[] | Default<[]>>;
   createdAt?: number | Default<0>;
-  createdBy?: Writable<TopicAuthor | undefined>;
+  createdBy?: TopicAuthor;
 
   /** Creator display name recorded without an author kind. */
   createdByName?: string;

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -13,11 +13,13 @@ import {
   type ReadonlyCell,
   SELF,
   Stream,
+  toSchema,
   UI,
   type VNode,
   wish,
   Writable,
 } from "commonfabric";
+import type {} from "commonfabric/schema";
 
 import { type NamesTableRow, ownName } from "../collection-naming/naming.ts";
 
@@ -302,8 +304,8 @@ export interface TopicComment {
 
 /** Stored comment fields available to the author migration. */
 interface StoredTopicComment extends TopicComment {
-  /** Display name recorded without an author kind. */
-  authorName?: string;
+  /** Unrestricted legacy storage; only nonblank strings supply a name. */
+  authorName?: unknown;
 }
 
 export interface TopicLink {
@@ -376,7 +378,7 @@ export interface TopicInput {
   createdBy?: TopicAuthor;
 
   /** Creator display name recorded without an author kind. */
-  createdByName?: string;
+  createdByName?: unknown;
 
   /** Completion of the per-topic migration from display names to authors. */
   authorFieldsMigratedV1?: Writable<boolean | Default<false>>;
@@ -1355,55 +1357,88 @@ const createdByOf = lift((
  * topic. Existing author kinds and avatars remain authoritative; an unknown
  * kind is recorded as `legacy`.
  */
-const migrateAuthorFields = lift((
-  {
-    authorFieldsMigratedV1,
-    createdByName,
-    createdBy,
-    comments,
-  }: {
-    /** Durable completion flag shared by every reader of this topic. */
+const migrateAuthorFields = lift(
+  (input: {
+    /** Durable completion shared by every reader of this topic. */
     authorFieldsMigratedV1: Writable<boolean>;
-
-    /** Legacy creator name, retained after migration. */
-    createdByName?: string;
-
-    /** Destination for the creator's structured display snapshot. */
+    /** Source handle whose read distinguishes an absent name from a pending link. */
+    createdByName: ReadonlyCell<unknown>;
+    /** Structured creator destination under its existing declared shape. */
     createdBy: Writable<TopicAuthor | undefined>;
+    /** Author fields addressed through the original comment identities. */
+    comments: Writable<Pick<StoredTopicComment, "author" | "authorName">[]>;
+  }): void => {
+    if (input.authorFieldsMigratedV1.get()) return;
+    const { createdByName, createdBy, comments } = input;
 
-    /** Stored comments, addressed individually to preserve their identity. */
-    comments: Writable<StoredTopicComment[]>;
+    const legacyCreatorName = createdByName.get();
+    const creator = createdBy.get();
+    const creatorKind = creator?.kind;
+    const creatorName = !creator?.name.trim() &&
+        typeof legacyCreatorName === "string" && legacyCreatorName.trim()
+      ? legacyCreatorName
+      : undefined;
+    // Resolve every source and destination before making the first write. A
+    // missing linked record must leave completion pending. Read through handles:
+    // optional property reads can turn unresolved links into `undefined`.
+    const commentAuthors = comments.get().map((_, index) => {
+      const comment = comments.key(index);
+      const author = comment.key("author").get();
+      const legacyName = comment.key("authorName").get();
+      return {
+        index,
+        name: !author?.name.trim() &&
+            typeof legacyName === "string" && legacyName.trim()
+          ? legacyName
+          : undefined,
+        kind: author?.kind,
+      };
+    });
+
+    if (creatorName !== undefined) {
+      createdBy.key("name").set(creatorName);
+      if (!creatorKind) createdBy.key("kind").set("legacy");
+    }
+    commentAuthors.forEach(({ index, name, kind }) => {
+      if (name === undefined) return;
+      const author = comments.key(index).key("author");
+      author.key("name").set(name);
+      if (!kind) author.key("kind").set("legacy");
+    });
+    input.authorFieldsMigratedV1.set(true);
   },
-): void => {
-  if (authorFieldsMigratedV1.get()) return;
-
-  const creator = createdBy.get();
-  const creatorKind = creator?.kind;
-  const creatorName = !creator?.name.trim() && createdByName?.trim()
-    ? createdByName
-    : undefined;
-  // Resolve every source and destination before making the first write. A
-  // missing linked record must leave completion pending.
-  const commentAuthors = comments.get().map((comment, index) => ({
-    index,
-    name: !comment.author?.name.trim() && comment.authorName?.trim()
-      ? comment.authorName
-      : undefined,
-    kind: comment.author?.kind,
-  }));
-
-  if (creatorName !== undefined) {
-    createdBy.key("name").set(creatorName);
-    if (!creatorKind) createdBy.key("kind").set("legacy");
-  }
-  commentAuthors.forEach(({ index, name, kind }) => {
-    if (name === undefined) return;
-    const author = comments.key(index).key("author");
-    author.key("name").set(name);
-    if (!kind) author.key("kind").set("legacy");
-  });
-  authorFieldsMigratedV1.set(true);
-});
+  {
+    type: "object",
+    properties: {
+      authorFieldsMigratedV1: toSchema<Writable<boolean>>(),
+      createdBy: toSchema<Writable<TopicAuthor | undefined>>(),
+      // Concrete strings are read; every other legacy value stays opaque.
+      // A TypeScript `string | unknown` collapses to opaque-only `unknown`.
+      createdByName: {
+        type: ["string", "unknown"],
+        asCell: ["readonly"],
+      },
+      comments: {
+        type: "array",
+        asCell: ["cell"],
+        items: {
+          type: "object",
+          properties: {
+            author: toSchema<TopicAuthor>(),
+            authorName: { type: ["string", "unknown"] },
+          },
+        },
+      },
+    },
+    required: [
+      "authorFieldsMigratedV1",
+      "createdByName",
+      "createdBy",
+      "comments",
+    ],
+  } as const,
+  toSchema<void>(),
+);
 
 // ===== The pattern =====
 

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -262,10 +262,17 @@ export default pattern(() => {
     kept: { destination: undefined, modifiedTitle: false },
     minted: { destination: undefined, modifiedTitle: true },
   });
+  const profileUpgrade = {
+    topicStateVersion: new Writable(1),
+    createdByName: new Writable<unknown>(),
+    createdBy: new Writable<TopicAuthor | undefined>(),
+    comments: profileComments,
+  };
   // Render the same cells the deterministic Profile handlers mutate. This
   // keeps their behavior and the detail UI in one end-to-end test path without
   // inventing a fallback identity for the pattern-test runtime.
   const profileTopic = Topic({
+    ...profileUpgrade,
     title: "Profile-authored topic",
     body: profileBody,
     comments: profileComments,
@@ -284,13 +291,16 @@ export default pattern(() => {
     profileName: " Ada ",
     profileAvatar: " 🦊 ",
   });
+
   const profileSubmitComment = submitProfileComment({
+    upgrade: profileUpgrade,
     comments: profileComments,
     commentDraft: profileCommentDraft,
     profileName: "Ada",
     profileAvatar: "🦊",
   });
   const profileSaveBody = saveProfileBody({
+    upgrade: profileUpgrade,
     body: profileBody,
     bodyDraft: profileBodyDraft,
     references: profileReferences,
@@ -302,6 +312,7 @@ export default pattern(() => {
     profileAvatar: "🦊",
   });
   const profileSubmitLink = submitProfileLink({
+    upgrade: profileUpgrade,
     links: profileLinks,
     linkUrlDraft: profileLinkUrlDraft,
     linkLabelDraft: profileLinkLabelDraft,
@@ -1012,6 +1023,7 @@ export default pattern(() => {
     uiMentioned.push(mentionTwo);
   });
   const uiDropMention = dropMention({
+    upgrade: profileUpgrade,
     mentioned: uiMentioned,
     topic: mentionOne,
   });
@@ -1099,6 +1111,7 @@ export default pattern(() => {
   >({ kind: "person", name: "" });
   const renameUpdatedAt = new Writable<number | Default<0>>(0);
   const profileSaveTitle = saveProfileTitle({
+    upgrade: profileUpgrade,
     title: renameTitle,
     titleDraft: renameTitleDraft,
     editingTitle: renameEditingTitle,


### PR DESCRIPTION
Deployed Topics can contain creator and comment display names in `createdByName` and `authorName`, while the current UI reads structured authors. This PR preserves that attribution through a pattern-owned, ordered state upgrade. Compatible content edits remain available while linked migration inputs are unavailable.

## Strategy

`topicStateVersion` defaults to zero. `topic.tsx` owns an append-only list of upgrade identifiers and a shared runner; the list length is the current version. The dispatcher's explicit boolean return type makes an unhandled identifier a compile error. Running a Topic runs the upgrade lift, even without a consumer reading its result. Every durable browser and headless mutation calls the same runner before writing. Both board creation paths stamp the current version immediately.

Each step reads every source and destination before its first write. It returns completion only after its writes; the runner then records the next version in the same transaction. An incomplete step stops the sequence without advancing its version. Reading first matters because a transaction can commit writes made before a later unavailable read. A completed earlier step can remain committed if a later step or the requested mutation is blocked. Steps must be deterministic, tolerate already-upgraded targets, and retain legacy storage-key spellings.

The lift suspends on unresolved links. Handler reads can return `undefined` for both absence and unresolved data, so the author step defers ambiguous reads without author writes or a version stamp. Classic legacy records with no structured author object therefore require the lift. A handler can complete the step when each author already has a nonblank structured name or supplies the defined fields required by its readiness guard. The upgrade is additive, so compatible content edits can still proceed on version-zero state. The runner neither queues nor retries a handler's own blocked mutation. A future step that changes the shape a handler needs must reject dependent mutations until its prerequisites are complete.

Future or invalid versions leave the lift inert and reject durable mutations. Session draft/editor controls remain independent. This guard supports rollback to version-aware code; it cannot constrain pre-mechanism code, already-running legacy clients, or direct cell writes. Restoring source does not undo stored data.

The [state upgrade design](https://github.com/commontoolsinc/labs/blob/codex/topics-author-migration-pr/packages/patterns/topics/state-upgrades.md) describes the mechanism, transaction boundaries, schema bindings, extension rules, and rollback limits. This uses existing pattern APIs and adds no runtime migration framework.

## First step: legacy authors

- Fill missing structured names from useful legacy strings, preserving their spelling. Blank strings and the trimmed placeholder `"someone"` supply no attribution.
- Preserve existing nonblank names, kinds, avatars, other properties, legacy fields, original comment identities, and unrelated content. Existing author objects receive individual field writes; absent or explicitly undefined authors receive new objects. A copied name with no known kind receives `kind: "legacy"`; no person/agent identity is inferred.
- Keep broad legacy input domains and the plain outer `createdBy` input contract. Explicit reader schemas materialize strings while retaining other legacy values as opaque data. Both structured-author projections use inline `Partial<TopicAuthor>` schemas. Because the reader is nested inside handler schemas, introducing references would require definitions at every containing schema document root; the code carries no empty definition-hoisting promise.
- Preserve the conservative handler guard. Once the step completes, later legacy writes are outside that pass, so legacy writers must be retired before rollout.

## Validation

- All nine authored Topics test entries: **170 assertions passed** on the revised PR branch and again with main `0cc82bd0887d517bb25a3361adf0e406fb723ebc` merged in an isolated checkout.
- **21 migration integration cases passed** on merged main, covering missing/partial/undefined authors, opaque inputs, linked comment identity, reopening, and title saves while migration inputs are unresolved.
- Topic and board compiler checks passed on merged main; transformed output confirms both author projections are inline. Separate source controls force a generated reference into each projection and reproduce the unresolved-reference failure in the existing state-version suite.
- All durable entry points retain future-version rejection coverage. Handler tests cover completion on unambiguous partially structured data and deferral while compatible edits succeed.
- Repository-wide formatting, lint, and type checks passed, as did the patterns package tests including its browser test.
- Topics compatibility passed on both the PR branch and merged main. Retained baselines and accepted-break declarations are unchanged by this cleanup; the append-only check passed against the pinned main commit.

The complete Rapids rehearsal at predecessor `3def745a3` migrated the board and all 241 Topics, with final preservation checks covering 337 comments and 267 links. This cleanup has not been applied to Rapids or Estuary. Its exact source package needs a fresh deployment admission check before any new apply.
