### PR TITLE
docs(shuttle): recall replays what a handle meant, not the handle

### DIFF
--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -324,7 +324,23 @@ invisible, the prompt renders the whole ambient record — place and scope
     separate feature and is deferred ([`futures.md`](futures.md)). The
     traversal runs over those lines and the line being typed, one position
     each, so an edit is held wherever it was made and everything that ends
-    the line returns the traversal to it. `tab` completes the token the line
+    the line returns the traversal to it. A line is recorded with each `%n`
+    replaced by what it bound to when it ran: `%n` is a reference only until
+    the next listing (decision 17) and recall outlives listings, so a
+    recalled handle would otherwise act on whichever row that number names
+    now — the wrong thing, silently and successfully, which is the one
+    failure a shell must not have. What is recorded resolves from
+    anywhere the session can stand: a piece row records the id the listing
+    resolved it to — a slug is repointable, so recording one would name
+    whichever piece it comes to mean — and a row inside a piece records
+    the reference naming
+    the cell — the piece and the path, which is what a callable row
+    already records for its receiver. A bare name would not do, two pieces
+    being free to hold a key of the same name, so a recalled name could
+    still reach a different cell without saying so. What the prompt shows
+    is what was typed; what recall replays is what it meant, and the
+    listing knows the difference already at mint time (decision 27). `tab`
+    completes the token the line
     ends in: a verb where the line names none, and otherwise whatever the
     verb declares its next operand completes, which the two arms of the arity
     that take an operand require and the arm that takes none cannot express.


### PR DESCRIPTION
## Why

A ruling, recorded before it is built.

`%n` is a reference only until the next listing (decision 17), and recall
outlives listings. So a recalled line carrying `%n` acts on whichever row that
number names *now*:

```
shuttle …> ls
%1 thermo   %2 tracker
shuttle …> set %1/target 25
Wrote `target` on `thermo`.
shuttle …> verbs %2            ← renumbers
shuttle …> <up><up><enter>     ← replays `set %1/target 25`
```

That second write lands on whatever `%1` names after the renumbering, and
receipts it. A wrong write reported as a success is the one failure a shell must
not have, and it is the shape this arc keeps meeting — #7118's false receipt,
#7113's confidently-wrong refusal. A message that misdirects costs far more than
one that stops you.

## The ruling

A line is recorded with each `%n` replaced by what it bound to when it ran.

**Substituting is never the worse answer**, which is what makes this an addition
rather than a trade:

- a **piece row** records an id that resolves anywhere;
- a **row inside a piece** records a name, still place-dependent — but replayed
  in the wrong place it fails *by name* rather than reaching a different row.

Neither is worse than keeping the handle, and the dangerous case becomes safe.

What the prompt shows stays what was typed; only what recall replays changes.
And nothing new is tracked to do it: a listing already records each row's kind
and receiver as it mints the handle (decision 27).

## What Changed

Text only — no behavior, no code. The rule is recorded inside **decision 29**,
which already owns recall and completion together, rather than as a decision of
its own.

Implementation follows in its own change.

## Test plan

- `deno fmt --check` — `Checked 6057 files`, clean.
- `deno task check-docs` — `All 599 checked code block(s) passed.`
- Wrapping verified not to regress: over-79-column lines are 15 on `origin/main`
  and 15 here; the widest line added is 76.

## Note

An adjacent question stays open and is **not** ruled here: whether tab
completion substitutes a `%n` it completes across (`futures.md`, candidate 7).
Decision 29 already says a completion offers what a listing prints and what `cd`
takes back — row operands, never `%n` itself — so that question is narrower than
it first appears, but it is still unanswered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

