### PR TITLE
feat(patterns): add a minimal file-share pattern and a files capability doc

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -86,6 +86,7 @@ on the Common Fabric runtime.
 
 - [capabilities/llm.md](capabilities/llm.md) — `generateText` / `generateObject`; reactive results, no `await`
 - [capabilities/fetch.md](capabilities/fetch.md) — `fetchJson` / `fetchText` / `fetchJsonUnchecked` / `fetchBinary`; reactive results, no `await`
+- [capabilities/files.md](capabilities/files.md) — uploading files with `cf-file-input`, what a pattern keeps from the upload, downloading by link, and the blob store's limits
 - [capabilities/sqlite.md](capabilities/sqlite.md) — reading a `SqliteDb` a pattern was given as an input: `db.query`, one statement per database, bounding a query's rows, session-scoped results under a read ceiling
 
 ### workflows/ — CLI and testing mechanics

--- a/docs/common/capabilities/files.md
+++ b/docs/common/capabilities/files.md
@@ -1,0 +1,76 @@
+# Files
+
+A file's bytes never live in a pattern's cells. A pattern that takes files
+uploads them to the space's blob store through `cf-file-input`, keeps the small
+descriptor the upload returns, and serves a download as a link to the
+descriptor's URL. The store keeps each blob as a content-addressed document of
+its own in the space, so the pattern's cells stay small however large the file
+is, and the list syncs like any other list of records. `packages/patterns/file-share/main.tsx` is the whole
+shape in one file.
+
+## Uploading
+
+`cf-file-input` opens the browser's file chooser, uploads each chosen file to
+the blob store of the space the pattern runs in, and fires `cf-change` with
+the files it just stored:
+
+```tsx
+// Shown for illustration only.
+interface UploadedFile {
+  id: string; // hash of the media type and bytes, prefixed `fid1:`
+  name: string;
+  mediaType: string;
+  size: number;
+  url: string; // absolute URL the bytes are served from
+}
+
+interface AddFilesEvent {
+  detail?: { files?: UploadedFile[] };
+}
+
+<cf-file-input multiple showPreview={false} oncf-change={addFiles} />;
+```
+
+The event carries more fields than these; keep the ones the pattern reads and
+push them into a shared list. Never keep the bytes or a data URL in a cell.
+`includeData` on the input puts a base64 copy of the file into `data` for a
+transient use such as sending an image to a model; a record that persists that
+copy makes the cell as large as the file, and a large cell syncs slowly and can
+fail to sync at all.
+
+With previews enabled the input renders its own remove buttons, and a click on
+one fires `cf-change` again with `files` holding every remaining file. A
+handler that treats `files` as new uploads then re-adds them. Either turn
+previews off, or handle `cf-remove` and read `allFiles` as the full list.
+
+## Downloading
+
+A download is an anchor: `<a href={file.url} download={file.name}>`. The
+store serves no filename of its own, so the `download` attribute is what names
+the saved file. Browsers honor it only when the link is same-origin with the
+page; a space served from another host saves the file under its hash instead.
+
+`cf-file-download` is not for stored files. It takes the content as a string
+and builds the download in the browser, so using it means holding the bytes in
+a cell.
+
+## What the store provides
+
+- One upload holds at most 10 MB; the server returns 413 above that.
+- A blob is addressed by the hash of its media type and bytes, so the same
+  file uploaded twice has the same id. The URL is that id plus a short suffix:
+  the file name's last extension when it is one to eight letters or digits,
+  otherwise one chosen from the media type, or `bin`. Two uploads of the same
+  bytes share a URL when they get the same suffix and have two URLs when they
+  do not. Each URL is immutable and cacheable forever.
+- The bytes stay in the space's own store beside its cells. There is no
+  offload to an object store, and no signed or expiring URL.
+- GIF, JPEG, PNG, and WebP are served as their own media type, so an `<img>`
+  can show them. Every other type is served as `application/octet-stream`, so
+  a browser downloads it rather than rendering it inline.
+- Nothing deletes a blob. Removing a record drops the reference; the bytes
+  stay.
+- The upload and download routes are not authenticated: anyone who holds a
+  blob's URL can fetch it, and anyone can upload into a space.
+
+The store is `packages/toolshed/routes/blobs/blobs.index.ts`.

--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -128,7 +128,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-fab` | Morphing floating action button that expands into a panel | |
 | `cf-field` | Labeled field wrapper: muted label, optional required/error/help text (see [cf-field](#cf-field)) | |
 | `cf-file-download` | File download button (encapsulates blob/anchor download) | `$data`, `$filename` |
-| `cf-file-input` | Generic file upload | |
+| `cf-file-input` | Generic file upload to the space's blob store (see [files](../capabilities/files.md)) | |
 | `cf-form` | Transactional form wrapper buffering field writes until submit (see [cf-form](#cf-form)) | |
 | `cf-fragment` | Transparent wrapper element (`display: contents`) | |
 | `cf-google-oauth` | Google OAuth login (wrapper over `cf-oauth`) | `$auth` |

--- a/packages/patterns/baselines/file-share/main.tsx/20260911T192937Z-qfHPcR9RVgERCLaF.json
+++ b/packages/patterns/baselines/file-share/main.tsx/20260911T192937Z-qfHPcR9RVgERCLaF.json
@@ -1,0 +1,247 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "SharedFile": {
+        "properties": {
+          "id": {
+            "description": "Hash of the media type and bytes, prefixed `fid1:`.",
+            "type": "string"
+          },
+          "mediaType": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "uploadedBy": {
+            "asCell": [
+              "cell"
+            ],
+            "properties": {
+              "avatar": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "url": {
+            "description": "Absolute URL the bytes are served from.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uploadedBy",
+          "id",
+          "name",
+          "mediaType",
+          "size",
+          "url"
+        ],
+        "type": "object"
+      },
+      "ViewerClaim": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "asCell": [
+              "cell"
+            ],
+            "properties": {
+              "avatar": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ViewerValue": {
+        "$ref": "#/$defs/ViewerClaim",
+        "default": {}
+      }
+    },
+    "properties": {
+      "files": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SharedFile"
+        },
+        "type": "array"
+      },
+      "viewer": {
+        "$ref": "#/$defs/ViewerValue",
+        "scope": "user"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "file-share/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddFilesEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "files": {
+                "items": {
+                  "$ref": "#/$defs/UploadedFile"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SharedFile": {
+        "properties": {
+          "id": {
+            "description": "Hash of the media type and bytes, prefixed `fid1:`.",
+            "type": "string"
+          },
+          "mediaType": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "uploadedBy": {
+            "properties": {
+              "avatar": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "url": {
+            "description": "Absolute URL the bytes are served from.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uploadedBy",
+          "id",
+          "name",
+          "mediaType",
+          "size",
+          "url"
+        ],
+        "type": "object"
+      },
+      "UploadedFile": {
+        "properties": {
+          "id": {
+            "description": "Hash of the media type and bytes, prefixed `fid1:`.",
+            "type": "string"
+          },
+          "mediaType": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "url": {
+            "description": "Absolute URL the bytes are served from.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "mediaType",
+          "size",
+          "url"
+        ],
+        "type": "object"
+      },
+      "ViewerClaim": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "properties": {
+              "avatar": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addFiles": {
+        "$ref": "#/$defs/AddFilesEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "claimViewer": {
+        "$ref": "#/$defs/ViewerClaim",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "fileCount": {
+        "type": "number"
+      },
+      "files": {
+        "default": [],
+        "description": "The shared list, as a read-only view.",
+        "items": {
+          "$ref": "#/$defs/SharedFile"
+        },
+        "scope": "space",
+        "type": "array"
+      }
+    },
+    "required": [
+      "files",
+      "fileCount",
+      "addFiles",
+      "claimViewer",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/file-share/main.test.tsx
+++ b/packages/patterns/file-share/main.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Drives File Share through its exported streams with descriptors shaped the
+ * way `cf-file-input` reports an upload, so the list logic is covered without
+ * a browser or a blob store. Identity is a profile cell claimed through the
+ * pattern's `claimViewer` seam, since the `#profile` wish has no resolving
+ * environment here.
+ *
+ * Run: deno task cf test packages/patterns/file-share/main.test.tsx --verbose
+ */
+
+import {
+  action,
+  assert,
+  NAME,
+  pattern,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
+import { findElementByText, hasText, propsOf } from "../test/vnode-helpers.ts";
+import FileShare from "./main.tsx";
+
+export default pattern(() => {
+  const tester = Writable.of<{ name?: string; avatar?: string }>({
+    name: "Tester",
+  });
+  const share = FileShare({});
+
+  const action_become_tester = action(() => {
+    share.claimViewer.send({ profile: tester, name: "Tester" });
+  });
+
+  const action_add_report = action(() => {
+    share.addFiles.send({
+      detail: {
+        files: [{
+          id: "fid1:report",
+          name: "report.pdf",
+          mediaType: "application/pdf",
+          size: 2048,
+          url: "https://example.test/space/blobs/report.pdf",
+        }],
+      },
+    });
+  });
+
+  const action_add_two_photos = action(() => {
+    share.addFiles.send({
+      detail: {
+        files: [{
+          id: "fid1:photo-a",
+          name: "photo-a.png",
+          mediaType: "image/png",
+          size: 4096,
+          url: "https://example.test/space/blobs/photo-a.png",
+        }, {
+          id: "fid1:photo-b",
+          name: "photo-b.png",
+          mediaType: "image/png",
+          size: 3 * 1024 * 1024,
+          url: "https://example.test/space/blobs/photo-b.png",
+        }],
+      },
+    });
+  });
+
+  const action_add_nothing = action(() => {
+    share.addFiles.send({ detail: {} });
+  });
+
+  // Removal is bound per row rather than exported, so the test fires the
+  // first row's button the way a click would.
+  const action_remove_first_row = action(() => {
+    const button = findElementByText(share[UI], "cf-button", "Remove");
+    const onClick = propsOf(button)?.onClick;
+    if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
+      (onClick as { send: (event: Record<string, never>) => void }).send({});
+    }
+  });
+
+  const assert_starts_empty = assert(() => share.fileCount === 0);
+  const assert_refused_without_profile = assert(() => share.fileCount === 0);
+  const assert_holds_report = assert(() =>
+    share.files[0]?.name === "report.pdf"
+  );
+  const assert_report_keeps_url = assert(() =>
+    share.files[0]?.url === "https://example.test/space/blobs/report.pdf"
+  );
+  const assert_report_names_uploader = assert(() =>
+    share.files[0]?.uploadedBy?.get()?.name === "Tester"
+  );
+  const assert_holds_three = assert(() => share.fileCount === 3);
+  const assert_name_counts_three = assert(() =>
+    share[NAME] === "File Share (3)"
+  );
+  const assert_renders_megabytes = assert(() => hasText(share[UI], "3.0 MB"));
+  const assert_photos_follow_report = assert(() =>
+    share.files[1]?.name === "photo-a.png" &&
+    share.files[2]?.name === "photo-b.png"
+  );
+  const assert_still_three = assert(() => share.fileCount === 3);
+  const assert_holds_two = assert(() => share.fileCount === 2);
+  const assert_photos_remain = assert(() =>
+    share.files[0]?.id === "fid1:photo-a" &&
+    share.files[1]?.id === "fid1:photo-b"
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_starts_empty },
+      { action: action_add_report },
+      { assertion: assert_refused_without_profile },
+      { action: action_become_tester },
+      { action: action_add_report },
+      { assertion: assert_holds_report },
+      { assertion: assert_report_keeps_url },
+      { assertion: assert_report_names_uploader },
+      { action: action_add_two_photos },
+      { assertion: assert_holds_three },
+      { assertion: assert_name_counts_three },
+      { assertion: assert_renders_megabytes },
+      { assertion: assert_photos_follow_report },
+      { action: action_add_nothing },
+      { assertion: assert_still_three },
+      { action: action_remove_first_row },
+      { assertion: assert_holds_two },
+      { assertion: assert_photos_remain },
+    ],
+    share,
+  };
+});

--- a/packages/patterns/file-share/main.tsx
+++ b/packages/patterns/file-share/main.tsx
@@ -1,0 +1,241 @@
+/**
+ * File Share
+ *
+ * A shared list of files for everyone in a space: upload, download, remove.
+ * It shows the shape every file-carrying pattern takes. The bytes never live
+ * in a pattern's cells: `cf-file-input` uploads them to the space's blob
+ * store and reports a small descriptor (name, media type, size, URL), and
+ * that descriptor is what the shared list holds. A download is a plain link
+ * to the URL. `docs/common/capabilities/files.md` describes the store the
+ * descriptor points into and the limits a pattern inherits from it.
+ *
+ * Every record names its uploader with a link to their profile, rendered with
+ * `cf-profile-badge`. A viewer without a profile is shown how to make one
+ * instead of the upload control, so no file is ever stored unattributed.
+ */
+
+import {
+  type Cell,
+  computed,
+  Default,
+  handler,
+  NAME,
+  pattern,
+  type PerSpace,
+  type PerUser,
+  Stream,
+  UI,
+  type VNode,
+  wish,
+  Writable,
+} from "commonfabric";
+
+/** The part of a profile a shared-file row reads. */
+export type UploaderProfileCell = Cell<{ name?: string; avatar?: string }>;
+
+/** The fields this pattern keeps from what `cf-file-input` reports. */
+export interface UploadedFile {
+  /** Hash of the media type and bytes, prefixed `fid1:`. */
+  id: string;
+  name: string;
+  mediaType: string;
+  size: number;
+  /** Absolute URL the bytes are served from. */
+  url: string;
+}
+
+/** One file in the shared list. */
+export interface SharedFile extends UploadedFile {
+  uploadedBy: UploaderProfileCell;
+}
+
+/**
+ * The `cf-change` event `cf-file-input` fires after an upload: `files` holds
+ * the files it just stored.
+ */
+export interface AddFilesEvent {
+  detail?: { files?: UploadedFile[] };
+}
+
+/**
+ * Test seam: a claimed viewer identity standing in for the `#profile` wish,
+ * which has no resolving environment in a unit test. The claim is per user,
+ * so a multi-user test claims one identity per runtime on one shared piece.
+ * Production UI never sends it. A claim always carries a name, and the name
+ * is what the pattern gates on: an absent cell-typed field reads as an empty
+ * cell handle rather than as absent, so `profile` alone cannot say whether a
+ * claim was made.
+ */
+export interface ViewerClaim {
+  profile?: UploaderProfileCell;
+  name?: string;
+}
+
+const DEFAULT_VIEWER: ViewerClaim = {};
+
+type ViewerValue = ViewerClaim | Default<typeof DEFAULT_VIEWER>;
+
+type ViewerCell = Writable<ViewerValue>;
+
+type FilesCell = Writable<SharedFile[] | Default<[]>>;
+
+export interface FileShareInput {
+  files?: PerSpace<FilesCell>;
+  viewer?: PerUser<ViewerValue>;
+}
+
+export interface FileShareOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  /** The shared list, as a read-only view. */
+  files: PerSpace<SharedFile[] | Default<[]>>;
+  fileCount: number;
+  addFiles: Stream<AddFilesEvent>;
+  claimViewer: Stream<ViewerClaim>;
+}
+
+/**
+ * Adds every file the event reports, each attributed to the bound profile. A
+ * handler rather than an action so the profile can be bound in as a cell,
+ * which is what the record stores. With no resolved profile the upload is
+ * refused: the UI withholds the input in that state, and this guard covers
+ * the stream.
+ */
+const addFiles = handler<AddFilesEvent, {
+  files: FilesCell;
+  profile: UploaderProfileCell | undefined;
+}>(({ detail }, { files, profile }) => {
+  const uploader = profile?.resolveAsCell();
+  if (uploader === undefined || uploader.get() === undefined) return;
+  (detail?.files ?? []).forEach((file) => {
+    files.push({
+      id: file.id,
+      name: file.name,
+      mediaType: file.mediaType,
+      size: file.size,
+      url: file.url,
+      uploadedBy: uploader,
+    });
+  });
+});
+
+/**
+ * Removes the row it is bound to. Each row binds its own element cell, so the
+ * removal names that row alone even when another row holds the same id, and
+ * removing the element rather than writing back a filtered list lets two
+ * people's edits merge instead of overwriting each other.
+ */
+const removeFile = handler<void, { files: FilesCell; file: Cell<SharedFile> }>(
+  (_, { files, file }) => {
+    files.removeByValue(file);
+  },
+);
+
+const claimViewer = handler<ViewerClaim, { viewer: ViewerCell }>(
+  ({ profile, name }, { viewer }) => {
+    viewer.set({
+      ...(profile !== undefined ? { profile } : {}),
+      ...(name !== undefined ? { name } : {}),
+    });
+  },
+);
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default pattern<FileShareInput, FileShareOutput>(
+  ({ files, viewer }) => {
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
+
+    // A claim takes precedence over the wish.
+    const hasViewerClaim = computed(() => (viewer.name ?? "").trim() !== "");
+    const uploaderProfile = hasViewerClaim
+      ? viewer.profile
+      : profileWish.result;
+    // Uploads open once the profile document itself has resolved, which is
+    // the condition `addFiles` requires, so the input never shows while an
+    // upload would still be refused. An unclaimed `viewer.profile` reads as
+    // an empty cell, whose value is undefined, so the wish decides then.
+    const hasProfile = computed(() => {
+      const name = viewer.profile?.get()?.name ?? profileWish.result?.name;
+      return (name ?? "").trim() !== "";
+    });
+
+    const boundAddFiles = addFiles({ files, profile: uploaderProfile });
+
+    const fileCount = computed(() => files.get().length);
+
+    return {
+      [NAME]: computed(() => `File Share (${fileCount})`),
+      [UI]: (
+        <cf-screen>
+          <cf-vstack slot="header" gap="1">
+            <cf-heading level={4}>File Share</cf-heading>
+          </cf-vstack>
+
+          <cf-vstack gap="3" padding="4">
+            {
+              /* Without previews the input has no remove buttons of its own,
+                so its `cf-change` event only ever reports an upload. */
+            }
+            {hasProfile
+              ? (
+                <cf-file-input
+                  multiple
+                  showPreview={false}
+                  buttonText="Upload files"
+                  oncf-change={boundAddFiles}
+                />
+              )
+              : (
+                <cf-text tone="muted">
+                  Create a profile in your home space to share files.
+                </cf-text>
+              )}
+
+            {fileCount === 0
+              ? <cf-text tone="muted">No files shared yet.</cf-text>
+              : null}
+
+            {files.map((file) => (
+              <cf-card>
+                <cf-hstack gap="3" align="center">
+                  <cf-vstack gap="0" style="flex: 1; min-width: 0;">
+                    <a
+                      href={file.url}
+                      download={file.name}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {file.name}
+                    </a>
+                    <cf-text variant="caption" tone="muted">
+                      {formatSize(file.size)} · {file.mediaType}
+                    </cf-text>
+                  </cf-vstack>
+                  <cf-profile-badge $profile={file.uploadedBy} size="xs" />
+                  <cf-button
+                    size="sm"
+                    variant="ghost"
+                    onClick={removeFile({ files, file })}
+                  >
+                    Remove
+                  </cf-button>
+                </cf-hstack>
+              </cf-card>
+            ))}
+          </cf-vstack>
+        </cf-screen>
+      ),
+      files,
+      fileCount,
+      addFiles: boundAddFiles,
+      claimViewer: claimViewer({ viewer }),
+    };
+  },
+);

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -114,11 +114,12 @@ App and integration directories: `activity-log/`, `agent/`, `airtable/`,
 `auth/`, `base/`, `battleship/`, `budget-tracker/`, `calendar/`, `card-piles/`,
 `collection-naming/` (the member-naming library and the board that exercises it;
 the library is the reference, the board is a demo), `contacts/`, `cozy-poll/`,
-`examples/`, `experimental/` (explicitly unhardened explorations), `google/`
-(the `core/` tree; `google/WIP/` is legacy), `habit-tracker/`, `lobby/`,
-`lunch-poll/`, `profile-group-chat/`, `project-list/`, `router/`,
-`scoped-group-chat/`, `scoped-user-directory/`, `scrabble/`,
-`shared-profile-demo/`, `shared-profile-roster/`, `suggestable/`,
+`examples/`, `experimental/` (explicitly unhardened explorations), `file-share/`
+(a minimal file-sharing example: bytes go to the blob store, cells hold
+descriptors), `google/` (the `core/` tree; `google/WIP/` is legacy),
+`habit-tracker/`, `lobby/`, `lunch-poll/`, `profile-group-chat/`,
+`project-list/`, `router/`, `scoped-group-chat/`, `scoped-user-directory/`,
+`scrabble/`, `shared-profile-demo/`, `shared-profile-roster/`, `suggestable/`,
 `weekly-calendar/`.
 
 Connector-owned patterns live with their connector families: the


### PR DESCRIPTION
## What

A minimal file-sharing pattern, plus a live document on how files work in patterns and what the blob store does and does not provide.

- `packages/patterns/file-share/main.tsx`: a `PerSpace` list of files. `cf-file-input` uploads bytes to the space's blob store and reports a descriptor (id, name, media type, size, URL); the handler pushes that descriptor with a link to the uploader's profile. Each row has a download link, a `cf-profile-badge`, and a Remove button bound to the row's element cell, so removal uses `removeByValue` on that element and concurrent edits merge. A viewer with no resolved profile sees how to create one instead of the upload control, and the handler refuses an unattributed upload from the stream. A per-user `claimViewer` seam (the lunch-poll idiom) lets tests claim an identity, since the `#profile` wish has no resolving environment headless.
- `packages/patterns/file-share/main.test.tsx`: refusal without a profile, uploads with a claimed identity, the rendered name and size text, and per-row removal through the rendered button. Twelve assertions; every line of the pattern is exercised.
- `packages/patterns/baselines/file-share/`: the pattern's recorded compatibility contract.
- `docs/common/capabilities/files.md`: why bytes never go in a pattern's cells, the upload event shape and its preview caveat, downloading by anchor and the same-origin condition on `download`, and the store's limits (10 MB cap, image-only media types, content-addressed URLs keyed by id and extension, no deletion, no offload, unauthenticated routes). Linked from `docs/common/README.md` and the `cf-file-input` row in COMPONENTS.md.
- `packages/patterns/index.md`: registers the pattern in the demo tier.

## Why

A partner team asked how to build file sharing having only seen numeric and text cells. This is the answer they can copy, and a document the answer can point at instead of restating the blob store's behavior in a pattern header.

## Verification

- `cf check`, `cf test` (12/12, no uncovered lines under `--pattern-coverage-dir`), `pattern-compat`, `deno fmt --check`, `deno lint`, `check-docs`, `check-pattern-tiers`, `check-baselines-append-only`, `check-skill-facts`, `check-docs-history-index` all pass.
- Browser runs against local dev servers: text and PNG uploads appear with correct name and size; descriptors read back with `fid1:` ids and absolute URLs; `curl` returns byte-identical content with the expected `application/octet-stream` / `image/png` types and immutable cache header; the same-origin download link saves under the original filename; with no profile the page shows the create-a-profile text and no upload control, and with one the badge names the uploader and navigates to their profile piece, stored as a `$link` rather than a copy; removing the middle of three rows leaves the other two in order, and removing the second of two rows that share an id leaves the first; clean console throughout.

## Side findings, not addressed here

- `fallback-name` on `cf-profile-badge`, as prescribed in multi-user-patterns.md and used in lunch-poll, is assigned by the renderer as a JS property and so likely never reaches Lit's `fallbackName`.
- A HEAD request to a blob URL reports `content-length: 0` while GET reports the real length.
- `docs/development/debugging/gotchas/custom-id-property-pitfall.md` says `.send({ id: item.id })` inside a map fails silently; it works under the current transformer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pT4pdg9BrectDDuPbcy5Q
