### PR TITLE
feat(shuttle): a recalled line acts on what it acted on first

### DIFF
--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -835,11 +835,11 @@ produce.
 
 ## Recall and completion
 
-`up` and `down` walk the lines this run typed. What they walk is those lines
-and the line being typed — one position each, the line being typed last — so
-an edit made at any of them is held there until the line is ended, and
-everything that ends a line ends the traversal with it: running the line, and
-`ctrl-c`. There is no wrap: `up` at the oldest line and `down` at the line
+`up` and `down` walk the lines this run has taken. What they walk is those
+lines and the line being typed — one position each, the line being typed
+last — so an edit made at any of them is held there until the line is ended,
+and everything that ends a line ends the traversal with it: running the line,
+and `ctrl-c`. There is no wrap: `up` at the oldest line and `down` at the line
 being typed each leave the prompt as it is. A line with nothing on it is not
 recorded, nor is one identical to the line recorded last, and the comparison is
 against that one line alone — comparing against every line would drop a line
@@ -853,16 +853,29 @@ own memory; persistent history is a separate feature
 A handle is a reference only until the next listing, and a recalled line
 outlives listings, so a line recorded as it was typed would — replayed after a
 listing had renumbered — act on whichever row its number names then, and report
-that as what the line did. What is written in the handle's place is the operand
-the listing minted for the row, which is the most stable spelling the row
-carries: a piece stands as the id that names it in either facet, and a row
-inside a piece stands as its own name, which is a name inside the place the
-listing was read at rather than from anywhere. A callable row is written as the
-two tokens `call` takes in its place — the receiver's reference and the verb
-name — since no operand names a verb. What the screen holds is untouched: the
-line was drawn as it was typed, and the replacement is what `up` puts back.
+that as what the line did. What is written in the handle's place is a spelling
+that reaches the row from anywhere the session stands. A row `pieces/` or
+`slugs/` listed stands as the id or the slug the listing printed, each of which
+names the piece from wherever the line comes back. A row a piece listed stands
+as the reference naming that piece and the path to the row —
+`/of:fid1:…@space/title` — rather than the key's own name, a key being a name
+inside one piece where two pieces hold a `title` apiece; the space is left out,
+one shuttle serving one space. A callable row stands as the two tokens `call`
+takes in its place — the receiver's reference and the verb name — since no
+operand names a verb. What the screen holds is untouched: the line was drawn as
+it was typed, and the replacement is what `up` puts back.
 
-A token that bound to nothing is recorded as it was typed, and three do. A
+What the reference costs is length: a recalled line naming a cell inside a piece
+runs some sixty characters longer than the handle did, and is harder to edit for
+it. A shorter spelling can be designed later; what it may not cost is a line
+that acts on a cell other than the one it acted on.
+
+A walk written after the handle rides the reference as further segments, and
+one that backs out through `..` does not: in a walk `..` is the level above,
+and in a reference it is a key's name, so a token holding one is recorded as it
+was typed and goes on naming what it named.
+
+Three other tokens are recorded as they were typed. A
 handle that named no row is one — `%0`, a number past the listing, a handle
 written before any listing — and a row that neither its name nor a reference
 reaches is another. The third is every token the operand grammar does not read:

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -844,10 +844,33 @@ being typed each leave the prompt as it is. A line with nothing on it is not
 recorded, nor is one identical to the line recorded last, and the comparison is
 against that one line alone — comparing against every line would drop a line
 from the middle of the run and leave the order no longer the order it was
-typed in. What is recorded is the line exactly as it was typed, at the moment
-it is taken rather than when it settles, so `up` reaches a line that is still
-running. The recall is the run's own memory; persistent history is a separate
-feature ([`futures.md`](futures.md)).
+typed in. A line is recorded at the moment it is taken rather than when it
+settles, so `up` reaches a line that is still running. The recall is the run's
+own memory; persistent history is a separate feature
+([`futures.md`](futures.md)).
+
+**A line is recorded with each `%n` replaced by what it bound to when it ran.**
+A handle is a reference only until the next listing, and a recalled line
+outlives listings, so a line recorded as it was typed would — replayed after a
+listing had renumbered — act on whichever row its number names then, and report
+that as what the line did. What is written in the handle's place is the operand
+the listing minted for the row, which is the most stable spelling the row
+carries: a piece stands as the id that names it in either facet, and a row
+inside a piece stands as its own name, which is a name inside the place the
+listing was read at rather than from anywhere. A callable row is written as the
+two tokens `call` takes in its place — the receiver's reference and the verb
+name — since no operand names a verb. What the screen holds is untouched: the
+line was drawn as it was typed, and the replacement is what `up` puts back.
+
+A token that bound to nothing is recorded as it was typed, and three do. A
+handle that named no row is one — `%0`, a number past the listing, a handle
+written before any listing — and a row that neither its name nor a reference
+reaches is another. The third is every token the operand grammar does not read:
+the verb, and everything from the first token that reads as an option, since
+from there what a token is for is the verb's own table to say, and a `%2`
+standing in an option's value or inside a callable's own section is a character
+of that value rather than a handle. A line carrying no handle is recorded
+character for character, its spacing and its quoting included.
 
 `tab` completes the token the line ends in, and it completes that token only:
 with the cursor anywhere else on the line it does nothing, the token being

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -286,6 +286,16 @@ to a recalled line is still there when you come back to it. A line with nothing
 on it is not recorded, nor is one you just ran again, and neither end wraps
 round. Running a line or pressing `ctrl-c` returns you to the line being typed.
 
+A line is recorded with each `%n` replaced by what it named. A handle is a
+reference only until the next listing, so a line recorded as you typed it would
+— recalled after a later listing — act on whichever row that number names then.
+What is written in its place is the operand the listing printed for the row, and
+for a callable row the receiver and the verb name `call %4` stands for. The line
+on the screen is the one you typed; the replacement is what `up` puts back. A
+handle that named no row, and a `%n` written where the line reads no operand —
+in an option's value, or inside a callable's own section — come back as you
+typed them, and a line with no handle on it comes back character for character.
+
 `tab` completes the token the line ends in: a verb where you have typed none,
 and after a verb whatever that verb takes at the position you are typing at — a
 verb name for `help`, and the rows that stand where you stand for the verbs that

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -289,12 +289,16 @@ round. Running a line or pressing `ctrl-c` returns you to the line being typed.
 A line is recorded with each `%n` replaced by what it named. A handle is a
 reference only until the next listing, so a line recorded as you typed it would
 — recalled after a later listing — act on whichever row that number names then.
-What is written in its place is the operand the listing printed for the row, and
-for a callable row the receiver and the verb name `call %4` stands for. The line
-on the screen is the one you typed; the replacement is what `up` puts back. A
-handle that named no row, and a `%n` written where the line reads no operand —
-in an option's value, or inside a callable's own section — come back as you
-typed them, and a line with no handle on it comes back character for character.
+What is written in its place is a spelling that reaches the row from wherever
+you stand: the id or the slug for a row `pieces/` or `slugs/` listed, the
+reference naming the piece and the path for a row a piece listed, and for a
+callable row the receiver and the verb name `call %4` stands for. So a recalled
+line naming a cell inside a piece comes back longer than you typed it, and reads
+the cell you read rather than the one under you now. The line on the screen is
+the one you typed; the replacement is what `up` puts back. A handle that named
+no row, and a `%n` written where the line reads no operand — in an option's
+value, or inside a callable's own section — come back as you typed them, and a
+line with no handle on it comes back character for character.
 
 `tab` completes the token the line ends in: a verb where you have typed none,
 and after a verb whatever that verb takes at the position you are typing at — a

--- a/packages/cli/lib/shuttle/handles.ts
+++ b/packages/cli/lib/shuttle/handles.ts
@@ -141,28 +141,30 @@ function refuse(reason: string): HandleReading {
  * What the person sees is untouched: the line on the screen and the transcript
  * above it are what was typed, and this is what `up` puts back.
  *
- * A row is written out as the operand the listing minted for it, which is the
- * most stable spelling a row carries. A piece stands as the id that names it
- * in either facet; a row inside a piece stands as its own name, which is a
- * name inside the place the listing was read at rather than from anywhere.
- * That last is accepted rather than absolute — replayed somewhere else the
- * name reaches nothing, or reaches what it names there, and either way the
- * line's own text says what it will act on, where a handle's said nothing.
+ * A row is written out as a spelling that reaches it from anywhere the session
+ * stands. A row a facet listed stands as the id or the slug the listing
+ * printed, each of which names the piece from wherever the line comes back; a
+ * row a piece listed stands as the reference naming that piece and the path to
+ * the row, since a key is a name inside one piece and two pieces hold a `title`
+ * apiece. What the reference costs is length — a recalled line naming a cell
+ * inside a piece runs some sixty characters longer than the handle did, and is
+ * harder to edit for it.
  *
  * A callable row is written out otherwise, its handle carrying a receiver and
  * a verb name rather than a path (decision 27): what goes in its place is the
  * two tokens `call` reads those from ({@link callSpelling}).
  *
- * Everything else is left exactly as typed, and each case for one reason —
- * nothing bound, so there is nothing to write out. A handle that named no row
- * is one, and a row that is no callable and that the listing offered no
- * operand for is another. The third is every token the operand grammar does
- * not read: the verb, and everything from the first token that reads as an
- * option, since from there what a token is for is a verb's own table to say,
- * and a `%2` standing in an option's value or inside a callable's own section
- * is a character of that value rather than a handle. A line carrying no handle
- * at all therefore comes back as the string it was given, and so does a line
- * the split refuses, which has no tokens to write out.
+ * Everything else is left exactly as typed, because nothing came of writing it
+ * out. A handle that named no row is one, and a row that is no callable and
+ * that the listing offered no operand for is another. A third is a token whose
+ * walk a reference has no spelling for ({@link referenceWalk}). The last is
+ * every token the operand grammar does not read: the verb, and everything from
+ * the first token that reads as an option, since from there what a token is
+ * for is a verb's own table to say, and a `%2` standing in an option's value
+ * or inside a callable's own section is a character of that value rather than
+ * a handle. A line carrying no handle at all therefore comes back as the
+ * string it was given, and so does a line the split refuses, which has no
+ * tokens to write out.
  */
 export function recordedForm(
   line: string,
@@ -194,11 +196,26 @@ export function recordedForm(
  * `place.ts`), so the handle this looks up is the one a verb would have looked
  * up and the walk written after it is the walk a verb would have taken.
  *
- * The walk rides the operand as a further segment, which is the same two steps
- * the handle took: the row's operand from the listing's place, and the walk
- * from there. What comes back is one token, printed as one, so a row whose
- * operand holds a separator or a character the grammar reserves is quoted the
- * way a listing prints it.
+ * Where the listing stood decides which spelling names its rows from anywhere.
+ * A listing read inside a piece names its rows by a key, and a key is a name
+ * inside that piece — two pieces hold a `title` apiece — so the row is written
+ * as the reference that reaches it, the piece and the path to the row, and the
+ * walk written after the handle as further segments of the same reference.
+ * A listing read at a facet or at the space root names its rows by a piece's
+ * id, by a slug, or by a facet, each of which reaches the row from wherever
+ * the line is recalled, so those are written as the operand the listing
+ * minted.
+ *
+ * The row's own name goes into the reference rather than its operand, which
+ * differs where the name is one no bare operand reaches: the operand is then
+ * the rendering the row already prints as, and a rendering nested inside a
+ * second reference names nothing. The operand is still what says a spelling
+ * reaches the row at all, so a row the listing offered none for is left alone
+ * either way.
+ *
+ * What comes back is one token, printed as one, so a row whose spelling holds
+ * a separator or a character the grammar reserves is quoted the way a listing
+ * prints it.
  */
 function spellingFor(
   handles: ListingHandles | undefined,
@@ -208,14 +225,48 @@ function spellingFor(
   if (move === undefined) return undefined;
   const bound = resolveHandle(handles, move.handle);
   if (bound.kind === "refused") return undefined;
+  const at = bound.at;
   if (move.rest === "" && bound.row.kind === "callable") {
-    return callSpelling(bound.at, bound.row.name);
+    return callSpelling(at, bound.row.name);
   }
   const operand = bound.row.operand;
   if (operand === undefined) return undefined;
+  const position = at.position;
+  if (position.kind === "piece") {
+    const walk = referenceWalk(move.rest);
+    return walk === undefined ? undefined : quoteToken(referenceForPlace({
+      position: {
+        ...position,
+        path: [...position.path, bound.row.name, ...walk],
+      },
+      scope: at.scope,
+    }));
+  }
   return quoteToken(
     move.rest === "" ? operand : `${operand}/${move.rest}`,
   );
+}
+
+/**
+ * Helper for {@link spellingFor}, which is the walk written after a handle as
+ * the segments a reference carries it in, and nothing where a reference cannot
+ * carry it at all.
+ *
+ * A `..` is what it cannot carry. In a walk it backs out of the level the
+ * segment before it reached, and in a reference it is the name of a key, so
+ * the two read one token as two cells. Such a token is left as the handle it
+ * was typed as — which names what it named before — rather than written with
+ * the key's own name, that being the spelling the reference is here to avoid.
+ *
+ * The trailing separator is dropped as the walk itself drops it
+ * (`moveBySegments`, `place.ts`): `%1/` and `%1` name one row, and a segment
+ * with no name in it would make them two.
+ */
+function referenceWalk(rest: string): readonly string[] | undefined {
+  if (rest === "") return [];
+  const segments = rest.split("/");
+  if (segments.at(-1) === "") segments.pop();
+  return segments.includes("..") ? undefined : segments;
 }
 
 /**

--- a/packages/cli/lib/shuttle/handles.ts
+++ b/packages/cli/lib/shuttle/handles.ts
@@ -9,16 +9,28 @@
  * the listing was read at, so the pair names a cell from anywhere and goes on
  * naming it after the place has moved.
  *
+ * Reading one back is half of what this does. The other half is writing one
+ * out: a line is recorded with each of its handles replaced by the row it
+ * named ({@link recordedForm}), so a line recalled after a later listing acts
+ * on what it acted on the first time.
+ *
  * Nothing here reads the fabric and nothing walks. What a row's operand
  * reaches is `place.ts`'s to say, and it says it through the arm a `%n`
  * operand comes back as; what a callable row's name resolves to is the
- * fabric's. This decides only which row was named, and why a token named
- * none.
+ * fabric's. This decides only which row was named, why a token named none,
+ * and how a row that was named is written back onto a line.
  */
 
+import { quoteToken, tokensOfLine } from "./line.ts";
 import type { ListingHandles, ListingRow } from "./listing.ts";
 import { handleFor } from "./listing.ts";
-import { HANDLE_SIGIL, type Place } from "./place.ts";
+import { readsAsOption } from "./options.ts";
+import {
+  HANDLE_SIGIL,
+  handleMove,
+  type Place,
+  referenceForPlace,
+} from "./place.ts";
 
 /** What reading a `%n` operand against a listing produced. */
 export type HandleReading =
@@ -113,4 +125,120 @@ function numberOf(token: string): number | undefined {
 /** Helper for {@link resolveHandle}, which builds a refusal carrying `reason`. */
 function refuse(reason: string): HandleReading {
   return { kind: "refused", reason };
+}
+
+/**
+ * `line` as the run records it: what was typed, except that a handle naming a
+ * row is written out as that row.
+ *
+ * A handle is a reference only until the next listing (decision 17) and a
+ * recalled line outlives listings, so a line recorded as typed would, replayed
+ * after a listing had renumbered, act on whichever row its number names then
+ * and report that as what the line did. A wrong write reported as a success is
+ * what writing the row out at the moment the line is taken prevents: a line
+ * recalled acts on what it acted on the first time.
+ *
+ * What the person sees is untouched: the line on the screen and the transcript
+ * above it are what was typed, and this is what `up` puts back.
+ *
+ * A row is written out as the operand the listing minted for it, which is the
+ * most stable spelling a row carries. A piece stands as the id that names it
+ * in either facet; a row inside a piece stands as its own name, which is a
+ * name inside the place the listing was read at rather than from anywhere.
+ * That last is accepted rather than absolute — replayed somewhere else the
+ * name reaches nothing, or reaches what it names there, and either way the
+ * line's own text says what it will act on, where a handle's said nothing.
+ *
+ * A callable row is written out otherwise, its handle carrying a receiver and
+ * a verb name rather than a path (decision 27): what goes in its place is the
+ * two tokens `call` reads those from ({@link callSpelling}).
+ *
+ * Everything else is left exactly as typed, and each case for one reason —
+ * nothing bound, so there is nothing to write out. A handle that named no row
+ * is one, and a row that is no callable and that the listing offered no
+ * operand for is another. The third is every token the operand grammar does
+ * not read: the verb, and everything from the first token that reads as an
+ * option, since from there what a token is for is a verb's own table to say,
+ * and a `%2` standing in an option's value or inside a callable's own section
+ * is a character of that value rather than a handle. A line carrying no handle
+ * at all therefore comes back as the string it was given, and so does a line
+ * the split refuses, which has no tokens to write out.
+ */
+export function recordedForm(
+  line: string,
+  handles: ListingHandles | undefined,
+): string {
+  const tokens = tokensOfLine(line);
+  if (tokens === undefined) return line;
+  let written = "";
+  let from = 0;
+  // The first token names the verb, which is no operand, so the walk starts
+  // after it. What is kept between one replacement and the next is the line
+  // itself rather than the tokens either side, so every character this does
+  // not replace is the character that was typed.
+  for (const token of tokens.slice(1)) {
+    if (readsAsOption(token.value)) break;
+    const spelling = spellingFor(handles, token.value);
+    if (spelling === undefined) continue;
+    written += line.slice(from, token.start) + spelling;
+    from = token.end;
+  }
+  return written + line.slice(from);
+}
+
+/**
+ * Helper for {@link recordedForm}, which is `token` written out as what it
+ * bound to, and nothing where it bound to nothing.
+ *
+ * The token is divided by the operand grammar's own reading (`handleMove`,
+ * `place.ts`), so the handle this looks up is the one a verb would have looked
+ * up and the walk written after it is the walk a verb would have taken.
+ *
+ * The walk rides the operand as a further segment, which is the same two steps
+ * the handle took: the row's operand from the listing's place, and the walk
+ * from there. What comes back is one token, printed as one, so a row whose
+ * operand holds a separator or a character the grammar reserves is quoted the
+ * way a listing prints it.
+ */
+function spellingFor(
+  handles: ListingHandles | undefined,
+  token: string,
+): string | undefined {
+  const move = handleMove(token);
+  if (move === undefined) return undefined;
+  const bound = resolveHandle(handles, move.handle);
+  if (bound.kind === "refused") return undefined;
+  if (move.rest === "" && bound.row.kind === "callable") {
+    return callSpelling(bound.at, bound.row.name);
+  }
+  const operand = bound.row.operand;
+  if (operand === undefined) return undefined;
+  return quoteToken(
+    move.rest === "" ? operand : `${operand}/${move.rest}`,
+  );
+}
+
+/**
+ * Helper for {@link spellingFor}, which is the receiver and the verb name a
+ * callable row's handle carries, written as the two tokens `call` takes in its
+ * place, and nothing where the listing stood at no piece.
+ *
+ * Two tokens, and no one token would do: a verb name is interface vocabulary
+ * rather than a data path (decision 27), so no operand names one and the
+ * receiver has to be written beside it. What comes back is the typed spelling
+ * of the same call — `call %4` records as `call <receiver> <name>` — and the
+ * receiver is the reference that names the piece from anywhere, which is the
+ * address the call itself hands the seam.
+ *
+ * A listing that numbered a callable was read inside a piece: `verbs` lists
+ * one receiver's callables, and `ls` marks one only among a piece's keys. So
+ * nothing comes back for a place that is no piece, rather than a spelling
+ * invented for a row that cannot stand there.
+ */
+function callSpelling(at: Place, name: string): string | undefined {
+  const position = at.position;
+  if (position.kind !== "piece") return undefined;
+  return `${quoteToken(referenceForPlace({ position, scope: at.scope }))} ${
+    quoteToken(name)
+  }`;
 }

--- a/packages/cli/lib/shuttle/history.ts
+++ b/packages/cli/lib/shuttle/history.ts
@@ -1,6 +1,12 @@
 /**
- * The lines a run has typed, and the traversal `up` and `down` make over
+ * The lines a run has taken, and the traversal `up` and `down` make over
  * them.
+ *
+ * A line arrives here written as it will be recalled rather than as it was
+ * typed: what it is recorded as is decided where it is taken, a handle on it
+ * written out as the row it named (`recordedForm`, `handles.ts`). Nothing here
+ * reads a line or changes one — what it is handed is what it holds and hands
+ * back.
  *
  * It is the run's own memory and nothing outside the process holds it: a
  * shuttle that exits takes its lines with it. Persistent, searchable history
@@ -45,7 +51,7 @@ export class LineHistory {
   #at = 0;
 
   /**
-   * Records `line` as a line this run typed, and returns the traversal to the
+   * Records `line` as a line this run took, and returns the traversal to the
    * line being typed.
    *
    * Two lines are not recorded, and each is its own decision. A line that is

--- a/packages/cli/lib/shuttle/line.ts
+++ b/packages/cli/lib/shuttle/line.ts
@@ -11,10 +11,11 @@
  * was given. That is what lets a value print bare where nothing in it needs
  * more, which is the common case and the point.
  *
- * {@link tailOfLine} is the third, and it is here for the same reason: where
- * a token ends is this module's question whether the line is whole or still
- * being typed, and a completion that answered it for itself would be a
- * second grammar to keep in step with this one.
+ * {@link tailOfLine} and {@link tokensOfLine} are the third and the fourth,
+ * and both are here for the same reason: where a token ends is this module's
+ * question whether the line is whole or still being typed, and a completion
+ * or a recording that answered it for itself would be a second grammar to
+ * keep in step with this one.
  *
  * What a token then means is decided elsewhere — `place.ts` reads an operand
  * as a reference or as one of the navigation spellings, and a verb reads its
@@ -171,6 +172,47 @@ export function tailOfLine(line: string): LineTail | undefined {
     : { before: tokens, head: line, prefix: "" };
 }
 
+/** One token of a line, and the run of the line it was written across. */
+export interface LineToken {
+  /** What the split reads the token as, rather than how it is spelled. */
+  readonly value: string;
+
+  /** Where the token opens on the line. */
+  readonly start: number;
+
+  /** The offset just past the token's last character. */
+  readonly end: number;
+}
+
+/**
+ * The tokens of `line`, each carrying where it was written, and nothing where
+ * the line is one the split refuses.
+ *
+ * It is {@link splitLine} with the spans kept, for the one caller that writes
+ * a line back out with some of its tokens replaced and the rest of it exactly
+ * as it was typed: the lines a run records, where a handle is written out as
+ * the row it named (`handles.ts`). A caller that had only the values would
+ * have to print the tokens it kept as well as the ones it replaced, and a
+ * printed token is a spelling of its value rather than the spelling that was
+ * typed.
+ *
+ * The span is the token's whole spelling, its quotes included, so the text
+ * between one token's end and the next one's start is the separators alone.
+ *
+ * A line the split refuses has no tokens to give, and nothing comes back for
+ * the same reason {@link tailOfLine} gives nothing: a token with no end is a
+ * token this cannot say the span of.
+ */
+export function tokensOfLine(line: string): readonly LineToken[] | undefined {
+  const scanned = scanLine(line);
+  if (scanned.kind === "refused") return undefined;
+  return scanned.tokens.map((value, index) => ({
+    value,
+    start: scanned.starts[index],
+    end: scanned.ends[index],
+  }));
+}
+
 /**
  * Whether `character` separates two tokens, which is the one question the
  * split asks of a character before any other.
@@ -193,6 +235,12 @@ type LineScan =
     /** Where each of them opened on the line, in the same order. */
     readonly starts: readonly number[];
     /**
+     * Where each of them ended, in the same order: the offset just past the
+     * token's last character, which is where the separator that closed it
+     * stands and is the line's length for a token the line's end closed.
+     */
+    readonly ends: readonly number[];
+    /**
      * Whether the last token was still open when the line ended — which is
      * what tells a token being typed from one a separator finished.
      */
@@ -212,6 +260,7 @@ type LineScan =
 function scanLine(line: string): LineScan {
   const tokens: string[] = [];
   const starts: number[] = [];
+  const ends: number[] = [];
   let current = "";
   let started = false;
   let openedTokenAt = 0;
@@ -242,6 +291,7 @@ function scanLine(line: string): LineScan {
       if (started) {
         tokens.push(current);
         starts.push(openedTokenAt);
+        ends.push(index);
         current = "";
         started = false;
       }
@@ -279,8 +329,9 @@ function scanLine(line: string): LineScan {
   if (started) {
     tokens.push(current);
     starts.push(openedTokenAt);
+    ends.push(line.length);
   }
-  return { kind: "scanned", tokens, starts, unterminated: started };
+  return { kind: "scanned", tokens, starts, ends, unterminated: started };
 }
 
 /**

--- a/packages/cli/lib/shuttle/place.ts
+++ b/packages/cli/lib/shuttle/place.ts
@@ -979,15 +979,8 @@ function movePlace(
   // level this module can walk to, so it comes back for the handle table the
   // way a wish target comes back for the connection. In any later segment `%`
   // is an ordinary character of a data key.
-  if (operand.startsWith(HANDLE_SIGIL)) {
-    const cut = operand.indexOf("/");
-    return {
-      kind: "handle",
-      handle: cut === -1 ? operand : operand.slice(0, cut),
-      rest: cut === -1 ? "" : operand.slice(cut + 1),
-      operand,
-    };
-  }
+  const handled = handleMove(operand);
+  if (handled !== undefined) return handled;
   return moveBySegments(from, operand, operand, verb);
 }
 
@@ -1506,6 +1499,32 @@ const SCOPE_HEAD = `${RELATIVE_HEAD}@`;
  * rather than by three authors spelling one character the same way.
  */
 export const HANDLE_SIGIL = "%";
+
+/**
+ * How a handle operand divides — the handle at its head, and the walk written
+ * after it — and nothing for an operand written as no handle.
+ *
+ * {@link HANDLE_SIGIL} at the head is the whole of the test, and the walk is
+ * whatever follows the first separator. A handle written with a trailing
+ * separator and one written without carry the same empty walk, so `%4` and
+ * `%4/` name the row and nothing inside it alike.
+ *
+ * It is a function rather than a branch inside {@link movePlace} because two
+ * readers ask it. {@link movePlace} hands back what it returns, and the
+ * recording that writes a line's handles out as the rows they named reads a
+ * token through it (`recordedForm`, `handles.ts`), so where the handle ends
+ * and the walk begins is decided once instead of twice.
+ */
+export function handleMove(operand: string): HandleMove | undefined {
+  if (!operand.startsWith(HANDLE_SIGIL)) return undefined;
+  const cut = operand.indexOf("/");
+  return {
+    kind: "handle",
+    handle: cut === -1 ? operand : operand.slice(0, cut),
+    rest: cut === -1 ? "" : operand.slice(cut + 1),
+    operand,
+  };
+}
 
 /**
  * The sentence a refusal adds where `operand` is a scope word written with no

--- a/packages/cli/lib/shuttle/prompt.ts
+++ b/packages/cli/lib/shuttle/prompt.ts
@@ -39,6 +39,7 @@
 import { EditBuffer } from "../view/editbuffer.ts";
 import type { Key } from "../view/keys.ts";
 import { completeLine } from "./completion.ts";
+import { recordedForm } from "./handles.ts";
 import { LineHistory, recall } from "./history.ts";
 import {
   escapeControlCharacters,
@@ -155,8 +156,11 @@ export interface PromptTerminal {
  *   the cursor at the end of the line.
  *
  * `up` and `down` are ordinary bindings rather than any of those: they walk
- * the lines this run typed (`history.ts`), which is a value the prompt holds
- * beside the line being edited and nothing reads.
+ * the lines this run has taken (`history.ts`), which is a value the prompt
+ * holds beside the line being edited and nothing reads. A line goes in with its
+ * handles written out as the rows they named, so a line recalled after a later
+ * listing acts on what it acted on first; what the screen holds is untouched,
+ * the line having been drawn as it was typed and ended where it was run.
  *
  * Cancelling is honest about what it can reach. The line is abandoned and the
  * prompt comes back, but a read already sent to the server is not something
@@ -216,8 +220,12 @@ export async function runPrompt(
       terminal.finish();
       buffer.setText("");
       // Recorded where the line is taken rather than where it settles, which
-      // is what puts a line still running under the first `up`.
-      history.record(line);
+      // is what puts a line still running under the first `up`. What is
+      // recorded is the line with its handles written out as the rows they
+      // name (`recordedForm`, `handles.ts`), and the handles read are the ones
+      // the line itself is about to read: a line runs against the listing
+      // standing when it was taken, and nothing has run between the two.
+      history.record(recordedForm(line, shuttle.session.handles));
       running = start(line, shuttle, deps);
       // Nothing is drawn: the prompt for the next line appears when the line
       // settles, or when a key is typed before it does, so a line that

--- a/packages/cli/test/shuttle-handles.test.ts
+++ b/packages/cli/test/shuttle-handles.test.ts
@@ -27,12 +27,23 @@ import type { MemorySpace } from "@commonfabric/memory/interface";
 
 import { recordedForm, resolveHandle } from "../lib/shuttle/handles.ts";
 import type { ListingHandles, ListingRow } from "../lib/shuttle/listing.ts";
-import { type Place, placeAtSpaceRoot } from "../lib/shuttle/place.ts";
+import {
+  CurrentPlace,
+  type Place,
+  placeAtSpaceRoot,
+} from "../lib/shuttle/place.ts";
+import { moved } from "./shuttle-place-helpers.ts";
 
 const SPACE = "did:key:z6MkConnectedSpace" as MemorySpace;
 
 /** The piece a listing inside one was read at. */
 const PIECE = "of:fid1:abcdefghijklmnop";
+
+/** A second piece, for the cases about recalling somewhere else. */
+const OTHER_PIECE = "of:fid1:ponmlkjihgfedcba";
+
+/** The reference naming the row `title` of the listing {@link IN_PIECE} made. */
+const TITLE_REFERENCE = `/${PIECE}@space/items/title`;
 
 /** Helper for the cases below, which is the place a listing was read at. */
 const AT = placeAtSpaceRoot(SPACE);
@@ -46,6 +57,11 @@ const IN_PIECE: Place = {
 /** Helper for the cases below, which is a listing numbering `rows`. */
 function listed(...rows: ListingRow[]): ListingHandles {
   return { place: AT, rows };
+}
+
+/** Helper for the cases below, which is a listing a piece numbered `rows` in. */
+function listedInPiece(...rows: ListingRow[]): ListingHandles {
+  return { place: IN_PIECE, rows };
 }
 
 /** Helper for the cases below, which is one row called `name`. */
@@ -211,6 +227,91 @@ describe("handles", () => {
       // either — one written there would name a segment with no name.
 
       expect(recordedForm("get %1/", listed(row("thermo")))).toBe("get thermo");
+    });
+
+    it("returns a row a piece listed as the reference naming that row", () => {
+      // A key is a name inside one piece, and two pieces hold a `title`
+      // apiece, so a line recorded with the key's own name would read
+      // whichever piece the prompt stands on when it comes back.
+
+      expect(recordedForm("get %1", listedInPiece(row("title"))))
+        .toBe(`get ${TITLE_REFERENCE}`);
+    });
+
+    it("returns a reference that reaches the row from another piece", () => {
+      // The claim the reference is for, read as what it names: the recorded
+      // token aimed from a piece that is not the listing's reaches the row the
+      // listing numbered, and a `title` standing in the piece it was aimed
+      // from is not what it reached.
+
+      const recorded = recordedForm("get %1", listedInPiece(row("title")));
+      const elsewhere = new CurrentPlace(SPACE);
+      moved(elsewhere, `/${OTHER_PIECE}`);
+      expect(elsewhere.aim(recorded.slice("get ".length), "get").move).toEqual({
+        kind: "moved",
+        place: {
+          position: {
+            kind: "piece",
+            space: SPACE,
+            piece: PIECE,
+            path: ["items", "title"],
+          },
+          scope: "space",
+        },
+      });
+    });
+
+    it("returns the walk written after such a handle as further segments", () => {
+      expect(recordedForm("set %1/target 25", listedInPiece(row("title"))))
+        .toBe(`set ${TITLE_REFERENCE}/target 25`);
+    });
+
+    it("returns a walk closed by a separator without a nameless segment", () => {
+      // The walk drops a trailing separator, so `%1/target/` and `%1/target`
+      // name one cell. Carried into the reference whole it would end in a
+      // segment with no name in it, which names another.
+
+      expect(recordedForm("set %1/target/ 25", listedInPiece(row("title"))))
+        .toBe(`set ${TITLE_REFERENCE}/target 25`);
+    });
+
+    it("returns the row's own name in the reference, not the operand", () => {
+      // The two differ exactly where no bare operand reaches the row: the
+      // operand is then the rendering the row prints as, and a rendering
+      // nested inside a second reference names nothing. The name is a segment,
+      // and the reference escapes the separator in it.
+
+      expect(recordedForm(
+        "get %1",
+        listedInPiece({
+          name: "a/b",
+          kind: "value",
+          operand: `/@${SPACE}/${PIECE}@space/items/a~1b`,
+        }),
+      )).toBe(`get /${PIECE}@space/items/a~1b`);
+    });
+
+    it("returns a handle whose walk backs out through `..` as it was typed", () => {
+      // A `..` is a level in a walk and a key's name in a reference, so the
+      // two would read one token as two cells. The handle stays, and goes on
+      // naming what it named.
+
+      expect(recordedForm("get %1/../other", listedInPiece(row("title"))))
+        .toBe("get %1/../other");
+    });
+
+    it("returns a row a facet listed as the operand the listing printed", () => {
+      // A piece's id names it from wherever the line comes back, so nothing is
+      // gained by writing it a second way — and the place a facet listing was
+      // read at is no piece for a reference to be built from.
+
+      expect(recordedForm("cd %1", {
+        place: {
+          position: { kind: "facet", space: SPACE, facet: "pieces" },
+          scope: "space",
+        },
+        rows: [row(OTHER_PIECE, "piece")],
+      })).toBe(`cd ${OTHER_PIECE}`);
     });
 
     it("returns a row whose operand needs quoting as a quoted token", () => {

--- a/packages/cli/test/shuttle-handles.test.ts
+++ b/packages/cli/test/shuttle-handles.test.ts
@@ -1,13 +1,20 @@
 /**
- * Unit tests for what a `%n` operand names: the row a listing numbered, and
- * the place that listing was read at.
+ * Unit tests for what a `%n` operand names — the row a listing numbered, and
+ * the place that listing was read at — and for the line a run records, which
+ * is that reading written back out.
  *
- * The claims divide in two. One is about the spelling — which tokens are a
- * handle at all — and it is closed by the digits: a listing prints `%3` and
- * nothing else, so every other spelling names no row. The other is about the
- * lookup, and what it turns on is that the row and the place come back
- * together, since a row's name is a name inside a place and neither alone
+ * The lookup's claims divide in two. One is about the spelling — which tokens
+ * are a handle at all — and it is closed by the digits: a listing prints `%3`
+ * and nothing else, so every other spelling names no row. The other is about
+ * the lookup itself, and what it turns on is that the row and the place come
+ * back together, since a row's name is a name inside a place and neither alone
  * names a cell.
+ *
+ * The recording's claims divide the same way. Either a token bound to a row,
+ * and the case says what the row is written as; or it bound to nothing, and
+ * the case says the token comes back the characters it was typed with. The
+ * second half is the larger one, since every token a line holds that is no
+ * operand belongs to it.
  *
  * Nothing here reads or walks, so every case drives the whole of it with no
  * connection and no fabric.
@@ -18,14 +25,23 @@ import { describe, it } from "@std/testing/bdd";
 
 import type { MemorySpace } from "@commonfabric/memory/interface";
 
-import { resolveHandle } from "../lib/shuttle/handles.ts";
+import { recordedForm, resolveHandle } from "../lib/shuttle/handles.ts";
 import type { ListingHandles, ListingRow } from "../lib/shuttle/listing.ts";
-import { placeAtSpaceRoot } from "../lib/shuttle/place.ts";
+import { type Place, placeAtSpaceRoot } from "../lib/shuttle/place.ts";
 
 const SPACE = "did:key:z6MkConnectedSpace" as MemorySpace;
 
+/** The piece a listing inside one was read at. */
+const PIECE = "of:fid1:abcdefghijklmnop";
+
 /** Helper for the cases below, which is the place a listing was read at. */
 const AT = placeAtSpaceRoot(SPACE);
+
+/** Helper for the cases below, which is a place standing inside a piece. */
+const IN_PIECE: Place = {
+  position: { kind: "piece", space: SPACE, piece: PIECE, path: ["items"] },
+  scope: "space",
+};
 
 /** Helper for the cases below, which is a listing numbering `rows`. */
 function listed(...rows: ListingRow[]): ListingHandles {
@@ -134,6 +150,162 @@ describe("handles", () => {
       expect(found(resolveHandle(listed(), "%1"))).toBe(
         "`%1` names no row: the listing numbered none.",
       );
+    });
+  });
+
+  describe("recordedForm()", () => {
+    it("returns the line with a handle written out as the row's own operand", () => {
+      expect(recordedForm("cd %1", listed(row("thermo"), row("tracker"))))
+        .toBe("cd thermo");
+    });
+
+    it("returns a spelling a later listing's numbering does not move", () => {
+      // The claim the recording exists for. A handle is a reference until the
+      // next listing, and a recalled line outlives listings, so the recorded
+      // line has to name the row rather than the number: `%1` names the other
+      // row once the second listing has run, and the line recorded against the
+      // first goes on naming what it acted on.
+
+      expect(recordedForm("set %1/target 25", listed(row("thermo"), row("t"))))
+        .toBe("set thermo/target 25");
+      const renumbered = listed(row("tracker"), row("thermo"));
+      expect(found(resolveHandle(renumbered, "%1"))).toBe("tracker");
+    });
+
+    it("returns a line carrying no handle as the string it was given", () => {
+      // Byte for byte, so the runs of whitespace and the quoting are the ones
+      // that were typed. A recording that split the line and printed its
+      // tokens back would pass a comparison of the words and fail this.
+
+      expect(recordedForm("ls   'first name'  ", listed(row("a")))).toBe(
+        "ls   'first name'  ",
+      );
+    });
+
+    it("returns the text around a handle untouched, the separators included", () => {
+      expect(recordedForm("cd   %1  ", listed(row("thermo"))))
+        .toBe("cd   thermo  ");
+    });
+
+    it("returns every handle on the line written out, not the first alone", () => {
+      expect(recordedForm("link %1 %2", listed(row("a"), row("b"))))
+        .toBe("link a b");
+    });
+
+    it("returns a later handle written out though an earlier named no row", () => {
+      // A token that bound to nothing stops nothing: the walk over the line
+      // carries on to the tokens after it, which bound to what they bound to.
+
+      expect(recordedForm("link %3 %1", listed(row("a"), row("b"))))
+        .toBe("link %3 a");
+    });
+
+    it("returns the walk written after a handle as a further segment", () => {
+      expect(recordedForm("set %1/target 25", listed(row("thermo"))))
+        .toBe("set thermo/target 25");
+    });
+
+    it("returns a handle written with a trailing separator as the row alone", () => {
+      // `%1/` names the row and nothing inside it, the walk after the handle
+      // being empty, so the operand written for it carries no separator
+      // either — one written there would name a segment with no name.
+
+      expect(recordedForm("get %1/", listed(row("thermo")))).toBe("get thermo");
+    });
+
+    it("returns a row whose operand needs quoting as a quoted token", () => {
+      expect(recordedForm("cd %1", listed(row("first name"))))
+        .toBe("cd 'first name'");
+    });
+
+    it("returns a handle the line quoted written out as the row", () => {
+      // The reading is over the token's value rather than over the characters
+      // the line holds, which is the same value the operand grammar reads.
+
+      expect(recordedForm("cd '%1'", listed(row("thermo")))).toBe("cd thermo");
+    });
+
+    it("returns a callable row as the receiver's reference and the verb name", () => {
+      // Two tokens for one, and no single token would do: the handle carries a
+      // receiver and a verb name, and a verb name is interface vocabulary
+      // rather than a data path, so nothing an operand spells names one.
+
+      const callable: ListingRow = { name: "add-reply", kind: "callable" };
+      expect(recordedForm('call %1 \'{"text":"jam"}\'', {
+        place: IN_PIECE,
+        rows: [callable],
+      })).toBe(
+        "call /of:fid1:abcdefghijklmnop@space/items add-reply " +
+          '\'{"text":"jam"}\'',
+      );
+    });
+
+    it("returns a callable row as typed where a walk is written after it", () => {
+      // A walk written after a handle ends at a cell, and a cell is a receiver
+      // rather than a verb, so such a token carries no name for the two-token
+      // spelling to be made of.
+
+      expect(recordedForm("get %1/deeper", {
+        place: IN_PIECE,
+        rows: [{ name: "add-reply", kind: "callable" }],
+      })).toBe("get %1/deeper");
+    });
+
+    it("returns a callable row as typed where the listing stood at no piece", () => {
+      // The receiver is the place the listing was read at, and a place that is
+      // no piece is no receiver. Nothing is written rather than a reference
+      // made up for it.
+
+      expect(recordedForm("call %1", listed({ name: "x", kind: "callable" })))
+        .toBe("call %1");
+    });
+
+    it("returns a row the listing offered no operand for as typed", () => {
+      // Neither the name nor the reference reaches such a row, so there is no
+      // spelling to write in the handle's place.
+
+      expect(recordedForm("cd %1", listed({ name: "-x", kind: "value" })))
+        .toBe("cd %1");
+    });
+
+    it("returns a handle that named no row as typed, so it names none again", () => {
+      expect(recordedForm("set %3 5", listed(row("a"), row("b"))))
+        .toBe("set %3 5");
+    });
+
+    it("returns a handle written before any listing as typed", () => {
+      expect(recordedForm("cd %1", undefined)).toBe("cd %1");
+    });
+
+    it("returns `%0` as typed, no listing having numbered one", () => {
+      expect(recordedForm("cd %0", listed(row("a")))).toBe("cd %0");
+    });
+
+    it("returns a handle standing in an option's value as typed", () => {
+      // What a token after an option is for is the verb's table to say, and a
+      // `%1` written there is a character of that value rather than a handle:
+      // the line sent it nowhere near the handle table, so a recording that
+      // wrote a row out there would replay a line that acts differently.
+
+      expect(recordedForm("ls --limit %1", listed(row("1"), row("2"))))
+        .toBe("ls --limit %1");
+    });
+
+    it("returns a handle inside a callable's own section as typed", () => {
+      // The section's tokens are the callable's input, and the call sent the
+      // characters `%2`. A replay sending anything else would send the verb an
+      // argument the first call never sent it.
+
+      expect(recordedForm("call %1 --text %2", listed(row("a"), row("b"))))
+        .toBe("call a --text %2");
+    });
+
+    it("returns a handle standing where the verb goes as typed", () => {
+      expect(recordedForm("%1", listed(row("a")))).toBe("%1");
+    });
+
+    it("returns a line the split refuses as the string it was given", () => {
+      expect(recordedForm("cd 'a %1", listed(row("a")))).toBe("cd 'a %1");
     });
   });
 });

--- a/packages/cli/test/shuttle-line.test.ts
+++ b/packages/cli/test/shuttle-line.test.ts
@@ -27,6 +27,7 @@ import {
   separatesTokens,
   splitLine,
   tailOfLine,
+  tokensOfLine,
 } from "../lib/shuttle/line.ts";
 
 /**
@@ -460,6 +461,46 @@ describe("line", () => {
         else expect(tail.before).toEqual([]);
       }
       expect(refused.sort()).toEqual(['"', "'"]);
+    });
+  });
+
+  describe("tokensOfLine()", () => {
+    it("returns each token with the run of the line it was written across", () => {
+      expect(tokensOfLine("cd a b")).toEqual([
+        { value: "cd", start: 0, end: 2 },
+        { value: "a", start: 3, end: 4 },
+        { value: "b", start: 5, end: 6 },
+      ]);
+    });
+
+    it("returns a quoted token's span over its whole spelling, quotes included", () => {
+      // The span is what a caller writes a replacement across, so it has to
+      // cover every character the token was written with. A span read off the
+      // value's length would leave the closing quote behind.
+
+      expect(tokensOfLine("cd 'a b'")).toEqual([
+        { value: "cd", start: 0, end: 2 },
+        { value: "a b", start: 3, end: 8 },
+      ]);
+    });
+
+    it("ends a token at the separator that closed it, not at the line's end", () => {
+      expect(tokensOfLine("cd  slugs ")).toEqual([
+        { value: "cd", start: 0, end: 2 },
+        { value: "slugs", start: 4, end: 9 },
+      ]);
+    });
+
+    it("returns no tokens for a line with nothing on it", () => {
+      expect(tokensOfLine("   ")).toEqual([]);
+    });
+
+    it("returns nothing where the line ends in a quote that never closes", () => {
+      expect(tokensOfLine("cd 'a b")).toBeUndefined();
+    });
+
+    it("returns nothing where the line ends in a backslash escaping nothing", () => {
+      expect(tokensOfLine("cd a\\")).toBeUndefined();
     });
   });
 });

--- a/packages/cli/test/shuttle-place.test.ts
+++ b/packages/cli/test/shuttle-place.test.ts
@@ -50,6 +50,7 @@ import type { MemorySpace } from "@commonfabric/memory/interface";
 import {
   CurrentPlace,
   FACETS,
+  handleMove,
   type Move,
   operandForChild,
   type PendingMove,
@@ -113,6 +114,56 @@ describe("place", () => {
         position: { kind: "root", space: SPACE },
         scope: "space",
       });
+    });
+  });
+
+  describe("handleMove()", () => {
+    // Where a handle operand divides, which two readers ask: the move a verb's
+    // operand comes back as, and the recording that writes a handle out as the
+    // row it named (`handles.ts`). One answer, so the pair cannot part.
+
+    it("returns the handle at the head and the walk written after it", () => {
+      expect(handleMove("%1/target/deeper")).toEqual({
+        kind: "handle",
+        handle: "%1",
+        rest: "target/deeper",
+        operand: "%1/target/deeper",
+      });
+    });
+
+    it("returns an empty walk for a handle written on its own", () => {
+      expect(handleMove("%12")).toEqual({
+        kind: "handle",
+        handle: "%12",
+        rest: "",
+        operand: "%12",
+      });
+    });
+
+    it("returns an empty walk for a handle written with a trailing separator", () => {
+      // `%4/` names the row and nothing inside it, the separator opening a
+      // walk with no segment in it.
+
+      expect(handleMove("%4/")).toEqual({
+        kind: "handle",
+        handle: "%4",
+        rest: "",
+        operand: "%4/",
+      });
+    });
+
+    it("returns nothing for an operand that does not open with the sigil", () => {
+      expect(handleMove("items/%1")).toBeUndefined();
+    });
+
+    it("reads a `cd` operand opening with the sigil, whatever the digits say", () => {
+      // The division is the one a verb's operand goes through, and the reading
+      // is reached by the sigil alone: whether the number names a row is the
+      // handle table's question and is asked after this.
+
+      const place = new CurrentPlace(SPACE);
+      expect(place.aim("%0/x", "get").move)
+        .toEqual(handleMove("%0/x"));
     });
   });
 

--- a/packages/cli/test/shuttle-prompt.test.ts
+++ b/packages/cli/test/shuttle-prompt.test.ts
@@ -37,6 +37,9 @@ import type { Key } from "../lib/view/keys.ts";
 const SPACE = "did:key:z6MkConnectedSpace" as MemorySpace;
 const HANDLE = "of:fid1:abcdefghijklmnop";
 
+/** The piece a listing was read inside, which is not the one shuttle stands on. */
+const LISTED_PIECE = "of:fid1:ponmlkjihgfedcba";
+
 const CONFIG: SpaceConfig = {
   apiUrl: "https://toolshed.example/",
   space: SPACE,
@@ -861,6 +864,44 @@ describe("prompt", () => {
         text: "shuttle /slugs/ @space> cd slugs",
         column: 32,
       });
+    });
+
+    it("recalls an in-piece line onto the piece it read, not the one under it", async () => {
+      // The hazard the recorded reference ends. Two pieces hold a `title`
+      // apiece, and the listing was read inside one while shuttle stands on
+      // the other, so a line recorded with the key's own name would read the
+      // piece under the prompt the second time round. Both reads are asserted,
+      // since what the claim is about is that the second names what the first
+      // named.
+
+      const shuttle = atPiece();
+      shuttle.session.listed({
+        place: {
+          position: {
+            kind: "piece",
+            space: SPACE,
+            piece: LISTED_PIECE,
+            path: [],
+          },
+          scope: "space",
+        },
+        rows: [{ name: "title", kind: "value", operand: "title" }],
+      });
+      const read: string[] = [];
+      await running(
+        [...typed("get %1"), ENTER, UP, ENTER],
+        shuttle,
+        {
+          getCellValue: (config, path) => {
+            read.push(`${config.piece}/${path.join("/")}`);
+            return Promise.resolve("a title");
+          },
+        },
+      );
+      expect(read).toEqual([
+        `${LISTED_PIECE}/title`,
+        `${LISTED_PIECE}/title`,
+      ]);
     });
 
     it("draws the line as it was typed, the handle included", async () => {

--- a/packages/cli/test/shuttle-prompt.test.ts
+++ b/packages/cli/test/shuttle-prompt.test.ts
@@ -27,7 +27,7 @@ import { UI } from "@commonfabric/runner";
 
 import type { SpaceConfig } from "../lib/piece.ts";
 import { HeldConnection } from "../lib/shuttle/connection.ts";
-import { CurrentPlace } from "../lib/shuttle/place.ts";
+import { CurrentPlace, placeAtSpaceRoot } from "../lib/shuttle/place.ts";
 import { ShuttleSession } from "../lib/shuttle/session.ts";
 import { moved } from "./shuttle-place-helpers.ts";
 import { type PromptTerminal, runPrompt } from "../lib/shuttle/prompt.ts";
@@ -842,6 +842,47 @@ describe("prompt", () => {
         kind: "edit",
         text: `${AT_ROOT}pwd`,
         column: 21,
+      });
+    });
+
+    it("recalls a line with its handles written out as the rows they named", async () => {
+      // A handle is a reference until the next listing, so a line recorded as
+      // it was typed would, recalled after a listing had renumbered, act on
+      // whichever row the number names then. What `up` puts back is the row.
+
+      const shuttle = shuttleIn();
+      shuttle.session.listed({
+        place: placeAtSpaceRoot(SPACE),
+        rows: [{ name: "slugs", kind: "container", operand: "slugs" }],
+      });
+      const writes = await running([...typed("cd %1"), ENTER, UP], shuttle);
+      expect(drawn(writes)).toEqual({
+        kind: "edit",
+        text: "shuttle /slugs/ @space> cd slugs",
+        column: 32,
+      });
+    });
+
+    it("draws the line as it was typed, the handle included", async () => {
+      // The other half of the pair above: only what is recorded differs, and
+      // the line on the screen is the one the person wrote. The reading is of
+      // the writes up to the `finish` that ended the line, which is the last
+      // the prompt drew of it.
+
+      const shuttle = shuttleIn();
+      shuttle.session.listed({
+        place: placeAtSpaceRoot(SPACE),
+        rows: [{ name: "slugs", kind: "container", operand: "slugs" }],
+      });
+      const writes = await running([...typed("cd %1"), ENTER], shuttle);
+      const typing = writes.slice(
+        0,
+        writes.findIndex((write) => write.kind === "finish"),
+      );
+      expect(drawn(typing)).toEqual({
+        kind: "edit",
+        text: `${AT_ROOT}cd %1`,
+        column: 23,
       });
     });
 


### PR DESCRIPTION
## Why

Implements the ruling recorded in decision 29 (#7346).

`%n` is a reference only until the next listing (decision 17), and recall
outlives listings. So a recalled line carrying a handle acts on whichever row
that number names *now*:

```
shuttle …> ls
%1 thermo   %2 tracker
shuttle …> set %1/target 25        → writes thermo
shuttle …> verbs %2                → renumbers
shuttle …> <up><up><enter>         → replays `set %1/target 25`
```

That replay writes to whatever `%1` names after the renumbering, **and receipts
it**. A wrong write reported as success is the failure this exists to prevent.

A line is now recorded with each `%n` replaced by what it bound to when it ran.
**What the prompt shows is still what was typed**; only what recall replays
changes. Nothing new is tracked to do it — a listing already records each row's
kind, name and operand as it mints the handle (decision 27), and a callable's
receiver is the listing's own place.

## What Changed

`recordedForm(line, handles)` walks the line's tokens and replaces each that
reads as a handle. `prompt.ts` calls it at the single site where a line is
committed. Two supporting pieces: `tokensOfLine()` keeps each token's span so
the untouched parts of the line survive byte-for-byte, and `handleMove()` lifts
the handle/walk split out of `movePlace`, so the recording and the operand
grammar divide a token the same way *by construction* rather than by two authors
agreeing.

## The edge cases, decided

- **A handle that never bound** (`%0`, past the listing, no listing yet) —
  recorded as typed. The line was refused, so there is no first action for a
  replay to diverge from, and fixing a refused line is the commonest reason to
  press `up`.
- **Several handles** — each replaced independently; one that bound to nothing
  does not stop the rest.
- **A handle that is a prefix of a longer operand** — replaced with the walk
  carried as a further segment: `set %1/target 25` → `set thermo/target 25`. A
  trailing separator alone carries no walk, so `get %1/` records as `get thermo`.
- **A callable handle off `verbs`** — **two tokens, and it cannot be one**:
  `call %4` → `call /of:fid1:…@space/items add-reply`. No single operand names a
  verb; `rowFor` refuses such a row outright and `verbs` mints those rows with no
  operand at all.

### A fifth case, which inverts the ruling's own failure

`call %1 --text %2` would have substituted `%2` — so the replay sends the
callable an argument the **first call never sent**. The same defect the ruling
exists to prevent, arriving from the other direction.

Substitution is therefore bounded to the tokens the operand grammar reads: skip
the verb, stop at the first token that reads as an option. Sound (never replaces
a non-operand) and deliberately incomplete (`ls --all %1` keeps its handle,
behaving exactly as today). A precise boundary would need `options.ts` to report
operand indices, since `ls --limit 3 3` has two identical tokens and only one is
an operand.

## A residual hazard, stated rather than hidden

The ruling accepts place-dependence for rows inside a piece, on the reasoning
that such a row fails *by name* where it does not resolve. **That reasoning is
not airtight:** two pieces can both have a `title`, so `set title 5` recalled
after a `cd` can write a different piece's key.

It remains better than the handle — the hazard now needs an intervening `cd` to a
place with a same-named key rather than *any* intervening listing, and the
recalled line displays what it will act on where `set %1 5` displayed nothing —
but it is not eliminated, and the ruling was argued partly on the stronger claim.

## Test plan

- `deno fmt --check`, `deno lint`, `deno task check` (root), `deno task test`
  (`packages/cli`) — every one exit **0**, each captured to a file rather than
  read through a pipe, all on the committed tree.
- The walkthrough: **78 passed, 0 failed, 0 gaps** — run as composition evidence
  for the `movePlace` refactor, not extended. `shuttle-terminal.py` structurally
  cannot press `up`: its model is one record per line typed, and its settle waits
  for a prompt with nothing typed at it, which an `up` never produces. Extending
  it needs its own justification against `waiting-in-tests.md`.
- Twenty-odd cases, each with the mutation it kills verified red. The two
  required: the substitution removed reds one case; rebuilding a handle-free line
  from its tokens reds another. Also pinned — the prompt still *draws* what was
  typed.
- Coverage measured per changed file: `handles.ts`, `line.ts`, `place.ts`,
  `prompt.ts`, `history.ts` — **0 uncovered lines each**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPyjSx5WXYepE9JsK4rBx3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

