### PR TITLE
feat(data-model): `value-visit` WIP, round two: `recurse` on containers and `visited*()` callbacks

### DIFF
--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -24,7 +24,6 @@ import {
   FabricPrimitive,
   FabricValue,
 } from "./interface.ts";
-import { isFabricArray, isFabricPlainObject } from "./type-check.ts";
 import {
   isValidFabricValue,
   isValidFabricValueLayer,
@@ -619,7 +618,10 @@ type VisitSubtypeOfForm<DomainExtra> = {
  */
 type RecurseOfForm = {
   type: "recurseOf";
-  containerTag: "Array" | "FabricInstance" | "Object";
+  containerTag:
+    | typeof VALUE_TAGS.Array
+    | typeof VALUE_TAGS.FabricInstance
+    | typeof VALUE_TAGS.Object;
   container: FabricContainerValue;
   doKeys: boolean;
   doValues: boolean;
@@ -721,7 +723,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       }
 
       case "recurseOf": {
-        return isFabricArray(result.container)
+        return (result.containerTag === VALUE_TAGS.Array)
           ? this.#iterateArray(result)
           : this.#iterateMap(result);
       }
@@ -971,7 +973,10 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    * `recurse` result.
    */
   #iterateMap(result: RecurseOfForm): BaselineVisitResult<ResultType> {
-    const { container, doKeys, doValues } = result;
+    const { container: looseTypedContainer, containerTag, doKeys, doValues } =
+      result;
+    const container =
+      looseTypedContainer as (FabricInstance | FabricPlainObject);
     const vis = this.#visitor;
 
     if (!(doKeys || doValues)) {
@@ -981,7 +986,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       return undefined;
     }
 
-    const mappings = isFabricPlainObject(container)
+    const mappings = (containerTag === VALUE_TAGS.Object)
       ? Object.entries(container)
       : (() => {
         // TODO(danfuzz): This is where we finally need to sort out
@@ -1032,7 +1037,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   #adjustRecurseForm(
     result: RecurseForm,
     finalValue: DomainFor<DomainExtra>,
-    finalValueTagIfKnown?: FabricValueTag | null | undefined,
+    finalValueTagIfKnown?: FabricValueTag | null,
   ): RecurseOfForm {
     const tag = (finalValueTagIfKnown === undefined)
       ? this.#tagFromValueElseNull(finalValue)

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -619,6 +619,7 @@ type VisitSubtypeOfForm<DomainExtra> = {
  */
 type RecurseOfForm = {
   type: "recurseOf";
+  containerTag: "Array" | "FabricInstance" | "Object";
   container: FabricContainerValue;
   doKeys: boolean;
   doValues: boolean;
@@ -762,13 +763,6 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       const resolvedResult = this.#visitResolvingCyclesAndReplacement(value);
 
       switch (resolvedResult?.type) {
-        case "recurse": {
-          // No dispatch required, but we do need to validate and adjust the
-          // result form.
-          const tag = this.#tagFromValueElseNull(value);
-          return this.#adjustRecurseForm(resolvedResult, tag, value);
-        }
-
         case "visitSubtype": {
           // Need dispatch. `value` _has not_ been replaced.
           break;
@@ -838,7 +832,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
       switch (result?.type) {
         case "recurse": {
-          return this.#adjustRecurseForm(result, tag, value);
+          return this.#adjustRecurseForm(result, value, tag);
         }
 
         case "replace": {
@@ -860,10 +854,11 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   #visitResolvingCyclesAndReplacement(
     value: DomainFor<DomainExtra>,
   ):
+    | RecurseOfForm
     | VisitSubtypeOfForm<DomainExtra>
     | Exclude<
       DispatchingVisitorResult<DomainExtra, ResultType>,
-      ReplaceForm<DomainExtra>
+      ReplaceForm<DomainExtra> | RecurseForm
     > {
     const vis = this.#visitor;
     const origValue = value;
@@ -875,13 +870,17 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         : vis.visitCycle(value, cycleAt, this.#stack.depth);
 
       switch (result?.type) {
-        case "visitSubtype": {
-          return this.#visitSubtypeFormFor(origValue, value);
+        case "recurse": {
+          return this.#adjustRecurseForm(result, value);
         }
 
         case "replace": {
           value = result.value;
           break;
+        }
+
+        case "visitSubtype": {
+          return this.#visitSubtypeFormFor(origValue, value);
         }
 
         default: {
@@ -1032,15 +1031,20 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    */
   #adjustRecurseForm(
     result: RecurseForm,
-    finalTag: FabricValueTag | null,
     finalValue: DomainFor<DomainExtra>,
+    finalValueTagIfKnown?: FabricValueTag | null | undefined
   ): RecurseOfForm {
-    switch (finalTag) {
+    const tag = (finalValueTagIfKnown === undefined)
+      ? this.#tagFromValueElseNull(finalValue)
+      : finalValueTagIfKnown;
+
+    switch (tag) {
       case VALUE_TAGS.Array:
       case VALUE_TAGS.FabricInstance:
       case VALUE_TAGS.Object: {
         return {
           type: "recurseOf",
+          containerTag: tag,
           container: finalValue as FabricContainerValue,
           doKeys: result.doKeys,
           doValues: result.doValues,

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -2,6 +2,10 @@
  * Types and classes for visiting (a/k/a, iterating or walking over)
  * `FabricValue`s.
  *
+ * As with the `data-model` in general, the visitor engine uses `Object.is()`
+ * comparisons (or equivalent) to determine value-sameness. This means that `0`
+ * and `-0` are considered distinct, and that `NaN` is equal to itself.
+ *
  * **IMPORTANT NOTE:** This file is a work-in-progress and not meant to be used
  * outside of the `data-model`. This is why it is _not_ exposed via the
  * `data-model`'s export map.
@@ -1044,9 +1048,9 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       }
 
       case "visitSubtype": {
-        // On the use of `Object.is()`: As of this writing, the recursion stack only
-        // ever has objects, but that could theoretically change, and this
-        // comparison function will always remain the most correct option.
+        // On the use of `Object.is()`: The visitor engine does not merge `-0`
+        // into `+0`, and it treats `NaN` is being equal to itself, making this
+        // the correct comparison function.
         if (Object.is(origValue, finalValue)) {
           return result;
         } else {

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -20,6 +20,7 @@ import {
   FabricPrimitive,
   FabricValue,
 } from "./interface.ts";
+import { isFabricArray, isFabricPlainObject } from "./type-check.ts";
 import {
   isValidFabricValue,
   isValidFabricValueLayer,
@@ -41,31 +42,6 @@ import { toCompactDebugString } from "./value-debug.ts";
 export type DomainFor<DomainExtra> = FabricValue | DomainExtra;
 
 /**
- * An `iterateArray` form. This is returned by visitor methods which wish to
- * treat the value they received as a container of array-like contents. `value`
- * indicates the contents of the container, and by returning this, the engine
- * will iterate over the contents, calling `ValueVisitor.visitArrayElement()` on
- * each element.
- */
-export type IterateArrayForm<DomainExtra> = {
-  type: "iterateArray";
-  elements: readonly DomainFor<DomainExtra>[];
-};
-
-/**
- * An `iterateMap` form. This is returned by visitor methods which wish to treat
- * the value they received as a container of map-like contents. `value`
- * indicates the contents of the container as `[key, value]` pairs (similar to
- * the return value from `Map.entries()` or `Object.entries()`), and by
- * returning this, the engine will iterate over the contents, calling
- * `ValueVisitor.visitMapping()` on each key-value pair in the mappings.
- */
-export type IterateMapForm<DomainExtra> = {
-  type: "iterateMap";
-  mappings: readonly [DomainFor<DomainExtra>, DomainFor<DomainExtra>][];
-};
-
-/**
  * A `mainResult` form. `value` is a value that is to be returned from the
  * original main (top-level) `visit()` call, and by returning this form, a
  * visitor indicates that the `visit()` should end promptly (do no further
@@ -77,14 +53,16 @@ export type MainResultForm<ResultType> = {
 };
 
 /**
- * A `recurse` form. This is returned by visitor methods which are used to
- * iterate over container contents. By returning this form, a visitor indicates
- * that the container elements should be visited by the engine, recursively,
- * such that each element is known by the engine to be contained by the
- * container which is being iterated over.
+ * A `recurse` form. This is returned by visitor methods which visit containers.
+ * (It is never a valid result for a non-container-specific visit method.) By
+ * returning this form, a visitor indicates that the container's elements or
+ * mappings should be visited by the engine, recursively, such that each visited
+ * item is known by the engine to be contained by the container which is being
+ * iterated over.
  *
- * The two `boolean` properties indicate which of the keys and/or values is to
- * be recursed over. `doKey` is ignored in a context where there is no key.
+ * The two `boolean` properties indicate whether the container's keys and/or
+ * values is to be recursed over. `doKey` is ignored in a context where there is
+ * no key.
  *
  * **Note:** The visit calls per-mapping are specifically in key-then-value
  * order, and if the result of visiting a key is a `mainResult`, then that ends
@@ -96,8 +74,8 @@ export type MainResultForm<ResultType> = {
  */
 export type RecurseForm = {
   type: "recurse";
-  doKey: boolean;
-  doValue: boolean;
+  doKeys: boolean;
+  doValues: boolean;
 };
 
 /**
@@ -125,8 +103,8 @@ export type VisitSubtypeForm = { type: "visitSubtype" };
  * The `DO_` prefix is intended to make it clear at use sites that it is telling
  * the visitor engine to "do" something.
  */
-export const DO_RECURSE_KEY_VALUE: RecurseForm = Object.freeze(
-  { type: "recurse", doKey: true, doValue: true } as const,
+export const DO_RECURSE_KEYS_VALUES: RecurseForm = Object.freeze(
+  { type: "recurse", doKeys: true, doValues: true } as const,
 );
 
 /**
@@ -136,8 +114,8 @@ export const DO_RECURSE_KEY_VALUE: RecurseForm = Object.freeze(
  * The `DO_` prefix is intended to make it clear at use sites that it is telling
  * the visitor engine to "do" something.
  */
-export const DO_RECURSE_KEY: RecurseForm = Object.freeze(
-  { type: "recurse", doKey: true, doValue: false } as const,
+export const DO_RECURSE_KEYS: RecurseForm = Object.freeze(
+  { type: "recurse", doKeys: true, doValues: false } as const,
 );
 
 /**
@@ -147,8 +125,8 @@ export const DO_RECURSE_KEY: RecurseForm = Object.freeze(
  * The `DO_` prefix is intended to make it clear at use sites that it is telling
  * the visitor engine to "do" something.
  */
-export const DO_RECURSE_VALUE: RecurseForm = Object.freeze(
-  { type: "recurse", doKey: false, doValue: true } as const,
+export const DO_RECURSE_VALUES: RecurseForm = Object.freeze(
+  { type: "recurse", doKeys: false, doValues: true } as const,
 );
 
 /**
@@ -160,30 +138,6 @@ export const DO_RECURSE_VALUE: RecurseForm = Object.freeze(
 export const DO_VISIT_SUBTYPE: VisitSubtypeForm = Object.freeze(
   { type: "visitSubtype" } as const,
 );
-
-/**
- * Constructs an `iterateArray` form.
- *
- * The `do` prefix is intended to make it clear at use sites that it is telling
- * the visitor engine to "do" something.
- */
-export function doIterateArray<DomainExtra>(
-  elements: readonly DomainFor<DomainExtra>[],
-): IterateArrayForm<DomainExtra> {
-  return { type: "iterateArray", elements };
-}
-
-/**
- * Constructs an `iterateMap` form.
- *
- * The `do` prefix is intended to make it clear at use sites that it is telling
- * the visitor engine to "do" something.
- */
-export function doIterateMap<DomainExtra>(
-  mappings: readonly [DomainFor<DomainExtra>, DomainFor<DomainExtra>][],
-): IterateMapForm<DomainExtra> {
-  return { type: "iterateMap", mappings };
-}
 
 //
 // `visit*()` method result union types
@@ -204,29 +158,6 @@ export type BaselineVisitResult<ResultType = FabricValue> =
   | undefined;
 
 /**
- * Possible results from a value-in-container visitor method, that is, methods
- * which are called per container element as part of an iteration.
- *
- * See the included result types for details on what they mean.
- */
-export type ContainerIterationResult<ResultType = FabricValue> =
-  | BaselineVisitResult<ResultType>
-  | RecurseForm;
-
-/**
- * Possible results from a visitor method which covers two or more subtypes of
- * value that the visitor engine can dispatch to.
- *
- * See the included result types for details on what they mean.
- */
-export type DispatchingVisitorResult<
-  DomainExtra = never,
-  ResultType = FabricValue,
-> =
-  | LeafVisitorResult<DomainExtra, ResultType>
-  | VisitSubtypeForm;
-
-/**
  * Possible results from a visitor method which accepts leaf (non-container)
  * values when not _directly_ being the subject of an iteration.
  *
@@ -239,9 +170,34 @@ export type DispatchingVisitorResult<
  */
 export type LeafVisitorResult<DomainExtra = never, ResultType = FabricValue> =
   | BaselineVisitResult<ResultType>
-  | ReplaceForm<DomainExtra>
-  | IterateArrayForm<DomainExtra>
-  | IterateMapForm<DomainExtra>;
+  | ReplaceForm<DomainExtra>;
+
+/**
+ * Possible results from container-specific visitor methods, that is, `visit*()`
+ * methods which are only ever passed container values. This type includes
+ * everything also allowed by `LeafVisitorResult`.
+ *
+ * See the included result types for details on what they mean.
+ */
+export type ContainerVisitorResult<
+  DomainExtra = never,
+  ResultType = FabricValue,
+> =
+  | LeafVisitorResult<DomainExtra, ResultType>
+  | RecurseForm;
+
+/**
+ * Possible results from a visitor method which covers two or more subtypes of
+ * value that the visitor engine can dispatch to.
+ *
+ * See the included result types for details on what they mean.
+ */
+export type DispatchingVisitorResult<
+  DomainExtra = never,
+  ResultType = FabricValue,
+> =
+  | ContainerVisitorResult<DomainExtra, ResultType>
+  | VisitSubtypeForm;
 
 //
 // Visitor interface and exported implementations thereof
@@ -263,18 +219,19 @@ export type LeafVisitorResult<DomainExtra = never, ResultType = FabricValue> =
  */
 export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
   /**
-   * Visits an item from an `iterateArray` result.
+   * Visits an element of an array. This method is called as a result of the
+   * visitor returning a `recurse` result for a visited array.
    */
   visitArrayElement(
     index: number,
     value: DomainFor<DomainExtra>,
-  ): ContainerIterationResult<ResultType>;
+  ): BaselineVisitResult<ResultType>;
 
   /**
-   * Visits a gap (one or more holes) in an `iterateArray` result. `start` is
-   * the start index of the gap (integer `>= 0`), and `count` is the number of
-   * holes in the gap (integer `>= 1`). The return type _does not_ include
-   * `recurse` as a possibility; there's nothing to recurse over.
+   * Visits a gap (one or more holes) in an array. `start` is the start index of
+   * the gap (integer `>= 0`), and `count` is the number of holes in the gap
+   * (integer `>= 1`). This method is called as a result of the visitor
+   * returning a `recurse` result for a visited array.
    */
   visitArrayGap(
     start: number,
@@ -328,12 +285,14 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
   ): DispatchingVisitorResult<DomainExtra, ResultType>;
 
   /**
-   * Visits an item from an `iterateMap` result.
+   * Visits an item from a map-like container (`FabricPlainObject` or
+   * `FabricInstance`). This method is called as a result of the visitor
+   * returning a `recurse` result for a visited map-like container.
    */
   visitMapping(
     key: DomainFor<DomainExtra>,
     value: DomainFor<DomainExtra>,
-  ): ContainerIterationResult<ResultType>;
+  ): BaselineVisitResult<ResultType>;
 
   /**
    * Visits a value determined to _not_ be a valid `FabricValue`.
@@ -381,7 +340,7 @@ export abstract class BaseValueVisitor<
   abstract visitArrayElement(
     index: number,
     value: DomainFor<DomainExtra>,
-  ): ContainerIterationResult<ResultType>;
+  ): BaselineVisitResult<ResultType>;
 
   /** @inheritDoc */
   abstract visitArrayGap(
@@ -420,7 +379,7 @@ export abstract class BaseValueVisitor<
   abstract visitMapping(
     key: DomainFor<DomainExtra>,
     value: DomainFor<DomainExtra>,
-  ): ContainerIterationResult<ResultType>;
+  ): BaselineVisitResult<ResultType>;
 
   /** @inheritDoc */
   abstract visitNonFabricValue(
@@ -462,7 +421,7 @@ export class EmptyValueVisitor<DomainExtra = never, ResultType = FabricValue>
   visitArrayElement(
     _index: number,
     _value: DomainFor<DomainExtra>,
-  ): ContainerIterationResult<ResultType> {
+  ): BaselineVisitResult<ResultType> {
     return undefined;
   }
 
@@ -515,7 +474,7 @@ export class EmptyValueVisitor<DomainExtra = never, ResultType = FabricValue>
   visitMapping(
     _key: DomainFor<DomainExtra>,
     _value: DomainFor<DomainExtra>,
-  ): ContainerIterationResult<ResultType> {
+  ): BaselineVisitResult<ResultType> {
     return undefined;
   }
 
@@ -552,33 +511,10 @@ export abstract class ContainerIteratingVisitor<
   ResultType = FabricValue,
 > extends BaseValueVisitor<DomainExtra, ResultType> {
   /** @inheritDoc */
-  visitFabricArray(
-    value: FabricArray,
-  ): LeafVisitorResult<DomainExtra, ResultType> {
-    return doIterateArray<DomainExtra>(value);
-  }
-
-  /** @inheritDoc */
-  visitFabricInstance(
-    _value: FabricInstance,
-  ): LeafVisitorResult<DomainExtra, ResultType> {
-    // TODO(danfuzz): This is where we finally need to sort out `FabricInstance`
-    // iteration.
-    throw new Error("`FabricInstance` not yet visitable");
-  }
-
-  /** @inheritDoc */
-  visitFabricPlainObject(
-    value: FabricPlainObject,
-  ): LeafVisitorResult<DomainExtra, ResultType> {
-    return doIterateMap<DomainExtra>(Object.entries(value));
-  }
-
-  /** @inheritDoc */
   visitFabricContainer(
     _value: FabricContainerValue,
   ): DispatchingVisitorResult<DomainExtra, ResultType> {
-    return DO_VISIT_SUBTYPE;
+    return DO_RECURSE_KEYS_VALUES;
   }
 }
 
@@ -598,21 +534,16 @@ type VisitSubtypeOfForm<DomainExtra> = {
 };
 
 /**
- * Similar to `VisitSubtypeOfForm`, but for `iterateArray`.
+ * Similar to `VisitSubtypeOfForm`, but for `recurse`. Unlike that one, though,
+ * this one is _always_ propagated in the engine after getting a plain `recurse`
+ * result, on the theory that if we're going to iterate the one extra allocation
+ * is small potatoes, and it keeps the code a wee bit simpler.
  */
-type IterateArrayOfForm<DomainExtra> = {
-  type: "iterateArrayOf";
-  value: DomainFor<DomainExtra>;
-  elements: readonly DomainFor<DomainExtra>[];
-};
-
-/**
- * Similar to `VisitSubtypeOfForm`, but for `iterateMap`.
- */
-type IterateMapOfForm<DomainExtra> = {
-  type: "iterateMapOf";
-  value: DomainFor<DomainExtra>;
-  mappings: readonly [DomainFor<DomainExtra>, DomainFor<DomainExtra>][];
+type RecurseOfForm = {
+  type: "recurseOf";
+  container: FabricContainerValue;
+  doKeys: boolean;
+  doValues: boolean;
 };
 
 /**
@@ -695,23 +626,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
     }
     // deno-coverage-ignore-stop
 
-    const result = this.#visitValue(value);
-
-    if (result === undefined) {
-      return undefined;
-    } else if (result.type === "mainResult") {
-      return result;
-    } else {
-      // deno-coverage-ignore-start
-
-      // This is a defense-in-depth protection against bugs in this file:
-      // `#visitValue()` consumes every iterate form, so nothing but a
-      // `mainResult` can reach here.
-      throw new Error(
-        `Shouldn't happen: Got result type \`${result.type}\` from top-level visit.`,
-      );
-    }
-    // deno-coverage-ignore-stop
+    return this.#visitValue(value);
   }
 
   /**
@@ -720,30 +635,30 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   #visitValue(value: DomainFor<DomainExtra>): BaselineVisitResult<ResultType> {
     const result = this.#visitResolvingSubtype(value);
 
-    if (result === undefined) {
-      return result;
-    }
-
-    switch (result.type) {
-      case "iterateArray": {
-        return this.#subvisitArray(value, result.elements);
-      }
-
-      case "iterateArrayOf": {
-        return this.#subvisitArray(result.value, result.elements);
-      }
-
-      case "mainResult": {
+    switch (result?.type) {
+      case "mainResult":
+      case undefined: {
         return result;
       }
 
-      case "iterateMap": {
-        return this.#subvisitMap(value, result.mappings);
+      case "recurseOf": {
+        return isFabricArray(result.container)
+          ? this.#iterateArray(result)
+          : this.#iterateMap(result);
       }
 
-      case "iterateMapOf": {
-        return this.#subvisitMap(result.value, result.mappings);
+      default: {
+        // deno-coverage-ignore-start
+
+        // This is a defense-in-depth protection against bugs in this file. The
+        // above is meant to cover all declared result types, so anything else
+        // is a bug, either in this method or in result production.
+        const type = (result as { type: string }).type;
+        throw new Error(
+          `Shouldn't happen: Got result type \`${type}\` from dispatched visitor method.`,
+        );
       }
+        // deno-coverage-ignore-stop
     }
   }
 
@@ -755,8 +670,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   #visitResolvingSubtype(
     value: DomainFor<DomainExtra>,
   ):
-    | IterateArrayOfForm<DomainExtra>
-    | IterateMapOfForm<DomainExtra>
+    | RecurseOfForm
     | Exclude<
       LeafVisitorResult<DomainExtra, ResultType>,
       ReplaceForm<DomainExtra>
@@ -768,6 +682,11 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       const resolvedResult = this.#visitResolvingCyclesAndReplacement(value);
 
       switch (resolvedResult?.type) {
+        case "recurse": {
+          // No dispatch required, but we do need to adjust the result form.
+          return this.#adjustResultForm(origValue, value, resolvedResult);
+        }
+
         case "visitSubtype": {
           // Need dispatch. `value` _has not_ been replaced.
           break;
@@ -836,8 +755,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       }
 
       switch (result?.type) {
-        case "iterateArray":
-        case "iterateMap": {
+        case "recurse": {
           return this.#adjustResultForm(origValue, value, result);
         }
 
@@ -860,8 +778,6 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   #visitResolvingCyclesAndReplacement(
     value: DomainFor<DomainExtra>,
   ):
-    | IterateArrayOfForm<DomainExtra>
-    | IterateMapOfForm<DomainExtra>
     | VisitSubtypeOfForm<DomainExtra>
     | Exclude<
       DispatchingVisitorResult<DomainExtra, ResultType>,
@@ -877,8 +793,6 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         : vis.visitCycle(value, cycleAt, this.#stack.depth);
 
       switch (result?.type) {
-        case "iterateArray":
-        case "iterateMap":
         case "visitSubtype": {
           return this.#adjustResultForm(origValue, value, result);
         }
@@ -896,27 +810,39 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   }
 
   /**
-   * Visits the items in an `iterateArray` result, recursing or returning as
-   * directed by `ValueVisitor.visitArrayElement()`.
+   * Iterates over all the elements in an array, in response to a `recurse`
+   * result.
    */
-  #subvisitArray(
-    value: DomainFor<DomainExtra>,
-    values: readonly DomainFor<DomainExtra>[],
-  ): BaselineVisitResult<ResultType> {
+  #iterateArray(result: RecurseOfForm) {
     const vis = this.#visitor;
+    const { container, doValues }: {
+      container: FabricContainerValue;
+      doValues: boolean;
+    } = result;
+    const array = container as FabricArray;
 
-    this.#stack.push(value);
+    if (!doValues) {
+      // `result` represents a no-op `recurse`. Though pointless, nothing
+      // prevents a client from returning it as a visit result, so just handle
+      // it gracefully here.
+      return;
+    }
+
+    this.#stack.push(array);
 
     let lastIdx = -1;
     try {
-      for (const idx in values) {
+      for (const idx in array) {
         if (!isArrayIndexPropertyName(idx)) {
-          throw new Error("Improper array returned in `iterateArray` result.");
+          throw new Error(
+            `Non-index property in alleged \`FabricArray\`: \`${idx}\``,
+          );
         }
 
         const idxNumber = Number(idx);
 
         if (idxNumber !== (lastIdx + 1)) {
+          // There's a gap just before this element.
           const result = vis.visitArrayGap(
             lastIdx + 1,
             idxNumber - lastIdx - 1,
@@ -928,31 +854,26 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
         lastIdx = idxNumber;
 
-        const item = values[idxNumber]!;
-        const result = vis.visitArrayElement(idxNumber, item);
+        const element = array[idxNumber]!;
+        const elemResult = this.#visitValue(element);
+        if (elemResult?.type === "mainResult") {
+          return elemResult;
+        }
 
-        if (result !== undefined) {
-          switch (result.type) {
-            case "mainResult": {
-              return result;
-            }
-            case "recurse": {
-              if (result.doValue) {
-                const recurseResult = this.#visitValue(item);
-                if (recurseResult?.type === "mainResult") {
-                  return recurseResult;
-                }
-              }
-            }
-          }
+        // TODO(danfuzz): When we have a non-`mainResult` visit-result type,
+        // we'll want to pass the result value from `elemResult` into
+        // `visitArrayElement()` and not the original `element`.
+        const result = vis.visitArrayElement(idxNumber, element);
+        if (result?.type === "mainResult") {
+          return result;
         }
       }
 
-      if (values.length !== (lastIdx + 1)) {
+      if (array.length !== (lastIdx + 1)) {
         // There's a gap at the end of the array.
         const result = vis.visitArrayGap(
           lastIdx + 1,
-          values.length - lastIdx - 1,
+          array.length - lastIdx - 1,
         );
         if (result?.type === "mainResult") {
           return result;
@@ -961,53 +882,67 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
       return undefined;
     } finally {
-      this.#stack.popExpect(value);
+      this.#stack.popExpect(array);
     }
   }
 
   /**
-   * Visits the items in an `iterateMap` result, recursing or returning as
-   * directed by `ValueVisitor.visitMapping()`.
+   * Iterates over all the elements in a map-like value, in response to a
+   * `recurse` result.
    */
-  #subvisitMap(
-    value: DomainFor<DomainExtra>,
-    mappings: readonly [DomainFor<DomainExtra>, DomainFor<DomainExtra>][],
-  ): BaselineVisitResult<ResultType> {
+  #iterateMap(result: RecurseOfForm) {
     const vis = this.#visitor;
+    const { container, doKeys, doValues }: {
+      container: FabricContainerValue;
+      doKeys: boolean;
+      doValues: boolean;
+    } = result;
 
-    this.#stack.push(value);
+    if (!(doKeys || doValues)) {
+      // `result` represents a no-op `recurse`. Though pointless, nothing
+      // prevents a client from returning it as a visit result, so just handle
+      // it gracefully here.
+      return;
+    }
+
+    const mappings = isFabricPlainObject(container)
+      ? Object.entries(container)
+      : (() => {
+        // TODO(danfuzz): This is where we finally need to sort out
+        // `FabricInstance` iteration.
+        throw new Error("`FabricInstance` not yet visitable");
+      })();
+
+    this.#stack.push(container);
 
     try {
-      for (const [key, item] of mappings) {
-        const result = vis.visitMapping(key, item);
-
-        if (result !== undefined) {
-          switch (result.type) {
-            case "mainResult": {
-              return result;
-            }
-            case "recurse": {
-              if (result.doKey) {
-                const keyResult = this.#visitValue(key);
-                if (keyResult?.type === "mainResult") {
-                  return keyResult;
-                }
-              }
-
-              if (result.doValue) {
-                const itemResult = this.#visitValue(item);
-                if (itemResult?.type === "mainResult") {
-                  return itemResult;
-                }
-              }
-            }
+      for (const [key, value] of mappings) {
+        if (doKeys) {
+          const keyResult = this.#visitValue(key);
+          if (keyResult?.type === "mainResult") {
+            return keyResult;
           }
+        }
+
+        if (doValues) {
+          const keyResult = this.#visitValue(key);
+          if (keyResult?.type === "mainResult") {
+            return keyResult;
+          }
+        }
+
+        // TODO(danfuzz): When we have a non-`mainResult` visit-result type,
+        // we'll want to pass the result value(s) from the visits immediately
+        // above instead of the original `key` and `value`.
+        const result = vis.visitMapping(key, value);
+        if (result?.type === "mainResult") {
+          return result;
         }
       }
 
       return undefined;
     } finally {
-      this.#stack.popExpect(value);
+      this.#stack.popExpect(container);
     }
   }
 
@@ -1016,77 +951,66 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   //
 
   /**
-   * Adjusts an `iterateArray`, `iterateMap`, or `visitSubtype` form if
-   * necessary, if it is meant to represent action on a replacement value.
+   * Adjusts a `recurse` or `visitSubtype` form if necessary, if it is meant to
+   * represent action on a replacement value.
    */
   #adjustResultForm(
     origValue: DomainFor<DomainExtra>,
     finalValue: DomainFor<DomainExtra>,
-    result:
-      | IterateArrayForm<DomainExtra>
-      | IterateMapForm<DomainExtra>,
-  ):
-    | IterateArrayForm<DomainExtra>
-    | IterateArrayOfForm<DomainExtra>
-    | IterateMapForm<DomainExtra>
-    | IterateMapOfForm<DomainExtra>;
+    result: RecurseForm,
+  ): RecurseOfForm;
   #adjustResultForm(
     origValue: DomainFor<DomainExtra>,
     finalValue: DomainFor<DomainExtra>,
-    result:
-      | IterateArrayForm<DomainExtra>
-      | IterateMapForm<DomainExtra>
-      | VisitSubtypeForm,
+    result: VisitSubtypeForm,
   ):
-    | IterateArrayForm<DomainExtra>
-    | IterateArrayOfForm<DomainExtra>
-    | IterateMapForm<DomainExtra>
-    | IterateMapOfForm<DomainExtra>
     | VisitSubtypeForm
     | VisitSubtypeOfForm<DomainExtra>;
   #adjustResultForm(
     origValue: DomainFor<DomainExtra>,
     finalValue: DomainFor<DomainExtra>,
-    result:
-      | IterateArrayForm<DomainExtra>
-      | IterateMapForm<DomainExtra>
-      | VisitSubtypeForm,
+    result: RecurseForm | VisitSubtypeForm,
   ):
-    | IterateArrayForm<DomainExtra>
-    | IterateArrayOfForm<DomainExtra>
-    | IterateMapForm<DomainExtra>
-    | IterateMapOfForm<DomainExtra>
+    | RecurseOfForm
     | VisitSubtypeForm
     | VisitSubtypeOfForm<DomainExtra> {
-    // On the use of `Object.is()`: Even though it's unlikely to be done in
-    // practice, this class _does_ let a visitor treat a number as a container,
-    // so this choice of comparison is the most correct option.
-    if (Object.is(origValue, finalValue)) {
-      return result;
-    }
-
     switch (result.type) {
-      case "iterateArray": {
-        return {
-          type: "iterateArrayOf",
-          value: finalValue,
-          elements: result.elements,
-        };
-      }
+      case "recurse": {
+        // We always transform `recurse` to `recurseOf`. See comment on the
+        // definition of `RecurseOfForm` for details.
 
-      case "iterateMap": {
+        const tag = this.#tagFromValueElseNull(finalValue);
+        if (
+          (tag !== VALUE_TAGS.Object) && (tag !== VALUE_TAGS.FabricInstance)
+        ) {
+          const desc = toCompactDebugString(finalValue, {
+            backtickQuote: true,
+          });
+          throw new Error(
+            `Cannot use \`recurse\` result with non-container: ${desc}`,
+          );
+        }
+
         return {
-          type: "iterateMapOf",
-          value: finalValue,
-          mappings: result.mappings,
+          type: "recurseOf",
+          container: finalValue as FabricContainerValue,
+          doKeys: result.doKeys,
+          doValues: result.doValues,
         };
       }
 
       case "visitSubtype": {
-        return {
-          type: "visitSubtypeOf",
-          value: finalValue,
-        };
+        // On the use of `Object.is()`: As of this writing, the recursion stack only
+        // ever has objects, but that could theoretically change, and this
+        // comparison function will always remain the most correct option.
+        if (Object.is(origValue, finalValue)) {
+          return result;
+        } else {
+          return {
+            type: "visitSubtypeOf",
+            value: finalValue,
+          };
+        }
       }
     }
   }

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -35,6 +35,7 @@ import {
   tagFromFabricValue,
   tagFromFabricValueElseNull,
   VALUE_TAGS,
+  ValueTag,
 } from "./value-tags.ts";
 import { toCompactDebugString } from "./value-debug.ts";
 
@@ -709,6 +710,9 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    * Iteratively calls `visitValue()`, `visitCycle()`, and the subtype-specific
    * visitor methods, until the visitor returns something other than a `replace`
    * or `visitSubtype` result.
+   *
+   * **Note:** We always transform `recurse` to `recurseOf` for returning from
+   * this method. See comment on the definition of `RecurseOfForm` for details.
    */
   #visitResolvingSubtype(
     value: DomainFor<DomainExtra>,
@@ -719,15 +723,16 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       ReplaceForm<DomainExtra>
     > {
     const vis = this.#visitor;
-    const origValue = value;
 
     for (;;) {
       const resolvedResult = this.#visitResolvingCyclesAndReplacement(value);
 
       switch (resolvedResult?.type) {
         case "recurse": {
-          // No dispatch required, but we do need to adjust the result form.
-          return this.#adjustResultForm(origValue, value, resolvedResult);
+          // No dispatch required, but we do need to validate and adjust the
+          // result form.
+          const tag = this.#tagFromValueElseNull(value);
+          return this.#adjustRecurseForm(resolvedResult, tag, value);
         }
 
         case "visitSubtype": {
@@ -799,7 +804,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
       switch (result?.type) {
         case "recurse": {
-          return this.#adjustResultForm(origValue, value, result);
+          return this.#adjustRecurseForm(result, tag, value);
         }
 
         case "replace": {
@@ -837,7 +842,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
       switch (result?.type) {
         case "visitSubtype": {
-          return this.#adjustResultForm(origValue, value, result);
+          return this.#visitSubtypeFormFor(origValue, value);
         }
 
         case "replace": {
@@ -996,67 +1001,51 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   //
 
   /**
-   * Adjusts a `recurse` or `visitSubtype` form if necessary, if it is meant to
-   * represent action on a replacement value.
+   * Validates and rewrites a `recurse` form as a `recurseOf` form.
    */
-  #adjustResultForm(
-    origValue: DomainFor<DomainExtra>,
-    finalValue: DomainFor<DomainExtra>,
+  #adjustRecurseForm(
     result: RecurseForm,
-  ): RecurseOfForm;
-  #adjustResultForm(
-    origValue: DomainFor<DomainExtra>,
+    finalTag: ValueTag | null,
     finalValue: DomainFor<DomainExtra>,
-    result: VisitSubtypeForm,
-  ):
-    | VisitSubtypeForm
-    | VisitSubtypeOfForm<DomainExtra>;
-  #adjustResultForm(
-    origValue: DomainFor<DomainExtra>,
-    finalValue: DomainFor<DomainExtra>,
-    result: RecurseForm | VisitSubtypeForm,
-  ):
-    | RecurseOfForm
-    | VisitSubtypeForm
-    | VisitSubtypeOfForm<DomainExtra> {
-    switch (result.type) {
-      case "recurse": {
-        // We always transform `recurse` to `recurseOf`. See comment on the
-        // definition of `RecurseOfForm` for details.
-
-        switch (this.#tagFromValueElseNull(finalValue)) {
-          case VALUE_TAGS.Array:
-          case VALUE_TAGS.FabricInstance:
-          case VALUE_TAGS.Object: {
-            return {
-              type: "recurseOf",
-              container: finalValue as FabricContainerValue,
-              doKeys: result.doKeys,
-              doValues: result.doValues,
-            };
-          }
-        }
-
-        const desc = toCompactDebugString(finalValue, { backtickQuote: true });
-        throw new Error(
-          `Cannot use \`recurse\` result with non-container: ${desc}`,
-        );
-      }
-
-      case "visitSubtype": {
-        // On the use of `Object.is()`: The visitor engine does not merge `-0`
-        // into `+0`, and it treats `NaN` is being equal to itself, making this
-        // the correct comparison function.
-        if (Object.is(origValue, finalValue)) {
-          return result;
-        } else {
-          return {
-            type: "visitSubtypeOf",
-            value: finalValue,
-          };
-        }
+  ): RecurseOfForm {
+    switch (finalTag) {
+      case VALUE_TAGS.Array:
+      case VALUE_TAGS.FabricInstance:
+      case VALUE_TAGS.Object: {
+        return {
+          type: "recurseOf",
+          container: finalValue as FabricContainerValue,
+          doKeys: result.doKeys,
+          doValues: result.doValues,
+        };
       }
     }
+
+    const desc = toCompactDebugString(finalValue, { backtickQuote: true });
+    throw new Error(
+      `Cannot use \`recurse\` result with non-container: ${desc}`,
+    );
+  }
+
+  /**
+   * Returns either a `visitSubtype` or `visitSubtypeOf` form as necessary,
+   * based on whether the visited value is a replacement.
+   */
+  #visitSubtypeFormFor(
+    origValue: DomainFor<DomainExtra>,
+    finalValue: DomainFor<DomainExtra>,
+  ):
+    | VisitSubtypeForm
+    | VisitSubtypeOfForm<DomainExtra>
+  {
+    if (Object.is(origValue, finalValue)) {
+      return DO_VISIT_SUBTYPE;
+    }
+
+    return {
+      type: "visitSubtypeOf",
+      value: finalValue,
+    };
   }
 
   /**

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -158,37 +158,28 @@ export type BaselineVisitResult<ResultType = FabricValue> =
   | undefined;
 
 /**
- * Possible results from a visitor method which accepts leaf (non-container)
- * values when not _directly_ being the subject of an iteration.
+ * Possible results from a `visit*()` method which accepts leaf (non-dispatched)
+ * values. This includes the `recurse` form, which is only valid to return when
+ * the value being visited is in fact a container; this constraint is checked at
+ * runtime and results in a `throw`n error when violated.
  *
- * This is a "leaf" in the sense of visitor dispatch -- there is not a
- * more-specific subtype-based visitor method to call -- but that said, the
- * value being visited itself might or might not be a leaf in the sense of the
- * graph structure of the value.
+ * About the name: This is a "leaf" in the sense of visitor dispatch -- there is
+ * not a more-specific subtype-based visitor method to call -- but that said,
+ * the value being visited itself might or might not be a leaf in the sense of
+ * the graph structure of the value.
  *
  * See the included result types for details on what they mean.
  */
 export type LeafVisitorResult<DomainExtra = never, ResultType = FabricValue> =
   | BaselineVisitResult<ResultType>
+  | RecurseForm
   | ReplaceForm<DomainExtra>;
 
 /**
- * Possible results from container-specific visitor methods, that is, `visit*()`
- * methods which are only ever passed container values. This type includes
- * everything also allowed by `LeafVisitorResult`.
- *
- * See the included result types for details on what they mean.
- */
-export type ContainerVisitorResult<
-  DomainExtra = never,
-  ResultType = FabricValue,
-> =
-  | LeafVisitorResult<DomainExtra, ResultType>
-  | RecurseForm;
-
-/**
  * Possible results from a visitor method which covers two or more subtypes of
- * value that the visitor engine can dispatch to.
+ * value that the visitor engine can dispatch to. Such a method is also allowed
+ * to take a non-dispatch action, and so all of the `LeafVisitorResults` are
+ * included as options with this type.
  *
  * See the included result types for details on what they mean.
  */
@@ -196,7 +187,7 @@ export type DispatchingVisitorResult<
   DomainExtra = never,
   ResultType = FabricValue,
 > =
-  | ContainerVisitorResult<DomainExtra, ResultType>
+  | LeafVisitorResult<DomainExtra, ResultType>
   | VisitSubtypeForm;
 
 //

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -417,6 +417,16 @@ export abstract class BaseValueVisitor<
     const desc = toCompactDebugString(value, { backtickQuote: true });
     throw new Error(`Cannot visit cyclic value: ${desc}`);
   }
+
+  /**
+   * Throws a "shouldn't happen" error, indicating a particular method should
+   * not have been called.
+   */
+  protected throwShouldntCall(methodName: string): never {
+    const desc = `\`${methodName}()\``;
+    const thisDesc = toCompactDebugString(this, { backtickQuote: true });
+    throw new Error(`Shouldn't happen: ${desc} called on ${thisDesc}`);
+  }
 }
 
 /**
@@ -516,7 +526,12 @@ export class EmptyValueVisitor<DomainExtra = never, ResultType = FabricValue>
 /**
  * Visitor which handles all containers by requesting that the engine iterate
  * over their contents. This class leaves all non-container `visit*()` methods
- * `abstract`.
+ * `abstract`, and implements no-op (empty) `visited*()` methods. Recursion is
+ * as follows:
+ *
+ * * `FabricArray` -- all elements.
+ * * `FabricInstance` -- keys and values.
+ * * `FabricPlainObject`s -- values only.
  */
 export abstract class ContainerIteratingVisitor<
   DomainExtra = never,
@@ -530,35 +545,55 @@ export abstract class ContainerIteratingVisitor<
   visitFabricArray(
     _value: FabricArray,
   ): LeafVisitorResult<DomainExtra, ResultType> {
-    this.#throwShouldnt("visitFabricArray");
+    return DO_RECURSE_VALUES;
   }
 
   /** @inheritDoc */
   visitFabricInstance(
     _value: FabricInstance,
   ): LeafVisitorResult<DomainExtra, ResultType> {
-    this.#throwShouldnt("visitFabricInstance");
+    return DO_RECURSE_KEYS_VALUES;
   }
 
   /** @inheritDoc */
   visitFabricPlainObject(
     _value: FabricPlainObject,
   ): LeafVisitorResult<DomainExtra, ResultType> {
-    this.#throwShouldnt("visitFabricPlainObject");
+    return DO_RECURSE_VALUES;
   }
 
   /** @inheritDoc */
   visitFabricContainer(
     _value: FabricContainerValue,
   ): DispatchingVisitorResult<DomainExtra, ResultType> {
-    return DO_RECURSE_KEYS_VALUES;
+    return DO_VISIT_SUBTYPE;
   }
 
-  /** Throws a "shouldn't happen" error, as appropriate for this class. */
-  #throwShouldnt(methodName: string): never {
-    const desc = `\`${methodName}()\``;
-    const thisDesc = toCompactDebugString(this, { backtickQuote: true });
-    throw new Error(`Shouldn't happen: ${desc} called on ${thisDesc}`);
+  /** @inheritDoc */
+  visitedArrayElement(
+    _array: FabricArray,
+    _index: number,
+    _value: DomainFor<DomainExtra>,
+  ): BaselineVisitResult<ResultType> {
+    return undefined;
+  }
+
+  /** @inheritDoc */
+  visitedArrayGap(
+    _array: FabricArray,
+    _start: number,
+    _count: number,
+  ): BaselineVisitResult<ResultType> {
+    return undefined;
+  }
+
+  /** @inheritDoc */
+  visitedMapping(
+    _container: FabricPlainObject | FabricInstance,
+    _key: DomainFor<DomainExtra>,
+    _value: DomainFor<DomainExtra>,
+  ): BaselineVisitResult<ResultType> {
+    return undefined;
   }
 }
 

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -35,7 +35,6 @@ import {
   tagFromFabricValue,
   tagFromFabricValueElseNull,
   VALUE_TAGS,
-  type ValueTag,
 } from "./value-tags.ts";
 import { toCompactDebugString } from "./value-debug.ts";
 
@@ -1040,7 +1039,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    */
   #adjustRecurseForm(
     result: RecurseForm,
-    finalTag: ValueTag | null,
+    finalTag: FabricValueTag | null,
     finalValue: DomainFor<DomainExtra>,
   ): RecurseOfForm {
     switch (finalTag) {

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -1140,8 +1140,8 @@ export function makeVisitFabricValueFunction<ResultType = FabricValue>(
  * Type checking can be performed either as a deep-validity check or a shallow
  * "shape of value" check:
  *
- * * The shallow check is a fast single-layer check and considers all arrays to
- *   be `FabricArray`s and all plain objects to be `FabricPlainObject`s.
+ * * The shallow check is a fast single-layer check based on
+ *   `isValidFabricValueLayer()`, see which for details.
  *
  * * The deep check performs a full-depth validity check anywhere an encountered
  *   value to be dispatched might turn out not to be a valid `FabricValue`,

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -517,11 +517,47 @@ export abstract class ContainerIteratingVisitor<
   DomainExtra = never,
   ResultType = FabricValue,
 > extends BaseValueVisitor<DomainExtra, ResultType> {
+  //
+  // Instance members
+  //
+
+  /** @inheritDoc */
+  visitFabricArray(
+    _value: FabricArray,
+  ): LeafVisitorResult<DomainExtra, ResultType> {
+    ContainerIteratingVisitor.#throwShouldnt("visitFabricArray");
+  }
+
+  /** @inheritDoc */
+  visitFabricInstance(
+    _value: FabricInstance,
+  ): LeafVisitorResult<DomainExtra, ResultType> {
+    ContainerIteratingVisitor.#throwShouldnt("visitFabricInstance");
+  }
+
+  /** @inheritDoc */
+  visitFabricPlainObject(
+    _value: FabricPlainObject,
+  ): LeafVisitorResult<DomainExtra, ResultType> {
+    ContainerIteratingVisitor.#throwShouldnt("visitFabricPlainObject");
+  }
+
   /** @inheritDoc */
   visitFabricContainer(
     _value: FabricContainerValue,
   ): DispatchingVisitorResult<DomainExtra, ResultType> {
     return DO_RECURSE_KEYS_VALUES;
+  }
+
+  //
+  // Static members
+  //
+
+  /** Throws a "shouldn't happen" error, as appropriate for this class. */
+  static #throwShouldnt(methodName: string): never {
+    const desc = `\`${methodName}()\``;
+    const thisCls = toCompactDebugString(this, { backtickQuote: true });
+    throw new Error(`Shouldn't happen: ${desc} called on ${thisCls}`);
   }
 }
 

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -997,24 +997,23 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         // We always transform `recurse` to `recurseOf`. See comment on the
         // definition of `RecurseOfForm` for details.
 
-        const tag = this.#tagFromValueElseNull(finalValue);
-        if (
-          (tag !== VALUE_TAGS.Object) && (tag !== VALUE_TAGS.FabricInstance)
-        ) {
-          const desc = toCompactDebugString(finalValue, {
-            backtickQuote: true,
-          });
-          throw new Error(
-            `Cannot use \`recurse\` result with non-container: ${desc}`,
-          );
+        switch (this.#tagFromValueElseNull(finalValue)) {
+          case VALUE_TAGS.Array:
+          case VALUE_TAGS.FabricInstance:
+          case VALUE_TAGS.Object: {
+            return {
+              type: "recurseOf",
+              container: finalValue as FabricContainerValue,
+              doKeys: result.doKeys,
+              doValues: result.doValues,
+            };
+          }
         }
 
-        return {
-          type: "recurseOf",
-          container: finalValue as FabricContainerValue,
-          doKeys: result.doKeys,
-          doValues: result.doValues,
-        };
+        const desc = toCompactDebugString(finalValue, { backtickQuote: true });
+        throw new Error(
+          `Cannot use \`recurse\` result with non-container: ${desc}`,
+        );
       }
 
       case "visitSubtype": {

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -35,7 +35,7 @@ import {
   tagFromFabricValue,
   tagFromFabricValueElseNull,
   VALUE_TAGS,
-  ValueTag,
+  type ValueTag,
 } from "./value-tags.ts";
 import { toCompactDebugString } from "./value-debug.ts";
 

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -943,9 +943,9 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         }
 
         if (doValues) {
-          const keyResult = this.#visitValue(key);
-          if (keyResult?.type === "mainResult") {
-            return keyResult;
+          const valueResult = this.#visitValue(value);
+          if (valueResult?.type === "mainResult") {
+            return valueResult;
           }
         }
 

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -896,12 +896,9 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    * result.
    */
   #iterateArray(result: RecurseOfForm): BaselineVisitResult<ResultType> {
-    const vis = this.#visitor;
-    const { container, doValues }: {
-      container: FabricContainerValue;
-      doValues: boolean;
-    } = result;
+    const { container, doValues } = result;
     const array = container as FabricArray;
+    const vis = this.#visitor;
 
     if (!doValues) {
       // `result` represents a no-op `recurse`. Though pointless, nothing
@@ -975,12 +972,8 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    * `recurse` result.
    */
   #iterateMap(result: RecurseOfForm): BaselineVisitResult<ResultType> {
+    const { container, doKeys, doValues } = result;
     const vis = this.#visitor;
-    const { container, doKeys, doValues }: {
-      container: FabricContainerValue;
-      doKeys: boolean;
-      doValues: boolean;
-    } = result;
 
     if (!(doKeys || doValues)) {
       // `result` represents a no-op `recurse`. Though pointless, nothing

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -646,7 +646,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   }
 
   //
-  // Instance members
+  // Public instance members
   //
 
   /**
@@ -675,6 +675,12 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
     this.#deepTypeCheck = deepTypeCheck;
     return this.#mainVisit(value);
   }
+
+  //
+  // Visitor engine implementation
+  //
+  // This is arranged in approximately top-down fashion, to aid in readability.
+  //
 
   /** Helper which implements most of a top-level visit. */
   #mainVisit(value: DomainFor<DomainExtra>): BaselineVisitResult<ResultType> {
@@ -737,6 +743,154 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
       case "iterateMapOf": {
         return this.#subvisitMap(result.value, result.mappings);
+      }
+    }
+  }
+
+  /**
+   * Iteratively calls `visitValue()`, `visitCycle()`, and the subtype-specific
+   * visitor methods, until the visitor returns something other than a `replace`
+   * or `visitSubtype` result.
+   */
+  #visitResolvingSubtype(
+    value: DomainFor<DomainExtra>,
+  ):
+    | IterateArrayOfForm<DomainExtra>
+    | IterateMapOfForm<DomainExtra>
+    | Exclude<
+      LeafVisitorResult<DomainExtra, ResultType>,
+      ReplaceForm<DomainExtra>
+    > {
+    const vis = this.#visitor;
+    const origValue = value;
+
+    for (;;) {
+      const resolvedResult = this.#visitResolvingCyclesAndReplacement(value);
+
+      switch (resolvedResult?.type) {
+        case "visitSubtype": {
+          // Need dispatch. `value` _has not_ been replaced.
+          break;
+        }
+
+        case "visitSubtypeOf": {
+          // Need dispatch. `value` _has_ been replaced.
+          value = resolvedResult.value;
+          break;
+        }
+
+        default: {
+          // No dispatch required.
+          return resolvedResult;
+        }
+      }
+
+      const tag = this.#tagFromValueElseNull(value);
+      let result: DispatchingVisitorResult<DomainExtra, ResultType>;
+
+      switch (tag) {
+        case VALUE_TAGS.Array: {
+          const array = value as FabricArray;
+          result = vis.visitFabricContainer(array);
+          if (result?.type === "visitSubtype") {
+            result = vis.visitFabricArray(array);
+          }
+          break;
+        }
+
+        case VALUE_TAGS.FabricInstance: {
+          const instance = value as FabricInstance;
+          result = vis.visitFabricContainer(instance);
+          if (result?.type === "visitSubtype") {
+            result = vis.visitFabricInstance(instance);
+          }
+          break;
+        }
+
+        case VALUE_TAGS.Object: {
+          const object = value as FabricPlainObject;
+          result = vis.visitFabricContainer(object);
+          if (result?.type === "visitSubtype") {
+            result = vis.visitFabricPlainObject(object);
+          }
+          break;
+        }
+
+        case null: {
+          // `null` means that `value` was not recognized as a `FabricValue`.
+          if (this.#assumeValid) {
+            const desc = toCompactDebugString(value);
+            throw new Error(
+              `Encountered a non-\`FabricValue\` while doing an "assume valid" visit: ${desc}`,
+            );
+          }
+          result = vis.visitNonFabricValue(value as DomainExtra);
+          break;
+        }
+
+        default: {
+          const prim = value as Primitive | FabricPrimitive;
+          result = vis.visitPrimitive(prim, tag);
+          break;
+        }
+      }
+
+      switch (result?.type) {
+        case "iterateArray":
+        case "iterateMap": {
+          return this.#adjustResultForm(origValue, value, result);
+        }
+
+        case "replace": {
+          value = result.value;
+          break; // ...and continue to iterate.
+        }
+
+        default: {
+          return result;
+        }
+      }
+    }
+  }
+
+  /**
+   * Iteratively calls `visitValue()` and `visitCycle()` on the visitor, until
+   * the visitor returns something other than a `replace` result.
+   */
+  #visitResolvingCyclesAndReplacement(
+    value: DomainFor<DomainExtra>,
+  ):
+    | IterateArrayOfForm<DomainExtra>
+    | IterateMapOfForm<DomainExtra>
+    | VisitSubtypeOfForm<DomainExtra>
+    | Exclude<
+      DispatchingVisitorResult<DomainExtra, ResultType>,
+      ReplaceForm<DomainExtra>
+    > {
+    const vis = this.#visitor;
+    const origValue = value;
+
+    for (;;) {
+      const cycleAt = this.#stack.indexOf(value);
+      const result = (cycleAt === -1)
+        ? vis.visitValue(value)
+        : vis.visitCycle(value, cycleAt, this.#stack.depth);
+
+      switch (result?.type) {
+        case "iterateArray":
+        case "iterateMap":
+        case "visitSubtype": {
+          return this.#adjustResultForm(origValue, value, result);
+        }
+
+        case "replace": {
+          value = result.value;
+          break;
+        }
+
+        default: {
+          return result;
+        }
       }
     }
   }
@@ -857,175 +1011,9 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
     }
   }
 
-  /**
-   * Iteratively calls `visitValue()` and `visitCycle()` on the visitor, until
-   * the visitor returns something other than a `replace` result.
-   */
-  #visitResolvingCyclesAndReplacement(
-    value: DomainFor<DomainExtra>,
-  ):
-    | IterateArrayOfForm<DomainExtra>
-    | IterateMapOfForm<DomainExtra>
-    | VisitSubtypeOfForm<DomainExtra>
-    | Exclude<
-      DispatchingVisitorResult<DomainExtra, ResultType>,
-      ReplaceForm<DomainExtra>
-    > {
-    const vis = this.#visitor;
-    const origValue = value;
-
-    for (;;) {
-      const cycleAt = this.#stack.indexOf(value);
-      const result = (cycleAt === -1)
-        ? vis.visitValue(value)
-        : vis.visitCycle(value, cycleAt, this.#stack.depth);
-
-      switch (result?.type) {
-        case "iterateArray":
-        case "iterateMap":
-        case "visitSubtype": {
-          return this.#adjustResultForm(origValue, value, result);
-        }
-
-        case "replace": {
-          value = result.value;
-          break;
-        }
-
-        default: {
-          return result;
-        }
-      }
-    }
-  }
-
-  /**
-   * Iteratively calls `visitValue()`, `visitCycle()`, and the subtype-specific
-   * visitor methods, until the visitor returns something other than a `replace`
-   * or `visitSubtype` result.
-   */
-  #visitResolvingSubtype(
-    value: DomainFor<DomainExtra>,
-  ):
-    | IterateArrayOfForm<DomainExtra>
-    | IterateMapOfForm<DomainExtra>
-    | Exclude<
-      LeafVisitorResult<DomainExtra, ResultType>,
-      ReplaceForm<DomainExtra>
-    > {
-    const vis = this.#visitor;
-    const origValue = value;
-
-    for (;;) {
-      const resolvedResult = this.#visitResolvingCyclesAndReplacement(value);
-
-      switch (resolvedResult?.type) {
-        case "visitSubtype": {
-          // Need dispatch. `value` _has not_ been replaced.
-          break;
-        }
-
-        case "visitSubtypeOf": {
-          // Need dispatch. `value` _has_ been replaced.
-          value = resolvedResult.value;
-          break;
-        }
-
-        default: {
-          // No dispatch required.
-          return resolvedResult;
-        }
-      }
-
-      const tag = this.#tagFromValueElseNull(value);
-      let result: DispatchingVisitorResult<DomainExtra, ResultType>;
-
-      switch (tag) {
-        case VALUE_TAGS.Array: {
-          const array = value as FabricArray;
-          result = vis.visitFabricContainer(array);
-          if (result?.type === "visitSubtype") {
-            result = vis.visitFabricArray(array);
-          }
-          break;
-        }
-
-        case VALUE_TAGS.FabricInstance: {
-          const instance = value as FabricInstance;
-          result = vis.visitFabricContainer(instance);
-          if (result?.type === "visitSubtype") {
-            result = vis.visitFabricInstance(instance);
-          }
-          break;
-        }
-
-        case VALUE_TAGS.Object: {
-          const object = value as FabricPlainObject;
-          result = vis.visitFabricContainer(object);
-          if (result?.type === "visitSubtype") {
-            result = vis.visitFabricPlainObject(object);
-          }
-          break;
-        }
-
-        case null: {
-          // `null` means that `value` was not recognized as a `FabricValue`.
-          if (this.#assumeValid) {
-            const desc = toCompactDebugString(value);
-            throw new Error(
-              `Encountered a non-\`FabricValue\` while doing an "assume valid" visit: ${desc}`,
-            );
-          }
-          result = vis.visitNonFabricValue(value as DomainExtra);
-          break;
-        }
-
-        default: {
-          const prim = value as Primitive | FabricPrimitive;
-          result = vis.visitPrimitive(prim, tag);
-          break;
-        }
-      }
-
-      switch (result?.type) {
-        case "iterateArray":
-        case "iterateMap": {
-          return this.#adjustResultForm(origValue, value, result);
-        }
-
-        case "replace": {
-          value = result.value;
-          break; // ...and continue to iterate.
-        }
-
-        default: {
-          return result;
-        }
-      }
-    }
-  }
-
-  /**
-   * Gets the tag for the given value, in a manner which honors the
-   * type-checking style indicated by the top-level `visit*()` call on this
-   * instance.
-   */
-  #tagFromValueElseNull(value: DomainFor<DomainExtra>): FabricValueTag | null {
-    if (this.#assumeValid) {
-      return tagFromFabricValueElseNull(value as FabricValue);
-    } else if (this.#deepTypeCheck) {
-      // TODO(danfuzz): If cached, `isValidDeepFrozenFabricValue()` is faster
-      // than `isValidFabricValue()`. The latter should actually sniff at the
-      // frozen cache.
-      const isFabricValue = isValidDeepFrozenFabricValue(value) ||
-        isValidFabricValue(value);
-      return isFabricValue ? tagFromFabricValue(value) : null;
-    } else {
-      return isValidFabricValueLayer(value)
-        ? tagFromFabricValue(value as FabricValue)
-        : null;
-    }
-  }
+  //
+  // Utility methods
+  //
 
   /**
    * Adjusts an `iterateArray`, `iterateMap`, or `visitSubtype` form if
@@ -1100,6 +1088,28 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
           value: finalValue,
         };
       }
+    }
+  }
+
+  /**
+   * Gets the tag for the given value, in a manner which honors the
+   * type-checking style indicated by the top-level `visit*()` call on this
+   * instance.
+   */
+  #tagFromValueElseNull(value: DomainFor<DomainExtra>): FabricValueTag | null {
+    if (this.#assumeValid) {
+      return tagFromFabricValueElseNull(value as FabricValue);
+    } else if (this.#deepTypeCheck) {
+      // TODO(danfuzz): If cached, `isValidDeepFrozenFabricValue()` is faster
+      // than `isValidFabricValue()`. The latter should actually sniff at the
+      // frozen cache.
+      const isFabricValue = isValidDeepFrozenFabricValue(value) ||
+        isValidFabricValue(value);
+      return isFabricValue ? tagFromFabricValue(value) : null;
+    } else {
+      return isValidFabricValueLayer(value)
+        ? tagFromFabricValue(value as FabricValue)
+        : null;
     }
   }
 }

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -219,26 +219,6 @@ export type DispatchingVisitorResult<
  */
 export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
   /**
-   * Visits an element of an array. This method is called as a result of the
-   * visitor returning a `recurse` result for a visited array.
-   */
-  visitArrayElement(
-    index: number,
-    value: DomainFor<DomainExtra>,
-  ): BaselineVisitResult<ResultType>;
-
-  /**
-   * Visits a gap (one or more holes) in an array. `start` is the start index of
-   * the gap (integer `>= 0`), and `count` is the number of holes in the gap
-   * (integer `>= 1`). This method is called as a result of the visitor
-   * returning a `recurse` result for a visited array.
-   */
-  visitArrayGap(
-    start: number,
-    count: number,
-  ): BaselineVisitResult<ResultType>;
-
-  /**
    * Visits a value which is already in the process of being visited. The
    * visitor engine calls this method _before_ calling `visitValue()` when the
    * value to be visited is already in the middle of being visited as a
@@ -285,16 +265,6 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
   ): DispatchingVisitorResult<DomainExtra, ResultType>;
 
   /**
-   * Visits an item from a map-like container (`FabricPlainObject` or
-   * `FabricInstance`). This method is called as a result of the visitor
-   * returning a `recurse` result for a visited map-like container.
-   */
-  visitMapping(
-    key: DomainFor<DomainExtra>,
-    value: DomainFor<DomainExtra>,
-  ): BaselineVisitResult<ResultType>;
-
-  /**
    * Visits a value determined to _not_ be a valid `FabricValue`.
    *
    * **Note:** When this visitor is called using a function that allows for
@@ -322,6 +292,43 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
   visitValue(
     value: DomainFor<DomainExtra>,
   ): DispatchingVisitorResult<DomainExtra, ResultType>;
+
+  /**
+   * Indicates that an array element was just visited. This method is called as
+   * a result of the visitor returning a `recurse` result for a visited array
+   * and is called _after_ the element itself was directly visited.
+   */
+  visitedArrayElement(
+    index: number,
+    value: DomainFor<DomainExtra>,
+  ): BaselineVisitResult<ResultType>;
+
+  /**
+   * Indicates that an array gap (one or more holes) was just nominally visited.
+   * This method is called as a result of the visitor returning a `recurse`
+   * result for a visited array and is called during iteration as gaps are
+   * encountered. The sequencingf of this call is meant to mirror
+   * `visitedArrayElement()`, but since there is nothing to recurse on (it's a
+   * gap, not any actual values), there is no regular `visitValue()` call which
+   * immediately precedes it (hence the visit was "nominal"). `start` is the
+   * start index of the gap (integer `>= 0`), and `count` is the number of holes
+   * in the gap (integer `>= 1`). This method is called as a result of the
+   * visitor returning a `recurse` result for a visited array.
+   */
+  visitedArrayGap(
+    start: number,
+    count: number,
+  ): BaselineVisitResult<ResultType>;
+
+  /**
+   * Indicates that a container mapping was just visited. This method is called
+   * as a result of the visitor returning a `recurse` result for a visited
+   * container and is called _after_ the mapping itself was directly visited.
+   */
+  visitedMapping(
+    key: DomainFor<DomainExtra>,
+    value: DomainFor<DomainExtra>,
+  ): BaselineVisitResult<ResultType>;
 }
 
 /**
@@ -335,18 +342,6 @@ export abstract class BaseValueVisitor<
   //
   // Subclass contract
   //
-
-  /** @inheritDoc */
-  abstract visitArrayElement(
-    index: number,
-    value: DomainFor<DomainExtra>,
-  ): BaselineVisitResult<ResultType>;
-
-  /** @inheritDoc */
-  abstract visitArrayGap(
-    start: number,
-    count: number,
-  ): BaselineVisitResult<ResultType>;
 
   /** @inheritDoc */
   abstract visitCycle(
@@ -376,12 +371,6 @@ export abstract class BaseValueVisitor<
   ): DispatchingVisitorResult<DomainExtra, ResultType>;
 
   /** @inheritDoc */
-  abstract visitMapping(
-    key: DomainFor<DomainExtra>,
-    value: DomainFor<DomainExtra>,
-  ): BaselineVisitResult<ResultType>;
-
-  /** @inheritDoc */
   abstract visitNonFabricValue(
     value: DomainExtra,
   ): LeafVisitorResult<DomainExtra, ResultType>;
@@ -396,6 +385,24 @@ export abstract class BaseValueVisitor<
   abstract visitValue(
     value: DomainFor<DomainExtra>,
   ): DispatchingVisitorResult<DomainExtra, ResultType>;
+
+  /** @inheritDoc */
+  abstract visitedArrayElement(
+    index: number,
+    value: DomainFor<DomainExtra>,
+  ): BaselineVisitResult<ResultType>;
+
+  /** @inheritDoc */
+  abstract visitedArrayGap(
+    start: number,
+    count: number,
+  ): BaselineVisitResult<ResultType>;
+
+  /** @inheritDoc */
+  abstract visitedMapping(
+    key: DomainFor<DomainExtra>,
+    value: DomainFor<DomainExtra>,
+  ): BaselineVisitResult<ResultType>;
 
   //
   // Instance members
@@ -417,22 +424,6 @@ export abstract class BaseValueVisitor<
  */
 export class EmptyValueVisitor<DomainExtra = never, ResultType = FabricValue>
   extends BaseValueVisitor<DomainExtra, ResultType> {
-  /** @inheritDoc */
-  visitArrayElement(
-    _index: number,
-    _value: DomainFor<DomainExtra>,
-  ): BaselineVisitResult<ResultType> {
-    return undefined;
-  }
-
-  /** @inheritDoc */
-  visitArrayGap(
-    _start: number,
-    _count: number,
-  ): BaselineVisitResult<ResultType> {
-    return undefined;
-  }
-
   /** @inheritDoc */
   visitCycle(
     _value: DomainFor<DomainExtra>,
@@ -471,14 +462,6 @@ export class EmptyValueVisitor<DomainExtra = never, ResultType = FabricValue>
   }
 
   /** @inheritDoc */
-  visitMapping(
-    _key: DomainFor<DomainExtra>,
-    _value: DomainFor<DomainExtra>,
-  ): BaselineVisitResult<ResultType> {
-    return undefined;
-  }
-
-  /** @inheritDoc */
   visitNonFabricValue(
     _value: DomainExtra,
   ): LeafVisitorResult<DomainExtra, ResultType> {
@@ -497,6 +480,30 @@ export class EmptyValueVisitor<DomainExtra = never, ResultType = FabricValue>
   visitValue(
     _value: DomainFor<DomainExtra>,
   ): DispatchingVisitorResult<DomainExtra, ResultType> {
+    return undefined;
+  }
+
+  /** @inheritDoc */
+  visitedArrayElement(
+    _index: number,
+    _value: DomainFor<DomainExtra>,
+  ): BaselineVisitResult<ResultType> {
+    return undefined;
+  }
+
+  /** @inheritDoc */
+  visitedArrayGap(
+    _start: number,
+    _count: number,
+  ): BaselineVisitResult<ResultType> {
+    return undefined;
+  }
+
+  /** @inheritDoc */
+  visitedMapping(
+    _key: DomainFor<DomainExtra>,
+    _value: DomainFor<DomainExtra>,
+  ): BaselineVisitResult<ResultType> {
     return undefined;
   }
 }
@@ -843,7 +850,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
         if (idxNumber !== (lastIdx + 1)) {
           // There's a gap just before this element.
-          const result = vis.visitArrayGap(
+          const result = vis.visitedArrayGap(
             lastIdx + 1,
             idxNumber - lastIdx - 1,
           );
@@ -862,8 +869,8 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
         // TODO(danfuzz): When we have a non-`mainResult` visit-result type,
         // we'll want to pass the result value from `elemResult` into
-        // `visitArrayElement()` and not the original `element`.
-        const result = vis.visitArrayElement(idxNumber, element);
+        // `visitedArrayElement()` and not the original `element`.
+        const result = vis.visitedArrayElement(idxNumber, element);
         if (result?.type === "mainResult") {
           return result;
         }
@@ -871,7 +878,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
       if (array.length !== (lastIdx + 1)) {
         // There's a gap at the end of the array.
-        const result = vis.visitArrayGap(
+        const result = vis.visitedArrayGap(
           lastIdx + 1,
           array.length - lastIdx - 1,
         );
@@ -934,7 +941,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         // TODO(danfuzz): When we have a non-`mainResult` visit-result type,
         // we'll want to pass the result value(s) from the visits immediately
         // above instead of the original `key` and `value`.
-        const result = vis.visitMapping(key, value);
+        const result = vis.visitedMapping(key, value);
         if (result?.type === "mainResult") {
           return result;
         }

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -1143,10 +1143,11 @@ export function makeVisitFabricValueFunction<ResultType = FabricValue>(
  * * The shallow check is a fast single-layer check based on
  *   `isValidFabricValueLayer()`, see which for details.
  *
- * * The deep check performs a full-depth validity check anywhere an encountered
- *   value to be dispatched might turn out not to be a valid `FabricValue`,
- *   resulting in a guarantee that anything of type `FabricValue` passed to the
- *   visitor is in fact a valid `FabricValue`.
+ * * The deep check performs a full-depth validity check, based on
+ *   `isValidFabricValue()`, anywhere an encountered value to be dispatched might
+ *   turn out not to be a valid `FabricValue`, resulting in a guarantee that
+ *   anything of type `FabricValue` passed to the visitor is in fact a valid
+ *   `FabricValue`.
  *
  *   This can incur significant performance overhead. As a worst-case, it can
  *   result in O(N^2) checks on the number of values in the graph of the

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -1071,8 +1071,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
     finalValue: DomainFor<DomainExtra>,
   ):
     | VisitSubtypeForm
-    | VisitSubtypeOfForm<DomainExtra>
-  {
+    | VisitSubtypeOfForm<DomainExtra> {
     if (Object.is(origValue, finalValue)) {
       return DO_VISIT_SUBTYPE;
     }

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -299,6 +299,7 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
    * and is called _after_ the element itself was directly visited.
    */
   visitedArrayElement(
+    array: FabricArray,
     index: number,
     value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType>;
@@ -316,6 +317,7 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
    * visitor returning a `recurse` result for a visited array.
    */
   visitedArrayGap(
+    array: FabricArray,
     start: number,
     count: number,
   ): BaselineVisitResult<ResultType>;
@@ -326,6 +328,7 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
    * container and is called _after_ the mapping itself was directly visited.
    */
   visitedMapping(
+    container: FabricPlainObject | FabricInstance,
     key: DomainFor<DomainExtra>,
     value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType>;
@@ -388,18 +391,21 @@ export abstract class BaseValueVisitor<
 
   /** @inheritDoc */
   abstract visitedArrayElement(
+    array: FabricArray,
     index: number,
     value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType>;
 
   /** @inheritDoc */
   abstract visitedArrayGap(
+    array: FabricArray,
     start: number,
     count: number,
   ): BaselineVisitResult<ResultType>;
 
   /** @inheritDoc */
   abstract visitedMapping(
+    container: FabricPlainObject | FabricInstance,
     key: DomainFor<DomainExtra>,
     value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType>;
@@ -485,6 +491,7 @@ export class EmptyValueVisitor<DomainExtra = never, ResultType = FabricValue>
 
   /** @inheritDoc */
   visitedArrayElement(
+    _array: FabricArray,
     _index: number,
     _value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType> {
@@ -493,6 +500,7 @@ export class EmptyValueVisitor<DomainExtra = never, ResultType = FabricValue>
 
   /** @inheritDoc */
   visitedArrayGap(
+    _array: FabricArray,
     _start: number,
     _count: number,
   ): BaselineVisitResult<ResultType> {
@@ -501,6 +509,7 @@ export class EmptyValueVisitor<DomainExtra = never, ResultType = FabricValue>
 
   /** @inheritDoc */
   visitedMapping(
+    _container: FabricPlainObject | FabricInstance,
     _key: DomainFor<DomainExtra>,
     _value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType> {
@@ -851,6 +860,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         if (idxNumber !== (lastIdx + 1)) {
           // There's a gap just before this element.
           const result = vis.visitedArrayGap(
+            array,
             lastIdx + 1,
             idxNumber - lastIdx - 1,
           );
@@ -870,7 +880,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         // TODO(danfuzz): When we have a non-`mainResult` visit-result type,
         // we'll want to pass the result value from `elemResult` into
         // `visitedArrayElement()` and not the original `element`.
-        const result = vis.visitedArrayElement(idxNumber, element);
+        const result = vis.visitedArrayElement(array, idxNumber, element);
         if (result?.type === "mainResult") {
           return result;
         }
@@ -879,6 +889,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       if (array.length !== (lastIdx + 1)) {
         // There's a gap at the end of the array.
         const result = vis.visitedArrayGap(
+          array,
           lastIdx + 1,
           array.length - lastIdx - 1,
         );
@@ -941,7 +952,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         // TODO(danfuzz): When we have a non-`mainResult` visit-result type,
         // we'll want to pass the result value(s) from the visits immediately
         // above instead of the original `key` and `value`.
-        const result = vis.visitedMapping(key, value);
+        const result = vis.visitedMapping(container, key, value);
         if (result?.type === "mainResult") {
           return result;
         }

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -1144,10 +1144,10 @@ export function makeVisitFabricValueFunction<ResultType = FabricValue>(
  *   `isValidFabricValueLayer()`, see which for details.
  *
  * * The deep check performs a full-depth validity check, based on
- *   `isValidFabricValue()`, anywhere an encountered value to be dispatched might
- *   turn out not to be a valid `FabricValue`, resulting in a guarantee that
- *   anything of type `FabricValue` passed to the visitor is in fact a valid
- *   `FabricValue`.
+ *   `isValidFabricValue()`, anywhere an encountered value to be dispatched
+ *   might turn out not to be a valid `FabricValue`, resulting in a guarantee
+ *   that anything of type `FabricValue` passed to the visitor is in fact a
+ *   valid `FabricValue`.
  *
  *   This can incur significant performance overhead. As a worst-case, it can
  *   result in O(N^2) checks on the number of values in the graph of the

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -1032,7 +1032,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   #adjustRecurseForm(
     result: RecurseForm,
     finalValue: DomainFor<DomainExtra>,
-    finalValueTagIfKnown?: FabricValueTag | null | undefined
+    finalValueTagIfKnown?: FabricValueTag | null | undefined,
   ): RecurseOfForm {
     const tag = (finalValueTagIfKnown === undefined)
       ? this.#tagFromValueElseNull(finalValue)

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -54,15 +54,15 @@ export type MainResultForm<ResultType> = {
 
 /**
  * A `recurse` form. This is returned by visitor methods which visit containers.
- * (It is never a valid result for a non-container-specific visit method.) By
- * returning this form, a visitor indicates that the container's elements or
- * mappings should be visited by the engine, recursively, such that each visited
- * item is known by the engine to be contained by the container which is being
- * iterated over.
+ * This tells the visitor engine that it should recursively visit the contents
+ * of the container, such that each visited item is known by the engine to be
+ * contained by the container which is being iterated over. The two `boolean`
+ * properties indicate whether the container's keys and/or values is to be
+ * recursed over. `doKeys` is ignored in a context where there is no key.
  *
- * The two `boolean` properties indicate whether the container's keys and/or
- * values is to be recursed over. `doKey` is ignored in a context where there is
- * no key.
+ * If a visitor returns an instance of this type which (implicitly) references a
+ * a non-container, that situation is detected at runtime and results in a
+ * `throw`n error.
  *
  * **Note:** The visit calls per-mapping are specifically in key-then-value
  * order, and if the result of visiting a key is a `mainResult`, then that ends

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -65,7 +65,7 @@ export type MainResultForm<ResultType> = {
  * recursed over. `doKeys` is ignored in a context where there is no key.
  *
  * If a visitor returns an instance of this type which (implicitly) references a
- * a non-container, that situation is detected at runtime and results in a
+ * non-container, that situation is detected at runtime and results in a
  * `throw`n error.
  *
  * **Note:** The visit calls per-mapping are specifically in key-then-value
@@ -529,21 +529,21 @@ export abstract class ContainerIteratingVisitor<
   visitFabricArray(
     _value: FabricArray,
   ): LeafVisitorResult<DomainExtra, ResultType> {
-    ContainerIteratingVisitor.#throwShouldnt("visitFabricArray");
+    this.#throwShouldnt("visitFabricArray");
   }
 
   /** @inheritDoc */
   visitFabricInstance(
     _value: FabricInstance,
   ): LeafVisitorResult<DomainExtra, ResultType> {
-    ContainerIteratingVisitor.#throwShouldnt("visitFabricInstance");
+    this.#throwShouldnt("visitFabricInstance");
   }
 
   /** @inheritDoc */
   visitFabricPlainObject(
     _value: FabricPlainObject,
   ): LeafVisitorResult<DomainExtra, ResultType> {
-    ContainerIteratingVisitor.#throwShouldnt("visitFabricPlainObject");
+    this.#throwShouldnt("visitFabricPlainObject");
   }
 
   /** @inheritDoc */
@@ -553,15 +553,11 @@ export abstract class ContainerIteratingVisitor<
     return DO_RECURSE_KEYS_VALUES;
   }
 
-  //
-  // Static members
-  //
-
   /** Throws a "shouldn't happen" error, as appropriate for this class. */
-  static #throwShouldnt(methodName: string): never {
+  #throwShouldnt(methodName: string): never {
     const desc = `\`${methodName}()\``;
-    const thisCls = toCompactDebugString(this, { backtickQuote: true });
-    throw new Error(`Shouldn't happen: ${desc} called on ${thisCls}`);
+    const thisDesc = toCompactDebugString(this, { backtickQuote: true });
+    throw new Error(`Shouldn't happen: ${desc} called on ${thisDesc}`);
   }
 }
 

--- a/packages/data-model/src/value-visit.ts
+++ b/packages/data-model/src/value-visit.ts
@@ -57,7 +57,7 @@ export type MainResultForm<ResultType> = {
  * This tells the visitor engine that it should recursively visit the contents
  * of the container, such that each visited item is known by the engine to be
  * contained by the container which is being iterated over. The two `boolean`
- * properties indicate whether the container's keys and/or values is to be
+ * properties indicate whether the container's keys and/or values are to be
  * recursed over. `doKeys` is ignored in a context where there is no key.
  *
  * If a visitor returns an instance of this type which (implicitly) references a
@@ -299,7 +299,7 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
    * Indicates that an array gap (one or more holes) was just nominally visited.
    * This method is called as a result of the visitor returning a `recurse`
    * result for a visited array and is called during iteration as gaps are
-   * encountered. The sequencingf of this call is meant to mirror
+   * encountered. The sequencing of this call is meant to mirror
    * `visitedArrayElement()`, but since there is nothing to recurse on (it's a
    * gap, not any actual values), there is no regular `visitValue()` call which
    * immediately precedes it (hence the visit was "nominal"). `start` is the
@@ -856,7 +856,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    * Iterates over all the elements in an array, in response to a `recurse`
    * result.
    */
-  #iterateArray(result: RecurseOfForm) {
+  #iterateArray(result: RecurseOfForm): BaselineVisitResult<ResultType> {
     const vis = this.#visitor;
     const { container, doValues }: {
       container: FabricContainerValue;
@@ -868,7 +868,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       // `result` represents a no-op `recurse`. Though pointless, nothing
       // prevents a client from returning it as a visit result, so just handle
       // it gracefully here.
-      return;
+      return undefined;
     }
 
     this.#stack.push(array);
@@ -935,7 +935,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    * Iterates over all the elements in a map-like value, in response to a
    * `recurse` result.
    */
-  #iterateMap(result: RecurseOfForm) {
+  #iterateMap(result: RecurseOfForm): BaselineVisitResult<ResultType> {
     const vis = this.#visitor;
     const { container, doKeys, doValues }: {
       container: FabricContainerValue;
@@ -947,7 +947,7 @@ class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       // `result` represents a no-op `recurse`. Though pointless, nothing
       // prevents a client from returning it as a visit result, so just handle
       // it gracefully here.
-      return;
+      return undefined;
     }
 
     const mappings = isFabricPlainObject(container)

--- a/packages/data-model/test/value-visit.test.ts
+++ b/packages/data-model/test/value-visit.test.ts
@@ -5,6 +5,8 @@ import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import {
   type FabricArray,
+  type FabricContainerValue,
+  type FabricInstance,
   type FabricPlainObject,
   type FabricPrimitive,
   type FabricValue,
@@ -13,14 +15,11 @@ import { type PrimitiveValueTag } from "@/value-tags.ts";
 import {
   type BaselineVisitResult,
   ContainerIteratingVisitor,
-  type ContainerIterationResult,
   type DispatchingVisitorResult,
-  DO_RECURSE_KEY,
-  DO_RECURSE_KEY_VALUE,
-  DO_RECURSE_VALUE,
+  DO_RECURSE_KEYS,
+  DO_RECURSE_KEYS_VALUES,
+  DO_RECURSE_VALUES,
   DO_VISIT_SUBTYPE,
-  doIterateArray,
-  doIterateMap,
   EmptyValueVisitor,
   type LeafVisitorResult,
   makeVisitFabricValueFunction,
@@ -36,32 +35,39 @@ import type { Primitive } from "@commonfabric/utils/types";
 type Event = [name: string, ...args: unknown[]];
 
 /**
- * Visitor that iterates every container, recurses into every element, key,
- * and value, and records each call it receives. Each hook can be overridden
- * per test by assigning the matching `on*` property.
+ * Visitor that dispatches every value to its subtype method, recurses into
+ * containers the way `ContainerIteratingVisitor` does by default, and records
+ * each call it receives. Each hook can be overridden per test by assigning the
+ * matching `on*` property.
  */
 class Recorder extends ContainerIteratingVisitor<unknown, unknown> {
   readonly events: Event[] = [];
 
   onValue?: (value: unknown) => DispatchingVisitorResult<unknown, unknown>;
-  onCycle?: (value: unknown) => LeafVisitorResult<unknown, unknown>;
-  onElement?: (
-    index: number,
+  onCycle?: (
     value: unknown,
-  ) => ContainerIterationResult<unknown>;
-  onMapping?: (
-    key: unknown,
-    value: unknown,
-  ) => ContainerIterationResult<unknown>;
-  onGap?: (start: number, count: number) => BaselineVisitResult<unknown>;
+    originalDepth: number,
+    thisDepth: number,
+  ) => LeafVisitorResult<unknown, unknown>;
+  onArray?: (value: FabricArray) => LeafVisitorResult<unknown, unknown>;
+  onPlainObject?: (
+    value: FabricPlainObject,
+  ) => LeafVisitorResult<unknown, unknown>;
+  onInstance?: (value: FabricInstance) => LeafVisitorResult<unknown, unknown>;
   onPrimitive?: (
     value: unknown,
     tag: PrimitiveValueTag,
   ) => LeafVisitorResult<unknown, unknown>;
   onNonFabric?: (value: unknown) => LeafVisitorResult<unknown, unknown>;
-  onPlainObject?: (
-    value: FabricPlainObject,
-  ) => LeafVisitorResult<unknown, unknown>;
+  onVisitedElement?: (
+    index: number,
+    value: unknown,
+  ) => BaselineVisitResult<unknown>;
+  onVisitedGap?: (start: number, count: number) => BaselineVisitResult<unknown>;
+  onVisitedMapping?: (
+    key: unknown,
+    value: unknown,
+  ) => BaselineVisitResult<unknown>;
 
   /** The names of the recorded calls, in order. */
   get names(): string[] {
@@ -81,11 +87,13 @@ class Recorder extends ContainerIteratingVisitor<unknown, unknown> {
     thisDepth: number,
   ): LeafVisitorResult<unknown, unknown> {
     this.events.push(["cycle", value, originalDepth, thisDepth]);
-    return this.onCycle ? this.onCycle(value) : undefined;
+    return this.onCycle
+      ? this.onCycle(value, originalDepth, thisDepth)
+      : undefined;
   }
 
   override visitFabricContainer(
-    value: FabricArray | FabricPlainObject | FabricMap,
+    value: FabricContainerValue,
   ): DispatchingVisitorResult<unknown, unknown> {
     this.events.push(["container", value]);
     return DO_VISIT_SUBTYPE;
@@ -95,7 +103,7 @@ class Recorder extends ContainerIteratingVisitor<unknown, unknown> {
     value: FabricArray,
   ): LeafVisitorResult<unknown, unknown> {
     this.events.push(["array", value]);
-    return super.visitFabricArray(value);
+    return this.onArray ? this.onArray(value) : super.visitFabricArray(value);
   }
 
   override visitFabricPlainObject(
@@ -108,10 +116,13 @@ class Recorder extends ContainerIteratingVisitor<unknown, unknown> {
   }
 
   override visitFabricInstance(
-    value: FabricMap,
+    value: FabricInstance,
   ): LeafVisitorResult<unknown, unknown> {
+    // Unlike the other container hooks, this one does not defer to the
+    // superclass by default: the engine cannot yet iterate an instance, so
+    // the default here is to stop.
     this.events.push(["instance", value]);
-    return undefined;
+    return this.onInstance ? this.onInstance(value) : undefined;
   }
 
   override visitPrimitive(
@@ -129,28 +140,35 @@ class Recorder extends ContainerIteratingVisitor<unknown, unknown> {
     return this.onNonFabric ? this.onNonFabric(value) : undefined;
   }
 
-  override visitArrayElement(
+  override visitedArrayElement(
+    array: FabricArray,
     index: number,
     value: unknown,
-  ): ContainerIterationResult<unknown> {
-    this.events.push(["element", index, value]);
-    return this.onElement ? this.onElement(index, value) : DO_RECURSE_VALUE;
+  ): BaselineVisitResult<unknown> {
+    this.events.push(["visitedElement", array, index, value]);
+    return this.onVisitedElement
+      ? this.onVisitedElement(index, value)
+      : undefined;
   }
 
-  override visitArrayGap(
+  override visitedArrayGap(
+    array: FabricArray,
     start: number,
     count: number,
   ): BaselineVisitResult<unknown> {
-    this.events.push(["gap", start, count]);
-    return this.onGap ? this.onGap(start, count) : undefined;
+    this.events.push(["visitedGap", array, start, count]);
+    return this.onVisitedGap ? this.onVisitedGap(start, count) : undefined;
   }
 
-  override visitMapping(
+  override visitedMapping(
+    container: FabricPlainObject | FabricInstance,
     key: unknown,
     value: unknown,
-  ): ContainerIterationResult<unknown> {
-    this.events.push(["mapping", key, value]);
-    return this.onMapping ? this.onMapping(key, value) : DO_RECURSE_KEY_VALUE;
+  ): BaselineVisitResult<unknown> {
+    this.events.push(["visitedMapping", container, key, value]);
+    return this.onVisitedMapping
+      ? this.onVisitedMapping(key, value)
+      : undefined;
   }
 }
 
@@ -176,41 +194,21 @@ function chain(depth: number, leaf: unknown): unknown {
 describe("value-visit", () => {
   describe("the `DO_*` constants", () => {
     const recurseCases: [string, RecurseForm, boolean, boolean][] = [
-      ["DO_RECURSE_KEY_VALUE", DO_RECURSE_KEY_VALUE, true, true],
-      ["DO_RECURSE_KEY", DO_RECURSE_KEY, true, false],
-      ["DO_RECURSE_VALUE", DO_RECURSE_VALUE, false, true],
+      ["DO_RECURSE_KEYS_VALUES", DO_RECURSE_KEYS_VALUES, true, true],
+      ["DO_RECURSE_KEYS", DO_RECURSE_KEYS, true, false],
+      ["DO_RECURSE_VALUES", DO_RECURSE_VALUES, false, true],
     ];
 
-    for (const [name, form, doKey, doValue] of recurseCases) {
-      it(`makes \`${name}\` a frozen \`recurse\` form with \`doKey\` ${doKey} and \`doValue\` ${doValue}`, () => {
+    for (const [name, form, doKeys, doValues] of recurseCases) {
+      it(`makes \`${name}\` a frozen \`recurse\` form with \`doKeys\` ${doKeys} and \`doValues\` ${doValues}`, () => {
         expect(Object.isFrozen(form)).toBe(true);
-        expect(form).toEqual({ type: "recurse", doKey, doValue });
+        expect(form).toEqual({ type: "recurse", doKeys, doValues });
       });
     }
 
     it("makes `DO_VISIT_SUBTYPE` a frozen `visitSubtype` form", () => {
       expect(Object.isFrozen(DO_VISIT_SUBTYPE)).toBe(true);
       expect(DO_VISIT_SUBTYPE).toEqual({ type: "visitSubtype" });
-    });
-  });
-
-  describe("doIterateArray()", () => {
-    it("returns an `iterateArray` form holding the given array itself", () => {
-      const elements = [1, 2, 3];
-      const form = doIterateArray(elements);
-
-      expect(form.type).toBe("iterateArray");
-      expect(form.elements).toBe(elements);
-    });
-  });
-
-  describe("doIterateMap()", () => {
-    it("returns an `iterateMap` form holding the given mappings themselves", () => {
-      const mappings: [string, number][] = [["a", 1]];
-      const form = doIterateMap(mappings);
-
-      expect(form.type).toBe("iterateMap");
-      expect(form.mappings).toBe(mappings);
     });
   });
 
@@ -231,23 +229,38 @@ describe("value-visit", () => {
         );
       });
     });
+
+    describe("throwShouldntCall()", () => {
+      it("throws an error naming the method and the visitor", () => {
+        class Refusing extends Recorder {
+          override visitPrimitive(): never {
+            return this.throwShouldntCall("visitPrimitive");
+          }
+        }
+
+        expect(() => visitValue(1, new Refusing())).toThrow(
+          /Shouldn't happen: `visitPrimitive\(\)` called on `.*Refusing/,
+        );
+      });
+    });
   });
 
   describe("EmptyValueVisitor", () => {
     it("returns `undefined` from every visitor method", () => {
       const vis = new EmptyValueVisitor<unknown, unknown>();
+      const instance = new FabricMap(new Map());
 
-      expect(vis.visitArrayElement(0, 1)).toBeUndefined();
-      expect(vis.visitArrayGap(0, 1)).toBeUndefined();
       expect(vis.visitCycle(1, 0, 1)).toBeUndefined();
       expect(vis.visitFabricArray([])).toBeUndefined();
       expect(vis.visitFabricContainer([])).toBeUndefined();
-      expect(vis.visitFabricInstance(new FabricMap(new Map()))).toBeUndefined();
+      expect(vis.visitFabricInstance(instance)).toBeUndefined();
       expect(vis.visitFabricPlainObject({})).toBeUndefined();
-      expect(vis.visitMapping("k", 1)).toBeUndefined();
       expect(vis.visitNonFabricValue(new Date(0))).toBeUndefined();
       expect(vis.visitPrimitive(1, "number")).toBeUndefined();
       expect(vis.visitValue(1)).toBeUndefined();
+      expect(vis.visitedArrayElement([1], 0, 1)).toBeUndefined();
+      expect(vis.visitedArrayGap([], 0, 1)).toBeUndefined();
+      expect(vis.visitedMapping({}, "k", 1)).toBeUndefined();
     });
 
     it("completes a visit of a nested value without descending", () => {
@@ -268,16 +281,7 @@ describe("value-visit", () => {
 
   describe("ContainerIteratingVisitor", () => {
     class Iterating extends ContainerIteratingVisitor<never, never> {
-      override visitArrayElement(): ContainerIterationResult<never> {
-        return undefined;
-      }
-      override visitArrayGap(): BaselineVisitResult<never> {
-        return undefined;
-      }
       override visitCycle(): LeafVisitorResult<never, never> {
-        return undefined;
-      }
-      override visitMapping(): ContainerIterationResult<never> {
         return undefined;
       }
       override visitNonFabricValue(): LeafVisitorResult<never, never> {
@@ -295,61 +299,60 @@ describe("value-visit", () => {
       expect(new Iterating().visitFabricContainer([])).toBe(DO_VISIT_SUBTYPE);
     });
 
-    it("returns an `iterateArray` form over the array itself from `visitFabricArray()`", () => {
-      const array = [1, 2];
-      const form = new Iterating().visitFabricArray(array);
-
-      expect(form).toEqual({ type: "iterateArray", elements: array });
-      expect((form as { elements: unknown }).elements).toBe(array);
+    it("returns `DO_RECURSE_VALUES` from `visitFabricArray()`", () => {
+      expect(new Iterating().visitFabricArray([1])).toBe(DO_RECURSE_VALUES);
     });
 
-    it("returns an `iterateMap` form over the entries from `visitFabricPlainObject()`", () => {
-      const form = new Iterating().visitFabricPlainObject({ a: 1, b: 2 });
-
-      expect(form).toEqual({
-        type: "iterateMap",
-        mappings: [["a", 1], ["b", 2]],
-      });
+    it("returns `DO_RECURSE_VALUES` from `visitFabricPlainObject()`", () => {
+      expect(new Iterating().visitFabricPlainObject({ a: 1 })).toBe(
+        DO_RECURSE_VALUES,
+      );
     });
 
-    it("throws from `visitFabricInstance()`", () => {
+    it("returns `DO_RECURSE_KEYS_VALUES` from `visitFabricInstance()`", () => {
       const instance = new FabricMap(new Map());
 
-      expect(() => new Iterating().visitFabricInstance(instance)).toThrow(
-        /not yet visitable/,
+      expect(new Iterating().visitFabricInstance(instance)).toBe(
+        DO_RECURSE_KEYS_VALUES,
       );
+    });
+
+    it("returns `undefined` from every `visited*()` method", () => {
+      const vis = new Iterating();
+
+      expect(vis.visitedArrayElement([1], 0, 1)).toBeUndefined();
+      expect(vis.visitedArrayGap([], 0, 1)).toBeUndefined();
+      expect(vis.visitedMapping({}, "k", 1)).toBeUndefined();
     });
   });
 
   describe("visitValue()", () => {
     describe("dispatch", () => {
-      it("visits a nested value in order, keys before values", () => {
+      it("visits a nested value depth-first, reporting each element and mapping after its value", () => {
         const rec = new Recorder();
-        const root = { a: [1, { b: null }] };
+        const inner = { b: null };
+        const array = [1, inner];
+        const root = { a: array };
 
         expect(visitValue(root, rec)).toBeUndefined();
-        expect(rec.names).toEqual([
-          "value",
-          "container",
-          "object",
-          "mapping",
-          "value",
-          "primitive", // The key `a`.
-          "value",
-          "container",
-          "array",
-          "element",
-          "value",
-          "primitive", // `1`.
-          "element",
-          "value",
-          "container",
-          "object",
-          "mapping",
-          "value",
-          "primitive", // The key `b`.
-          "value",
-          "primitive", // `null`.
+        expect(rec.events).toEqual([
+          ["value", root],
+          ["container", root],
+          ["object", root],
+          ["value", array],
+          ["container", array],
+          ["array", array],
+          ["value", 1],
+          ["primitive", 1, "number"],
+          ["visitedElement", array, 0, 1],
+          ["value", inner],
+          ["container", inner],
+          ["object", inner],
+          ["value", null],
+          ["primitive", null, "null"],
+          ["visitedMapping", inner, "b", null],
+          ["visitedElement", array, 1, inner],
+          ["visitedMapping", root, "a", array],
         ]);
       });
 
@@ -395,7 +398,7 @@ describe("value-visit", () => {
       it("does not call a subtype visitor when `visitFabricContainer()` returns something other than `visitSubtype`", () => {
         class Stopping extends Recorder {
           override visitFabricContainer(
-            value: FabricArray | FabricPlainObject | FabricMap,
+            value: FabricContainerValue,
           ): DispatchingVisitorResult<unknown, unknown> {
             this.events.push(["container", value]);
             return mainResult("stopped");
@@ -471,6 +474,17 @@ describe("value-visit", () => {
         ]);
       });
 
+      it("reports the original element, not its replacement, to `visitedArrayElement()`", () => {
+        const rec = new Recorder();
+        rec.onValue = (v) => (v === "x") ? replace(42) : DO_VISIT_SUBTYPE;
+        const array = ["x"];
+
+        visitValue(array, rec);
+        expect(rec.events.filter((e) => e[0] === "visitedElement")).toEqual([
+          ["visitedElement", array, 0, "x"],
+        ]);
+      });
+
       it("puts a replacement plain object on the cycle stack", () => {
         const replacement: Record<string, unknown> = {};
         replacement.self = replacement;
@@ -486,7 +500,7 @@ describe("value-visit", () => {
       });
 
       for (const path of ["directly", "via subtype dispatch"] as const) {
-        it(`puts a replacement array on the cycle stack when the iterate form is produced ${path}`, () => {
+        it(`puts a replacement array on the cycle stack when the \`recurse\` form is produced ${path}`, () => {
           const replacement: unknown[] = [];
           replacement.push(replacement);
 
@@ -494,7 +508,7 @@ describe("value-visit", () => {
           rec.onValue = (v) => {
             if (v === "x") return replace(replacement);
             if (v === replacement && path === "directly") {
-              return doIterateArray<unknown>(replacement);
+              return DO_RECURSE_VALUES;
             }
             return DO_VISIT_SUBTYPE;
           };
@@ -541,53 +555,75 @@ describe("value-visit", () => {
 
         expect(visitValue(a, rec)).toEqual(mainResult("cycle!"));
       });
+
+      it("honors a `recurse` from `visitCycle()`, re-entering the value at the next depth", () => {
+        const a: Record<string, unknown> = {};
+        a.self = a;
+
+        const rec = new Recorder();
+        rec.onCycle = (_v, _orig, depth) =>
+          (depth < 3) ? DO_RECURSE_VALUES : undefined;
+
+        visitValue(a, rec);
+        expect(rec.events.filter((e) => e[0] === "cycle")).toEqual([
+          ["cycle", a, 0, 1],
+          ["cycle", a, 0, 2],
+          ["cycle", a, 0, 3],
+        ]);
+      });
     });
 
     describe("`mainResult` results", () => {
-      it("ends the visit from an element visitor, skipping later elements", () => {
+      it("ends the visit from `visitedArrayElement()`, skipping later elements", () => {
         const rec = new Recorder();
-        rec.onElement = (i) =>
-          (i === 1) ? mainResult("at 1") : DO_RECURSE_VALUE;
+        rec.onVisitedElement = (i) =>
+          (i === 1) ? mainResult("at 1") : undefined;
+        const array = [10, 20, 30];
 
-        expect(visitValue([10, 20, 30], rec)).toEqual(mainResult("at 1"));
-        expect(rec.events.filter((e) => e[0] === "element")).toEqual([
-          ["element", 0, 10],
-          ["element", 1, 20],
+        expect(visitValue(array, rec)).toEqual(mainResult("at 1"));
+        expect(rec.events.filter((e) => e[0] === "visitedElement")).toEqual([
+          ["visitedElement", array, 0, 10],
+          ["visitedElement", array, 1, 20],
         ]);
+        expect(rec.events.map((e) => e[1])).not.toContain(30);
       });
 
-      it("ends the visit from a mapping visitor", () => {
+      it("ends the visit from `visitedMapping()`, skipping later mappings", () => {
         const rec = new Recorder();
-        rec.onMapping = () => mainResult("first");
+        rec.onVisitedMapping = () => mainResult("first");
+        const object = { a: 1, b: 2 };
 
-        expect(visitValue({ a: 1, b: 2 }, rec)).toEqual(mainResult("first"));
-        expect(rec.events.filter((e) => e[0] === "mapping")).toEqual([
-          ["mapping", "a", 1],
+        expect(visitValue(object, rec)).toEqual(mainResult("first"));
+        expect(rec.events.filter((e) => e[0] === "visitedMapping")).toEqual([
+          ["visitedMapping", object, "a", 1],
         ]);
+        expect(rec.events.map((e) => e[1])).not.toContain(2);
       });
 
       it("ends the visit from a key's recursion, before the value is visited", () => {
         const rec = new Recorder();
+        rec.onPlainObject = () => DO_RECURSE_KEYS_VALUES;
         rec.onPrimitive = (v) => (v === "a") ? mainResult("key") : undefined;
 
         expect(visitValue({ a: 1 }, rec)).toEqual(mainResult("key"));
         expect(rec.events.filter((e) => e[0] === "primitive")).toEqual([
           ["primitive", "a", "string"],
         ]);
+        expect(rec.names).not.toContain("visitedMapping");
       });
 
-      it("ends the visit from a gap visitor, for a gap before an element", () => {
+      it("ends the visit from `visitedArrayGap()`, for a gap before an element", () => {
         const rec = new Recorder();
-        rec.onGap = () => mainResult("gap");
+        rec.onVisitedGap = () => mainResult("gap");
 
         // deno-lint-ignore no-sparse-arrays
         expect(visitValue([, 1], rec)).toEqual(mainResult("gap"));
-        expect(rec.names).not.toContain("element");
+        expect(rec.names).not.toContain("visitedElement");
       });
 
-      it("ends the visit from a gap visitor, for a gap at the end", () => {
+      it("ends the visit from `visitedArrayGap()`, for a gap at the end", () => {
         const rec = new Recorder();
-        rec.onGap = () => mainResult("gap");
+        rec.onVisitedGap = () => mainResult("gap");
 
         // deno-lint-ignore no-sparse-arrays
         expect(visitValue([[1, ,], 2], rec)).toEqual(mainResult("gap"));
@@ -608,30 +644,32 @@ describe("value-visit", () => {
     });
 
     describe("`recurse` results", () => {
-      it("recurses into both key and value for `DO_RECURSE_KEY_VALUE`", () => {
+      it("visits both keys and values of a plain object for `DO_RECURSE_KEYS_VALUES`, each key before its value", () => {
         const rec = new Recorder();
-        rec.onMapping = () => DO_RECURSE_KEY_VALUE;
+        rec.onPlainObject = () => DO_RECURSE_KEYS_VALUES;
+
+        visitValue({ a: 1, b: 2 }, rec);
+        expect(rec.events.filter((e) => e[0] === "primitive")).toEqual([
+          ["primitive", "a", "string"],
+          ["primitive", 1, "number"],
+          ["primitive", "b", "string"],
+          ["primitive", 2, "number"],
+        ]);
+      });
+
+      it("visits only the keys of a plain object for `DO_RECURSE_KEYS`", () => {
+        const rec = new Recorder();
+        rec.onPlainObject = () => DO_RECURSE_KEYS;
 
         visitValue({ a: 1 }, rec);
         expect(rec.events.filter((e) => e[0] === "primitive")).toEqual([
           ["primitive", "a", "string"],
-          ["primitive", 1, "number"],
         ]);
       });
 
-      it("recurses into the key only for `DO_RECURSE_KEY`", () => {
+      it("visits only the values of a plain object for `DO_RECURSE_VALUES`", () => {
         const rec = new Recorder();
-        rec.onMapping = () => DO_RECURSE_KEY;
-
-        visitValue({ a: 1 }, rec);
-        expect(rec.events.filter((e) => e[0] === "primitive")).toEqual([
-          ["primitive", "a", "string"],
-        ]);
-      });
-
-      it("recurses into the value only for `DO_RECURSE_VALUE`", () => {
-        const rec = new Recorder();
-        rec.onMapping = () => DO_RECURSE_VALUE;
+        rec.onPlainObject = () => DO_RECURSE_VALUES;
 
         visitValue({ a: 1 }, rec);
         expect(rec.events.filter((e) => e[0] === "primitive")).toEqual([
@@ -639,26 +677,117 @@ describe("value-visit", () => {
         ]);
       });
 
-      it("recurses into nothing for `DO_RECURSE_KEY` on an array element", () => {
+      it("visits the elements of an array for `DO_RECURSE_VALUES`", () => {
         const rec = new Recorder();
-        rec.onElement = () => DO_RECURSE_KEY;
+        rec.onArray = () => DO_RECURSE_VALUES;
+
+        visitValue([1, 2], rec);
+        expect(rec.events.filter((e) => e[0] === "primitive")).toEqual([
+          ["primitive", 1, "number"],
+          ["primitive", 2, "number"],
+        ]);
+      });
+
+      it("visits the elements of an array for `DO_RECURSE_KEYS_VALUES`, there being no keys", () => {
+        const rec = new Recorder();
+        rec.onArray = () => DO_RECURSE_KEYS_VALUES;
+
+        visitValue([1], rec);
+        expect(rec.events.filter((e) => e[0] === "primitive")).toEqual([
+          ["primitive", 1, "number"],
+        ]);
+      });
+
+      it("reports each mapping to `visitedMapping()` whichever of keys or values is recursed", () => {
+        for (const form of [DO_RECURSE_KEYS, DO_RECURSE_VALUES]) {
+          const rec = new Recorder();
+          rec.onPlainObject = () => form;
+          const object = { a: 1 };
+
+          visitValue(object, rec);
+          expect(rec.events.filter((e) => e[0] === "visitedMapping")).toEqual([
+            ["visitedMapping", object, "a", 1],
+          ]);
+        }
+      });
+
+      it("iterates nothing for `DO_RECURSE_KEYS` on an array", () => {
+        const rec = new Recorder();
+        rec.onArray = () => DO_RECURSE_KEYS;
 
         visitValue([1, 2], rec);
         expect(rec.names).not.toContain("primitive");
+        expect(rec.names).not.toContain("visitedElement");
       });
 
-      it("recurses into nothing for `undefined`", () => {
+      it("iterates nothing for a `recurse` form with both flags `false`, on a plain object", () => {
         const rec = new Recorder();
-        rec.onElement = () => undefined;
-        rec.onMapping = () => undefined;
+        rec.onPlainObject = () => ({
+          type: "recurse",
+          doKeys: false,
+          doValues: false,
+        });
 
-        visitValue({ a: [1] }, rec);
+        visitValue({ a: 1 }, rec);
         expect(rec.names).not.toContain("primitive");
+        expect(rec.names).not.toContain("visitedMapping");
+      });
+
+      it("honors a `recurse` returned directly from `visitValue()`, without subtype dispatch", () => {
+        const rec = new Recorder();
+        rec.onValue = (v) =>
+          Array.isArray(v) ? DO_RECURSE_VALUES : DO_VISIT_SUBTYPE;
+
+        visitValue([1], rec);
+        expect(rec.names).toEqual([
+          "value",
+          "value",
+          "primitive",
+          "visitedElement",
+        ]);
+      });
+
+      it("throws for a `recurse` from `visitValue()` on a primitive", () => {
+        const rec = new Recorder();
+        rec.onValue = () => DO_RECURSE_VALUES;
+
+        expect(() => visitValue(1, rec)).toThrow(
+          /Cannot use `recurse` result with non-container: `1`/,
+        );
+      });
+
+      it("throws for a `recurse` from `visitPrimitive()`", () => {
+        const rec = new Recorder();
+        rec.onPrimitive = () => DO_RECURSE_VALUES;
+
+        expect(() => visitValue("x", rec)).toThrow(
+          /Cannot use `recurse` result with non-container: /,
+        );
+      });
+
+      it("throws for a `recurse` from `visitNonFabricValue()`", () => {
+        const rec = new Recorder();
+        rec.onNonFabric = () => DO_RECURSE_VALUES;
+
+        expect(() => visitValue(new Date(0), rec)).toThrow(
+          /Cannot use `recurse` result with non-container: /,
+        );
+      });
+
+      it("throws for a `recurse` on a `FabricInstance`", () => {
+        const rec = new Recorder();
+        rec.onInstance = () => DO_RECURSE_KEYS_VALUES;
+        const instance = new FabricMap(new Map());
+
+        expect(() => visitValue(instance, rec)).toThrow(/not yet visitable/);
       });
     });
 
     describe("array gaps", () => {
-      const cases: [string, unknown[], Event[]][] = [
+      /** Expected gap and element events, without the array argument. */
+      type Expected = [name: string, ...args: unknown[]][];
+
+      const cases: [string, unknown[], Expected][] = [
         // deno-lint-ignore no-sparse-arrays
         ["a leading hole", [, 5], [["gap", 0, 1], ["element", 1, 5]]],
         // deno-lint-ignore no-sparse-arrays
@@ -685,23 +814,37 @@ describe("value-visit", () => {
           const rec = new Recorder();
 
           visitValue(array, rec);
-          expect(
-            rec.events.filter((e) => e[0] === "gap" || e[0] === "element"),
-          ).toEqual(expected);
+
+          const actual = rec.events
+            .filter((e) => e[0] === "visitedGap" || e[0] === "visitedElement")
+            .map(([name, arr, ...rest]) => {
+              expect(arr).toBe(array);
+              return [name === "visitedGap" ? "gap" : "element", ...rest];
+            });
+          expect(actual).toEqual(expected);
         });
       }
-    });
 
-    describe("`iterateArray` validation", () => {
-      it("throws when the elements array carries a named property", () => {
+      it("throws when an array taken as valid carries a named property", () => {
+        // The shallow check does not take such an array to be a
+        // `FabricArray`, so the only way to reach the iteration with one is
+        // to assert validity.
+        const rec = new Recorder() as unknown as ValueVisitor<never, unknown>;
+        const array: unknown[] & { extra?: number } = [1];
+        array.extra = 2;
+
+        expect(() => visitFabricValue(array as FabricValue, rec)).toThrow(
+          /Non-index property in alleged `FabricArray`: `extra`/,
+        );
+      });
+
+      it("routes an array carrying a named property to `visitNonFabricValue()` under the shallow check", () => {
         const rec = new Recorder();
-        rec.onPlainObject = () => {
-          const elements: unknown[] & { extra?: number } = [1];
-          elements.extra = 2;
-          return doIterateArray<unknown>(elements);
-        };
+        const array: unknown[] & { extra?: number } = [1];
+        array.extra = 2;
 
-        expect(() => visitValue({}, rec)).toThrow(/Improper array/);
+        visitValue(array, rec);
+        expect(rec.events).toEqual([["value", array], ["nonFabric", array]]);
       });
     });
 
@@ -714,17 +857,6 @@ describe("value-visit", () => {
         expect(rec.events).toEqual([["value", date], ["nonFabric", date]]);
       });
 
-      it("routes a non-fabric value synthesized under a valid root to `visitNonFabricValue()`", () => {
-        const rec = new Recorder();
-        const date = new Date(0);
-        rec.onPlainObject = () => doIterateMap<unknown>([["d", date]]);
-
-        visitValue({ ok: 1 }, rec);
-        expect(rec.events.filter((e) => e[0] === "nonFabric")).toEqual([
-          ["nonFabric", date],
-        ]);
-      });
-
       it("treats an array holding a function as a `FabricArray` under the shallow check, and routes the function to `visitNonFabricValue()`", () => {
         const rec = new Recorder();
         const fn = () => 1;
@@ -734,9 +866,9 @@ describe("value-visit", () => {
           "value",
           "container",
           "array",
-          "element",
           "value",
           "nonFabric",
+          "visitedElement",
         ]);
       });
 
@@ -811,17 +943,12 @@ describe("value-visit", () => {
   });
 
   describe("visitFabricValue()", () => {
-    it("visits a value and returns the visitor's `mainResult`", () => {
-      class Count extends Recorder {
-        override visitPrimitive(): LeafVisitorResult<unknown, unknown> {
-          return undefined;
-        }
-      }
-
-      const vis = new Count() as unknown as ValueVisitor<never, number>;
+    it("visits a value and returns `undefined` absent a `mainResult`", () => {
+      const rec = new Recorder() as unknown as ValueVisitor<never, number>;
       const value = { a: [1, 2] } as FabricValue;
 
-      expect(visitFabricValue(value, vis)).toBeUndefined();
+      expect(visitFabricValue(value, rec)).toBeUndefined();
+      expect((rec as unknown as Recorder).names).toContain("primitive");
     });
 
     it("returns a `mainResult` typed by the visitor's `ResultType`", () => {
@@ -849,6 +976,16 @@ describe("value-visit", () => {
       const lying = [1, new Date(0)] as unknown as FabricValue;
 
       expect(() => visitFabricValue(lying, rec)).toThrow(/assume valid/);
+    });
+
+    it("throws for a `recurse` on a value that is not a `FabricValue`", () => {
+      const rec = new Recorder();
+      rec.onValue = () => DO_RECURSE_VALUES;
+      const lying = new Date(0) as unknown as FabricValue;
+
+      expect(() =>
+        visitFabricValue(lying, rec as unknown as ValueVisitor<never, unknown>)
+      ).toThrow(/Cannot use `recurse` result with non-container: /);
     });
   });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## Summary

Second round on `packages/data-model/src/value-visit.ts`, the visitor over `FabricValue`s that #7281 landed. The module remains **work in progress and not for use yet**: its file header says so, it stays absent from the package's export map, and the `FabricInstance` descent still throws. Documentation prose and links follow once the facility is ready to be used.

The thrust of this round is that `recurse` is now a result on a whole container rather than a per-item decision. The engine, not the visitor, defines what a container's contents are, which is the point of having one sanctioned descent.

## What changed

* **`recurse` on the container.** A visitor returns a `recurse` form (`DO_RECURSE_KEYS`, `DO_RECURSE_VALUES`, `DO_RECURSE_KEYS_VALUES`; the fields are `doKeys` and `doValues`) from a container's visit, and the engine iterates that container's own elements or mappings. The `iterateArray` and `iterateMap` forms and their `doIterate*()` builders are gone with the per-item hooks they fed.
* **`visited*()` callbacks.** `visitArrayElement()`, `visitArrayGap()`, and `visitMapping()` are replaced by `visitedArrayElement(array, index, value)`, `visitedArrayGap(array, start, count)`, and `visitedMapping(container, key, value)`, each called after its item's visit, with the container in hand.
* **Result hierarchy.** `RecurseForm` folds into `LeafVisitorResult`; `ContainerVisitorResult` is gone. A `recurse` returned for a non-container is rejected at runtime with an error naming the value, so `visitCycle()` may legitimately recurse (bounded by the depths it is handed) and `visitPrimitive()` may not.
* **`ContainerIteratingVisitor`** dispatches to the subtype methods and recurses values only for arrays and plain objects, but keys and values for instances, since instance keys are not necessarily strings. Its `visited*()` methods are no-ops.
* **Engine.** The internal `recurseOf` form carries a `containerTag` typed from `VALUE_TAGS`, which `#visitValue()` and `#iterateMap()` dispatch on; the result rewriters are split into `#adjustRecurseForm()` and `#visitSubtypeFormFor()`; and the tag computed for dispatch is threaded through, so deep mode does not re-run the validity check on a container it already checked.
* **`BaseValueVisitor.throwShouldntCall()`** joins `throwNoCycles()`.
* **Docs.** The file header states the `Object.is()` sameness rule, and the shallow and deep checks are described by deferring to `isValidFabricValueLayer()` and `isValidFabricValue()` rather than restating them.

Deferred by design, to be taken up when a need is identified: a pre-visit per-item hook (declining to descend a particular key or index), and descending a non-fabric `Map` or array in the extra domain in place rather than through `replace`.

## Tests

`packages/data-model/test/value-visit.test.ts` is rewritten to the new shape: 96 cases (up from 87). The `Recorder` observes the `visited*()` calls with their containers. New cases pin the `ContainerIteratingVisitor` defaults, `recurse` from `visitCycle()` and directly from `visitValue()`, the runtime rejection of `recurse` on a primitive, a non-fabric value, and (for now) an instance, the no-op recurse forms, `replace` followed by `recurse`, and `throwShouldntCall()`. Line coverage of the module is 100%.

## Authorship

This was a true collaboration between @danfuzz and an agent (Fable 5.1). The design and the implementation are @danfuzz's, developed across many small commits; the agent reviewed each round, found and measured the defects along the way (`recurse` rejecting every array, the values branch of a mapping visiting the key again, a `recurse` returned for a replacement being applied to the original, and a doc claim about the shallow check that the check did not bear out), and wrote the unit tests. Neither party should get all the credit for this one.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

