### PR TITLE
Gate coverage over one suite's tests and one package's lines

### DIFF
--- a/.github/workflows/test-selection.yml
+++ b/.github/workflows/test-selection.yml
@@ -41,7 +41,11 @@ on:
         description: Days of submissions to read (default 2, or 60 with a cold start)
         required: false
 
+# `actions: read` is what lets the publisher read the `perf-metrics`
+# artifact of each recent run on main, which is where the coverage gate's
+# baselines come from. Read-only, and over this repository's own runs.
 permissions:
+  actions: read
   contents: read
   id-token: write
 
@@ -109,6 +113,7 @@ jobs:
           TEST_SELECTION_PREFIX: ${{ vars.TEST_SELECTION_PREFIX }}
           PUBLISH_BOOTSTRAP: ${{ inputs.bootstrap }}
           PUBLISH_DAYS: ${{ inputs.days }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           args=()

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -714,6 +714,15 @@ The marker names the source group — `workspace`, a top-level directory such as
 lines are counted in. Only `packages` splits into a second level, because that is
 where the collection stops rolling a file up; `tasks/foo` names no group.
 
+The same marker also accepts a rise in a measured set, and there it names a
+workspace member, which can sit deeper than a source group:
+`packages/connectors/github`. A name below `packages/` that is deeper than a
+group is read by the coverage gate alone, and this ratchet measures nothing for
+it and passes over it. The coverage gate fails on a name that is neither a
+member nor a group, so a name nothing could ever consult still fails a
+job — this one or that one. Which gate a marker is for follows from the
+name; see [the test-selection contract](../specs/test-selection.md#coverage).
+
 A name can have the shape of a group and still name none — a package that is not
 there, or a misspelling of one that is. Nothing would ever consult such a line,
 so rather than let it pass for an acceptance that had no effect, the check fails

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -50,10 +50,15 @@ where the value comes from, and which way you would move it.
 
 ### `coverage`
 
-Every workspace member, whether it carries the per-package coverage gate,
-the reason beside it when it does not, and the baseline the newest
-manifest holds for it. This is what answers "why is my package not gated?"
-and "what am I being compared against?".
+Every measured set — one suite's units over one workspace member's lines
+— with how many units it holds and the baseline the newest manifest holds
+for it, and then every workspace member that carries no set, with the
+reason. This is what answers "why is my package not gated?" and "what am
+I being compared against?".
+
+A member with two measured sets has two lines and two baselines. The
+counts are never added together: a line one suite's tests cover says
+nothing about whether another suite's do.
 
 ### `plan --dry-run [--lane N]`
 
@@ -96,6 +101,58 @@ tree instead — the larger of the number of suites with anything to run
 and what packing the stand-ins asks for — and says on the error stream
 that it did so, since a projection from costs nobody has measured would
 be arithmetic over an invented figure.
+
+## The coverage gate
+
+A **measured set** is one suite's units over one workspace member's lines.
+`deno task test-selection coverage` lists them.
+
+A change that touches a member's tree reaches its set, and reaching a set
+makes every one of its units run, with coverage turned on. How often each
+of them runs is unchanged: a unit its flake rate says to repeat is still
+repeated, and the repeats leave the set's number where it was, since a
+coverage count is the union over what the runs reached. The job that
+joins the lanes adds up what they measured for each set, scores each set
+over its member's own source, and compares that against what the same set
+measured at the newest `main` commit the branch contains. A rise fails the
+pull request.
+
+Run it yourself the way that job does:
+
+```
+deno run -A tasks/coverage-gate.ts --base origin/main --reports <directory>
+```
+
+where the directory holds the lanes' uploaded coverage. It prints a row
+per set — the baseline, this run's count, the change, and the outcome —
+and stops with a non-zero status on a rise nothing accepted.
+
+Four things are worth knowing before reading a failure.
+
+- **Each set is on its own.** A member with two measured sets has two
+  numbers, and neither pays the other down. Nor does the source group over
+  the same member, which is that member's source measured by every test in
+  the run: `deno task test-selection coverage` shows the set's number and
+  the coverage tile shows the group's.
+- **Accept a rise in the pull request's description**, on a line of its
+  own at the left margin, naming the member and the rise:
+  `ACCEPT_COVERAGE_DEBT: packages/memory +12 lines`. The gate prints the
+  line to paste with the number already filled in. One marker covers every
+  set over that member.
+- **A change reaching more than `LOCAL_COVERAGE_MAX_SETS` sets forces
+  none of them**, and the summary says so. The tests still run under the
+  ordinary rules; it is the run-the-whole-set part that stops. A set some
+  run measured anyway is still scored, so a pull request labelled
+  `ci: full`, which measures every set, is gated whatever the cap says.
+- **A run with a failing test is reported rather than gated.** Coverage
+  measured through a failure says nothing about whether the change was
+  tested, and the failing test is what to fix. So is a set whose reports
+  name no line of its member: that is a conversion that produced
+  nothing, not a set that covered nothing.
+
+Nothing about coverage fails a run on `main`. That run measures every set,
+which is where the baselines come from, and merges every report into the
+repository-wide figure the dashboard tile shows.
 
 ## Every dial
 
@@ -171,10 +228,10 @@ setting to fix.
 | `MAX_EXECUTIONS` | 10 | runs of one item | chosen | Where the line stops. Up when the flakiest items a change forces in still are not proven by what runs; down when they crowd a lane. |
 | `SUITE_FLAKE_PRIOR_RATE` | 0.02 | share of runs | chosen | Up when too many suites count as flake-prone and their new items are repeated needlessly; down when new tests in a noisy suite land unrepeated and then flake. |
 | `COVERAGE_COMMENT_LINES` | 25 | lines | chosen | Up when coverage comments are too noisy; down when debt is climbing unnoticed. |
-| `LOCAL_COVERAGE_MAX_SECONDS` | 30 | seconds | chosen | Up when too many packages are reported as expensive for the report to be worth reading; down when one is quietly eating a lane. Nothing is excluded either way; it only decides what the summary mentions. |
-| `LOCAL_COVERAGE_MAX_PACKAGES` | 2 | packages | chosen | Up when broader changes should still be gated and the run can afford their packages' whole test sets; down when sweeping changes are crowding lanes. |
-| `EXCLUDED_FROM_COVERAGE_GATE` | 9 | workspace members | chosen | Not a quantity. A line comes off when a package fits the run's budget or gains a Deno-only half, which turns its gate on. A line goes on when a package's own tests stop being what covers it. |
-| `LOCAL_COVERAGE_BASELINE_DAYS` | 7 | days | chosen | Up when branches based further back are being reported for want of an ancestor baseline; down when the manifest carries more history than anybody reads. |
+| `LOCAL_COVERAGE_MAX_SECONDS` | 30 | seconds | chosen | Up when too many sets are reported as expensive for the report to be worth reading; down when one is quietly eating a lane. Nothing is excluded either way; it only decides what the summary mentions. |
+| `LOCAL_COVERAGE_MAX_SETS` | 2 | measured sets | chosen | Up when broader changes should still be gated and the run can afford those sets' whole unit lists; down when sweeping changes are crowding lanes. |
+| `EXCLUDED_FROM_COVERAGE_GATE` | 9 | workspace members | chosen | Not a quantity. A line comes off when a package fits the run's budget or gains a Deno-only half, which gives it a measured set. A line goes on when a package's own tests stop being what covers it. |
+| `LOCAL_COVERAGE_BASELINE_DAYS` | 7 | days | chosen | Up when branches based further back are being reported for want of a baseline they contain; down when the manifest carries more history than anybody reads. |
 | `COVERAGE_TREND_WEEKS` | 3 | weeks | chosen | Up when the tile goes amber too readily; down when debt climbs for a month before anybody is told. |
 | `CATCH_BREADTH_WINDOW_DAYS` | 2 | days | chosen | Up when a broken runner's failures are being counted as catches; down when genuine breadth is being written off as environmental. |
 | `SAME_COMMIT_REACH_DAYS` | 2 | days | chosen | How far back the fold remembers a commit's outcomes, so that a rerun landing in a later batch than the run it repeats is still read as the test disagreeing with itself. Up when reruns land far enough behind that their disagreement is being counted as a catch; down when the fold's memory is the thing that will not fit. It costs the number of identities that have failed times the number of commits, so it is the dial to check first when a run runs out of memory. |
@@ -581,22 +638,23 @@ itself.
   failure, and never for one line. A change that touched no source at
   all is not asked about, because the repository-wide figure moves a
   little between runs on its own.
-- **A rise in a covered package's own-tests number**, naming what let it
-  past the per-package gate. As with the repository-wide figure, a change
-  that touched no source at all is not asked about. The routes are: the package is on
-  `EXCLUDED_FROM_COVERAGE_GATE`; the change touched more covered packages
-  than `LOCAL_COVERAGE_MAX_PACKAGES` allows, so the gate did not run; the
-  change did not touch the package, so the gate had nothing to compare;
-  or the gate did measure the package and passed it, which means the two
-  measurements disagree. Each calls for something different, which is why
-  the note names it. The number is the package's source measured by only
-  the package's own tests, which a run measures whole however much of the
-  corpus it ran. That is a different number from the source group of the
-  same name, which is the package measured by every test in the run and
-  which a selected run only samples; `ownTestsCoverageMetric` in
-  `tasks/ci-check-lib.ts` is the one name the producer and the reader
-  share. The per-package gate is what publishes it, so this note is
-  silent until that gate lands.
+- **A rise in a measured set's number**, naming what let it past the
+  coverage gate. As with the repository-wide figure, a change that
+  touched no source at all is not asked about. The routes are: the
+  member is on `EXCLUDED_FROM_COVERAGE_GATE`, so it carries no set; the
+  change reached more measured sets than `LOCAL_COVERAGE_MAX_SETS`
+  allows, so the gate did not run; the change did not touch the member,
+  so the gate had nothing to compare; or the gate did measure the set
+  and passed it, which means the two measurements disagree. Each calls
+  for something different, which is why the note names it. The number is
+  one member's source measured by one suite's tests alone, which a run
+  measures whole however much of the corpus it ran. That is a different
+  number from the source group over the same member, which is that
+  member measured by every test in the run and which a selected run only
+  samples; `measuredSetCoverageMetric` in `tasks/ci-check-lib.ts` is the
+  one name the producer and the reader share. The full run on the
+  default branch is what publishes it, so this note is silent until the
+  lanes carry that run.
 - **A new test that turned out to be flaky.** A test this run ran, the
   previous run did not, and the store has never seen — that third
   condition is what stops a run that shipped part of its records making

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -3257,11 +3257,12 @@ history back from the tip also costs only the distance to the answer,
 where asking about each commit in turn costs a question per commit and
 the window holds a week of them.
 
-Two cases report instead of failing here. A set with no baseline yet is
-reported, because the first pull request to reach a new package should not
-inherit the whole of that package's debt. And when the manifest holds no
-run the branch contains, the comparison would be against a tree the branch
-does not have, so a rise measured against it is not the branch's rise.
+Two of the cases that report instead of failing are about the baseline. A
+set with no baseline yet is reported, because the first pull request to
+reach a new package should not inherit the whole of that package's debt.
+And when the manifest holds no run the branch contains, the comparison
+would be against a tree the branch does not have, so a rise measured
+against it is not the branch's rise.
 
 A third is not about the baseline at all: a set whose joined reports name
 no line of its member measured nothing, rather than covering nothing.

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -912,8 +912,8 @@ being imposed.
 
 ### What does not change
 
-- The per-package coverage gate runs a package's whole measured set, so
-  its invocations carry no skip list.
+- A measured set runs whole, so the invocations of a set the coverage
+  gate is scoring carry no skip list.
 - Suites that are not `deno test` need no mechanism. Every one of their
   invocation units holds a single identity, so skipping it is declining to
   invoke it.
@@ -1690,9 +1690,8 @@ does not run it is not something this repository should permit, so a
 changed test file's items are mandatory. A unit that is not a file, such
 as a type-check group or a binary, is one its suite maps the change onto,
 since only the suite knows what its unit covers. A changed *source* file
-forces nothing else in, apart from the whole of a covered package's
-measured set under [the per-package
-gate](#the-one-coverage-gate-that-survives). What runs for it otherwise is
+forces nothing else in, apart from the whole of a [measured
+set](#the-measured-set) the change reaches. What runs for it otherwise is
 what the score chose, which is the trade named under [consequences we are
 choosing](#consequences-we-are-choosing).
 
@@ -1942,36 +1941,38 @@ share near nothing and a score raised by its own noise.
 Two rules answer this. They are separable, and only the second carries any
 risk, so they are argued separately.
 
-**An excluded identity whose independence is established runs on `main` as
-many times as its share asks for.** [The line that decides the
-count](#flakes-and-repeats) already runs past the exclusion rate, so
-nothing new decides anything; what changes is that the mandatory pass
-places such an identity with that count rather than with the single run it
-gives every mandatory identity. Any share above the threshold asks for at
-least four runs, so this is at least three further runs at each commit.
+**An excluded identity runs on `main` as many times as its share asks
+for.** [The line that decides the count](#flakes-and-repeats) already
+runs past the exclusion rate, and the mandatory pass already places every
+identity with the count its share asks for, so this half is in place. Any
+share above the threshold asks for at least four runs, so it is at least
+three further runs at each commit.
 
 Those further runs are what let a share rise as well as fall. They also
 put a pass beside a spurious failure at its own commit, which classifies
 it as a disagreement rather than crediting it as a catch, so both
 paragraphs above close on one mechanism.
 
-**The independence flag is a precondition and not a detail.** A repeat
-invokes the identity's file with every other identity skipped, and an
+**The independence flag is what these runs still want.** A repeat should
+invoke the identity's file with every other identity skipped, and an
 identity without the flag may not have its siblings skipped, so its file
-would have to be invoked whole several times. Every sibling in that file
-would then run several times, and every sibling still gates, so a file
-holding one flaky test would fail lanes several times as often for tests
-that are not flaky at all. So an identity without the flag keeps its
-single run, and gains the measurement when the flag is established. [The
-`main`-side check that establishes it](#establishing-it) is already part
-of this design, and this gives it a second thing to be worth.
+is invoked whole several times. Every sibling in that file then runs
+several times, and every sibling still gates, so a file holding one flaky
+test fails lanes several times as often for tests that are not flaky at
+all. [The `main`-side check that establishes the
+flag](#establishing-it) is already part of this design, and this gives it
+a second thing to be worth: with it, the identity is skipped in its
+file's own invocation and run alone, and the siblings go back to running
+once.
 
-With the flag, the identity is skipped in its file's own invocation and
-run alone the whole count of times. Every run of it at that commit is then
-the same shape, and the same shape the independence check uses. Without
-that, an identity would run once beside its siblings and again alone, and
-a test sensitive to the difference would be recorded as disagreeing with
-itself at every commit, which would pin its exclusion in place for good.
+The count of runs is what the identity gets either way, and the flag
+decides their shape. With it, the identity is skipped in its file's own
+invocation and run alone the whole count of times; every run of it at
+that commit is then the same shape, and the same shape the independence
+check uses. Running it once beside its siblings and again alone is the
+one shape to avoid, since a test sensitive to the difference would be
+recorded as disagreeing with itself at every commit, which would pin its
+exclusion in place for good.
 
 **What these runs cannot separate is a bad machine.** All of an identity's
 runs at one commit go in one lane, so they run on one runner, and a runner
@@ -1984,13 +1985,12 @@ already names, and these runs sit inside it rather than widening it.
 
 What this costs is runner time. Each run is an invocation of its own, so
 the cost model charges every one its invocation rather than charging the
-file once, and the floor `--lane-count` starts its search from has to
-count them as well, which today it does not. Most of the cost then arrives
-as more lanes. Not all of it: one identity's runs go in one lane, so an
+file once. Most of the cost then arrives as more lanes, which the search
+`--lane-count` runs finds by packing what the lanes will actually be
+packed against. Not all of it: one identity's runs go in one lane, so an
 expensive identity multiplied past the bound its job is killed at cannot
-be helped by adding lanes. The mandatory pass has to give up runs until
-what is left fits, down to one, which is what the discretionary passes
-already do and what the mandatory pass does not.
+be helped by adding lanes. The mandatory pass gives up runs until what
+is left fits, down to one, which is what the discretionary passes do.
 
 **A failure of an excluded test does not fail the run.** This is the
 second rule and it is a different question, which is what a `main` failure
@@ -2034,10 +2034,11 @@ no lane chose it.
 
 Three things elsewhere have to move with this rule.
 
-- **Coverage.** A covered package whose lane held a non-gating failure is
-  reported rather than having a baseline published from it, which is the
-  rule the per-package gate already applies to a package with a failing
-  test. Coverage measured through a failing suite says nothing either way.
+- **Coverage.** A [measured set](#the-measured-set) whose lane held a
+  non-gating failure is reported rather than having a baseline published
+  from it, which is the rule the gate already applies to a run with a
+  failing test. Coverage measured through a failing suite says nothing
+  either way.
 - **The pending-failure list.** A `main` failure waits in `pendingMain`
   until a later `main` run judges it, and nothing ages that list. Today a
   broken test turns `main` red and somebody fixes it; under this rule an
@@ -2174,9 +2175,8 @@ From what is left, given every item's value and cost and a budget of five
 lanes times 230 seconds each, it fills in four passes.
 
 1. **Mandatory.** Everything mandatory goes in first: the items the diff
-   touched directly, every item of a covered package the diff touched as
-   described in [The one coverage gate that
-   survives](#the-one-coverage-gate-that-survives), and the items with no
+   touched directly, every unit of a [measured set](#the-measured-set)
+   the diff reached, and the items with no
    history. An item excluded above comes back into this pass if the
    change edits the test itself, or its suite maps the change onto its
    unit, since that is very likely a fix. Every
@@ -2461,9 +2461,9 @@ The object carries:
 - the `unschedulable` list;
 - a count and digest of the known item-level identities, for the
   unknown-item rule;
-- each covered workspace member's own-tests uncovered-line count, against
-  the commit it was measured at, which is what the per-package gate
-  compares a pull request against.
+- each measured set's uncovered-line count, against the commit it was
+  measured at, which is what the coverage gate compares a pull request
+  against.
 
 The size is measured rather than bounded. A publisher run over one day of
 the store — 18,849 objects holding 5,487,611 executions — produced 20,091
@@ -2839,25 +2839,27 @@ the topology or to the test machinery itself, and the moment somebody
 wants to know whether a lane failure is real.
 
 `Status` also joins what the lanes measured. Each lane uploads the
-coverage it produced, one report per workspace member, and `Status`
-downloads the five, adds them up per member, and runs the [per-package
-coverage gate](#the-one-coverage-gate-that-survives) over the totals. It
-is the only job in a position to do that, and it is a job that has to
-exist regardless, so the gate costs a download and an arithmetic pass
-rather than a job.
+coverage it produced, one report per [measured set](#the-measured-set),
+and `Status` downloads the five, adds them up per set, and runs the
+coverage gate over the totals. It is the only job in a position to do
+that, and it is a job that has to exist regardless, so the gate costs a
+download and an arithmetic pass rather than a job.
 
-`Status` decides which packages the gate covers by running the same
-function the lanes run, over the same diff and the same manifest, rather
-than by trusting what a lane reported. That includes the cap on how many
-covered packages a change may touch, so a lane cannot talk `Status` into
-gating something or into skipping something.
+`Status` decides which sets the gate covers by running the same function
+the lanes run, over the same diff and the same topology, rather than by
+trusting what a lane reported. That includes the cap on how many measured
+sets a change may reach, so a lane cannot talk `Status` into gating
+something or into skipping something.
 
 Two rules keep the joined result honest. A coverage failure says in the
 summary that it is a coverage failure, so it is never mistaken for a test
-failure. And when any test in a covered package failed, that package is
-reported rather than gated, because coverage measured through a failing
-suite says nothing about whether the change was tested and the failure is
-the thing to fix.
+failure. And when any lane failed, every set is reported rather than
+gated, because coverage measured through a failing run says nothing about
+whether the change was tested. Every set rather than the sets the failure
+was in: `Status` is already failing for the lane, so a second failure over
+a measurement taken through it buys nothing, and attributing a lane's
+failure to a set would be a second way of asking which tests belong to
+which set.
 
 ### What moves to `main`, and what happens to coverage
 
@@ -2865,17 +2867,17 @@ the thing to fix.
 and `full-tests`, with the two-clause rule above.
 
 Repository-wide coverage measurement moves to the full run and stops
-gating; the per-package gate that stays on pull requests is in [The one
-coverage gate that survives](#the-one-coverage-gate-that-survives), and it
-runs inside a lane rather than in a job of its own. Concretely: the
+gating; the gate that stays on pull requests is over [measured
+sets](#the-measured-set), and it runs inside a lane rather than in a job
+of its own. Concretely: the
 `Coverage Check` job becomes push-only and reports rather than fails,
 which takes a job off every pull request. The barrier it sat behind does
 not go away, because `Status` is a barrier by construction, but what
 happens at that barrier shrinks from a 12-artifact download and a
 repository-wide metric to five small reports and an addition. The
 compile-cache state recording that feeds it moves with it. The full run
-converts each workspace member's coverage directory separately, so the
-per-package baselines come out of it. And `coverage-comment.yml` is
+converts each measured set's coverage directory separately, so the
+baselines come out of it. And `coverage-comment.yml` is
 generalized into the reporter described in [Telling a pull request what
 `main` found](#telling-a-pull-request-what-main-found) rather than deleted
 — it already does the hard part, which is posting to a pull request from a
@@ -2895,7 +2897,7 @@ is no longer the same thing.
 What the gate was actually for is worth separating from how it worked. It
 was there so that coverage keeps going up, or at least stops going down
 quietly. That goal survives, and it is served two ways: as a trend on
-`main`, and as a gate over the packages a pull request can still measure
+`main`, and as a gate over the sets a pull request can still measure
 whole.
 
 ### The repository-wide number is a trend, not a gate
@@ -2904,8 +2906,8 @@ Coverage debt across the repository is measured on `main`, from the full
 run, and it gates nothing. Not on pull requests, where a run of a fifth of
 the test time measures a fifth of the coverage, and not on `main`, where a
 red build for one uncovered line would make `main`'s color mean nothing.
-One narrower measurement does still gate pull requests, and it is the
-subject of [the next section](#the-one-coverage-gate-that-survives).
+Narrower measurements do still gate pull requests, and they are the
+subject of [the next section](#the-measured-set).
 
 It is a dashboard tile instead, and the tile follows [the wall's
 rules](../../packages/dashboard/README.md#philosophy-and-values). It shows
@@ -2921,84 +2923,116 @@ a scoreboard.
 That tile is live, ahead of the rest of this plan. It reads the
 repository-wide `coverage-debt: workspace uncovered lines` figure out of
 each `main` run's `perf-metrics` artifact, which the full run on `main`
-produces today and goes on producing under selection.
+produces today and goes on producing under selection. The full run
+produces it by merging every report its lanes wrote, which is the same
+merge the present gate does over the present matrix's artifacts.
 
 The `ACCEPT_COVERAGE_DEBT` markers stay. They are how somebody says "yes,
 knowingly", and they remain the right escape hatch whether or not anything
 gates on them.
 
 Nothing about coverage fails a run on `main`, and that includes the
-per-package numbers the next section gates on. `main`'s job is to measure:
-its full run produces the repository-wide figure for the trend and each
-covered package's own-tests figure for the baselines, and a landed change
-that added an uncovered line must not turn `main` red for it. What happens
+per-set numbers the next section gates on. `main`'s job is to measure: its
+full run produces the repository-wide figure for the trend and each
+measured set's own figure for the baselines, and a landed change that
+added an uncovered line must not turn `main` red for it. What happens
 instead is that the rise is reported back to the pull request that caused
 it, by [the reporter](#telling-a-pull-request-what-main-found). The
 ratchet has teeth in the one place a person can still act on it, which is
 before the change lands.
 
-### The one coverage gate that survives
+### The measured set
 
 What stops the repository-wide gate working under selection is that its
 two sides no longer measure the same thing. There is a case where they
-still do. Take a package that owns its own unit tests, score only that
-package's source, and count as covered only what those tests reached. Run
-every one of those tests and the measurement is complete, whatever
-selection did anywhere else in the run. Nothing about it depends on how
-many tests the pull request chose, so the comparison against `main` stays
-honest, and so it can gate.
+still do. Take one suite's tests over one workspace member's lines, run
+every one of those tests, and count as covered only what those tests
+reached. The measurement is complete, whatever selection did anywhere else
+in the run. Nothing about it depends on how many tests the pull request
+chose, so the comparison against `main` stays honest, and so it can gate.
 
-That is also the comparison an author most wants. It answers "did the
-change I just made to this package leave more of this package untested
-than before", which is a question about the diff in front of them.
+That pair — one suite's tests, one member's lines — is a **measured set**,
+and it is the unit of everything below. A member's Deno-only unit tests
+are one: the `workspace-unit` suite's tests over `packages/memory`. So are
+`runner-unit`'s tests over `packages/runner`. A member whose tests are a
+suite of their own is one measured set the same way, so nothing here
+depends on which suite a member's tests sit in.
 
-#### The measurement is already being made and thrown away
+A measured set is also the comparison an author most wants. It answers
+"did the change I just made to this package leave more of this package
+untested than before", which is a question about the diff in front of
+them.
 
-`tasks/workspace-tests.ts` runs one `deno task test` per workspace member,
-and it already points each one at a coverage directory named for that
-member. The per-package split exists on disk in every workspace unit
-shard today. `tasks/write-coverage-lcov.ts` then walks those directories
-and merges everything under a shard into one report, which is where the
-split is lost.
+### Each set is measured on its own, and never merged with another
 
-Converting each member's directory on its own instead yields, for every
-package, exactly the coverage its own tests produced. On `main` that costs
-no runner time at all, because those tests already ran that way and the
-profiles are already written. It is a change to how the profiles are
-converted, not to how anything runs.
+Two measured sets over the same member are different numbers and are never
+added together. `pattern-unit` and `pattern-integration` both reach
+authored pattern code; a line one of them covers says nothing about
+whether the other covers it, and a merged figure would let either suite
+pay the other's debt down. Two sets over different members are separate
+for the same reason in the other direction: `packages/memory`'s tests load
+`packages/piece`, so a merged figure would credit `packages/piece` with
+lines nothing in `packages/piece` tests.
 
-The directory belongs to the member rather than to the walk that happens
-to run it. A package whose tests are a suite of their own writes one the
-same way, so nothing about the gate depends on which suite a package's
-tests sit in.
+So each set writes its coverage profiles into a directory of its own,
+named for the suite and the member, and each set's number is converted
+from that directory alone. The isolation is a property of where the
+profiles land rather than a filter applied afterwards, which is what stops
+a later reader merging them by accident.
+
+A suite is never run once per set. A set's tests are mandatory items like
+any others, so a suite two sets reach runs the union of them, and the two
+directories catch what each set's own tests covered. Running the suite a
+second time to keep two numbers apart would cost the run twice over and
+measure nothing the one pass does not.
 
 The counting rules are the existing ones in `tasks/coverage-metrics.ts`,
 including the rule that a file compiling to nothing is charged nothing, so
-a declarations-only file costs a package nothing here either. The result
+a declarations-only file costs a set nothing here either. A member's lines
+are the tracked source files under its own directory, and a file under a
+member nested inside it belongs to that nested member instead. The result
 is a separate series from `coverage-debt: packages/<name> uncovered
 lines`, which sums every job in the repository that loads those files. The
 two are never compared against each other, and the manifest keeps them
 under distinct names so nothing can.
 
-#### Which directories are covered
+### Which sets exist, and what reaches them
 
-Every workspace member under `packages/` carries the gate, at whatever
-depth the member sits: `packages/memory`, `packages/connectors/github`,
-and anything nested deeper the same way. The unit is the workspace member
-rather than a fixed path depth, which is what makes depth stop mattering.
-Adding a package means adding it to the `workspace` array in the root
-`deno.jsonc`, because nothing in the repository knows a package exists
-until it is there, so a new package is covered from the moment it exists.
+A suite declares its measured sets. Each one names the member whose lines
+it counts, the units that measure it, and the paths a change reaches it
+by. Reaching a set is what makes every one of its units mandatory, which
+is the same rule and the same declaration vocabulary as [what the change
+touches must run](#two-rules-that-force-a-test-in), rather than a rule of
+its own. Two mechanisms answering one question is two things to be wrong
+about, and the failure they produce is silent: the gate would run a set's
+tests and decline to score it, or score a set whose tests it did not
+force.
 
-Nothing else is. `tasks` is one coverage group rather than a directory
-tree of them, and `scripts` is left out of coverage accounting entirely
-today.
+That also settles what a set may declare. The bounds the declarations are
+under are the ones stated there — nothing reached by a significant share
+of the tree, and no file reaching a significant share of the things
+declaring — and a member's own tree satisfies the first by construction.
+`LOCAL_COVERAGE_MAX_SETS` is the second, said in measured sets.
+
+The unit suites declare one set per workspace member under `packages/`, at
+whatever depth the member sits: `packages/memory`,
+`packages/connectors/github`, and anything nested deeper the same way. The
+unit is the workspace member rather than a fixed path depth, which is what
+makes depth stop mattering. Adding a package means adding it to the
+`workspace` array in the root `deno.jsonc`, because nothing in the
+repository knows a package exists until it is there, so a new package is
+measured from the moment it exists. A member's set is reached by its own
+tree.
+
+`tasks` is one coverage group rather than a directory tree of them, and
+`scripts` is left out of coverage accounting entirely today, so neither
+carries a set.
 
 A member is out only by being named in `EXCLUDED_FROM_COVERAGE_GATE` in
 `tasks/test-selection/policy.ts`, beside every other dial, each entry
 carrying the reason it is there. A list is the right shape for this
-because the alternative — a rule that measures each package and decides —
-can take a package's gate away for a change nobody meant as a change to
+because the alternative — a rule that measures each member and decides —
+can take a member's gate away for a change nobody meant as a change to
 coverage, and a gate that silently stops gating is worse than no gate. The
 list is what it is today:
 
@@ -3014,20 +3048,20 @@ list is what it is today:
 | `packages/deno-web-test` | Its tests drive the browser harness end to end. |
 | `packages/toolshed` | Its tests want the service's own environment and its initialized database. |
 
-That leaves 33 of the 42 members under `packages/` covered,
-`packages/memory` among them. `packages/agents-host` and `packages/piece`
-are two of them: both are hand-sharded today, and being hand-sharded stops
-meaning anything once the packer does the sharding and `Status` joins what
-the lanes measured.
+That leaves 35 measured sets in the tree today, `packages/memory` among
+them, out of the 45 members `deno.jsonc` lists under `packages/`: the
+nine on the list, and one member with no Deno-only tests to measure.
+`packages/agents-host` and `packages/piece` are two of the 35: both are
+hand-sharded today, and being hand-sharded stops meaning anything once
+the packer does the sharding and `Status` joins what the lanes measured.
 
 One entry is there for size. Because `Status` joins the lanes' coverage, a
-package's tests do not have to land in one lane, or even in one batch —
-they are ordinary mandatory items that the packer distributes like any
-others, and the totals meet again afterwards. What a package's tests have
-to fit inside is the whole run's budget rather than a lane's, which is
-five times the room. `packages/runner` still does not fit it, at around
-1,600 seconds against about 1,150 for all five lanes together. Nothing
-else comes close to that.
+set's tests do not have to land in one lane, or even in one batch — they
+are ordinary mandatory items that the packer distributes like any others,
+and the totals meet again afterwards. What a set has to fit inside is the
+whole run's budget rather than a lane's, which is five times the room.
+`packages/runner` still does not fit it, at around 1,600 seconds against
+about 1,150 for all five lanes together. Nothing else comes close to that.
 
 None of this is special to those packages any more either: [sharding stops
 being written down](#sharding-stops-being-written-down) in the same pull
@@ -3037,13 +3071,13 @@ reference build and are what the item-level dry run checks; a package
 listed for a size it no longer has comes off.
 
 The list is a starting position and is expected to shrink. The publisher
-reports which listed packages would now fit the run's budget, the same way
-it reports a covered package that has grown expensive, so a line comes off
+reports which listed members would now fit the run's budget, the same way
+it reports a measured set that has grown expensive, so a line comes off
 because somebody read a measurement rather than because a threshold moved
-on its own. Two entries are there because the package has no Deno-only
+on its own. Two entries are there because the member has no Deno-only
 tests at all, and the moment one gains some, the same holds.
 
-#### Adding a browser test must not cost a package its gate
+### Adding a browser test must not cost a member its gate
 
 A package that mixes Deno-only tests with tests that need a browser should
 keep the gate over the Deno-only half rather than losing it. That is
@@ -3056,127 +3090,204 @@ with the browser files listed in `--ignore`, then `&&`, then those same
 files handed to the browser harness.
 
 So the convention is the one `packages/static` already follows. A member
-that has a Deno-only half names it `deno-test`. The gate measures
-`deno-test` when a member defines one and `test` otherwise, and
-`tasks/workspace-tests.ts` gives `deno-test` a coverage directory of its
-own so that the baseline on `main` and the run on a pull request measure
-the same half. A member with no `deno-test` is unchanged in every respect.
+that has a Deno-only half names it `deno-test`. A member's measured set
+holds the units of that half and never its browser unit. The browser unit
+then writes no coverage into the set's directory either: it is not one of
+the set's units, so a lane that happened to select it would move a number
+a lane that did not select it would not, which is exactly what the set
+exists to rule out. A member with no `deno-test` is unchanged in every
+respect: its whole test task is its Deno-only half.
 
 `packages/ui` and `packages/iframe-sandbox` get their one-string tasks
 split into `deno-test` and `browser-test` the way `packages/static` writes
 it. Both keep the gate over their Deno-only halves, which is coverage the
 share-based rule this replaced would have taken away from them. Adding a
-browser test to any covered package is then an edit to `browser-test`, and
+browser test to any measured member is then an edit to `browser-test`, and
 the gate does not notice.
 
-#### What a covered package costs is reported, never enforced
+### What a measured set costs is reported, never enforced
 
-A package whose measured set grows past `LOCAL_COVERAGE_MAX_SECONDS` is
-named in the publisher's summary, and by the `coverage` operator mode
-below. Nothing happens to it automatically. Somebody then decides whether
-to split the package's tests, let the run carry the cost, or add a line to
-the exclusion list — all three being decisions about the repository rather
+A set whose measured units grow past `LOCAL_COVERAGE_MAX_SECONDS` is named
+in the publisher's summary, and by the `coverage` operator mode below.
+Nothing happens to it automatically. Somebody then decides whether to
+split the member's tests, let the run carry the cost, or add a line to the
+exclusion list — all three being decisions about the repository rather
 than about one pull request, which is why they belong to a person and not
 to a threshold.
 
-#### Which packages a change reaches
+### A change that reaches more than two measured sets forces none of them
 
-The gate makes two decisions — which tests to run, and which packages to
-measure — and both are the same question: which covered packages did this
-change reach. It answers that question the way everything else in this
-design answers it, from the declarations described under [what the change
-touches must run](#two-rules-that-force-a-test-in), rather than from a
-rule of its own. A covered package declares the paths a change reaches
-its own measured test set by, which is its own tree; the packages a
-change reaches are the packages whose sets become mandatory and the
-packages the gate scores. Two mechanisms answering one question is two
-things to be wrong about, and the failure they produce is silent: the
-gate would run a package's tests and decline to score it, or score a
-package whose tests it did not force.
+The mandatory set a measured set adds is every one of its units, and a
+change reaching several sets adds all of theirs. A sweeping change would
+spend most of a run re-running suites it barely touched, and the gate's
+value falls as the change gets broader anyway: over three or four sets at
+once, "did this leave more untested" stops being a question about one
+thing somebody can look at.
 
-That also settles what a package may declare. The bounds the declarations
-are under are the ones stated there — nothing reached by a significant
-share of the tree, and no file reaching a significant share of the things
-declaring — and a package's own tree satisfies the first by construction.
-`LOCAL_COVERAGE_MAX_PACKAGES` is the second, said in packages.
-
-#### A change that touches more than two covered packages is not gated
-
-The mandatory set a covered package adds is its whole measured test set,
-and a change touching several packages adds all of theirs. A sweeping
-change would spend most of a run re-running suites it barely touched, and
-the gate's value falls as the change gets broader anyway: over three or
-four packages at once, "did this leave more untested" stops being a
-question about one thing somebody can look at.
-
-So when the diff reaches more than `LOCAL_COVERAGE_MAX_PACKAGES` covered
-packages, the gate is off for that pull request entirely. No package's set
-is forced whole, nothing is gated, and `Status` says the gate did not run
-and why. The tests are still selected normally, and the items the diff
-touched directly are still mandatory under [what the change touches must
-run](#two-rules-that-force-a-test-in); it is only the run-the-whole-package
+So when the diff reaches more than `LOCAL_COVERAGE_MAX_SETS` measured
+sets, none of them is forced whole, and `Status` says so and why. The
+tests are still selected normally, and the items the diff touched directly
+are still mandatory under [what the change touches must
+run](#two-rules-that-force-a-test-in); it is only the run-the-whole-set
 part that stops.
 
-Off entirely rather than off for some of them. Gating two of the four
-packages a change touched would mean the gate quietly ignored the other
-two, which is the failure this design keeps refusing elsewhere. A cliff is
-also predictable: an author can tell from the diff whether the gate
-applies, without knowing what any package's tests cost.
+None of them rather than some of them. Forcing two of the four sets a
+change reached would mean the gate quietly ignored the other two, which
+is the failure this design keeps refusing elsewhere. A cliff is also
+predictable: an author can tell from the diff whether their change is
+about to run whole packages, without knowing what any set's tests cost.
 
-Nothing is lost permanently. The full run on `main` measures every
-package, so a rise that a skipped gate let through is caught there and
-[reported back to the pull
-request](#telling-a-pull-request-what-main-found), named as a rise the
-gate would have caught.
+What the cap bounds is what a change is made to run, which is a cost.
+Whether a number may be compared against the baseline is a different
+question, and it turns on whether the set ran whole rather than on why it
+did. So a set the cap left unforced that some run measured anyway is
+still scored: the comparison is exactly as sound as a forced one, and
+throwing it away would leave the gate silent over work the run has
+already paid for. A pull request labelled `ci: full` measures every set
+in the repository, so a sweeping change carrying that label is gated on
+every set it reaches.
 
-#### What a pull request does
+Nothing is lost permanently. The full run on `main` measures every set, so
+a rise that a skipped gate let through is caught there and [reported back
+to the pull request](#telling-a-pull-request-what-main-found), named as a
+rise the gate would have caught.
 
-When the diff reaches a covered package, by the declaration that package
-carries, and the pull request is under the cap above, every item in that
-package's measured test set becomes mandatory, and runs once with
-coverage turned on. They are packed like any other mandatory items, so a large package
-spreads across lanes rather than filling one.
+### What a pull request does
 
-Run once is enforced rather than hoped for. A mandatory item leaves the
-selectable set, so no later pass can pick it a second time, and repeats do
-not apply to a measured item: running it twice covers nothing a first run
-did not. Coverage makes those tests slower, so their items are costed from
-the lane runner's recorded with-coverage durations rather than from the
-ordinary ones, fitted the same way every other cost in this design is.
+When the diff reaches a measured set, by the declaration that set carries,
+and the pull request is under the cap above, every unit in that set
+becomes mandatory and runs with coverage turned on. They are packed like
+any other mandatory items, so a large set spreads across lanes rather than
+filling one. Coverage is turned on for the members being measured and for
+no others, so a lane that also holds a few sampled tests from elsewhere
+pays nothing for them.
 
-Each lane converts the coverage it produced into one report per workspace
-member and uploads it. `Status` adds the five together, scores each
-covered package the diff reached, and fails when the uncovered count has
-risen. A rise is accepted with the marker the repository already has, in
-the same form and with the same rebase-proof meaning:
+Each unit is placed once, and that is enforced rather than hoped for: a
+mandatory item leaves the selectable set, so no later pass picks it a
+second time and no unit is placed in two lanes at once. That is what
+stops a lane's budget being spent twice on the same work, and what keeps
+a set's units from being scattered across lanes by two passes that both
+chose them.
+
+How many times a placed unit then runs is what its share asks for, and
+measuring it changes nothing about that. A test that would have been run
+three times to catch it disagreeing with itself is still run three times,
+with coverage on. Those runs leave the set's number where it was, since a
+coverage count is the union over what the runs reached.
+
+A repeat reaches the unit that asked for it and no further. A lane's
+batch is a suite's whole share of the lane, and a set the gate pulled in
+whole is a great many units of one suite, so a batch that repeated at
+its noisiest unit's count would run everything beside it again — time
+the packer never charged, on tests nobody doubted.
+
+None of this is special to the gate. How often an identity runs is what
+its share asks for, whatever put it in the lane, so an identity a change
+edited carries the same count as one the gate reached.
+
+Nor does it depend on which run it is. The full run requires every
+identity, the exclusion rule therefore takes none of them out, and every
+identity withheld for disagreeing with itself runs in it the count its
+share asks for. That is [what the default branch owes such a
+test](#an-excluded-test-still-runs-on-main): those extra runs are the
+only thing that lets a share rise rather than fall on a branch where an
+identity runs once per commit. It rests on that section's other half,
+which is that a failure of an excluded test does not fail the run.
+
+All of one identity's runs go in one lane, so a lane cannot be added to
+make room for them, and the mandatory pass gives up runs until what is
+left fits, down to one.
+
+Coverage makes those tests slower, and the packer charges them what a run
+without it costs. That is an underestimate whose size nothing has measured
+yet, because no lane has run anything with coverage on. What closes it is
+a record surface of its own for a measured batch, so a with-coverage
+duration is fitted the way every other cost in this design is; until the
+lanes produce those durations there is nothing to fit.
+
+Each lane converts the profiles under each measured set's directory into
+one report and uploads it. `Status` adds the five together per set, scores
+each set the diff reached, and fails when the uncovered count has risen. A
+rise is accepted with the marker the repository already has, in the same
+form and with the same rebase-proof meaning:
 
 ```text
 ACCEPT_COVERAGE_DEBT: packages/memory +12 lines
 ```
 
-#### The baseline, and when it declines to fail
+The marker names the member, and it accepts the rise for every measured
+set over that member. A marker that had to name a suite as well would ask
+an author to know which suite measured what before they could say "yes,
+knowingly". Where a member carries two sets, one marker therefore accepts
+a rise in both; no member carries two today, since the sets in the tree
+are the unit suites' and those divide the members between them.
 
-The manifest carries the per-package numbers for every full `main` run in
-the last `LOCAL_COVERAGE_BASELINE_DAYS`, each against its commit. `Status`
-picks the nearest ancestor of the merge base, which is the walk the
-present ratchet does over downloaded artifacts, done here over data the
-newest manifest already holds.
+### What `main` does
 
-Two cases report instead of failing. A package with no baseline yet is
-reported, because the first pull request to touch a new package should not
+The full run measures every set, because it runs every test in every
+suite: the profiles land in the same per-set directories, and the same
+conversion produces the same numbers. Those are the baselines. Nothing
+gates on them there.
+
+Then, separately, the run merges every report its lanes wrote into one and
+takes the repository-wide figure out of that, which is the trend the
+dashboard shows. The merge is over everything the run measured rather than
+over the per-set reports alone, so the trend goes on counting the coverage
+that integration tests and pattern runs contribute, as it does today.
+
+The two figures come from the same profiles and answer different
+questions, so they are published under different names and nothing
+compares one against the other.
+
+### The baseline, and when it declines to fail
+
+The manifest carries the per-set numbers for every full `main` run in the
+last `LOCAL_COVERAGE_BASELINE_DAYS`, each against its commit. The gate
+takes the newest of them the branch contains, and which one that is comes
+from git: it reads the branch's own history back from the tip and takes
+the first of those commits it meets. That is the walk the present ratchet
+does over downloaded artifacts, done here over data the newest manifest
+already holds.
+
+The branch's history rather than the moment each run was created. A
+re-run of an older commit is created after the run of a newer one, so run
+times can order two baselines the opposite way from the trees they
+measured, and the tree is what a rise is measured against. Reading the
+history back from the tip also costs only the distance to the answer,
+where asking about each commit in turn costs a question per commit and
+the window holds a week of them.
+
+Two cases report instead of failing here. A set with no baseline yet is
+reported, because the first pull request to reach a new package should not
 inherit the whole of that package's debt. And when the manifest holds no
-run that is an ancestor of the merge base, the comparison is against a
-tree the branch does not contain, so a rise measured against it is not the
-branch's rise.
+run the branch contains, the comparison would be against a tree the branch
+does not have, so a rise measured against it is not the branch's rise.
 
-#### Why this one is sound
+A third is not about the baseline at all: a set whose joined reports name
+no line of its member measured nothing, rather than covering nothing.
+Charging it every tracked line would fail a change for a measurement that
+never happened, and a set's tests always load some of their own member's
+source, so an empty report is the conversion having produced nothing.
 
-Both sides run the same complete set of tests over the same package.
-Selection cannot skew it, because within that package nothing is selected.
-Sharding cannot skew it, because the package is one invocation either way.
-The count moves when the package's own source or its own tests change,
-which is the change the author is looking at. That is the whole of the
-argument, and it is why this gate keeps its teeth while the
+The publisher fills those numbers from the `perf-metrics` artifact of each
+run on `main` it has not read yet, and carries forward what the previous
+manifest held for the rest of the window. Reading one run's figures costs
+an artifact listing and a download, and a week holds far more runs than a
+four-hourly publish should ask about, so what each run reads is the
+handful since the last one. A publisher run that cannot read them at all
+publishes what the previous manifest held, and every set with no baseline
+is reported rather than gated.
+
+### Why this one is sound
+
+Both sides run the same complete set of tests over the same member's
+lines. Selection cannot skew it, because within that set nothing is
+selected. Sharding cannot skew it, because the profiles are joined by the
+set they belong to rather than by the job that produced them. Another
+suite cannot skew it, because another suite's profiles are in another
+directory. The count moves when the member's own source or the set's own
+tests change, which is the change the author is looking at. That is the
+whole of the argument, and it is why this gate keeps its teeth while the
 repository-wide one gives them up.
 
 ## Telling a pull request what `main` found
@@ -3212,12 +3323,11 @@ pull request's own run could not have:
   groups the change touched that rose as well, which is as near as this
   gets to saying where a test would go. Never as a failure — the run is
   green — and never for one line.
-- **A rise in a covered package's own-tests number**, named as one the
-  per-package gate exists to catch. There are three ways one reaches
-  `main`: the change reached more covered packages than the cap allows, so
-  the gate did not run; a package the change reached is on the exclusion
-  list; or a change somewhere else moved which lines of that package its
-  own tests reach. The comment says which, because the three call for
+- **A rise in a measured set's number**, named as one the coverage gate
+  exists to catch. There are three ways one reaches `main`: the change
+  reached more measured sets than the cap allows, so the gate did not run;
+  a member the change reached is on the exclusion list; or a change
+  somewhere else moved which lines of that member the set's tests reach. The comment says which, because the three call for
   different things — nothing, a look at the exclusion list, and a look at
   the change respectively. A fourth state is possible and the comment
   names it too: the gate measured the package on the pull request and
@@ -3298,13 +3408,12 @@ on is one people learn to read past, which costs the signal for everything
 else on it. Running these tests several times and keeping every failure
 gating is the alternative, and it is set out beside the rule.
 
-**Outside a covered package, a change to a source file does not pull in
-the tests that execute it.** Selection knows which test files a change
-edited, and which units the declarations reach. Where those reach a
-covered package and the diff stays under the cap, [the per-package
-gate](#the-one-coverage-gate-that-survives) makes that package's whole
-measured set mandatory, which reaches the tests executing the changed
-lines by running every test the package has. Everywhere else, selection
+**Outside a measured set, a change to a source file does not pull in the
+tests that execute it.** Selection knows which test files a change edited,
+and which units the declarations reach. Where those reach a [measured
+set](#the-measured-set) and the diff stays under the cap, the gate makes
+that whole set mandatory, which reaches the tests executing the changed
+lines by running every test the set holds. Everywhere else, selection
 does not know which tests execute a changed line, so what runs for an
 edited source file is what the score chose. The finer answer is buildable
 and is not being built. Deno writes one coverage profile per pair of test
@@ -3335,15 +3444,14 @@ often as it would have. The net is an empirical question and the
 dashboard is where it gets answered.
 
 **Coverage stops being enforced across the repository, and stays enforced
-per package.** Nothing will fail because a change lowered the repository's
-whole coverage number. What replaces that is a weekly trend somebody has
-to choose to look at, plus a comment naming the source groups where the
-debt rose. Over the 31 packages that carry the [per-package
-gate](#the-one-coverage-gate-that-survives) the ratchet still fails a pull
-request, because there both sides measure the same complete thing. The
-reduction in enforcement is real and confined to what could no longer be
-measured per change: the code covered by suites a pull request only
-samples. If debt starts climbing there, the response is a conversation
+over each measured set.** Nothing will fail because a change lowered the
+repository's whole coverage number. What replaces that is a weekly trend
+somebody has to choose to look at, plus a comment naming the source
+groups where the debt rose. Over the 35 [measured
+sets](#the-measured-set) the ratchet still fails a pull request, because
+there both sides measure the same complete thing. The reduction in
+enforcement is real and confined to what could no longer be measured per
+change: the code covered by suites a pull request only samples. If debt starts climbing there, the response is a conversation
 about the trend, not a reinstated gate on a number a selected run cannot
 produce.
 
@@ -3371,12 +3479,13 @@ is pinned to the commit's date. And if none of that settles it,
 | A variant deliberately skips a file or leaf | The topology reads the existing skip registry and the manifest reports the test as unavailable with its phase and reason. It is not unknown. Removing the skip makes it mandatory until `main` records it. |
 | One item is bigger than a lane's planned budget | It gets a lane to itself, up to the hard five-minute bound. Bigger than that, a mandatory item is still placed and its lane over-runs, while a discretionary one is listed as unschedulable in the manifest and reported; the 60-second ratchet is the fix. |
 | The mandatory set alone exceeds the budget | The lane runs it anyway and over-runs, past the five-minute step bound where the set demands it. The summary says by how much, which is what argues for raising the bound. |
-| A covered package has no baseline, or none from an ancestor of the merge base | The lane reports the comparison and does not fail. The next full `main` run supplies one. |
-| A covered package gains a test needing a browser or a server | It goes in the package's `browser-test` half, which the gate does not measure, so the Deno-only half keeps its gate. A package with no such half yet names one. |
-| A covered package's measured set grows expensive | Reported in the publisher's summary and by `deno task test-selection coverage`. Nothing is excluded automatically; somebody splits the tests or adds a line to the exclusion list. |
-| A test in a covered package fails | That package is reported rather than gated. Coverage measured through a failing suite says nothing about whether the change was tested, and the failure is the thing to fix. |
-| A change touches more than two covered packages | The per-package gate does not run at all, and `Status` says so. The full run on `main` still measures every package, and a rise it finds is reported back to the pull request. |
+| A measured set has no baseline, or none from an ancestor of the merge base | `Status` reports the comparison and does not fail. The next full `main` run supplies one. |
+| A measured member gains a test needing a browser or a server | It goes in the member's `browser-test` half, which no measured set holds, so the Deno-only half keeps its gate. A member with no such half yet names one. |
+| A measured set grows expensive | Reported in the publisher's summary and by `deno task test-selection coverage`. Nothing is excluded automatically; somebody splits the member's tests or adds a line to the exclusion list. |
+| A test in a measured set fails | Every set is reported rather than gated. Coverage measured through a failing run says nothing about whether the change was tested, and the failure is the thing to fix. |
+| A change reaches more than two measured sets | The gate does not run at all, and `Status` says so. The full run on `main` still measures every set, and a rise it finds is reported back to the pull request. |
 | A lane dies without uploading its coverage | `Status` is already failing for the dead lane. It says the coverage total is incomplete rather than gating on a partial one. |
+| Two measured sets over one member disagree | Nothing joins them. Each carries its own baseline and its own verdict, and an `ACCEPT_COVERAGE_DEBT` marker naming the member accepts a rise in either. |
 | A lane exceeds five minutes repeatedly | The correction factors rise on the next publisher run and less is packed. If it persists, the publisher's summary shows the miss and somebody looks. |
 | Two attempts of one run straddle a UTC midnight | The later attempt's relay writes the earlier attempt's records a second time, under the later day, and the publisher folds both. Not observed in the store so far; see [What the store is missing](#what-the-store-is-missing). |
 | A fork pull request | Works unchanged. The manifest is world-readable, and the existing member gate decides whether the fork's records ship. |
@@ -3471,28 +3580,30 @@ variant is declared and its topology warning for a marked direct record in
 a default batch. A repeated-item fixture gives every execution fresh paths
 and proves that records from every execution reach the lane spool.
 
-The per-package coverage gate is tested from recorded profile directories
-rather than by running tests. A fixture holding one workspace member's
-coverage directory proves that converting it alone gives that member's own
-figure, and that merging it with its siblings gives today's shard figure,
-so the two series are shown to be the two readings of one set of profiles.
-A workspace fixture proves that every member under `packages/` is covered
-at whatever depth it sits, that a member added to the fixture's workspace
-array is covered without any other edit, and that only the members in
-`EXCLUDED_FROM_COVERAGE_GATE` are left out. A member defining `deno-test`
-proves that the gate measures that task, that its coverage directory is
-separate from the rest of `test`, and that a test added to `browser-test`
-moves neither the measured half nor the member's place in the gate. The
-packer gets a fixture proving that a covered package's items are not
-reachable by the value, density, or exploration pass, and are not
-repeated. The join gets a fixture of five lanes' reports for one package
-split across them, proving that the total equals the same tests measured
-in one run, and that a package whose items landed in three lanes is scored
-once. A diff touching one, two, and three covered packages proves the
-cap: gated, gated, and not gated at all rather than gated for two of the
-three. And the baseline walk is tested against recorded chains of `main`
-commits: a rise against an ancestor fails, a rise against a run the merge
-base does not contain reports, and a package with no baseline reports.
+The coverage gate is tested from recorded profile directories rather than
+by running tests. A fixture holding one measured set's coverage directory
+proves that converting it alone gives that set's own figure, and that
+merging it with its siblings gives today's shard figure, so the two series
+are shown to be the two readings of one set of profiles. A fixture holding
+two suites' directories over one member proves that neither suite's
+coverage moves the other's number. A workspace fixture proves that every
+member under `packages/` carries a set at whatever depth it sits, that a
+member added to the fixture's workspace array carries one without any
+other edit, and that only the members in `EXCLUDED_FROM_COVERAGE_GATE` are
+left out. A member defining `deno-test` proves that the set holds that
+task's units, that its coverage directory is separate from the rest of
+`test`, and that a test added to `browser-test` moves neither the measured
+half nor the member's place in the gate. The packer gets a fixture proving
+that a measured set's items are not reachable by the value, density, or
+exploration pass, and are not repeated. The join gets a fixture of five
+lanes' reports for one set split across them, proving that the total
+equals the same tests measured in one run, and that a set whose items
+landed in three lanes is scored once. A diff reaching one, two, and three
+measured sets proves the cap: gated, gated, and not gated at all rather
+than gated for two of the three. And the baseline walk is tested against
+recorded chains of `main` commits: a rise against an ancestor fails, a
+rise against a run the merge base does not contain reports, and a set with
+no baseline reports.
 
 The full run's treatment of a flaky test is tested at both ends. In
 `plan()`, a withheld and independent identity is placed under the
@@ -3543,11 +3654,11 @@ test-selection`. Its modes are also how the system is tested by hand.
   publisher measures it, or it is computed from other dials, and for a
   measured one whether the figure shown is still the checked-in seed or
   one the publisher has since written back.
-- `coverage` prints every workspace member, whether it carries the
-  per-package coverage gate, the reason beside it when it does not, the
-  task the gate measures, and the baseline the newest manifest holds for
-  it. This is what somebody uses to answer "why is my package not gated?"
-  and "what am I being compared against?".
+- `coverage` prints every measured set, the suite and the member it pairs,
+  the task the set measures, and the baseline the newest manifest holds
+  for it, and beside them every workspace member that carries no set and
+  the reason it does not. This is what somebody uses to answer "why is my
+  package not gated?" and "what am I being compared against?".
 
 `tasks/ci-lane.ts` keeps a `--dry-run` of its own, because that is how
 continuous integration asks the same question from inside a job.
@@ -3791,15 +3902,13 @@ exercised on the branch on its own.
 - [ ] `deno.yml`: `plan-full` and `full-tests` on push, with the build,
       attestation, coverage and deploy jobs repointed at them.
 - [ ] The full run's treatment of a test too flaky for pull requests.
-      `tasks/test-selection/plan.ts` places a withheld, independent
-      identity with the count `executionsFor` already returns for its
-      share rather than the single run the mandatory pass gives, skips it
-      in its file's own invocation so every run of it at one commit shares
-      one shape, gives up runs until what is left fits rather than putting
-      a lane past its bound, and returns a `nonGating` list beside
-      `withheld` naming the identities whose failures do not fail the run.
-      A withheld identity without the independence flag keeps its single
-      run, and a withheld repository gate is in neither list.
+      The count is placed already: `tasks/test-selection/plan.ts` gives
+      every mandatory identity the count `executionsFor` returns for its
+      share, and gives up runs until what is left fits rather than
+      putting a lane past its bound. What is left is that it returns a
+      `nonGating` list beside `withheld` naming the identities whose
+      failures do not fail the run, and that a withheld repository gate
+      is in neither list.
       `tasks/ci-lane.ts` reads each batch's gathered records, exits
       non-zero only where a failing identity is outside `nonGating`, fails
       the lane whenever a batch did not account for every identity it was
@@ -3812,17 +3921,19 @@ exercised on the branch on its own.
       waits there until a later run judges it, and an excluded test that
       stays broken no longer turns `main` red, so nothing bounds what
       accumulates.
-- [ ] A covered package whose lane held a non-gating failure is reported
+- [ ] A measured set whose lane held a non-gating failure is reported
       rather than having a baseline published from it, the same way the
-      per-package gate already reports a package with a failing test.
+      gate already reports a run with a failing test.
 - [ ] `explain <identity>` gains the runs it is given and whether it is
       withheld, replacing the three-way answer that no longer partitions.
 - [ ] Repository-wide coverage measurement moves to the full run and stops
       failing anything.
-- [ ] `tasks/write-coverage-lcov.ts` converts each workspace member's
-      coverage directory on its own as well as merging them, so the full
-      run yields a per-package own-tests figure beside the existing
-      per-shard report. No test changes how it runs.
+- [x] Each suite writes its coverage profiles into a directory of its
+      own, one level per suite and one per member below it, and the lane
+      converts every one of them into a report named for the measured
+      set. `tasks/write-coverage-lcov.ts` carries the conversion as a
+      function `tasks/ci-lane.ts` calls as well as a command. No test
+      changes how it runs.
 - [ ] Delete the hand-maintained sharding: `tasks/test-timing-weights.ts`,
       `tasks/select-runner-test-files.ts`,
       `tasks/run-sharded-test-files.ts`, `INTERNALLY_SHARDED_PACKAGES` and
@@ -3831,14 +3942,28 @@ exercised on the branch on its own.
       matrix. `tasks/weighted-shards.ts` stays and the lane packer calls
       it. Nothing may be balanced by a transcribed number afterwards, and
       `check-test-topology` is what proves the items are all still there.
-- [ ] `tasks/workspace-tests.ts` gives a member's `deno-test` task, where
-      it defines one, a coverage directory separate from the rest of its
-      `test` task, and `packages/ui` and `packages/iframe-sandbox` split
-      their one-string test tasks the way `packages/static` already writes
-      the same split.
-- [ ] The publisher carries each covered member's own-tests figure and its
-      commit in the manifest, along with the exclusion list it used and
-      the batches it found expensive.
+- [ ] `packages/ui` and `packages/iframe-sandbox` split their one-string
+      test tasks the way `packages/static` already writes the same split,
+      so each keeps a measured set over its Deno-only half. The topology
+      already reads `deno-test` where a member defines one, so this is an
+      edit to two manifests and nothing else.
+- [x] The publisher carries each measured set's figure and its commit in
+      the manifest, read from the `perf-metrics` artifact of each `main`
+      run it has not read yet and carried forward from the previous
+      manifest for the rest of the window.
+      `.github/workflows/test-selection.yml` gains `actions: read` for it,
+      and a run without the credential publishes what the previous
+      manifest held rather than failing.
+- [ ] The publisher's summary names the exclusion-list entries that would
+      now fit the run's budget, and the measured sets past
+      `LOCAL_COVERAGE_MAX_SECONDS`. Both read the fitted costs of the
+      lanes, which have none until the lanes run.
+- [ ] A measured batch records its duration under a surface of its own, so
+      that what a unit costs with coverage on is fitted separately from
+      what it costs without. Until then the packer charges a measured
+      unit what an unmeasured run of it costs, which is an underestimate
+      of unknown size; there is nothing to fit until the lanes have run
+      something with coverage on.
 - [ ] Before merging: `plan --verify` against the last `main` run, proving
       the manifest accounts for every item the topology enumerates under
       its exact variant, apart from explicitly unavailable skip entries,
@@ -3863,8 +3988,8 @@ exercised on the branch on its own.
 - [ ] The `ci: full` label.
 - [x] `coverage-comment.yml` generalized into the reporter, with the
       first-failure attribution, the selected-or-not line, the coverage
-      note, the per-package rise note naming which of the three routes let
-      it through, the flaky-new-test note, and the rename suggestion with
+      note, the measured-set rise note naming which of the three routes
+      let it through, the flaky-new-test note, and the rename suggestion with
       its ready-to-append alias line. It is
       `.github/workflows/pull-request-comments.yml`, which now holds both
       comments this repository posts from the trusted context, and
@@ -3879,31 +4004,51 @@ exercised on the branch on its own.
       which are readable before the relay has shipped them. Whether the
       pull request ran a test is settled by its own run's records, and the
       manifest it resolved answers why it did not; the two together are
-      honest both before and after the lanes land. The per-package rise
-      reads a covered package's own-tests figure out of the run's
-      `perf-metrics` artifact, under the metric name
-      `ownTestsCoverageMetric` builds, so it reads the quantity the gate
-      compares rather than the source group of the same name that a
-      selected run only samples. The gate publishes that figure, so the
-      note is silent until the gate lands and needs nothing further
-      then.
+      honest both before and after the lanes land. The measured-set rise
+      reads a set's figure out of the run's `perf-metrics` artifact,
+      under the metric name `measuredSetCoverageMetric` builds, so it
+      reads the quantity the gate compares rather than the source group
+      over the same member that a selected run only samples. The full run
+      publishes those figures, so the note is silent until it does and
+      needs nothing further then.
 - [ ] The reporter's note for a test too flaky for pull requests that
       failed every one of its runs at this commit and passed every one at
       the parent. It needs the full run's extra runs to exist before it can
       say anything, and it says the test is a known flaky one and that the
       run stayed green.
-- [ ] The per-package coverage gate, in two halves. `tasks/ci-lane.ts`
-      makes every item of a covered package the diff touches mandatory,
-      keeps those items out of later passes and out of repeats, and
-      uploads one coverage report per workspace member. `Status`
-      downloads the five, adds them per member, walks the manifest for the
-      nearest-ancestor baseline, checks for a rise, and reads
-      `ACCEPT_COVERAGE_DEBT` from the pull request's description. `Status`
-      works out which packages the gate covers by running the same
-      function the lanes run, cap included, rather than trusting a lane's
-      report. A coverage failure names itself as one, a package with a
-      failing test is reported rather than gated, and a change over the
-      cap turns the gate off with a line saying so.
+- [x] The coverage gate, in two halves. `tasks/ci-lane.ts` makes every
+      unit of a measured set the diff reaches mandatory, keeps those
+      units out of later passes, runs each of them as many times as its
+      own share asks for, turns coverage on for those members alone, and
+      converts what it collected into one report per set.
+      `tasks/coverage-gate.ts` reads the reports, adds them per set,
+      walks the manifest for the nearest baseline the branch contains,
+      checks for a rise, and reads `ACCEPT_COVERAGE_DEBT` from the pull
+      request's description. It works out which sets the gate covers by
+      running the same function the lanes run, cap included, rather than
+      trusting a lane's report. A coverage failure names itself as one, a
+      run with a failing test is reported rather than gated, and a change
+      over the cap forces no set, with a line saying so, and still
+      scores any set some run measured anyway.
+- [ ] The gate's workflow half, which only the lanes can carry. Each
+      `pr-tests` lane uploads what is under its coverage directory as an
+      artifact, `Status` downloads all five into one directory, and
+      `Status` runs `deno run -A tasks/coverage-gate.ts --base <merge
+      base> --reports <that directory> --body <the pull request's
+      description>`, passing `--tests-failed` when any lane did not
+      succeed. Nothing else has to change: which sets are gated, what
+      each is scored over, and what the baseline is are all decided
+      inside that command. Its checkout has to hold the commits the
+      baselines name, because it asks git whether the branch contains
+      one; a checkout too shallow to answer reports every set as having
+      no baseline, which turns the gate off without failing anything.
+- [ ] The full run's half of the same, which only the lanes can carry.
+      Each `full-tests` lane uploads its coverage the same way, and the
+      job that publishes `perf-metrics` merges every report for the
+      repository-wide figure and reads each set's report for the figure
+      `measuredSetCoverageMetric` names. Both come out of the same
+      reports; the merge is what the present `Coverage Check` job already
+      does over the present matrix's artifacts.
 - [ ] `tasks/ci-workflow.test.ts` updated for the new anchors and shapes,
       including that the shared lane ship step carries no job-wide variant.
 - [ ] Documentation, in the same pull request rather than after it:
@@ -3912,14 +4057,14 @@ exercised on the branch on its own.
       trust-boundary amendment and new dataset area in
       `docs/specs/test-records.md`, `docs/development/COVERAGE.md`
       rewritten around a trend for the repository-wide number and around
-      the per-package gate that keeps its teeth,
+      the measured sets that keep their teeth,
       `docs/development/CI_PERFORMANCE.md` around lanes rather than shard
       balance, and `.claude/rules/github-workflows.md` and
       `.claude/rules/tests.md` where "add a job" becomes "add a suite".
       `.claude/rules/workspace-packages.md` gains the `deno-test`
       convention: a package that mixes Deno-only tests with tests needing
       a browser names the Deno-only half `deno-test`, and that half is
-      what the coverage gate measures.
+      what its measured set holds.
 - [ ] The workflow half turned around, once the lanes carry the gates.
       It asks today whether every recording step's identity is in the
       topology, which is the right question while the workflows and the

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -281,6 +281,18 @@ execution, so a test run five times fails a lane spuriously about five
 times as often as its share says. That cost is deliberate, and the
 exclusion is what bounds which tests pay it.
 
+How often an identity runs does not depend on what put it in the lane,
+or on which run it is. An identity a change edited, an identity a
+declaration reached, an identity chosen for what it is worth, and every
+identity of a run over the whole corpus all run the count their share
+asks for.
+
+All of one identity's runs go in one lane, so a lane cannot be added to
+make room for them. An identity that would be repeated and fits in no
+lane runs fewer times, down to once, and a mandatory one is placed at
+that single run however far past a lane's capacity it is; [what must run,
+and what must not](#what-must-run-and-what-must-not) carries the rule.
+
 **An execution is not a retry.** Every one must pass, and any failure
 among them fails the run. Five runs of a test is strictly stricter than
 one, never laxer. Nothing is retried and nothing is masked. Where a
@@ -371,6 +383,22 @@ all; [what the default branch does with an excluded
 identity](#what-the-default-branch-does-with-an-excluded-identity) says
 how it runs there.
 
+**A mandatory identity runs, whatever it costs.** Nothing weighs it
+against a budget, a lane's capacity, or the time the run is trying to
+hold to, and no rule anywhere takes one out. An identity whose own cost
+is past what a lane is killed at is placed in a lane regardless, and what
+that produces is a lane that runs long and says by how much. The
+alternative is a run that reports a pass over a test it decided not to
+run, which is the one failure this design will not have: a consumer is
+told a test did not run, never left to infer it from a green result.
+Weighing cost is for the identities nothing requires, and the list of
+work no lane can hold names those alone.
+
+The count of runs is the one thing that bends. An identity that would be
+repeated and fits nowhere runs fewer times, down to once, since all of
+one identity's runs go in one lane and one observation beats none. Down
+to once and never to nothing.
+
 Two rules force a test in.
 
 - **An identity with no records must run.** This is required of any
@@ -402,6 +430,86 @@ Two rules force a test in.
   source file forces a test in except through a declaration that reaches
   it. Which tests run for it otherwise is what the score decides.
 
+## Coverage
+
+Selection breaks a gate on the repository's whole coverage number: a
+change that runs a fifth of the test time measures a fifth of the
+coverage, and the two sides of that comparison are no longer the same
+thing. One narrower measurement survives, and it is the unit of
+everything here.
+
+A **measured set** is one suite's units over one workspace member's
+lines. Run every unit of the set and what those tests reached in that
+member is complete, whatever selection did anywhere else in the run, so
+the comparison against the default branch stays honest.
+
+A suite declares its measured sets. Each one names the member whose lines
+it counts, the units that measure it, and the paths a change reaches it
+by. Those paths are declarations in the sense above, and reaching one is
+what makes every unit of the set mandatory: the coverage gate adds no
+second way of asking what a change touched. A set every one of whose
+units the configuration deliberately does not run is not a set at all,
+since scoring it would score whatever else happened to write into its
+directory.
+
+Four rules hold of every measurement.
+
+- **Each set is counted on its own.** A set's units write their coverage
+  profiles into a directory named for the suite and the member, and a
+  set's count is converted from that directory alone. Two sets over one
+  member are two counts and are never added together, and neither is
+  added to the source group of the same name, which is the same lines
+  measured by every test in the run.
+- **Measuring a set does not change how often anything runs.** Its units
+  are mandatory, so they leave the selectable set and no later pass
+  takes them again; each runs as many times as its own flake rate asks
+  for, which is the count anything else in the run would have given it,
+  and a repeat reaches that unit and no other. A repeat leaves the set's
+  number where it was, since a count is the union over what the runs
+  reached. Two sets reaching one suite run the union of their units.
+- **A set's lines are its member's own tree**, less the tree of any
+  member nested inside it, counted by the rules the repository-wide
+  metric already uses. A member's browser half is not part of any set,
+  so that adding a test needing a browser costs a member nothing here,
+  and what that half reaches is not counted toward the set.
+- **Nothing about coverage fails a run on the default branch.** That run
+  measures every set, which is where the baselines come from, and merges
+  every report it produced into the one repository-wide figure, which is
+  a trend rather than a gate.
+
+A change forces the sets it reaches when it reaches at most
+`LOCAL_COVERAGE_MAX_SETS` of them. Past that it forces none, rather than
+some of the ones it reached, and what stopped the forcing is reported.
+
+What is scored is a separate question from what is forced. Forcing costs
+a run the whole of a set's unit list, and the cap is what bounds that
+cost. Whether a number may be compared against the baseline turns on
+whether the set ran whole, so every set the change reached that some run
+measured is scored, however that run came to measure it. A run that
+measures every set — which is what the default branch does, and what a
+change may ask for — has produced comparisons exactly as sound as forced
+ones.
+
+A set is compared against the count the same set had at the newest
+default-branch commit the change contains, which the manifest carries.
+Newest is settled by the order of those commits in the default branch's
+own history, and never by when the run that measured one was created: a
+re-run of an older commit produces a later run of an earlier tree.
+
+Five states report rather than fail, and each is one where the
+comparison would be against something other than the change: a set with
+no baseline the change contains, a set the cap left unforced that no run
+measured, a set no report was written for, a set whose reports name no
+line of its member and so measured nothing, and a run with a failing
+test, whose coverage was measured through that failure.
+
+A rise is accepted by an `ACCEPT_COVERAGE_DEBT` marker in the change's
+description, which names the member and the lines, and accepts the rise
+for every measured set over that member. Two markers naming one thing
+are refused, since the author meant one number and would be given the
+other. A marker naming neither a workspace member nor a coverage source
+group fails, because nothing would ever consult it.
+
 ## The manifest
 
 One gzipped JSON object per publisher run, created — never overwritten —
@@ -414,7 +522,8 @@ score and its flake share and the inputs and counts behind both, the
 withheld set with its reason, the
 tests a configuration deliberately does not run, a reference packing into
 lanes, the unschedulable list, a count and digest of known identities, and
-the per-package coverage baselines.
+the coverage baselines, one per measured set per default-branch run
+inside `LOCAL_COVERAGE_BASELINE_DAYS`.
 
 A manifest is **untrusted input**. It is validated whole, and one bad
 field rejects the object rather than leaving a consumer obeying half of

--- a/packages/test-support/src/records/selection.test.ts
+++ b/packages/test-support/src/records/selection.test.ts
@@ -236,8 +236,18 @@ describe("selection", () => {
       [
         "a baseline with no member",
         withField("coverageBaselines", [{
+          suite: "workspace-unit",
           commit: "c",
-          day: "2026-08-20",
+          createdAt: "2026-08-20T00:00:00.000Z",
+          uncoveredLines: 0,
+        }]),
+      ],
+      [
+        "a baseline with no suite",
+        withField("coverageBaselines", [{
+          member: "packages/memory",
+          commit: "c",
+          createdAt: "2026-08-20T00:00:00.000Z",
           uncoveredLines: 0,
         }]),
       ],
@@ -498,9 +508,10 @@ describe("selection", () => {
           phase: "compile",
         }],
         coverageBaselines: [{
+          suite: "workspace-unit",
           member: "packages/memory",
           commit: "c",
-          day: "2026-08-20",
+          createdAt: "2026-08-20T00:00:00.000Z",
           uncoveredLines: 3,
         }],
         withheld: [{

--- a/packages/test-support/src/records/selection.ts
+++ b/packages/test-support/src/records/selection.ts
@@ -490,7 +490,7 @@ function parseBaseline(value: unknown): CoverageBaseline | undefined {
   if (
     !isNonEmptyString(value.suite) || !isNonEmptyString(value.member) ||
     !isNonEmptyString(value.commit) ||
-    !isNonEmptyString(value.createdAt) ||
+    !isTimestamp(value.createdAt) ||
     !isFiniteNumber(value.uncoveredLines) ||
     value.uncoveredLines < 0
   ) {

--- a/packages/test-support/src/records/selection.ts
+++ b/packages/test-support/src/records/selection.ts
@@ -168,11 +168,27 @@ export interface LanePlan {
   batches: Array<{ suite: string; identities: string[] }>;
 }
 
-/** What a covered package's own tests reached at one `main` commit. */
+/**
+ * What one measured set reached at one `main` commit: the uncovered line
+ * count of `member` as one suite's tests alone measured it.
+ *
+ * Two sets over one member are two baselines and are never added
+ * together, which is why the suite is part of what identifies one.
+ */
 export interface CoverageBaseline {
+  suite: string;
   member: string;
   commit: string;
-  day: string;
+
+  /**
+   * When the run that measured it was created, ISO 8601. It decides one
+   * thing: a publisher keeps a baseline while it is younger than the
+   * window a manifest covers, and drops it once it is older than that.
+   * Which baseline a comparison takes is decided by the order of their
+   * commits in the default branch's history, and never by this.
+   */
+  createdAt: string;
+
   uncoveredLines: number;
 }
 
@@ -472,16 +488,19 @@ function parseLane(value: unknown): LanePlan | undefined {
 function parseBaseline(value: unknown): CoverageBaseline | undefined {
   if (!isRecord(value)) return undefined;
   if (
-    !isNonEmptyString(value.member) || !isNonEmptyString(value.commit) ||
-    !isNonEmptyString(value.day) || !isFiniteNumber(value.uncoveredLines) ||
+    !isNonEmptyString(value.suite) || !isNonEmptyString(value.member) ||
+    !isNonEmptyString(value.commit) ||
+    !isNonEmptyString(value.createdAt) ||
+    !isFiniteNumber(value.uncoveredLines) ||
     value.uncoveredLines < 0
   ) {
     return undefined;
   }
   return {
+    suite: value.suite,
     member: value.member,
     commit: value.commit,
-    day: value.day,
+    createdAt: value.createdAt,
     uncoveredLines: value.uncoveredLines,
   };
 }

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -7,6 +7,7 @@ import {
   assertThrows,
 } from "@std/assert";
 import {
+  acceptedCoverageDebt,
   acceptsCoverageDebt,
   aggregateCacheStates,
   type Artifact,
@@ -20,6 +21,7 @@ import {
   coverageGroupsForChangedFiles,
   coverageMetricForGroup,
   coverageMetricGroupName,
+  coverageMetricMeasuredSet,
   downloadAndExtractArtifact,
   fetchArtifactsForRun,
   fetchCurrentPRBody,
@@ -31,9 +33,8 @@ import {
   githubPatch,
   githubPost,
   isNotFound,
+  measuredSetCoverageMetric,
   newestArtifactsByName,
-  ownTestsCoverageMember,
-  ownTestsCoverageMetric,
   parseAddedLinesFromPatch,
   parseBaselineOverrides,
   parseCacheStateFiles,
@@ -297,7 +298,7 @@ Deno.test("baseline override parser rejects a total in place of an increment", (
         "ACCEPT_COVERAGE_DEBT: packages/runner = 123 lines",
       ),
     Error,
-    "<source group> +N lines",
+    "<source group or workspace member> +N lines",
   );
 });
 
@@ -308,24 +309,57 @@ Deno.test("baseline override parser rejects a metric name in place of a group", 
         "ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines +7 lines",
       ),
     Error,
-    "<source group> +N lines",
+    "<source group or workspace member> +N lines",
   );
 });
 
-Deno.test("baseline override parser rejects a name no source group could have", () => {
-  assertThrows(
-    () =>
-      parseBaselineOverrides("ACCEPT_COVERAGE_DEBT: packages/a/b/c +7 lines"),
-    Error,
-    "name a coverage source group",
-  );
-
-  // Only `packages` splits into a second level, so a path below any other
-  // top-level directory names nothing the collection rolls a file up to.
+Deno.test("baseline override parser rejects a name nothing could measure", () => {
+  // Only `packages` splits below its top level, so a path below any other
+  // top-level directory names neither a source group nor a member.
   assertThrows(
     () => parseBaselineOverrides("ACCEPT_COVERAGE_DEBT: tasks/foo +7 lines"),
     Error,
     "name a coverage source group",
+  );
+});
+
+Deno.test("two acceptances of one name are refused", () => {
+  // The author meant one number and would be given the other, with
+  // nothing saying which.
+  assertThrows(
+    () =>
+      acceptedCoverageDebt(
+        "ACCEPT_COVERAGE_DEBT: packages/runner +12 lines\n" +
+          "ACCEPT_COVERAGE_DEBT: packages/runner +3 lines",
+      ),
+    Error,
+    "Two ACCEPT_COVERAGE_DEBT acceptances",
+  );
+  // A merged body cannot be rewritten, so the larger stands there.
+  assertEquals(
+    acceptedCoverageDebt(
+      "ACCEPT_COVERAGE_DEBT: packages/runner +12 lines\n" +
+        "ACCEPT_COVERAGE_DEBT: packages/runner +3 lines",
+      true,
+    ).get("packages/runner"),
+    12,
+  );
+});
+
+Deno.test("a workspace member deeper than a group is not one of this ratchet's", () => {
+  // The coverage gate reads it, and this ratchet measures nothing for it,
+  // so taking it as a group would fail the run for an acceptance that
+  // names no group.
+  const overrides = parseBaselineOverrides(
+    "ACCEPT_COVERAGE_DEBT: packages/connectors/github +7 lines",
+  );
+  assertEquals(overrides.metrics.size, 0);
+  assertEquals(
+    acceptedCoverageDebt(
+      "ACCEPT_COVERAGE_DEBT: packages/connectors/github +7 lines",
+    )
+      .get("packages/connectors/github"),
+    7,
   );
 });
 
@@ -1197,19 +1231,34 @@ Deno.test("isNotFound tells a thing that is not there from an interface that cou
   assertEquals(isNotFound("404"), false);
 });
 
-Deno.test("a covered package's own-tests metric is not one of its source groups", () => {
-  const metric = ownTestsCoverageMetric("packages/memory");
-  assertEquals(ownTestsCoverageMember(metric), "packages/memory");
+Deno.test("a measured set's metric is not one of its member's source groups", () => {
+  const metric = measuredSetCoverageMetric("workspace-unit/packages/memory");
+  assertEquals(
+    coverageMetricMeasuredSet(metric),
+    "workspace-unit/packages/memory",
+  );
   // The two carry the same package name, and reading one as the other
   // would ratchet a figure the gate has no opinion about.
   assertEquals(coverageMetricGroupName(metric), null);
   assertEquals(
-    ownTestsCoverageMember(coverageMetricForGroup("packages/memory")),
+    coverageMetricMeasuredSet(coverageMetricForGroup("packages/memory")),
     null,
   );
   assertEquals(
     coverageMetricGroupName(coverageMetricForGroup("packages/memory")),
     "packages/memory",
+  );
+});
+
+Deno.test("two suites over one member are two metrics", () => {
+  const unit = measuredSetCoverageMetric("workspace-unit/packages/memory");
+  const integration = measuredSetCoverageMetric(
+    "memory-integration/packages/memory",
+  );
+  assertEquals(unit === integration, false);
+  assertEquals(
+    coverageMetricMeasuredSet(integration),
+    "memory-integration/packages/memory",
   );
 });
 

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -481,6 +481,25 @@ export function newestArtifactsByName(artifacts: Artifact[]): Artifact[] {
 }
 
 /** The GitHub page of a workflow run: the URL the baseline file records. */
+/**
+ * The API path listing the runs a coverage baseline could come from:
+ * successful pushes to the default branch, newest first.
+ *
+ * One path rather than one per reader, because the workflow the runs
+ * belong to has to be the same for everything that compares against a
+ * baseline, and a second copy is a second place to update when the run
+ * moves to another workflow.
+ */
+export function workflowRunsPathForBaseline(perPage: number): string {
+  const params = new URLSearchParams({
+    branch: "main",
+    status: "success",
+    event: "push",
+    per_page: String(perPage),
+  });
+  return `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?${params}`;
+}
+
 export function workflowRunUrl(runId: number): string {
   return `${SERVER_URL}/${REPO}/actions/runs/${runId}`;
 }
@@ -814,38 +833,39 @@ export function coverageMetricGroupName(metric: string): string | null {
   if (!metric.startsWith(prefix) || !metric.endsWith(suffix)) return null;
 
   const name = metric.slice(prefix.length, -suffix.length);
-  // A package's own-tests figure carries the package's name and is not a
-  // source group. Whatever iterates the coverage metrics of a run sees
-  // both, and reading one as the other would ratchet the wrong number.
-  return name.endsWith(OWN_TESTS_MARKER) ? null : name;
+  // A measured set's figure carries a member's name and is not a source
+  // group. Whatever iterates the coverage metrics of a run sees both, and
+  // reading one as the other would ratchet the wrong number.
+  return name.startsWith(MEASURED_SET_MARKER) ? null : name;
 }
 
-/** What separates a covered package's own-tests metric from its group. */
-const OWN_TESTS_MARKER = " own-tests";
+/** What separates a measured set's metric from a source group's. */
+const MEASURED_SET_MARKER = "measured set ";
 
 /**
- * The metric one covered package's own tests are counted in.
+ * The metric one measured set's uncovered lines are counted in, named by
+ * the suite and the member the set pairs.
  *
- * A different quantity from the source group of the same name: that one
- * is the package's source measured by every test in the run, and this one
- * is the same source measured by only the package's own tests. The two
+ * A different quantity from the source group over the same member: that
+ * one is the member's source measured by every test in the run, and this
+ * one is the same source measured by one suite's tests alone. The two
  * come apart under test selection, because a run that samples the corpus
  * measures a sample of the first and the whole of the second. That is
- * what makes this the figure a per-package gate can compare and the other
+ * what makes this the figure the coverage gate can compare and the other
  * one a trend.
  */
-export function ownTestsCoverageMetric(member: string): string {
-  return `${COVERAGE_METRIC_PREFIX} ${member}` +
-    `${OWN_TESTS_MARKER} uncovered lines`;
+export function measuredSetCoverageMetric(set: string): string {
+  return `${COVERAGE_METRIC_PREFIX} ${MEASURED_SET_MARKER}${set} ` +
+    `uncovered lines`;
 }
 
-/** The covered package one own-tests metric names, or null for anything else. */
-export function ownTestsCoverageMember(metric: string): string | null {
-  const prefix = `${COVERAGE_METRIC_PREFIX} `;
-  const suffix = `${OWN_TESTS_MARKER} uncovered lines`;
+/** The measured set one metric names, or null for anything else. */
+export function coverageMetricMeasuredSet(metric: string): string | null {
+  const prefix = `${COVERAGE_METRIC_PREFIX} ${MEASURED_SET_MARKER}`;
+  const suffix = " uncovered lines";
   if (!metric.startsWith(prefix) || !metric.endsWith(suffix)) return null;
-  const member = metric.slice(prefix.length, -suffix.length);
-  return member.length === 0 ? null : member;
+  const set = metric.slice(prefix.length, -suffix.length);
+  return set.length === 0 ? null : set;
 }
 
 /** The metric a source group's uncovered lines are counted in. */
@@ -1658,9 +1678,84 @@ const COVERAGE_ACCEPTANCE_TERMS =
  * A coverage source group. Metric collection rolls a file up to its top-level
  * directory, `packages` excepted, where the package directory below it carries
  * the group. So `workspace` and `tasks` are groups and `packages/runner` is
- * one, while `tasks/foo` is not — nothing measures a group at that depth.
+ * one, while `tasks/foo` and `packages/connectors/github` are not — nothing
+ * measures a group at that depth.
  */
 const COVERAGE_GROUP_NAME = /^(?:[A-Za-z0-9._-]+|packages\/[A-Za-z0-9._-]+)$/;
+
+/** Whether an accepted name is one the repository-wide ratchet measures. */
+export function namesCoverageSourceGroup(name: string): boolean {
+  return COVERAGE_GROUP_NAME.test(name);
+}
+
+/**
+ * What an acceptance may name: a coverage source group, or a workspace member
+ * nested deeper than one. The coverage gate scores a measured set over a
+ * member, which sits at whatever depth the workspace puts it, so an acceptance
+ * has to be able to name `packages/connectors/github`.
+ */
+const COVERAGE_ACCEPTANCE_NAME =
+  /^(?:[A-Za-z0-9._-]+|packages(?:\/[A-Za-z0-9._-]+)+)$/;
+
+/**
+ * Each `ACCEPT_COVERAGE_DEBT:` acceptance in a description, as the name it
+ * gives against the lines it allows.
+ *
+ * The name is read as written. Two gates take it differently — the
+ * repository-wide ratchet reads it as a coverage source group, and the
+ * coverage gate reads it as a workspace member — and one parse serving both
+ * is what keeps an author writing one marker rather than two.
+ *
+ * `mergedPullRequestBody` says a merged pull request's description is what is
+ * being read, in which case a marker this cannot read is passed over rather
+ * than rejected: a body that has already merged cannot be rewritten to suit a
+ * later parser.
+ */
+export function acceptedCoverageDebt(
+  body: string,
+  mergedPullRequestBody = false,
+): Map<string, number> {
+  const accepted = new Map<string, number>();
+  for (const marker of body.match(COVERAGE_ACCEPTANCE_MARKER) ?? []) {
+    const terms = COVERAGE_ACCEPTANCE_TERMS.exec(marker);
+    if (terms === null) {
+      if (mergedPullRequestBody) continue;
+      throw new Error(
+        `Invalid ACCEPT_COVERAGE_DEBT acceptance "${marker.trim()}": write it ` +
+          "as `ACCEPT_COVERAGE_DEBT: <source group or workspace member> +N " +
+          "lines`, where N is how many lines above the baseline to allow the " +
+          "rise.",
+      );
+    }
+    const name = terms[1];
+    if (!COVERAGE_ACCEPTANCE_NAME.test(name)) {
+      throw new Error(
+        `Invalid ACCEPT_COVERAGE_DEBT acceptance for "${name}": name a ` +
+          "coverage source group or a workspace member, such as " +
+          "`packages/runner`, `packages/connectors/github`, `tasks`, or " +
+          "`workspace`.",
+      );
+    }
+    const lines = parseInt(terms[2], 10);
+    const already = accepted.get(name);
+    if (already !== undefined) {
+      // Two acceptances of one name is an author who meant one number
+      // and would be given the other. A body that has already merged
+      // cannot be rewritten, so there the larger stands.
+      if (!mergedPullRequestBody) {
+        throw new Error(
+          `Two ACCEPT_COVERAGE_DEBT acceptances name "${name}", for ` +
+            `${already} and ${lines} lines. Write one, for the whole rise ` +
+            `you are accepting.`,
+        );
+      }
+      accepted.set(name, Math.max(already, lines));
+      continue;
+    }
+    accepted.set(name, lines);
+  }
+  return accepted;
+}
 
 /**
  * Parse a PR body for coverage-debt overrides.
@@ -1722,27 +1817,15 @@ export function parseBaselineOverrides(
     }
   }
 
-  for (const marker of body.match(COVERAGE_ACCEPTANCE_MARKER) ?? []) {
-    const terms = COVERAGE_ACCEPTANCE_TERMS.exec(marker);
-    if (terms === null) {
-      if (mergedPullRequestBody) continue;
-      throw new Error(
-        `Invalid ACCEPT_COVERAGE_DEBT acceptance "${marker.trim()}": write it ` +
-          "as `ACCEPT_COVERAGE_DEBT: <source group> +N lines`, where N is how " +
-          "many lines above the baseline to allow the group to rise.",
-      );
-    }
-
-    const group = terms[1];
-    if (!COVERAGE_GROUP_NAME.test(group)) {
-      throw new Error(
-        `Invalid ACCEPT_COVERAGE_DEBT acceptance for "${group}": name a ` +
-          "coverage source group, such as `packages/runner`, `tasks`, or " +
-          "`workspace`.",
-      );
-    }
-
-    result.metrics.set(coverageMetricForGroup(group), parseInt(terms[2], 10));
+  for (
+    const [name, lines] of acceptedCoverageDebt(body, mergedPullRequestBody)
+  ) {
+    // An acceptance naming a workspace member deeper than a source group
+    // is one the coverage gate reads and this ratchet measures nothing
+    // for. Taking it as a group would fail the run for an acceptance
+    // that names no group.
+    if (!namesCoverageSourceGroup(name)) continue;
+    result.metrics.set(coverageMetricForGroup(name), lines);
   }
 
   if (mergedPullRequestBody) {

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -9,9 +9,16 @@ import type { CapabilityId } from "./ci-capabilities.ts";
 import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
 
 import {
+  batchCoverage,
   batchesOf,
+  batchRepeats,
   changedFiles,
+  convertCoverage,
+  COVERAGE_PROFILE_DIR,
+  COVERAGE_REPORT_DIR,
+  COVERAGE_REPORT_FILE,
   describeConflicts,
+  describeCoverage,
   describePlan,
   describeWithheld,
   fullLanes,
@@ -22,6 +29,7 @@ import {
   runInvocation,
   runLane,
   spoolRecords,
+  unitsForRun,
 } from "./ci-lane.ts";
 import { census } from "./test-selection/census.ts";
 import type { Suite } from "./test-topology/suite.ts";
@@ -233,7 +241,7 @@ describe("turning a lane's selections into batches", () => {
       reason: "value",
       repeats: 3,
     }]);
-    expect(batches[0]!.repeats).toBe(3);
+    expect(batchRepeats(batches[0]!)).toBe(3);
   });
 
   it("holds the most runs when a later identity asks for fewer", () => {
@@ -247,12 +255,12 @@ describe("turning a lane's selections into batches", () => {
       { entry: manifest.entries[0]!, reason: "value", repeats: 3 },
       { entry: manifest.entries[1]!, reason: "value", repeats: 1 },
     ]);
-    expect(batches[0]!.repeats).toBe(3);
+    expect(batchRepeats(batches[0]!)).toBe(3);
   });
 
-  it("holds the most runs across the units of one batch", () => {
-    // A batch runs its units together under one count, so a unit asking
-    // for fewer cannot cut short the one that asked for more.
+  it("runs each unit of a batch as many times as that unit asked for", () => {
+    // A unit that asked for fewer runs stops when it has had them: one
+    // flaky unit is not a reason to run the rest of the batch again.
     const twoUnits = suite({
       id: "workspace-unit",
       units: ["packages/bakery/glaze.test.ts", "packages/bakery/ice.test.ts"],
@@ -269,7 +277,30 @@ describe("turning a lane's selections into batches", () => {
       { entry: manifest.entries[1]!, reason: "value", repeats: 2 },
     ]);
     expect(batches.length).toBe(1);
-    expect(batches[0]!.repeats).toBe(4);
+    expect(batchRepeats(batches[0]!)).toBe(4);
+    const round = (run: number) =>
+      unitsForRun(batches[0]!, run).map((request) => request.unit);
+    expect(round(1)).toEqual([
+      "packages/bakery/glaze.test.ts",
+      "packages/bakery/ice.test.ts",
+    ]);
+    expect(round(2)).toEqual([
+      "packages/bakery/glaze.test.ts",
+      "packages/bakery/ice.test.ts",
+    ]);
+    expect(round(3)).toEqual(["packages/bakery/glaze.test.ts"]);
+    expect(round(4)).toEqual(["packages/bakery/glaze.test.ts"]);
+  });
+
+  it("runs a unit nothing asked to repeat exactly once", () => {
+    const manifest = manifestOf([{}]);
+    const batches = batchesOf([bakery], manifest, [{
+      entry: manifest.entries[0]!,
+      reason: "coverage-gate",
+      repeats: 1,
+    }]);
+    expect(batchRepeats(batches[0]!)).toBe(1);
+    expect(unitsForRun(batches[0]!, 2)).toEqual([]);
   });
 });
 
@@ -791,8 +822,8 @@ describe("running a lane's work", () => {
     const passing = await runBatch(
       {
         suite: runnable([Deno.execPath(), "eval", "0"]),
-        units: [],
-        repeats: 3,
+        units: [{ unit: "a-unit", skip: [] }],
+        runs: new Map([["a-unit", 3]]),
       },
       lane,
       workDir,
@@ -804,8 +835,8 @@ describe("running a lane's work", () => {
     const failing = await runBatch(
       {
         suite: runnable([Deno.execPath(), "eval", "Deno.exit(1)"], "red"),
-        units: [],
-        repeats: 2,
+        units: [{ unit: "a-unit", skip: [] }],
+        runs: new Map([["a-unit", 2]]),
       },
       lane,
       workDir,
@@ -836,8 +867,8 @@ describe("running a lane's work", () => {
             ${JSON.stringify(written + "\n")},
           )`,
         ]),
-        units: [],
-        repeats: 1,
+        units: [{ unit: "a-unit", skip: [] }],
+        runs: new Map([["a-unit", 1]]),
       },
       lane,
       workDir,
@@ -857,8 +888,8 @@ describe("running a lane's work", () => {
         lane,
         [{
           suite: runnable(["true"], "workspace-unit"),
-          units: [],
-          repeats: 2,
+          units: [{ unit: "a-unit", skip: [] }],
+          runs: new Map([["a-unit", 2]]),
         }],
         ["deno", "toolshed"],
         { objectName: "manifest-x.json.gz" },
@@ -901,7 +932,7 @@ describe("running a lane's work", () => {
         [{
           suite: runnable(["true"], "workspace-unit"),
           units: [{ unit: "packages/bakery/glaze.test.ts", skip: [] }],
-          repeats: 2,
+          runs: new Map([["packages/bakery/glaze.test.ts", 2]]),
         }],
         ["deno"],
         { objectName: "manifest-x.json.gz" },
@@ -1367,7 +1398,7 @@ describe("what a lane records about itself", () => {
         }]),
     });
     const result = await runBatch(
-      { suite: suiteUnderTest, units: [], repeats: 1 },
+      { suite: suiteUnderTest, units: [], runs: new Map() },
       lane,
       workDir,
       spool,
@@ -1430,8 +1461,8 @@ describe("what a lane records about itself", () => {
               }]),
             ...declared,
           }),
-          units: [],
-          repeats: 1,
+          units: [{ unit: "a-unit", skip: [] }],
+          runs: new Map([["a-unit", 1]]),
         },
         lane,
         workDir,
@@ -1797,5 +1828,202 @@ describe("what a lane does with the batches it was given", () => {
       await Deno.remove(outside, { recursive: true });
     }
     expect(lines.join("\n")).toContain("cannot read the commit's date");
+  });
+});
+
+describe("what a lane measures", () => {
+  const options = {
+    lane: 1,
+    of: 5,
+    full: false,
+    dryRun: false,
+    laneCount: false,
+    root: "/repo",
+  };
+
+  const gated = (member: string) =>
+    census(
+      [suite({
+        id: "workspace-unit",
+        units: [`${member}/one.test.ts`],
+        measured: [{
+          member,
+          reachedBy: [`${member}/`],
+          units: [`${member}/one.test.ts`],
+        }],
+      })],
+      undefined,
+      new Set([`${member}/src/main.ts`]),
+    ).coverage;
+
+  it("measures the members of the sets the gate is scoring", () => {
+    const coverage = batchCoverage(
+      options,
+      "workspace-unit",
+      gated("packages/bakery"),
+    );
+    expect(coverage?.dir)
+      .toBe(`/repo/coverage/${COVERAGE_PROFILE_DIR}/workspace-unit`);
+    expect([...coverage!.members!]).toEqual(["packages/bakery"]);
+  });
+
+  it("measures nothing in a suite the gate is not scoring", () => {
+    expect(batchCoverage(options, "runner-unit", gated("packages/bakery")))
+      .toBeUndefined();
+  });
+
+  it("measures every member of every suite in a full run", () => {
+    const coverage = batchCoverage(
+      { ...options, full: true },
+      "runner-unit",
+      gated("packages/bakery"),
+    );
+    expect(coverage?.members).toBeUndefined();
+    expect(coverage?.dir)
+      .toBe(`/repo/coverage/${COVERAGE_PROFILE_DIR}/runner-unit`);
+  });
+
+  it("puts coverage where the command line said", () => {
+    const coverage = batchCoverage(
+      { ...options, full: true, coverageDir: "elsewhere" },
+      "runner-unit",
+      gated("packages/bakery"),
+    );
+    expect(coverage?.dir)
+      .toBe(`/repo/elsewhere/${COVERAGE_PROFILE_DIR}/runner-unit`);
+  });
+});
+
+describe("converting what a lane collected", () => {
+  /** A lane's coverage directory holding one profile per named set. */
+  async function collected(sets: readonly string[]): Promise<string> {
+    const root = await Deno.makeTempDir({ prefix: "lane-coverage-" });
+    for (const set of sets) {
+      const dir = `${root}/coverage/${COVERAGE_PROFILE_DIR}/${set}`;
+      await Deno.mkdir(dir, { recursive: true });
+      // An empty profile directory converts to an empty report, which is
+      // enough to prove the walk found it and named it.
+      await Deno.writeTextFile(`${dir}/empty.json`, "");
+    }
+    return root;
+  }
+
+  it("writes one report per profile directory, named for the set", async () => {
+    const root = await collected([
+      "workspace-unit/packages__bakery",
+      "runner-unit/packages__runner",
+    ]);
+    const converted = await convertCoverage({ ...options(root) });
+    expect(converted.ok).toBe(true);
+    expect(converted.reports).toEqual([
+      "runner-unit/packages__runner",
+      "workspace-unit/packages__bakery",
+    ]);
+    const at = `${root}/coverage/${COVERAGE_REPORT_DIR}/workspace-unit/` +
+      `packages__bakery/${COVERAGE_REPORT_FILE}`;
+    expect((await Deno.stat(at)).isFile).toBe(true);
+  });
+
+  it("converts a directory no measured set names", async () => {
+    // The repository-wide figure the full run publishes is the merge of
+    // every report, so a directory the gate will not score is still
+    // converted.
+    const root = await collected(["cli-core/packages__cli"]);
+    const converted = await convertCoverage({ ...options(root) });
+    expect(converted.reports).toEqual(["cli-core/packages__cli"]);
+  });
+
+  it("fails the lane when a conversion loses what it was given", async () => {
+    // Every line of a file the report lost reads as uncovered
+    // downstream, so a gate scored from it would fail somebody for a
+    // report that was never complete.
+    const root = await Deno.makeTempDir({ prefix: "lane-coverage-" });
+    const dir =
+      `${root}/coverage/${COVERAGE_PROFILE_DIR}/workspace-unit/packages__bakery`;
+    await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeTextFile(`${dir}/broken.json`, "this is not a profile");
+    const converted = await convertCoverage({ ...options(root) });
+    expect(converted.ok).toBe(false);
+    expect(converted.reports).toEqual(["workspace-unit/packages__bakery"]);
+  });
+
+  it("writes nothing where the lane measured nothing", async () => {
+    const root = await Deno.makeTempDir({ prefix: "lane-coverage-" });
+    const converted = await convertCoverage({ ...options(root) });
+    expect(converted).toEqual({ ok: true, reports: [] });
+  });
+
+  function options(root: string) {
+    return {
+      lane: 1,
+      of: 5,
+      full: false,
+      dryRun: false,
+      laneCount: false,
+      root,
+    };
+  }
+});
+
+describe("what a lane says about coverage", () => {
+  it("says nothing where the change reaches no set and nothing measured", () => {
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    try {
+      describeCoverage({ sets: [], reached: [] }, []);
+    } finally {
+      console.log = log;
+    }
+    expect(lines).toEqual([]);
+  });
+
+  it("names the sets it is scoring, and the reports it wrote", () => {
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    try {
+      describeCoverage({
+        sets: [{
+          suite: "workspace-unit",
+          set: {
+            member: "packages/bakery",
+            reachedBy: ["packages/bakery/"],
+            units: ["packages/bakery/one.test.ts"],
+          },
+        }],
+        reached: [],
+      }, ["workspace-unit/packages__bakery"]);
+    } finally {
+      console.log = log;
+    }
+    const text = lines.join("\n");
+    expect(text).toContain("workspace-unit/packages/bakery");
+    expect(text).toContain("workspace-unit/packages__bakery");
+  });
+
+  it("says why nothing is forced, and what the change reached", () => {
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    try {
+      describeCoverage({
+        sets: [],
+        reached: [{
+          suite: "workspace-unit",
+          set: {
+            member: "packages/bakery",
+            reachedBy: ["packages/bakery/"],
+            units: ["packages/bakery/one.test.ts"],
+          },
+        }],
+        off: "the change reaches 3 measured sets",
+      }, []);
+    } finally {
+      console.log = log;
+    }
+    const text = lines.join("\n");
+    expect(text).toContain("No measured set is forced");
+    expect(text).toContain("workspace-unit/packages/bakery");
   });
 });

--- a/tasks/ci-lane.test.ts
+++ b/tasks/ci-lane.test.ts
@@ -32,7 +32,7 @@ import {
   unitsForRun,
 } from "./ci-lane.ts";
 import { census } from "./test-selection/census.ts";
-import type { Suite } from "./test-topology/suite.ts";
+import type { CommandContext, Suite } from "./test-topology/suite.ts";
 import {
   plan,
   type Selection,
@@ -815,6 +815,73 @@ describe("running a lane's work", () => {
     expect(bad.ok).toBe(false);
   });
 
+  it("hands a measured batch the directory and members to measure", async () => {
+    // The suite decides where under that directory each member's
+    // profiles land, so what the lane passes is the directory and which
+    // members are being scored.
+    const workDir = await Deno.makeTempDir({ prefix: "lane-batch-" });
+    let given: CommandContext | undefined;
+    const recording: Suite = {
+      id: "workspace-unit",
+      recordSurfaces: [{ kind: "unit", scope: "bakery" }],
+      needs: [],
+      units: ["packages/bakery/glaze.test.ts"],
+      unavailable: [],
+      locate: () => undefined,
+      command: (_units, context) => {
+        given = context;
+        return Promise.resolve([]);
+      },
+    };
+    await runBatch(
+      {
+        suite: recording,
+        units: [{ unit: "packages/bakery/glaze.test.ts", skip: [] }],
+        runs: new Map([["packages/bakery/glaze.test.ts", 1]]),
+      },
+      lane,
+      workDir,
+      undefined,
+      {},
+      { dir: "/cov/workspace-unit", members: new Set(["packages/bakery"]) },
+    );
+    expect(given?.coverageDir).toBe("/cov/workspace-unit");
+    expect([...(given?.measuredMembers ?? [])]).toEqual(["packages/bakery"]);
+    await Deno.remove(workDir, { recursive: true });
+  });
+
+  it("measures every member a full run's batch holds", async () => {
+    const workDir = await Deno.makeTempDir({ prefix: "lane-batch-" });
+    let given: CommandContext | undefined;
+    const recording: Suite = {
+      id: "workspace-unit",
+      recordSurfaces: [{ kind: "unit", scope: "bakery" }],
+      needs: [],
+      units: ["packages/bakery/glaze.test.ts"],
+      unavailable: [],
+      locate: () => undefined,
+      command: (_units, context) => {
+        given = context;
+        return Promise.resolve([]);
+      },
+    };
+    await runBatch(
+      {
+        suite: recording,
+        units: [{ unit: "packages/bakery/glaze.test.ts", skip: [] }],
+        runs: new Map([["packages/bakery/glaze.test.ts", 1]]),
+      },
+      { ...lane, full: true },
+      workDir,
+      undefined,
+      {},
+      { dir: "/cov/workspace-unit" },
+    );
+    expect(given?.coverageDir).toBe("/cov/workspace-unit");
+    expect(given?.measuredMembers).toBeUndefined();
+    await Deno.remove(workDir, { recursive: true });
+  });
+
   it("runs a batch once per repeat, and every one must pass", async () => {
     // A repeat is not a retry: three runs of a test is strictly stricter
     // than one, so a batch that fails once has failed.
@@ -1285,6 +1352,94 @@ describe("the lane's own housekeeping", () => {
     }
     expect(await Deno.readTextFile(summary)).toContain("manifest-x.json.gz");
     await Deno.remove(summary);
+  });
+
+  it("fails a lane whose coverage would not convert", async () => {
+    // A conversion that lost a tracked file leaves a report every line
+    // of which reads as uncovered, so a gate scored from it would fail
+    // somebody for a report that was never complete.
+    const root = await Deno.makeTempDir({ prefix: "lane-convert-" });
+    const temp = await Deno.makeTempDir({ prefix: "lane-tmp-" });
+    const previous = Deno.env.get("TMPDIR");
+    Deno.env.set("TMPDIR", temp);
+    const dir =
+      `${root}/coverage/${COVERAGE_PROFILE_DIR}/workspace-unit/packages__bakery`;
+    await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeTextFile(`${dir}/broken.json`, "this is not a profile");
+    const bare: Suite = {
+      id: "workspace-unit",
+      recordSurfaces: [{ kind: "unit", scope: "bakery" }],
+      needs: [],
+      units: [],
+      unavailable: [],
+      locate: () => undefined,
+      command: () => Promise.resolve([]),
+    };
+    const log = console.log;
+    console.log = () => {};
+    let ok: boolean;
+    try {
+      ok = await runLane({
+        lane: 1,
+        of: 1,
+        full: true,
+        dryRun: false,
+        laneCount: false,
+        root,
+      }, {
+        topology: () => Promise.resolve([bare]),
+        manifest: (at) =>
+          Promise.resolve({ absent: `no manifest at ${at}: held out here` }),
+      });
+    } finally {
+      console.log = log;
+      if (previous === undefined) Deno.env.delete("TMPDIR");
+      else Deno.env.set("TMPDIR", previous);
+    }
+    expect(ok).toBe(false);
+    await Deno.remove(temp, { recursive: true });
+    await Deno.remove(root, { recursive: true });
+  });
+
+  it("gives its work directory back when a capability will not open", async () => {
+    // The directory belongs to the lane from the moment it exists, so a
+    // capability that refuses is not a reason to leave one behind.
+    const root = await Deno.makeTempDir({ prefix: "lane-caps-" });
+    const temp = await Deno.makeTempDir({ prefix: "lane-tmp-" });
+    const previous = Deno.env.get("TMPDIR");
+    Deno.env.set("TMPDIR", temp);
+    const wanting: Suite = {
+      id: "wanting",
+      recordSurfaces: [{ kind: "unit", scope: "wanting" }],
+      needs: ["nothing-opens-this" as CapabilityId],
+      units: ["packages/bakery/glaze.test.ts"],
+      unavailable: [],
+      locate: () => undefined,
+      command: () => Promise.resolve([]),
+    };
+    const log = console.log;
+    console.log = () => {};
+    try {
+      await expect(runLane({
+        lane: 1,
+        of: 1,
+        full: true,
+        dryRun: false,
+        laneCount: false,
+        root,
+      }, {
+        topology: () => Promise.resolve([wanting]),
+        manifest: (at) =>
+          Promise.resolve({ absent: `no manifest at ${at}: held out here` }),
+      })).rejects.toThrow();
+    } finally {
+      console.log = log;
+      if (previous === undefined) Deno.env.delete("TMPDIR");
+      else Deno.env.set("TMPDIR", previous);
+    }
+    expect([...Deno.readDirSync(temp)]).toEqual([]);
+    await Deno.remove(temp, { recursive: true });
+    await Deno.remove(root, { recursive: true });
   });
 
   it("runs a lane that was given no share of the work", async () => {
@@ -1933,6 +2088,21 @@ describe("converting what a lane collected", () => {
     expect(converted.reports).toEqual(["cli-core/packages__cli"]);
   });
 
+  it("takes the directory its coverage goes under from the command line", () => {
+    const options = parseLaneArgs(["--coverage-dir", "/somewhere/coverage"]);
+    expect(options?.coverageDir).toBe("/somewhere/coverage");
+  });
+
+  it("refuses a profile directory it cannot walk", async () => {
+    // An absent directory is a lane that measured nothing, which is
+    // ordinary. Anything else is a failure worth ending on.
+    const root = await Deno.makeTempDir({ prefix: "lane-coverage-" });
+    const at = `${root}/coverage/${COVERAGE_PROFILE_DIR}`;
+    await Deno.mkdir(`${root}/coverage`, { recursive: true });
+    await Deno.writeTextFile(at, "");
+    await expect(convertCoverage({ ...options(root) })).rejects.toThrow();
+  });
+
   it("fails the lane when a conversion loses what it was given", async () => {
     // Every line of a file the report lost reads as uncovered
     // downstream, so a gate scored from it would fail somebody for a
@@ -2000,6 +2170,35 @@ describe("what a lane says about coverage", () => {
     const text = lines.join("\n");
     expect(text).toContain("workspace-unit/packages/bakery");
     expect(text).toContain("workspace-unit/packages__bakery");
+  });
+
+  it("names a report by its set where the change reached that set", () => {
+    // A report belonging to a set is named as the set, so one summary
+    // does not spell one thing two ways.
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (line: string) => lines.push(line);
+    const ref = {
+      suite: "workspace-unit",
+      set: {
+        member: "packages/bakery",
+        reachedBy: ["packages/bakery/"],
+        units: ["packages/bakery/one.test.ts"],
+      },
+    };
+    try {
+      describeCoverage(
+        { sets: [ref], reached: [ref] },
+        ["workspace-unit/packages__bakery", "workspace-unit/packages__cellar"],
+      );
+    } finally {
+      console.log = log;
+    }
+    const text = lines.join("\n");
+    expect(text).toContain("- workspace-unit/packages/bakery");
+    // A directory no set is scored from keeps the name the suite wrote.
+    expect(text).toContain("- workspace-unit/packages__cellar");
+    expect(text).not.toContain("- workspace-unit/packages__bakery");
   });
 
   it("says why nothing is forced, and what the change reached", () => {

--- a/tasks/ci-lane.ts
+++ b/tasks/ci-lane.ts
@@ -43,6 +43,7 @@ import {
   type Invocation,
   type Suite,
   unavailableUnits,
+  type Unit,
   type UnitRequest,
 } from "./test-topology/suite.ts";
 import { collectRecords } from "./test-records-gather.ts";
@@ -54,8 +55,15 @@ import {
   type SelectionReason,
 } from "./test-selection/plan.ts";
 import { type Census, census } from "./test-selection/census.ts";
+import {
+  type CoverageGateSelection,
+  measuredMembersOf,
+  measuredSetDirectory,
+  measuredSetName,
+} from "./test-selection/coverage.ts";
 import type { Manifest, WithheldReason } from "./test-selection/manifest.ts";
 import { LANES } from "./test-selection/policy.ts";
+import { writeLcovReport } from "./write-coverage-lcov.ts";
 import {
   LANE_MEASUREMENT_PREFIX,
   LANE_MEASUREMENT_SURFACE,
@@ -91,7 +99,38 @@ export interface LaneOptions {
    */
   at?: string;
 
+  /**
+   * Where coverage profiles and the reports converted from them go,
+   * relative to the root. The job uploads what is under it.
+   */
+  coverageDir?: string;
+
   root: string;
+}
+
+/** Where coverage goes when the command line names nowhere else. */
+export const DEFAULT_COVERAGE_DIR = "coverage";
+
+/** Where a lane puts the profiles it collects, under its coverage directory. */
+export const COVERAGE_PROFILE_DIR = "raw";
+
+/** Where a lane puts the reports it converts, under its coverage directory. */
+export const COVERAGE_REPORT_DIR = "lcov/sets";
+
+/**
+ * What a lane calls each report. One directory per measured set rather
+ * than one file per set in a shared directory, because the conversion
+ * puts what a report does not cover beside the report, and two sets
+ * sharing a directory would share that too.
+ */
+export const COVERAGE_REPORT_FILE = "coverage.lcov";
+
+/** Where this lane's coverage goes, absolute. */
+export function coverageRoot(options: LaneOptions): string {
+  return path.resolve(
+    options.root,
+    options.coverageDir ?? DEFAULT_COVERAGE_DIR,
+  );
 }
 
 /** Reads the command line, or returns undefined for a malformed one. */
@@ -136,6 +175,9 @@ export function parseLaneArgs(
         break;
       case "--at":
         options.at = value;
+        break;
+      case "--coverage-dir":
+        options.coverageDir = value;
         break;
       default:
         return undefined;
@@ -238,8 +280,27 @@ export interface Batch {
   /** Each unit, and the identities inside it that are not to run. */
   units: UnitRequest[];
 
-  /** How many times this batch runs. Every run must pass. */
-  repeats: number;
+  /**
+   * How many times each unit runs, by unit. Every run must pass.
+   *
+   * Per unit rather than per batch, because what a repeat is for is
+   * catching one test disagreeing with itself. One flaky unit is not a
+   * reason to run the rest of the batch again, and running it again
+   * would cost the lane time the packer never charged it for.
+   */
+  runs: Map<Unit, number>;
+}
+
+/** How many times a batch's longest-running unit runs. */
+export function batchRepeats(batch: Batch): number {
+  let most = 1;
+  for (const runs of batch.runs.values()) most = Math.max(most, runs);
+  return most;
+}
+
+/** The units of a batch that are still running on the `run`th time round. */
+export function unitsForRun(batch: Batch, run: number): UnitRequest[] {
+  return batch.units.filter((unit) => (batch.runs.get(unit.unit) ?? 1) >= run);
 }
 
 /**
@@ -287,10 +348,14 @@ export function batchesOf(
     const batch = batches.get(suiteId);
     const request: UnitRequest = { unit, skip };
     if (batch === undefined) {
-      batches.set(suiteId, { suite, units: [request], repeats });
+      batches.set(suiteId, {
+        suite,
+        units: [request],
+        runs: new Map([[unit, repeats]]),
+      });
     } else {
       batch.units.push(request);
-      batch.repeats = Math.max(batch.repeats, repeats);
+      batch.runs.set(unit, repeats);
     }
   }
   // Both orders are the tree's rather than the packer's, so what a
@@ -377,6 +442,83 @@ export function spoolRecords(
   writer.close();
 }
 
+/** Where one batch's coverage profiles go, and which members write them. */
+export interface BatchCoverage {
+  /** The directory this suite's profiles go under, absolute. */
+  dir: string;
+
+  /**
+   * The members to measure, or nothing to measure every member the batch
+   * runs, which is what the full run asks for.
+   */
+  members?: ReadonlySet<string>;
+}
+
+/**
+ * What a lane measures, given what the coverage gate decided.
+ *
+ * A pull request measures the members of the sets the gate is scoring and
+ * no others: coverage costs time, and a profile no set is scored from is
+ * time spent on something nothing reads. The full run measures every
+ * member of every suite, because both the baselines and the
+ * repository-wide trend come out of it.
+ */
+export function batchCoverage(
+  options: LaneOptions,
+  suiteId: string,
+  gate: CoverageGateSelection,
+): BatchCoverage | undefined {
+  const dir = path.join(coverageRoot(options), COVERAGE_PROFILE_DIR, suiteId);
+  if (options.full) return { dir };
+  const members = measuredMembersOf(gate, suiteId);
+  return members.size === 0 ? undefined : { dir, members };
+}
+
+/**
+ * Converts every profile directory a lane wrote into one report beside
+ * it, and says whether every conversion accounted for what it was given.
+ *
+ * Every directory is converted rather than only the ones a measured set
+ * names, because the repository-wide figure the full run publishes is the
+ * merge of all of them. Which of the reports the gate scores is decided
+ * from the declarations, so an unscored report costs a conversion and
+ * nothing else.
+ */
+export async function convertCoverage(
+  options: LaneOptions,
+): Promise<{ ok: boolean; reports: string[] }> {
+  const root = coverageRoot(options);
+  const profiles = path.join(root, COVERAGE_PROFILE_DIR);
+  const reports: string[] = [];
+  let ok = true;
+  for (const suiteId of await directoriesIn(profiles)) {
+    for (const member of await directoriesIn(path.join(profiles, suiteId))) {
+      const name = `${suiteId}/${member}`;
+      const outcome = await writeLcovReport(
+        path.join(profiles, suiteId, member),
+        path.join(root, COVERAGE_REPORT_DIR, name, COVERAGE_REPORT_FILE),
+      );
+      if (!outcome.ok) ok = false;
+      reports.push(name);
+    }
+  }
+  return { ok, reports: reports.sort() };
+}
+
+/** The subdirectories of a directory, or none where it does not exist. */
+async function directoriesIn(at: string): Promise<string[]> {
+  const names: string[] = [];
+  try {
+    for await (const entry of Deno.readDir(at)) {
+      if (entry.isDirectory) names.push(entry.name);
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return [];
+    throw error;
+  }
+  return names.sort();
+}
+
 /**
  * Runs one batch, once per repeat, gathering each execution's records
  * before the next can reuse a path the runner owns. Every repeat must
@@ -396,6 +538,7 @@ export async function runBatch(
   workDir: string,
   spool: string | undefined,
   env: Record<string, string>,
+  coverage?: BatchCoverage,
 ): Promise<{
   ok: boolean;
   records: TestRecord[];
@@ -406,15 +549,21 @@ export async function runBatch(
   const conflicts: TestRecord[] = [];
   let ok = true;
   let seconds = 0;
-  for (let run = 1; run <= batch.repeats; run++) {
+  for (let run = 1; run <= batchRepeats(batch); run++) {
     const outputDir = path.join(workDir, `${batch.suite.id}-${run}`);
     const batchSpool = path.join(outputDir, "spool");
     await Deno.mkdir(batchSpool, { recursive: true });
-    const invocations = await batch.suite.command(batch.units, {
+    const invocations = await batch.suite.command(unitsForRun(batch, run), {
       root: options.root,
       outputDir,
       spoolDir: batchSpool,
       ...(options.base === undefined ? {} : { baseRef: options.base }),
+      ...(coverage === undefined ? {} : {
+        coverageDir: coverage.dir,
+        ...(coverage.members === undefined
+          ? {}
+          : { measuredMembers: coverage.members }),
+      }),
     });
     for (const invocation of invocations) {
       const outcome = await runInvocation(invocation, {
@@ -596,7 +745,8 @@ export function describePlan(
     const share = chosenFor(batch.suite.id, chosen.selections);
     lines.push(
       `| ${batch.suite.id} | ${batch.units.length} | ${share.identities} | ` +
-        `${share.seconds.toFixed(1)}s | ${batch.repeats} | ${share.why} |`,
+        `${share.seconds.toFixed(1)}s | ${batchRepeats(batch)} | ` +
+        `${share.why} |`,
     );
   }
   if (unschedulable.length > 0) {
@@ -862,6 +1012,7 @@ export async function runLane(
         // things by it, and the two server-execution arms can share a
         // lane.
         opened.envFor(batch.suite.needs),
+        batchCoverage(options, batch.suite.id, seen.coverage),
       );
       if (!result.ok) ok = false;
       conflicts.push(...result.conflicts);
@@ -873,7 +1024,52 @@ export async function runLane(
     await Deno.remove(workDir, { recursive: true }).catch(() => {});
   }
   describeConflicts(conflicts);
+  // After the capabilities are closed, because a conversion is the lane's
+  // own work and needs nothing a suite opened. A conversion that lost a
+  // tracked file fails the lane: every line of that file reads as
+  // uncovered downstream, so a gate scored from it would fail somebody
+  // for a report that was never complete.
+  const converted = await convertCoverage(options);
+  if (!converted.ok) ok = false;
+  describeCoverage(seen.coverage, converted.reports);
   return ok;
+}
+
+/**
+ * Says what the coverage gate is doing, and what this lane measured for
+ * it. A change that reached a set and is not being gated says why here,
+ * so that a set the cap left unforced is visible rather than absent.
+ */
+export function describeCoverage(
+  gate: CoverageGateSelection,
+  reports: readonly string[],
+): void {
+  if (gate.reached.length === 0 && reports.length === 0) return;
+  const lines = ["## Coverage", ""];
+  if (gate.off !== undefined) {
+    lines.push(`No measured set is forced: ${gate.off}.`, "");
+    lines.push("Reached, and not forced:", "");
+    for (const ref of gate.reached) lines.push(`- ${measuredSetName(ref)}`);
+  } else if (gate.sets.length > 0) {
+    lines.push("Measured sets this change reaches, run whole and scored:", "");
+    for (const ref of gate.sets) lines.push(`- ${measuredSetName(ref)}`);
+  }
+  if (reports.length > 0) {
+    // A report belonging to a set is named as the set, so one summary
+    // does not spell one thing two ways. What is left is a directory a
+    // suite wrote and no set is scored from, which only the full run's
+    // merge reads.
+    const named = new Map(
+      gate.reached.map((
+        ref,
+      ) => [measuredSetDirectory(ref), measuredSetName(ref)]),
+    );
+    lines.push("", "Reports this lane wrote:", "");
+    for (const report of reports) {
+      lines.push(`- ${named.get(report) ?? report}`);
+    }
+  }
+  say(lines);
 }
 
 /**
@@ -890,7 +1086,7 @@ export async function main(
   if (options === undefined) {
     console.error(
       "usage: ci-lane.ts [--lane N] [--of M] [--full] [--dry-run] " +
-        "[--lane-count] [--base <ref>] [--at <iso>]",
+        "[--lane-count] [--base <ref>] [--at <iso>] [--coverage-dir <dir>]",
     );
     return 2;
   }

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -14,6 +14,7 @@ import {
   PERF_METRICS_ARTIFACT_NAME,
   type PRInfo,
   type WorkflowRun,
+  workflowRunsPathForBaseline,
 } from "./ci-check-lib.ts";
 import {
   baselineLcovForRun,
@@ -57,7 +58,6 @@ import {
   unscoredGroupsReport,
   validateBaselineRunsForMainHead,
   walkBaselineRuns,
-  workflowRunsPathForBaseline,
   writeCoverageComment,
   writeCoverageDebtSuggestion,
   writeCoverageResolved,
@@ -413,9 +413,10 @@ Deno.test("invalid merged PR baseline override metadata is ignored", () => {
   const overrides = parseMergedBaselineOverrides(
     {
       number: 123,
-      // A directory below the group level names no source group, so accepting
-      // it throws.
-      body: "ACCEPT_COVERAGE_DEBT: packages/runner/src +7 lines",
+      // Only `packages` splits below its top level, so a directory under
+      // any other one names neither a source group nor a workspace
+      // member, and accepting it throws.
+      body: "ACCEPT_COVERAGE_DEBT: tasks/runner +7 lines",
     },
     (message) => warnings.push(message),
   );
@@ -424,6 +425,17 @@ Deno.test("invalid merged PR baseline override metadata is ignored", () => {
   assertEquals(warnings.length, 1);
   assertStringIncludes(warnings[0], "merged PR #123");
   assertStringIncludes(warnings[0], "name a coverage source group");
+});
+
+Deno.test("a merged PR's acceptance of a workspace member is not this ratchet's", () => {
+  // It names a member deeper than any source group, which the coverage
+  // gate reads and this ratchet measures nothing for.
+  const overrides = parseMergedBaselineOverrides({
+    number: 125,
+    body: "ACCEPT_COVERAGE_DEBT: packages/connectors/github +7 lines",
+  });
+
+  assertEquals(overrides?.metrics.size, 0);
 });
 
 Deno.test("valid merged PR baseline override metadata is parsed", () => {

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -66,8 +66,8 @@ import {
   REPO,
   shouldGateCoverageDebtMetric,
   unknownAcceptedMetrics,
-  WORKFLOW_FILE,
   type WorkflowRun,
+  workflowRunsPathForBaseline,
   workflowRunUrl,
   writeCoverageBaselineFile,
 } from "./ci-check-lib.ts";
@@ -185,18 +185,6 @@ export function parseMergedBaselineOverrides(
     );
     return null;
   }
-}
-
-export function workflowRunsPathForBaseline(
-  perPage: number,
-): string {
-  const params = new URLSearchParams({
-    branch: "main",
-    status: "success",
-    event: "push",
-    per_page: String(perPage),
-  });
-  return `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?${params}`;
 }
 
 export interface BaselineMainHeadValidation {

--- a/tasks/coverage-gate.test.ts
+++ b/tasks/coverage-gate.test.ts
@@ -1,0 +1,879 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import * as path from "@std/path";
+import {
+  collectSetReports,
+  formatGateReport,
+  type GateInput,
+  nearestBaseline,
+  nearestOnBranch,
+  parseGateArgs,
+  runGate,
+} from "./coverage-gate.ts";
+import { coverageGateFor } from "./test-selection/coverage.ts";
+import type { MeasuredSet, Suite } from "./test-topology/suite.ts";
+import type { CoverageBaseline } from "./test-selection/manifest.ts";
+
+/** A suite carrying only what the gate reads. */
+function suite(id: string, measured: MeasuredSet[]): Suite {
+  return {
+    id,
+    recordSurfaces: [{ kind: "unit", scope: id }],
+    needs: [],
+    units: measured.flatMap((set) => set.units),
+    unavailable: [],
+    measured,
+    locate: () => undefined,
+    command: () => Promise.resolve([]),
+  };
+}
+
+/**
+ * A workspace holding one member, whose source is one file of `lines`
+ * statements, and the LCOV covering `covered` of them.
+ */
+async function workspace(
+  member: string,
+  lines: number,
+  covered: number,
+): Promise<{ root: string; lcov: string }> {
+  const root = await Deno.makeTempDir({ prefix: "coverage-gate-" });
+  await Deno.writeTextFile(
+    path.join(root, "deno.jsonc"),
+    JSON.stringify({ workspace: [`./${member}`] }),
+  );
+  const dir = path.join(root, member, "src");
+  await Deno.mkdir(dir, { recursive: true });
+  const file = path.join(dir, "main.ts");
+  const body = Array.from(
+    { length: lines },
+    (_, at) => `const v${at} = ${at};`,
+  );
+  await Deno.writeTextFile(file, `${body.join("\n")}\n`);
+  const records = body.map((_, at) => `DA:${at + 1},${at < covered ? 1 : 0}`);
+  const lcov = `SF:${file}\n${records.join("\n")}\nend_of_record\n`;
+  return { root, lcov };
+}
+
+/** Every field the gate reads, with one report and no acceptance. */
+function gateInput(
+  over: Partial<GateInput> & Pick<GateInput, "root" | "gate">,
+): GateInput {
+  return {
+    reports: new Map(),
+    members: [],
+    baselines: [],
+    nearest: (commits) => Promise.resolve(commits[0]),
+    accepted: new Map(),
+    testsFailed: false,
+    ...over,
+  };
+}
+
+/** A set over `member`, and the suites declaring it. */
+function bakery(member = "packages/bakery"): {
+  suites: Suite[];
+  changed: Set<string>;
+} {
+  return {
+    suites: [suite("workspace-unit", [{
+      member,
+      reachedBy: [`${member}/`],
+      units: [`${member}/one.test.ts`],
+    }])],
+    changed: new Set([`${member}/src/main.ts`]),
+  };
+}
+
+/** Writes one lane's report for a set, and answers with the reports map. */
+async function reportsFor(
+  entries: readonly (readonly [string, string])[],
+): Promise<{ dir: string; reports: Map<string, string[]> }> {
+  const dir = await Deno.makeTempDir({ prefix: "coverage-reports-" });
+  for (const [at, lcov] of entries) {
+    const full = path.join(dir, at);
+    await Deno.mkdir(path.dirname(full), { recursive: true });
+    await Deno.writeTextFile(full, lcov);
+  }
+  return { dir, reports: await collectSetReports(dir) };
+}
+
+describe("coverage-gate", () => {
+  describe("reading the lanes' reports", () => {
+    it("joins the reports several lanes wrote for one set", async () => {
+      const { reports } = await reportsFor([
+        [
+          "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+          "a",
+        ],
+        [
+          "lane-3/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+          "b",
+        ],
+      ]);
+      expect(reports.get("workspace-unit/packages__bakery")).toHaveLength(2);
+    });
+
+    it("keeps two suites' reports over one member apart", async () => {
+      const { reports } = await reportsFor([
+        [
+          "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+          "a",
+        ],
+        [
+          "lane-1/coverage/lcov/sets/bakery-e2e/packages__bakery/coverage.lcov",
+          "b",
+        ],
+      ]);
+      expect([...reports.keys()].sort()).toEqual([
+        "bakery-e2e/packages__bakery",
+        "workspace-unit/packages__bakery",
+      ]);
+    });
+
+    it("names a report by the directory the suite wrote it under", async () => {
+      // The suite that wrote the directory is the one that names it, so
+      // nothing here works a member back out of the name.
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/" +
+        "packages__connectors__github/coverage.lcov",
+        "a",
+      ]]);
+      expect([...reports.keys()])
+        .toEqual(["workspace-unit/packages__connectors__github"]);
+    });
+
+    it("scores a set from the directory its own suite names", async () => {
+      const { root, lcov } = await workspace(
+        "packages/connectors/github",
+        4,
+        1,
+      );
+      const suites = [suite("workspace-unit", [{
+        member: "packages/connectors/github",
+        reachedBy: ["packages/connectors/github/"],
+        units: ["packages/connectors/github/one.test.ts"],
+      }])];
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/" +
+        "packages__connectors__github/coverage.lcov",
+        lcov,
+      ]]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(
+          suites,
+          new Set(["packages/connectors/github/src/main.ts"]),
+        ),
+        reports,
+        members: ["packages/connectors/github"],
+      }));
+      expect(report.verdicts[0]?.uncoveredLines).toBe(3);
+    });
+
+    it("passes over a report that is not one of a set's", async () => {
+      const { reports } = await reportsFor([
+        ["lane-1/coverage/lcov/workspace.lcov", "a"],
+        ["lane-1/coverage/lcov/sets/deeper/than/expected/coverage.lcov", "b"],
+      ]);
+      expect([...reports.keys()]).toEqual([]);
+    });
+
+    it("finds nothing where no lane uploaded anything", async () => {
+      const dir = await Deno.makeTempDir({ prefix: "coverage-reports-" });
+      expect((await collectSetReports(path.join(dir, "gone"))).size).toBe(0);
+    });
+  });
+
+  describe("the baseline walk", () => {
+    const baselines: CoverageBaseline[] = [
+      {
+        suite: "workspace-unit",
+        member: "packages/bakery",
+        commit: "newest",
+        createdAt: "2026-09-03T00:00:00.000Z",
+        uncoveredLines: 5,
+      },
+      {
+        suite: "workspace-unit",
+        member: "packages/bakery",
+        commit: "older",
+        createdAt: "2026-09-01T00:00:00.000Z",
+        uncoveredLines: 9,
+      },
+      {
+        suite: "bakery-e2e",
+        member: "packages/bakery",
+        commit: "newest",
+        createdAt: "2026-09-03T00:00:00.000Z",
+        uncoveredLines: 900,
+      },
+    ];
+
+    /** The nearest of `held`, in that order, among the ones asked about. */
+    const onBranch = (...held: string[]) => (commits: readonly string[]) =>
+      Promise.resolve(held.find((commit) => commits.includes(commit)));
+
+    it("takes the one the branch holds most recently", async () => {
+      const found = await nearestBaseline(
+        baselines,
+        "workspace-unit",
+        "packages/bakery",
+        onBranch("newest", "older"),
+      );
+      expect(found?.commit).toBe("newest");
+    });
+
+    it("takes a commit the branch holds over one it does not", async () => {
+      const found = await nearestBaseline(
+        baselines,
+        "workspace-unit",
+        "packages/bakery",
+        onBranch("older"),
+      );
+      expect(found?.uncoveredLines).toBe(9);
+    });
+
+    it("goes by the branch's history and not by when a run was made", async () => {
+      // A re-run of an older commit is created after the run of a newer
+      // one. Taking the newer commit is what the branch's own order
+      // says, whatever order the runs arrived in.
+      const reversed: CoverageBaseline[] = [
+        {
+          suite: "workspace-unit",
+          member: "packages/bakery",
+          commit: "older",
+          createdAt: "2026-09-09T00:00:00.000Z",
+          uncoveredLines: 9,
+        },
+        {
+          suite: "workspace-unit",
+          member: "packages/bakery",
+          commit: "newest",
+          createdAt: "2026-09-01T00:00:00.000Z",
+          uncoveredLines: 5,
+        },
+      ];
+      const found = await nearestBaseline(
+        reversed,
+        "workspace-unit",
+        "packages/bakery",
+        onBranch("newest", "older"),
+      );
+      expect(found?.commit).toBe("newest");
+    });
+
+    it("finds nothing where the branch holds none of them", async () => {
+      expect(
+        await nearestBaseline(
+          baselines,
+          "workspace-unit",
+          "packages/bakery",
+          () => Promise.resolve(undefined),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("never takes another suite's baseline over the same member", async () => {
+      const found = await nearestBaseline(
+        baselines,
+        "bakery-e2e",
+        "packages/bakery",
+        onBranch("newest", "older"),
+      );
+      expect(found?.uncoveredLines).toBe(900);
+    });
+  });
+
+  describe("the coverage gate", () => {
+    it("passes a set that covers as much as the baseline did", async () => {
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+        lcov,
+      ]]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        reports,
+        members: ["packages/bakery"],
+        baselines: [{
+          suite: "workspace-unit",
+          member: "packages/bakery",
+          commit: "abc",
+          createdAt: "2026-09-01T00:00:00.000Z",
+          uncoveredLines: 4,
+        }],
+      }));
+      expect(report.ok).toBe(true);
+      expect(report.verdicts[0]?.outcome).toBe("passed");
+      expect(report.verdicts[0]?.uncoveredLines).toBe(4);
+    });
+
+    it("fails a set that covers less than the baseline did", async () => {
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+        lcov,
+      ]]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        reports,
+        members: ["packages/bakery"],
+        baselines: [{
+          suite: "workspace-unit",
+          member: "packages/bakery",
+          commit: "abc",
+          createdAt: "2026-09-01T00:00:00.000Z",
+          uncoveredLines: 1,
+        }],
+      }));
+      expect(report.ok).toBe(false);
+      expect(report.verdicts[0]?.outcome).toBe("rose");
+      const lines = formatGateReport(report).join("\n");
+      expect(lines).toContain("coverage failure rather than a test failure");
+      expect(lines).toContain("ACCEPT_COVERAGE_DEBT: packages/bakery +3 lines");
+    });
+
+    it("accepts a rise the description allows", async () => {
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+        lcov,
+      ]]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        reports,
+        members: ["packages/bakery"],
+        accepted: new Map([["packages/bakery", 3]]),
+        baselines: [{
+          suite: "workspace-unit",
+          member: "packages/bakery",
+          commit: "abc",
+          createdAt: "2026-09-01T00:00:00.000Z",
+          uncoveredLines: 1,
+        }],
+      }));
+      expect(report.ok).toBe(true);
+      expect(report.verdicts[0]?.outcome).toBe("accepted");
+    });
+
+    it("fails a rise larger than the description allows", async () => {
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+        lcov,
+      ]]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        reports,
+        members: ["packages/bakery"],
+        accepted: new Map([["packages/bakery", 1]]),
+        baselines: [{
+          suite: "workspace-unit",
+          member: "packages/bakery",
+          commit: "abc",
+          createdAt: "2026-09-01T00:00:00.000Z",
+          uncoveredLines: 1,
+        }],
+      }));
+      expect(report.ok).toBe(false);
+      expect(report.verdicts[0]?.outcome).toBe("rose");
+    });
+
+    it("reports rather than fails a set with no baseline", async () => {
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+        lcov,
+      ]]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        reports,
+        members: ["packages/bakery"],
+      }));
+      expect(report.ok).toBe(true);
+      expect(report.verdicts[0]?.outcome).toBe("no-baseline");
+    });
+
+    it("reports rather than fails against a tree the branch lacks", async () => {
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+        lcov,
+      ]]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        reports,
+        members: ["packages/bakery"],
+        nearest: () => Promise.resolve(undefined),
+        baselines: [{
+          suite: "workspace-unit",
+          member: "packages/bakery",
+          commit: "abc",
+          createdAt: "2026-09-01T00:00:00.000Z",
+          uncoveredLines: 1,
+        }],
+      }));
+      expect(report.ok).toBe(true);
+      expect(report.verdicts[0]?.outcome).toBe("no-baseline");
+    });
+
+    it("reports rather than fails when the run has a failing test", async () => {
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+        lcov,
+      ]]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        reports,
+        members: ["packages/bakery"],
+        testsFailed: true,
+        baselines: [{
+          suite: "workspace-unit",
+          member: "packages/bakery",
+          commit: "abc",
+          createdAt: "2026-09-01T00:00:00.000Z",
+          uncoveredLines: 1,
+        }],
+      }));
+      expect(report.ok).toBe(true);
+      expect(report.verdicts[0]?.outcome).toBe("not-scored");
+    });
+
+    it("reports rather than fails when the report names no line of the member", async () => {
+      // An empty report is a conversion that produced nothing. Charging
+      // the member every tracked line would fail the change for a
+      // measurement that never happened.
+      const { root } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+        "",
+      ]]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        reports,
+        members: ["packages/bakery"],
+        baselines: [{
+          suite: "workspace-unit",
+          member: "packages/bakery",
+          commit: "abc",
+          createdAt: "2026-09-01T00:00:00.000Z",
+          uncoveredLines: 1,
+        }],
+      }));
+      expect(report.ok).toBe(true);
+      expect(report.verdicts[0]?.outcome).toBe("nothing-measured");
+    });
+
+    it("fails an acceptance that names neither a member nor a group", async () => {
+      const { root } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        members: ["packages/bakery"],
+        accepted: new Map([["packages/bakery/src/oven", 3]]),
+      }));
+      expect(report.ok).toBe(false);
+      expect(report.unknownAcceptances).toEqual(["packages/bakery/src/oven"]);
+      expect(formatGateReport(report).join("\n"))
+        .toContain("nothing would ever consult them");
+    });
+
+    it("leaves an acceptance the other ratchet reads alone", async () => {
+      const { root } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        members: ["packages/bakery"],
+        accepted: new Map([["tasks", 3], ["packages/runner", 4]]),
+      }));
+      expect(report.unknownAcceptances).toEqual([]);
+    });
+
+    it("reports rather than fails when no lane wrote the report", async () => {
+      const { root } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        members: ["packages/bakery"],
+      }));
+      expect(report.ok).toBe(true);
+      expect(report.verdicts[0]?.outcome).toBe("no-report");
+    });
+
+    it("says the gate did not run when the change is over the cap", async () => {
+      const { root } = await workspace("packages/bakery", 10, 6);
+      const members = ["packages/a", "packages/b", "packages/c"];
+      const suites = [suite(
+        "workspace-unit",
+        members.map((member) => ({
+          member,
+          reachedBy: [`${member}/`],
+          units: [`${member}/one.test.ts`],
+        })),
+      )];
+      const changed = new Set(members.map((member) => `${member}/src/main.ts`));
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+      }));
+      expect(report.ran).toBe(false);
+      expect(report.ok).toBe(true);
+      expect(report.verdicts.map((verdict) => verdict.outcome))
+        .toEqual(["not-forced", "not-forced", "not-forced"]);
+      expect(formatGateReport(report).join("\n"))
+        .toContain("No measured set was forced to run");
+    });
+
+    it("scores a set the cap left unforced that a run measured anyway", async () => {
+      // A full run measures every set. The cap bounds what a change is
+      // made to run, not what a complete measurement may be compared
+      // against, so a number already paid for is not thrown away.
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const members = ["packages/bakery", "packages/b", "packages/c"];
+      const suites = [suite(
+        "workspace-unit",
+        members.map((member) => ({
+          member,
+          reachedBy: [`${member}/`],
+          units: [`${member}/one.test.ts`],
+        })),
+      )];
+      const changed = new Set(members.map((member) => `${member}/src/main.ts`));
+      const gate = coverageGateFor(suites, changed);
+      expect(gate.sets).toEqual([]);
+      const { reports } = await reportsFor([[
+        "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/" +
+        "coverage.lcov",
+        lcov,
+      ]]);
+      const report = await runGate(gateInput({
+        root,
+        gate,
+        reports,
+        members: ["packages/bakery"],
+        baselines: [{
+          suite: "workspace-unit",
+          member: "packages/bakery",
+          commit: "abc",
+          createdAt: "2026-09-01T00:00:00.000Z",
+          uncoveredLines: 1,
+        }],
+      }));
+      expect(report.ran).toBe(true);
+      expect(report.ok).toBe(false);
+      const bakery = report.verdicts
+        .find((verdict) => verdict.member === "packages/bakery");
+      expect(bakery?.outcome).toBe("rose");
+      expect(
+        report.verdicts.filter((verdict) => verdict.outcome === "not-forced"),
+      ).toHaveLength(2);
+    });
+
+    it("scores only the sets the change reached", async () => {
+      // A lane may write a report for a member it sampled a few tests
+      // from. The gate scores from the declarations, so such a report is
+      // not one of its numbers.
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const { suites, changed } = bakery();
+      const { reports } = await reportsFor([
+        [
+          "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/" +
+          "coverage.lcov",
+          lcov,
+        ],
+        [
+          "lane-1/coverage/lcov/sets/workspace-unit/packages__cellar/" +
+          "coverage.lcov",
+          lcov,
+        ],
+      ]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        reports,
+        members: ["packages/bakery"],
+      }));
+      expect(report.verdicts.map((verdict) => verdict.set))
+        .toEqual(["workspace-unit/packages/bakery"]);
+    });
+
+    it("says there is nothing to compare when the change reaches no set", async () => {
+      const { root } = await workspace("packages/bakery", 10, 6);
+      const { suites } = bakery();
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, new Set(["docs/README.md"])),
+      }));
+      expect(report.ran).toBe(false);
+      expect(formatGateReport(report).join("\n"))
+        .toContain("reaches no measured set");
+    });
+
+    it("adds up what several lanes measured for one set", async () => {
+      const { root } = await workspace("packages/bakery", 4, 0);
+      const file = path.join(root, "packages/bakery/src/main.ts");
+      // Two lanes ran different halves of the set, so a line either of them
+      // covered is covered.
+      const first =
+        `SF:${file}\nDA:1,1\nDA:2,0\nDA:3,0\nDA:4,0\nend_of_record\n`;
+      const second =
+        `SF:${file}\nDA:1,0\nDA:2,1\nDA:3,0\nDA:4,0\nend_of_record\n`;
+      const { suites, changed } = bakery();
+      const { reports } = await reportsFor([
+        [
+          "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+          first,
+        ],
+        [
+          "lane-2/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+          second,
+        ],
+      ]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, changed),
+        reports,
+        members: ["packages/bakery"],
+      }));
+      expect(report.verdicts[0]?.uncoveredLines).toBe(2);
+    });
+  });
+
+  describe("asking git what the branch contains", () => {
+    /** A repository with two commits on one branch and one beside it. */
+    async function repository(): Promise<
+      { root: string; contained: string; newer: string; apart: string }
+    > {
+      const root = await Deno.makeTempDir({ prefix: "coverage-gate-git-" });
+      const git = async (...args: string[]) => {
+        const result = await new Deno.Command("git", {
+          args,
+          cwd: root,
+          stdout: "piped",
+          stderr: "piped",
+        }).output();
+        return new TextDecoder().decode(result.stdout).trim();
+      };
+      await git("init", "-q", "-b", "main");
+      await git("config", "user.email", "tests@example.com");
+      await git("config", "user.name", "Tests");
+      await Deno.writeTextFile(path.join(root, "one.txt"), "one");
+      await git("add", "-A");
+      await git("commit", "-qm", "one");
+      const contained = await git("rev-parse", "HEAD");
+      await Deno.writeTextFile(path.join(root, "two.txt"), "two");
+      await git("add", "-A");
+      await git("commit", "-qm", "two");
+      const newer = await git("rev-parse", "HEAD");
+      await git("checkout", "-q", "-b", "apart");
+      await Deno.writeTextFile(path.join(root, "three.txt"), "three");
+      await git("add", "-A");
+      await git("commit", "-qm", "three");
+      const apart = await git("rev-parse", "HEAD");
+      await git("checkout", "-q", "main");
+      return { root, contained, newer, apart };
+    }
+
+    it("names a commit the tree under test descends from", async () => {
+      const { root, contained } = await repository();
+      expect(await nearestOnBranch(root)([contained])).toBe(contained);
+    });
+
+    it("takes the commit further down the branch's own history", async () => {
+      // Both are on the branch, and the newer one is the answer whatever
+      // order they are offered in.
+      const { root, contained, newer } = await repository();
+      expect(await nearestOnBranch(root)([contained, newer])).toBe(newer);
+      expect(await nearestOnBranch(root)([newer, contained])).toBe(newer);
+    });
+
+    it("passes over a commit on a branch beside it", async () => {
+      const { root, apart, contained } = await repository();
+      expect(await nearestOnBranch(root)([apart])).toBeUndefined();
+      expect(await nearestOnBranch(root)([apart, contained]))
+        .toBe(contained);
+    });
+
+    it("names nothing for a commit the checkout does not hold", async () => {
+      // A checkout too shallow to answer reports every set as having no
+      // baseline rather than failing anything.
+      const { root } = await repository();
+      expect(await nearestOnBranch(root)(["0".repeat(40)])).toBeUndefined();
+    });
+
+    it("names nothing when asked about no commits at all", async () => {
+      const { root } = await repository();
+      expect(await nearestOnBranch(root)([])).toBeUndefined();
+    });
+  });
+
+  describe("the gate's command line", () => {
+    it("refuses a command line with no base to measure against", () => {
+      // With no diff the gate reaches no set and passes, which reads the
+      // same as a change that touched nothing, so a workflow that lost the
+      // flag would pass every pull request in silence.
+      expect(parseGateArgs([], "/tmp/root")).toBeUndefined();
+    });
+
+    it("defaults to the artifact directory and a passing run", () => {
+      const options = parseGateArgs(["--base", "origin/main"], "/tmp/root");
+      expect(options?.reports).toBe("coverage-artifacts");
+      expect(options?.testsFailed).toBe(false);
+      expect(options?.body).toBe("");
+    });
+
+    it("takes the base, the reports, the body, and the failure flag", () => {
+      const options = parseGateArgs([
+        "--base",
+        "origin/main",
+        "--reports",
+        "downloaded",
+        "--body",
+        "ACCEPT_COVERAGE_DEBT: packages/bakery +3 lines",
+        "--tests-failed",
+      ], "/tmp/root");
+      expect(options?.base).toBe("origin/main");
+      expect(options?.reports).toBe("downloaded");
+      expect(options?.body).toContain("ACCEPT_COVERAGE_DEBT");
+      expect(options?.testsFailed).toBe(true);
+    });
+
+    it("refuses a flag it does not know, and one with no value", () => {
+      expect(parseGateArgs(["--nonsense", "x"], "/tmp/root")).toBeUndefined();
+      expect(parseGateArgs(["--base"], "/tmp/root")).toBeUndefined();
+    });
+  });
+
+  describe("what the summary offers to paste", () => {
+    it("offers one acceptance per member, at the larger of its rises", async () => {
+      // The marker names the member, so two sets over one member that both
+      // rose take one line, and the line has to cover the larger rise.
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const member = "packages/bakery";
+      const suites = [
+        suite("workspace-unit", [{
+          member,
+          reachedBy: [`${member}/`],
+          units: [`${member}/one.test.ts`],
+        }]),
+        suite("bakery-e2e", [{
+          member,
+          reachedBy: [`${member}/`],
+          units: [`${member}/two.test.ts`],
+        }]),
+      ];
+      const { reports } = await reportsFor([
+        [
+          "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+          lcov,
+        ],
+        [
+          "lane-1/coverage/lcov/sets/bakery-e2e/packages__bakery/coverage.lcov",
+          lcov,
+        ],
+      ]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, new Set([`${member}/src/main.ts`])),
+        reports,
+        members: [member],
+        baselines: [
+          {
+            suite: "workspace-unit",
+            member,
+            commit: "abc",
+            createdAt: "2026-09-01T00:00:00.000Z",
+            uncoveredLines: 3,
+          },
+          {
+            suite: "bakery-e2e",
+            member,
+            commit: "abc",
+            createdAt: "2026-09-01T00:00:00.000Z",
+            uncoveredLines: 1,
+          },
+        ],
+      }));
+      expect(report.ok).toBe(false);
+      const offered = formatGateReport(report)
+        .filter((line) => line.startsWith("ACCEPT_COVERAGE_DEBT:"));
+      expect(offered).toEqual([
+        "ACCEPT_COVERAGE_DEBT: packages/bakery +3 lines",
+      ]);
+    });
+
+    it("accepts both sets over one member from one marker", async () => {
+      const { root, lcov } = await workspace("packages/bakery", 10, 6);
+      const member = "packages/bakery";
+      const suites = [
+        suite("workspace-unit", [{
+          member,
+          reachedBy: [`${member}/`],
+          units: [`${member}/one.test.ts`],
+        }]),
+        suite("bakery-e2e", [{
+          member,
+          reachedBy: [`${member}/`],
+          units: [`${member}/two.test.ts`],
+        }]),
+      ];
+      const { reports } = await reportsFor([
+        [
+          "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery/coverage.lcov",
+          lcov,
+        ],
+        [
+          "lane-1/coverage/lcov/sets/bakery-e2e/packages__bakery/coverage.lcov",
+          lcov,
+        ],
+      ]);
+      const report = await runGate(gateInput({
+        root,
+        gate: coverageGateFor(suites, new Set([`${member}/src/main.ts`])),
+        reports,
+        members: [member],
+        accepted: new Map([[member, 3]]),
+        baselines: [
+          {
+            suite: "workspace-unit",
+            member,
+            commit: "abc",
+            createdAt: "2026-09-01T00:00:00.000Z",
+            uncoveredLines: 3,
+          },
+          {
+            suite: "bakery-e2e",
+            member,
+            commit: "abc",
+            createdAt: "2026-09-01T00:00:00.000Z",
+            uncoveredLines: 1,
+          },
+        ],
+      }));
+      expect(report.ok).toBe(true);
+      expect(report.verdicts.map((verdict) => verdict.outcome))
+        .toEqual(["accepted", "accepted"]);
+    });
+  });
+});

--- a/tasks/coverage-gate.test.ts
+++ b/tasks/coverage-gate.test.ts
@@ -9,6 +9,7 @@ import {
   nearestBaseline,
   nearestOnBranch,
   parseGateArgs,
+  publishedBaselines,
   runGate,
 } from "./coverage-gate.ts";
 import { coverageGateFor } from "./test-selection/coverage.ts";
@@ -178,6 +179,15 @@ describe("coverage-gate", () => {
         ["lane-1/coverage/lcov/sets/deeper/than/expected/coverage.lcov", "b"],
       ]);
       expect([...reports.keys()]).toEqual([]);
+    });
+
+    it("refuses a report directory it cannot walk", async () => {
+      // An absent directory is a lane that uploaded nothing, which the
+      // gate reports. Anything else is a failure worth ending on.
+      const dir = await Deno.makeTempDir({ prefix: "coverage-reports-" });
+      const file = path.join(dir, "not-a-directory");
+      await Deno.writeTextFile(file, "");
+      await expect(collectSetReports(file)).rejects.toThrow();
     });
 
     it("finds nothing where no lane uploaded anything", async () => {
@@ -925,6 +935,28 @@ describe("coverage-gate", () => {
       expect(lines.join("\n")).toContain("ACCEPT_COVERAGE_DEBT");
     });
 
+    it("writes what it says into the job's summary", async () => {
+      const { root, reports, suites } = await job(10, 6);
+      const summary = await Deno.makeTempFile({ prefix: "step-summary-" });
+      const before = Deno.env.get("GITHUB_STEP_SUMMARY");
+      Deno.env.set("GITHUB_STEP_SUMMARY", summary);
+      const log = console.log;
+      console.log = () => {};
+      try {
+        await main(["--base", "HEAD~1", "--reports", reports], root, {
+          topology: () => Promise.resolve(suites),
+          baselines: () => Promise.resolve([]),
+        });
+      } finally {
+        console.log = log;
+        if (before === undefined) Deno.env.delete("GITHUB_STEP_SUMMARY");
+        else Deno.env.set("GITHUB_STEP_SUMMARY", before);
+      }
+      expect(await Deno.readTextFile(summary))
+        .toContain("workspace-unit/packages/bakery");
+      await Deno.remove(summary);
+    });
+
     it("refuses a command line it cannot read", async () => {
       const { root } = await job(10, 6);
       const error = console.error;
@@ -934,6 +966,22 @@ describe("coverage-gate", () => {
       } finally {
         console.error = error;
       }
+    });
+  });
+
+  describe("the baselines a manifest carries", () => {
+    it("reads none where there is no manifest to read", async () => {
+      // A set with no baseline is reported rather than failed, so a
+      // store that cannot be reached costs the gate its opinion alone.
+      const empty: typeof globalThis.fetch = () =>
+        Promise.resolve(
+          new Response(
+            '<?xml version="1.0"?><ListBucketResult></ListBucketResult>',
+            { status: 200 },
+          ),
+        );
+      expect(await publishedBaselines("2026-09-10T00:00:00.000Z", empty))
+        .toEqual([]);
     });
   });
 

--- a/tasks/coverage-gate.test.ts
+++ b/tasks/coverage-gate.test.ts
@@ -5,6 +5,7 @@ import {
   collectSetReports,
   formatGateReport,
   type GateInput,
+  main,
   nearestBaseline,
   nearestOnBranch,
   parseGateArgs,
@@ -725,6 +726,214 @@ describe("coverage-gate", () => {
     it("names nothing when asked about no commits at all", async () => {
       const { root } = await repository();
       expect(await nearestOnBranch(root)([])).toBeUndefined();
+    });
+  });
+
+  describe("running the gate the way the job runs it", () => {
+    /**
+     * A repository holding one member whose source is `lines` statements,
+     * a commit on the branch, and a report covering `covered` of them.
+     */
+    async function job(lines: number, covered: number): Promise<
+      { root: string; commit: string; reports: string; suites: Suite[] }
+    > {
+      const root = await Deno.makeTempDir({ prefix: "coverage-gate-job-" });
+      const member = "packages/bakery";
+      await Deno.writeTextFile(
+        path.join(root, "deno.jsonc"),
+        JSON.stringify({ workspace: [`./${member}`] }),
+      );
+      const dir = path.join(root, member, "src");
+      await Deno.mkdir(dir, { recursive: true });
+      const file = path.join(dir, "main.ts");
+      const body = Array.from(
+        { length: lines },
+        (_, at) => `const v${at} = ${at};`,
+      );
+      await Deno.writeTextFile(file, `${body.join("\n")}\n`);
+      const git = async (...args: string[]) => {
+        const result = await new Deno.Command("git", {
+          args,
+          cwd: root,
+          stdout: "piped",
+          stderr: "piped",
+        }).output();
+        return new TextDecoder().decode(result.stdout).trim();
+      };
+      await git("init", "-q", "-b", "main");
+      await git("config", "user.email", "tests@example.com");
+      await git("config", "user.name", "Tests");
+      await git("add", "-A");
+      await git("commit", "-qm", "one");
+      const commit = await git("rev-parse", "HEAD");
+      // The change the gate measures: a second commit touching the
+      // member's tree, which is what reaches its set. A test file, so
+      // that what the member is scored over does not move with it.
+      await Deno.writeTextFile(
+        path.join(root, member, "one.test.ts"),
+        "// the change under test\n",
+      );
+      await git("add", "-A");
+      await git("commit", "-qm", "two");
+
+      const records = body.map((_, at) =>
+        `DA:${at + 1},${at < covered ? 1 : 0}`
+      );
+      const reports = path.join(root, "artifacts");
+      const at = path.join(
+        reports,
+        "lane-1/coverage/lcov/sets/workspace-unit/packages__bakery",
+      );
+      await Deno.mkdir(at, { recursive: true });
+      await Deno.writeTextFile(
+        path.join(at, "coverage.lcov"),
+        `SF:${file}\n${records.join("\n")}\nend_of_record\n`,
+      );
+      return {
+        root,
+        commit,
+        reports,
+        suites: [suite("workspace-unit", [{
+          member,
+          reachedBy: [`${member}/`],
+          units: [`${member}/one.test.ts`],
+        }])],
+      };
+    }
+
+    it("passes, and says what it compared", async () => {
+      const { root, commit, reports, suites } = await job(10, 6);
+      const lines: string[] = [];
+      const log = console.log;
+      console.log = (line: string) => lines.push(line);
+      let status: number;
+      try {
+        status = await main(
+          ["--base", "HEAD~1", "--reports", reports],
+          root,
+          {
+            topology: () => Promise.resolve(suites),
+            baselines: () =>
+              Promise.resolve([{
+                suite: "workspace-unit",
+                member: "packages/bakery",
+                commit,
+                createdAt: "2026-09-01T00:00:00.000Z",
+                uncoveredLines: 4,
+              }]),
+          },
+        );
+      } finally {
+        console.log = log;
+      }
+      expect(status).toBe(0);
+      const said = lines.join("\n");
+      expect(said).toContain("workspace-unit/packages/bakery");
+      expect(said).toContain("no rise");
+    });
+
+    it("fails a rise, and prints the marker that accepts it", async () => {
+      const { root, commit, reports, suites } = await job(10, 6);
+      const lines: string[] = [];
+      const log = console.log;
+      console.log = (line: string) => lines.push(line);
+      let status: number;
+      try {
+        status = await main(
+          ["--base", "HEAD~1", "--reports", reports],
+          root,
+          {
+            topology: () => Promise.resolve(suites),
+            baselines: () =>
+              Promise.resolve([{
+                suite: "workspace-unit",
+                member: "packages/bakery",
+                commit,
+                createdAt: "2026-09-01T00:00:00.000Z",
+                uncoveredLines: 1,
+              }]),
+          },
+        );
+      } finally {
+        console.log = log;
+      }
+      expect(status).toBe(1);
+      expect(lines.join("\n"))
+        .toContain("ACCEPT_COVERAGE_DEBT: packages/bakery +3 lines");
+    });
+
+    it("takes the acceptance from the description", async () => {
+      const { root, commit, reports, suites } = await job(10, 6);
+      const log = console.log;
+      console.log = () => {};
+      let status: number;
+      try {
+        status = await main(
+          [
+            "--base",
+            "HEAD~1",
+            "--reports",
+            reports,
+            "--body",
+            "ACCEPT_COVERAGE_DEBT: packages/bakery +3 lines",
+          ],
+          root,
+          {
+            topology: () => Promise.resolve(suites),
+            baselines: () =>
+              Promise.resolve([{
+                suite: "workspace-unit",
+                member: "packages/bakery",
+                commit,
+                createdAt: "2026-09-01T00:00:00.000Z",
+                uncoveredLines: 1,
+              }]),
+          },
+        );
+      } finally {
+        console.log = log;
+      }
+      expect(status).toBe(0);
+    });
+
+    it("stops on a marker it cannot read", async () => {
+      const { root, reports, suites } = await job(10, 6);
+      const lines: string[] = [];
+      const log = console.log;
+      console.log = (line: string) => lines.push(line);
+      let status: number;
+      try {
+        status = await main(
+          [
+            "--base",
+            "HEAD~1",
+            "--reports",
+            reports,
+            "--body",
+            "ACCEPT_COVERAGE_DEBT: packages/bakery 3 lines",
+          ],
+          root,
+          {
+            topology: () => Promise.resolve(suites),
+            baselines: () => Promise.resolve([]),
+          },
+        );
+      } finally {
+        console.log = log;
+      }
+      expect(status).toBe(1);
+      expect(lines.join("\n")).toContain("ACCEPT_COVERAGE_DEBT");
+    });
+
+    it("refuses a command line it cannot read", async () => {
+      const { root } = await job(10, 6);
+      const error = console.error;
+      console.error = () => {};
+      try {
+        expect(await main([], root, {})).toBe(2);
+      } finally {
+        console.error = error;
+      }
     });
   });
 

--- a/tasks/coverage-gate.ts
+++ b/tasks/coverage-gate.ts
@@ -545,6 +545,23 @@ export interface GateDeps {
   baselines?: (at: string) => Promise<readonly CoverageBaseline[]>;
 }
 
+/**
+ * The baselines the manifest current at `at` carries, or none where
+ * there is no manifest to read. A set with no baseline is reported
+ * rather than failed, so a store that cannot be reached costs the gate
+ * its opinion and nothing else.
+ */
+export async function publishedBaselines(
+  at: string,
+  fetch?: typeof globalThis.fetch,
+): Promise<readonly CoverageBaseline[]> {
+  const found = await fetchManifest({
+    at,
+    ...(fetch === undefined ? {} : { fetch }),
+  });
+  return found.manifest?.coverageBaselines ?? [];
+}
+
 /** Runs the gate the way the job runs it, and answers with its status. */
 export async function main(
   args: readonly string[] = Deno.args,
@@ -570,11 +587,7 @@ export async function main(
     laneCount: false,
     root: options.root,
   });
-  const baselines = await (deps.baselines ??
-    (async (at: string) =>
-      (await fetchManifest({ at })).manifest?.coverageBaselines ?? []))(
-      moment.at,
-    );
+  const baselines = await (deps.baselines ?? publishedBaselines)(moment.at);
   let accepted: ReadonlyMap<string, number>;
   try {
     accepted = acceptedCoverageDebt(options.body);

--- a/tasks/coverage-gate.ts
+++ b/tasks/coverage-gate.ts
@@ -1,0 +1,606 @@
+#!/usr/bin/env -S deno run -A
+
+/**
+ * The coverage gate, as the job that joins the lanes runs it.
+ *
+ * A measured set is one suite's units over one workspace member's lines.
+ * The lanes run every unit of every set the change reaches, with coverage
+ * turned on, and each writes one report per set. This adds those reports
+ * up per set, scores each set over its member's own lines, and compares
+ * the count against what the same set measured at the newest `main`
+ * commit the branch contains. A rise fails, unless the pull request's
+ * description accepts it.
+ *
+ * Which sets are gated is worked out here from the topology and the diff,
+ * by the same function the lanes run, rather than read out of what a lane
+ * reported. Two answers to that question would let a lane talk this into
+ * gating something it did not measure, or into skipping something it did.
+ *
+ *   deno run -A tasks/coverage-gate.ts --base origin/main --reports artifacts
+ */
+
+import * as path from "@std/path";
+import { walk } from "@std/fs/walk";
+import {
+  changedFiles,
+  COVERAGE_REPORT_DIR,
+  COVERAGE_REPORT_FILE,
+  manifestMoment,
+} from "./ci-lane.ts";
+import {
+  acceptedCoverageDebt,
+  namesCoverageSourceGroup,
+} from "./ci-check-lib.ts";
+import { collectMeasuredSetDebt } from "./coverage-metrics.ts";
+import { readWorkspaceMembers } from "./workspace-tests.ts";
+import { loadTopology } from "./test-topology.ts";
+import type { Suite } from "./test-topology/suite.ts";
+import {
+  coverageGateFor,
+  type CoverageGateSelection,
+  measuredSetDirectory,
+  measuredSetName,
+} from "./test-selection/coverage.ts";
+import { fetchManifest } from "./test-selection/store.ts";
+import type { CoverageBaseline } from "./test-selection/manifest.ts";
+
+/** What the command line asked for. */
+export interface GateOptions {
+  /**
+   * What the change is measured against. Required: with no diff the gate
+   * reaches no set and passes, which reads exactly like a change that
+   * touched nothing, so a workflow that lost the flag would pass every
+   * pull request and say nothing.
+   */
+  base: string;
+
+  /** Where the lanes' coverage reports were downloaded to. */
+  reports: string;
+
+  /** The pull request's description, which is where an acceptance is. */
+  body: string;
+
+  /**
+   * Whether anything else in the run failed. Coverage measured through a
+   * failing run says nothing about whether the change was tested, and the
+   * run is already red, so the gate reports rather than adding a failure.
+   */
+  testsFailed: boolean;
+
+  root: string;
+}
+
+/** Reads the command line, or returns undefined for a malformed one. */
+export function parseGateArgs(
+  args: readonly string[],
+  root: string = Deno.cwd(),
+): GateOptions | undefined {
+  const options: Partial<GateOptions> & Omit<GateOptions, "base"> = {
+    reports: "coverage-artifacts",
+    body: "",
+    testsFailed: false,
+    root,
+  };
+  const rest = [...args];
+  while (rest.length > 0) {
+    const flag = rest.shift()!;
+    if (flag === "--tests-failed") {
+      options.testsFailed = true;
+      continue;
+    }
+    const value = rest.shift();
+    if (value === undefined) return undefined;
+    switch (flag) {
+      case "--base":
+        options.base = value;
+        break;
+      case "--reports":
+        options.reports = value;
+        break;
+      case "--body":
+        options.body = value;
+        break;
+      default:
+        return undefined;
+    }
+  }
+  if (options.base === undefined) return undefined;
+  return { ...options, base: options.base };
+}
+
+/**
+ * The reports each measured set has, by the directory a lane wrote them
+ * under, gathered from wherever the lanes' artifacts were unpacked.
+ *
+ * A set's units are ordinary mandatory items, so the packer spreads them
+ * over as many lanes as it likes and each lane writes the part it ran.
+ * The set is what joins them again, which is why the report is named for
+ * the set rather than for the lane.
+ *
+ * The key is the directory rather than the set the directory stands for.
+ * The suite that wrote it is the one that names it, so a reader that
+ * worked the set back out of the name would be a second answer to that
+ * question, and the two could disagree.
+ */
+export async function collectSetReports(
+  reportsDir: string,
+): Promise<Map<string, string[]>> {
+  const found = new Map<string, string[]>();
+  const layout = COVERAGE_REPORT_DIR.split("/");
+  try {
+    for await (
+      const entry of walk(reportsDir, {
+        includeDirs: false,
+        exts: [".lcov"],
+      })
+    ) {
+      const parts = entry.path.replaceAll("\\", "/").split("/");
+      // The lane's own layout, matched whole rather than by its last
+      // segment, so that a suite named after one of those segments
+      // cannot be read as the layout itself.
+      const at = parts.findIndex((_, index) =>
+        parts.slice(index, index + layout.length).join("/") ===
+          COVERAGE_REPORT_DIR
+      );
+      if (at === -1) continue;
+      const rest = parts.slice(at + layout.length);
+      if (rest.length !== 3 || rest[2] !== COVERAGE_REPORT_FILE) continue;
+      const name = `${rest[0]}/${rest[1]}`;
+      found.set(name, [...found.get(name) ?? [], entry.path]);
+    }
+  } catch (error) {
+    // Nothing was downloaded, which is a lane that did not get as far as
+    // uploading. The gate reports that rather than treating an absent
+    // directory as a set with no coverage.
+    if (!(error instanceof Deno.errors.NotFound)) throw error;
+  }
+  return found;
+}
+
+/** What the gate decided about one measured set. */
+export interface SetVerdict {
+  /** The suite and member the set pairs, as one name. */
+  set: string;
+
+  /** The workspace member whose lines were counted. */
+  member: string;
+
+  /** What this run measured, absent where no lane reported one. */
+  uncoveredLines?: number;
+
+  /** The `main` run this is compared against. */
+  baseline?: { commit: string; uncoveredLines: number };
+
+  /** Lines the pull request's description accepts for this member. */
+  accepted?: number;
+
+  /** How far above the baseline this run came, where it came above it. */
+  rise?: number;
+
+  outcome:
+    | "passed"
+    | "rose"
+    | "accepted"
+    | "no-baseline"
+    | "no-report"
+    | "not-forced"
+    | "nothing-measured"
+    | "not-scored";
+}
+
+/** What the gate came to over one change. */
+export interface GateReport {
+  /** Whether the gate ran at all. */
+  ran: boolean;
+
+  /** Why it did not, where it did not. */
+  off?: string;
+
+  verdicts: SetVerdict[];
+
+  /** Acceptances naming something no gate in this repository measures. */
+  unknownAcceptances: string[];
+
+  /** Whether the pull request may proceed as far as coverage is concerned. */
+  ok: boolean;
+}
+
+/**
+ * The accepted names nothing could ever consult: neither a workspace
+ * member, which is what this gate scores, nor a coverage source group,
+ * which is what the repository-wide ratchet scores.
+ *
+ * An acceptance that names nothing was written to have an effect and has
+ * none, so it fails here rather than passing for one that worked.
+ */
+export function unknownAcceptances(
+  accepted: ReadonlyMap<string, number>,
+  members: readonly string[],
+): string[] {
+  const known = new Set(members);
+  return [...accepted.keys()]
+    .filter((name) => !known.has(name) && !namesCoverageSourceGroup(name))
+    .sort();
+}
+
+/** What the gate reads beyond the working tree. */
+export interface GateInput {
+  root: string;
+  gate: CoverageGateSelection;
+
+  /** The reports the lanes wrote, by set name. */
+  reports: ReadonlyMap<string, readonly string[]>;
+
+  members: readonly string[];
+  baselines: readonly CoverageBaseline[];
+
+  /** Which of these commits the tree under test holds most recently. */
+  nearest: (commits: readonly string[]) => Promise<string | undefined>;
+
+  /** Lines accepted, by the name the description gave. */
+  accepted: ReadonlyMap<string, number>;
+
+  testsFailed: boolean;
+}
+
+/**
+ * The baseline for one set measured at the newest default-branch commit
+ * the tree under test contains.
+ *
+ * A baseline the branch does not contain measures a tree the branch does
+ * not have, so a rise against it is not the branch's rise. Which of the
+ * ones it does contain is newest is decided by their order in the
+ * default branch's history, which is the order in which the trees they
+ * measured came into being. When a run was created says something about
+ * the machine that ran it, and a re-run of an older commit is what
+ * separates the two.
+ */
+export async function nearestBaseline(
+  baselines: readonly CoverageBaseline[],
+  suite: string,
+  member: string,
+  nearest: (commits: readonly string[]) => Promise<string | undefined>,
+): Promise<CoverageBaseline | undefined> {
+  const mine = baselines
+    .filter((base) => base.suite === suite && base.member === member);
+  const commit = await nearest([...new Set(mine.map((base) => base.commit))]);
+  return commit === undefined
+    ? undefined
+    : mine.find((base) => base.commit === commit);
+}
+
+/**
+ * Scores every set the change reached that some run measured, and says
+ * whether the change may proceed.
+ *
+ * Every set the change reached rather than only the ones the cap left
+ * forced. The cap bounds what a change is made to run, which is a cost;
+ * whether a number may be compared against the baseline turns on whether
+ * the set ran whole, which is a different question. A run that measured
+ * a set for its own reasons — the full run measures every one of them —
+ * has produced a comparison that is exactly as sound as a forced one, and
+ * discarding it would leave the gate silent over work already paid for.
+ *
+ * Five states report rather than fail, and each is a case where the
+ * comparison would be against something other than the change. A set with
+ * no baseline is one nothing has measured on `main` yet, and the first
+ * pull request to reach a new package should not inherit the whole of
+ * that package's debt. A set the cap left unforced that no run measured
+ * has no number at all. A set with no report is a lane that did not get
+ * as far as writing one, which is a failure the run is already carrying.
+ * A set whose reports name no line of its member measured nothing, rather
+ * than covering nothing. And a run with a failing test measures coverage
+ * through that failure, which says nothing about whether the change was
+ * tested.
+ *
+ * One state fails whatever else happened: an acceptance naming something
+ * no gate in this repository measures was written to have an effect and
+ * has none.
+ */
+export async function runGate(input: GateInput): Promise<GateReport> {
+  const unknown = unknownAcceptances(input.accepted, input.members);
+  const forced = new Set(input.gate.sets.map(measuredSetName));
+  const verdicts: SetVerdict[] = [];
+  let ok = unknown.length === 0;
+  for (const ref of input.gate.reached) {
+    const set = measuredSetName(ref);
+    const member = ref.set.member;
+    const accepted = input.accepted.get(member);
+    const paths = input.reports.get(measuredSetDirectory(ref)) ?? [];
+    if (paths.length === 0) {
+      verdicts.push({
+        set,
+        member,
+        outcome: forced.has(set) ? "no-report" : "not-forced",
+      });
+      continue;
+    }
+    const lcov = (await Promise.all(
+      paths.map((at) => Deno.readTextFile(at)),
+    )).join("\n");
+    const measured = await collectMeasuredSetDebt({
+      rootDir: input.root,
+      lcov,
+      member,
+      members: input.members,
+    });
+    // A report naming no file of this member is a conversion that
+    // produced nothing rather than a set that covered nothing. Charging
+    // it every tracked line would fail the change for a measurement that
+    // never happened, and a set's tests always load some of their own
+    // member's source.
+    if (measured.files === 0) {
+      verdicts.push({ set, member, outcome: "nothing-measured" });
+      continue;
+    }
+    const uncoveredLines = measured.uncoveredLines;
+    if (input.testsFailed) {
+      verdicts.push({ set, member, uncoveredLines, outcome: "not-scored" });
+      continue;
+    }
+    const base = await nearestBaseline(
+      input.baselines,
+      ref.suite,
+      member,
+      input.nearest,
+    );
+    if (base === undefined) {
+      verdicts.push({ set, member, uncoveredLines, outcome: "no-baseline" });
+      continue;
+    }
+    const baseline = {
+      commit: base.commit,
+      uncoveredLines: base.uncoveredLines,
+    };
+    const rise = uncoveredLines - base.uncoveredLines;
+    if (rise <= 0) {
+      verdicts.push({
+        set,
+        member,
+        uncoveredLines,
+        baseline,
+        outcome: "passed",
+      });
+      continue;
+    }
+    if (accepted !== undefined && rise <= accepted) {
+      verdicts.push({
+        set,
+        member,
+        uncoveredLines,
+        baseline,
+        accepted,
+        rise,
+        outcome: "accepted",
+      });
+      continue;
+    }
+    ok = false;
+    verdicts.push({
+      set,
+      member,
+      uncoveredLines,
+      baseline,
+      ...(accepted === undefined ? {} : { accepted }),
+      rise,
+      outcome: "rose",
+    });
+  }
+  return {
+    ran: verdicts.some((verdict) => verdict.uncoveredLines !== undefined),
+    ...(input.gate.off === undefined ? {} : { off: input.gate.off }),
+    verdicts,
+    unknownAcceptances: unknown,
+    ok,
+  };
+}
+
+/** What each outcome means, in the words the summary uses. */
+const OUTCOME_PROSE: Record<SetVerdict["outcome"], string> = {
+  passed: "no rise",
+  rose: "rose",
+  accepted: "rose, accepted",
+  "no-baseline": "no baseline on `main` yet, so nothing to compare",
+  "no-report": "no lane reported one, so there is nothing to score",
+  "not-forced": "the cap left this set unforced, and no run measured it",
+  "nothing-measured": "the reports name no line of this member, so " +
+    "nothing measured it",
+  "not-scored": "the run has a failing test, so this is not scored",
+};
+
+/** The lines the job summary carries. */
+export function formatGateReport(report: GateReport): string[] {
+  const lines = ["## Coverage gate", ""];
+  if (report.unknownAcceptances.length > 0) {
+    lines.push(
+      "These acceptances name neither a workspace member nor a coverage " +
+        "source group, so nothing would ever consult them:",
+      "",
+    );
+    for (const name of report.unknownAcceptances) lines.push(`- \`${name}\``);
+    lines.push("");
+  }
+  if (report.verdicts.length === 0) {
+    lines.push(
+      "This change reaches no measured set, so the coverage gate has " +
+        "nothing to compare.",
+    );
+    return lines;
+  }
+  if (report.off !== undefined) {
+    lines.push(
+      `No measured set was forced to run: ${report.off}. A set some run ` +
+        `measured anyway is still scored.`,
+      "",
+    );
+  }
+  lines.push("| Measured set | Baseline | This run | Change | Outcome |");
+  lines.push("| --- | --- | --- | --- | --- |");
+  for (const verdict of report.verdicts) {
+    const now = verdict.uncoveredLines;
+    const was = verdict.baseline?.uncoveredLines;
+    const change = now !== undefined && was !== undefined
+      ? `${now - was >= 0 ? "+" : ""}${now - was}`
+      : "";
+    lines.push(
+      `| ${verdict.set} | ${was ?? ""} | ${now ?? ""} | ${change} | ` +
+        `${OUTCOME_PROSE[verdict.outcome]} |`,
+    );
+  }
+  // One line per member rather than per set: the marker names the member,
+  // so two sets over one member that both rose are accepted by the larger
+  // of the two rises.
+  const rose = new Map<string, number>();
+  for (const verdict of report.verdicts) {
+    if (verdict.outcome !== "rose" || verdict.rise === undefined) continue;
+    rose.set(
+      verdict.member,
+      Math.max(rose.get(verdict.member) ?? 0, verdict.rise),
+    );
+  }
+  if (rose.size > 0) {
+    lines.push("");
+    lines.push(
+      "This is a coverage failure rather than a test failure. Cover the " +
+        "lines, or accept the rise in the pull request's description:",
+    );
+    lines.push("");
+    lines.push("```text");
+    for (const [member, rise] of rose) {
+      lines.push(`ACCEPT_COVERAGE_DEBT: ${member} +${rise} lines`);
+    }
+    lines.push("```");
+  }
+  return lines;
+}
+
+/** Says something both on the job's output and in its summary. */
+function say(lines: readonly string[]): void {
+  const text = `${lines.join("\n")}\n`;
+  console.log(text);
+  const summary = Deno.env.get("GITHUB_STEP_SUMMARY");
+  if (summary !== undefined && summary.length > 0) {
+    Deno.writeTextFileSync(summary, text, { append: true });
+  }
+}
+
+/**
+ * Which of a set of commits the tree under test holds most recently, or
+ * nothing where it holds none of them.
+ *
+ * A checkout too shallow to reach any of them answers with nothing, and
+ * every set is then reported as having no baseline rather than gated.
+ */
+export function nearestOnBranch(
+  root: string,
+): (commits: readonly string[]) => Promise<string | undefined> {
+  return async (commits: readonly string[]) => {
+    if (commits.length === 0) return undefined;
+    const wanted = new Set(commits);
+    // The tree's own history, newest first, read until one of them
+    // appears. Git stops on its own once nothing is reading, so what
+    // this walks is the distance back to the answer rather than the
+    // whole of the history.
+    const child = new Deno.Command("git", {
+      args: ["rev-list", "HEAD"],
+      cwd: root,
+      stdout: "piped",
+      stderr: "null",
+    }).spawn();
+    const reader = child.stdout.getReader();
+    const decoder = new TextDecoder();
+    let carried = "";
+    let found: string | undefined;
+    try {
+      while (found === undefined) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        carried += decoder.decode(value, { stream: true });
+        const lines = carried.split("\n");
+        carried = lines.pop() ?? "";
+        for (const line of lines) {
+          if (wanted.has(line)) {
+            found = line;
+            break;
+          }
+        }
+      }
+    } finally {
+      await reader.cancel().catch(() => {});
+      try {
+        child.kill();
+      } catch {
+        // It ended on its own, which is what reaching the root of the
+        // history or losing its reader does.
+      }
+      await child.status;
+    }
+    return found;
+  };
+}
+
+/** What the gate reaches for beyond its own arguments. */
+export interface GateDeps {
+  topology?: (root: string) => Promise<Suite[]>;
+  baselines?: (at: string) => Promise<readonly CoverageBaseline[]>;
+}
+
+/** Runs the gate the way the job runs it, and answers with its status. */
+export async function main(
+  args: readonly string[] = Deno.args,
+  root: string = Deno.cwd(),
+  deps: GateDeps = {},
+): Promise<number> {
+  const options = parseGateArgs(args, root);
+  if (options === undefined) {
+    console.error(
+      "usage: coverage-gate.ts --base <ref> [--reports <dir>] " +
+        "[--body <text>] [--tests-failed]",
+    );
+    return 2;
+  }
+  const suites = await (deps.topology ?? loadTopology)(options.root);
+  const changed = await changedFiles(options.root, options.base);
+  const gate = coverageGateFor(suites, changed);
+  const moment = await manifestMoment({
+    lane: 1,
+    of: 1,
+    full: false,
+    dryRun: false,
+    laneCount: false,
+    root: options.root,
+  });
+  const baselines = await (deps.baselines ??
+    (async (at: string) =>
+      (await fetchManifest({ at })).manifest?.coverageBaselines ?? []))(
+      moment.at,
+    );
+  let accepted: ReadonlyMap<string, number>;
+  try {
+    accepted = acceptedCoverageDebt(options.body);
+  } catch (error) {
+    // A marker this cannot read was written to have an effect. Saying so
+    // and stopping is the answer; carrying on would gate the change as
+    // though nobody had accepted anything.
+    say(["## Coverage gate", "", `${error}`]);
+    return 1;
+  }
+  const report = await runGate({
+    root: options.root,
+    gate,
+    reports: await collectSetReports(
+      path.resolve(options.root, options.reports),
+    ),
+    members: (await readWorkspaceMembers(
+      path.join(options.root, "deno.jsonc"),
+    )).map((member) => member.replace(/^\.\//, "")),
+    baselines,
+    nearest: nearestOnBranch(options.root),
+    accepted,
+    testsFailed: options.testsFailed,
+  });
+  say(formatGateReport(report));
+  return report.ok ? 0 : 1;
+}
+
+if (import.meta.main) Deno.exitCode = await main();

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -4,6 +4,7 @@ import * as path from "@std/path";
 import {
   collectCoverageDebtMetrics,
   collectCoverageDebtMetricsFromLcov,
+  collectMeasuredSetDebt,
   collectRegressedLines,
   collectSourceFiles,
   collectUncoveredLinesForFiles,
@@ -723,4 +724,168 @@ Deno.test("collectRegressedLines counts a file the baseline reported and this ru
   } finally {
     await Deno.remove(rootDir, { recursive: true });
   }
+});
+
+/** A tree holding one file of `lines` statements under each named member. */
+async function membersWithSource(
+  members: readonly string[],
+  lines = 4,
+): Promise<string> {
+  const rootDir = await Deno.makeTempDir({ prefix: "measured-set-" });
+  for (const member of members) {
+    const dir = path.join(rootDir, member, "src");
+    await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeTextFile(
+      path.join(dir, "main.ts"),
+      `${
+        Array.from({ length: lines }, (_, at) => `const v${at} = ${at};`)
+          .join("\n")
+      }\n`,
+    );
+  }
+  return rootDir;
+}
+
+/** An LCOV record covering the first `covered` lines of one file. */
+function lcovFor(file: string, lines: number, covered: number): string {
+  const records = Array.from(
+    { length: lines },
+    (_, at) => `DA:${at + 1},${at < covered ? 1 : 0}`,
+  );
+  return `SF:${file}\n${records.join("\n")}\nend_of_record\n`;
+}
+
+Deno.test("collectMeasuredSetDebt counts only the member's own lines", async () => {
+  const rootDir = await membersWithSource([
+    "packages/bakery",
+    "packages/cellar",
+  ]);
+  const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
+  const cellar = path.join(rootDir, "packages/cellar/src/main.ts");
+  // The set's tests covered lines in both members. Only the member the
+  // set is scored over is counted, so what the tests reached elsewhere
+  // cannot pay another set's debt down.
+  const lcov = lcovFor(bakery, 4, 1) + lcovFor(cellar, 4, 4);
+  assertEquals(
+    (await collectMeasuredSetDebt({
+      rootDir,
+      lcov,
+      member: "packages/bakery",
+      members: ["packages/bakery", "packages/cellar"],
+    })).uncoveredLines,
+    3,
+  );
+  assertEquals(
+    (await collectMeasuredSetDebt({
+      rootDir,
+      lcov: "",
+      member: "packages/cellar",
+      members: ["packages/bakery", "packages/cellar"],
+    })).uncoveredLines,
+    4,
+  );
+});
+
+Deno.test("collectMeasuredSetDebt charges a nested member to itself", async () => {
+  const rootDir = await membersWithSource([
+    "packages/bakery",
+    "packages/bakery/cellar",
+  ]);
+  assertEquals(
+    (await collectMeasuredSetDebt({
+      rootDir,
+      lcov: "",
+      member: "packages/bakery",
+      members: ["packages/bakery", "packages/bakery/cellar"],
+    })).uncoveredLines,
+    4,
+  );
+  assertEquals(
+    (await collectMeasuredSetDebt({
+      rootDir,
+      lcov: "",
+      member: "packages/bakery/cellar",
+      members: ["packages/bakery", "packages/bakery/cellar"],
+    })).uncoveredLines,
+    4,
+  );
+});
+
+Deno.test("collectMeasuredSetDebt charges a file no test loaded in full", async () => {
+  const rootDir = await membersWithSource(["packages/bakery"]);
+  assertEquals(
+    (await collectMeasuredSetDebt({
+      rootDir,
+      lcov: "",
+      member: "packages/bakery",
+      members: ["packages/bakery"],
+    })).uncoveredLines,
+    4,
+  );
+});
+
+Deno.test("collectMeasuredSetDebt refuses a member with no tree", async () => {
+  // Scoring it as nothing uncovered would pass a gate over a name that
+  // measures nothing, which a count of zero cannot be told apart from.
+  const rootDir = await membersWithSource(["packages/bakery"]);
+  await assertRejects(
+    () =>
+      collectMeasuredSetDebt({
+        rootDir,
+        lcov: "",
+        member: "packages/nowhere",
+        members: ["packages/bakery"],
+      }),
+    Error,
+    "no directory for the workspace member packages/nowhere",
+  );
+});
+
+Deno.test("collectMeasuredSetDebt counts the files the report named", async () => {
+  const rootDir = await membersWithSource(["packages/bakery"]);
+  const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
+  assertEquals(
+    (await collectMeasuredSetDebt({
+      rootDir,
+      lcov: lcovFor(bakery, 4, 1),
+      member: "packages/bakery",
+      members: ["packages/bakery"],
+    })).files,
+    1,
+  );
+  // An empty report names none of them, which says the measurement
+  // produced nothing rather than that it covered nothing.
+  assertEquals(
+    (await collectMeasuredSetDebt({
+      rootDir,
+      lcov: "",
+      member: "packages/bakery",
+      members: ["packages/bakery"],
+    })).files,
+    0,
+  );
+});
+
+Deno.test("a measured set and its source group are two readings of one report", async () => {
+  const rootDir = await membersWithSource([
+    "packages/bakery",
+    "packages/cellar",
+  ]);
+  const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
+  const lcov = lcovFor(bakery, 4, 2);
+  // The group counts every member's lines the report speaks for; the set
+  // counts one member's. Neither is the other, which is why they are
+  // published under different names.
+  const group = (await collectCoverageDebtMetricsFromLcov({ rootDir, lcov }))
+    .find((metric) => metric.name.includes("packages/bakery"));
+  assertEquals(group?.uncoveredLines, 2);
+  assertEquals(
+    (await collectMeasuredSetDebt({
+      rootDir,
+      lcov,
+      member: "packages/cellar",
+      members: ["packages/bakery", "packages/cellar"],
+    })).uncoveredLines,
+    4,
+  );
 });

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -841,6 +841,21 @@ Deno.test("collectMeasuredSetDebt refuses a member with no tree", async () => {
   );
 });
 
+Deno.test("collectMeasuredSetDebt reads a record with no line as none at all", async () => {
+  // Such a record says nothing about the file, so counting it as
+  // measured would let the gate score a report that measured nothing.
+  const rootDir = await membersWithSource(["packages/bakery"]);
+  const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
+  const measured = await collectMeasuredSetDebt({
+    rootDir,
+    lcov: `SF:${bakery}\nend_of_record\n`,
+    member: "packages/bakery",
+    members: ["packages/bakery"],
+  });
+  assertEquals(measured.files, 0);
+  assertEquals(measured.uncoveredLines, 4);
+});
+
 Deno.test("collectMeasuredSetDebt counts the files the report named", async () => {
   const rootDir = await membersWithSource(["packages/bakery"]);
   const bakery = path.join(rootDir, "packages/bakery/src/main.ts");

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -726,11 +726,15 @@ Deno.test("collectRegressedLines counts a file the baseline reported and this ru
   }
 });
 
-/** A tree holding one file of `lines` statements under each named member. */
-async function membersWithSource(
+/**
+ * Runs `body` over a tree holding one file of `lines` statements under
+ * each named member, and removes the tree afterwards.
+ */
+async function withMembers(
   members: readonly string[],
+  body: (rootDir: string) => Promise<void>,
   lines = 4,
-): Promise<string> {
+): Promise<void> {
   const rootDir = await Deno.makeTempDir({ prefix: "measured-set-" });
   for (const member of members) {
     const dir = path.join(rootDir, member, "src");
@@ -743,7 +747,11 @@ async function membersWithSource(
       }\n`,
     );
   }
-  return rootDir;
+  try {
+    await body(rootDir);
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
 }
 
 /** An LCOV record covering the first `covered` lines of one file. */
@@ -756,151 +764,158 @@ function lcovFor(file: string, lines: number, covered: number): string {
 }
 
 Deno.test("collectMeasuredSetDebt counts only the member's own lines", async () => {
-  const rootDir = await membersWithSource([
+  await withMembers([
     "packages/bakery",
     "packages/cellar",
-  ]);
-  const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
-  const cellar = path.join(rootDir, "packages/cellar/src/main.ts");
-  // The set's tests covered lines in both members. Only the member the
-  // set is scored over is counted, so what the tests reached elsewhere
-  // cannot pay another set's debt down.
-  const lcov = lcovFor(bakery, 4, 1) + lcovFor(cellar, 4, 4);
-  assertEquals(
-    (await collectMeasuredSetDebt({
-      rootDir,
-      lcov,
-      member: "packages/bakery",
-      members: ["packages/bakery", "packages/cellar"],
-    })).uncoveredLines,
-    3,
-  );
-  assertEquals(
-    (await collectMeasuredSetDebt({
-      rootDir,
-      lcov: "",
-      member: "packages/cellar",
-      members: ["packages/bakery", "packages/cellar"],
-    })).uncoveredLines,
-    4,
-  );
+  ], async (rootDir) => {
+    const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
+    const cellar = path.join(rootDir, "packages/cellar/src/main.ts");
+    // The set's tests covered lines in both members. Only the member the
+    // set is scored over is counted, so what the tests reached elsewhere
+    // cannot pay another set's debt down.
+    const lcov = lcovFor(bakery, 4, 1) + lcovFor(cellar, 4, 4);
+    assertEquals(
+      (await collectMeasuredSetDebt({
+        rootDir,
+        lcov,
+        member: "packages/bakery",
+        members: ["packages/bakery", "packages/cellar"],
+      })).uncoveredLines,
+      3,
+    );
+    assertEquals(
+      (await collectMeasuredSetDebt({
+        rootDir,
+        lcov: "",
+        member: "packages/cellar",
+        members: ["packages/bakery", "packages/cellar"],
+      })).uncoveredLines,
+      4,
+    );
+  });
 });
 
 Deno.test("collectMeasuredSetDebt charges a nested member to itself", async () => {
-  const rootDir = await membersWithSource([
+  await withMembers([
     "packages/bakery",
     "packages/bakery/cellar",
-  ]);
-  assertEquals(
-    (await collectMeasuredSetDebt({
-      rootDir,
-      lcov: "",
-      member: "packages/bakery",
-      members: ["packages/bakery", "packages/bakery/cellar"],
-    })).uncoveredLines,
-    4,
-  );
-  assertEquals(
-    (await collectMeasuredSetDebt({
-      rootDir,
-      lcov: "",
-      member: "packages/bakery/cellar",
-      members: ["packages/bakery", "packages/bakery/cellar"],
-    })).uncoveredLines,
-    4,
-  );
+  ], async (rootDir) => {
+    assertEquals(
+      (await collectMeasuredSetDebt({
+        rootDir,
+        lcov: "",
+        member: "packages/bakery",
+        members: ["packages/bakery", "packages/bakery/cellar"],
+      })).uncoveredLines,
+      4,
+    );
+    assertEquals(
+      (await collectMeasuredSetDebt({
+        rootDir,
+        lcov: "",
+        member: "packages/bakery/cellar",
+        members: ["packages/bakery", "packages/bakery/cellar"],
+      })).uncoveredLines,
+      4,
+    );
+  });
 });
 
 Deno.test("collectMeasuredSetDebt charges a file no test loaded in full", async () => {
-  const rootDir = await membersWithSource(["packages/bakery"]);
-  assertEquals(
-    (await collectMeasuredSetDebt({
-      rootDir,
-      lcov: "",
-      member: "packages/bakery",
-      members: ["packages/bakery"],
-    })).uncoveredLines,
-    4,
-  );
+  await withMembers(["packages/bakery"], async (rootDir) => {
+    assertEquals(
+      (await collectMeasuredSetDebt({
+        rootDir,
+        lcov: "",
+        member: "packages/bakery",
+        members: ["packages/bakery"],
+      })).uncoveredLines,
+      4,
+    );
+  });
 });
 
 Deno.test("collectMeasuredSetDebt refuses a member with no tree", async () => {
-  // Scoring it as nothing uncovered would pass a gate over a name that
-  // measures nothing, which a count of zero cannot be told apart from.
-  const rootDir = await membersWithSource(["packages/bakery"]);
-  await assertRejects(
-    () =>
-      collectMeasuredSetDebt({
-        rootDir,
-        lcov: "",
-        member: "packages/nowhere",
-        members: ["packages/bakery"],
-      }),
-    Error,
-    "no directory for the workspace member packages/nowhere",
-  );
+  await withMembers(["packages/bakery"], async (rootDir) => {
+    // Scoring it as nothing uncovered would pass a gate over a name that
+    // measures nothing, which a count of zero cannot be told apart from.
+    await assertRejects(
+      () =>
+        collectMeasuredSetDebt({
+          rootDir,
+          lcov: "",
+          member: "packages/nowhere",
+          members: ["packages/bakery"],
+        }),
+      Error,
+      "no directory for the workspace member packages/nowhere",
+    );
+  });
 });
 
 Deno.test("collectMeasuredSetDebt reads a record with no line as none at all", async () => {
-  // Such a record says nothing about the file, so counting it as
-  // measured would let the gate score a report that measured nothing.
-  const rootDir = await membersWithSource(["packages/bakery"]);
-  const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
-  const measured = await collectMeasuredSetDebt({
-    rootDir,
-    lcov: `SF:${bakery}\nend_of_record\n`,
-    member: "packages/bakery",
-    members: ["packages/bakery"],
+  await withMembers(["packages/bakery"], async (rootDir) => {
+    // Such a record says nothing about the file, so counting it as
+    // measured would let the gate score a report that measured nothing.
+    const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
+    const measured = await collectMeasuredSetDebt({
+      rootDir,
+      lcov: `SF:${bakery}\nend_of_record\n`,
+      member: "packages/bakery",
+      members: ["packages/bakery"],
+    });
+    assertEquals(measured.files, 0);
+    assertEquals(measured.uncoveredLines, 4);
   });
-  assertEquals(measured.files, 0);
-  assertEquals(measured.uncoveredLines, 4);
 });
 
 Deno.test("collectMeasuredSetDebt counts the files the report named", async () => {
-  const rootDir = await membersWithSource(["packages/bakery"]);
-  const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
-  assertEquals(
-    (await collectMeasuredSetDebt({
-      rootDir,
-      lcov: lcovFor(bakery, 4, 1),
-      member: "packages/bakery",
-      members: ["packages/bakery"],
-    })).files,
-    1,
-  );
-  // An empty report names none of them, which says the measurement
-  // produced nothing rather than that it covered nothing.
-  assertEquals(
-    (await collectMeasuredSetDebt({
-      rootDir,
-      lcov: "",
-      member: "packages/bakery",
-      members: ["packages/bakery"],
-    })).files,
-    0,
-  );
+  await withMembers(["packages/bakery"], async (rootDir) => {
+    const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
+    assertEquals(
+      (await collectMeasuredSetDebt({
+        rootDir,
+        lcov: lcovFor(bakery, 4, 1),
+        member: "packages/bakery",
+        members: ["packages/bakery"],
+      })).files,
+      1,
+    );
+    // An empty report names none of them, which says the measurement
+    // produced nothing rather than that it covered nothing.
+    assertEquals(
+      (await collectMeasuredSetDebt({
+        rootDir,
+        lcov: "",
+        member: "packages/bakery",
+        members: ["packages/bakery"],
+      })).files,
+      0,
+    );
+  });
 });
 
 Deno.test("a measured set and its source group are two readings of one report", async () => {
-  const rootDir = await membersWithSource([
+  await withMembers([
     "packages/bakery",
     "packages/cellar",
-  ]);
-  const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
-  const lcov = lcovFor(bakery, 4, 2);
-  // The group counts every member's lines the report speaks for; the set
-  // counts one member's. Neither is the other, which is why they are
-  // published under different names.
-  const group = (await collectCoverageDebtMetricsFromLcov({ rootDir, lcov }))
-    .find((metric) => metric.name.includes("packages/bakery"));
-  assertEquals(group?.uncoveredLines, 2);
-  assertEquals(
-    (await collectMeasuredSetDebt({
-      rootDir,
-      lcov,
-      member: "packages/cellar",
-      members: ["packages/bakery", "packages/cellar"],
-    })).uncoveredLines,
-    4,
-  );
+  ], async (rootDir) => {
+    const bakery = path.join(rootDir, "packages/bakery/src/main.ts");
+    const lcov = lcovFor(bakery, 4, 2);
+    // The group counts every member's lines the report speaks for; the set
+    // counts one member's. Neither is the other, which is why they are
+    // published under different names.
+    const group = (await collectCoverageDebtMetricsFromLcov({ rootDir, lcov }))
+      .find((metric) => metric.name.includes("packages/bakery"));
+    assertEquals(group?.uncoveredLines, 2);
+    assertEquals(
+      (await collectMeasuredSetDebt({
+        rootDir,
+        lcov,
+        member: "packages/cellar",
+        members: ["packages/bakery", "packages/cellar"],
+      })).uncoveredLines,
+      4,
+    );
+  });
 });

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -216,7 +216,11 @@ export async function collectMeasuredSetDebt(
   let uncoveredLines = 0;
   let files = 0;
   for (const source of sourceFiles) {
-    const coverage = lcovCoverage.get(source.absolutePath);
+    const record = lcovCoverage.get(source.absolutePath);
+    // A record naming a file and carrying no line says nothing about it,
+    // so it is read as the absence of a record rather than as a file
+    // every line of which ran.
+    const coverage = record?.lineHits.size ? record : undefined;
     if (coverage) files += 1;
     uncoveredLines += coverage
       ? countUncoveredProfileLines(coverage)

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -162,6 +162,104 @@ export async function collectCoverageDebtMetricsFromLcov(
   return metrics;
 }
 
+export interface MeasuredSetDebtOptions {
+  rootDir: string;
+
+  /** The joined LCOV of everything one measured set's units produced. */
+  lcov: string;
+
+  /** The workspace member whose lines are counted, repository-relative. */
+  member: string;
+
+  /**
+   * Every workspace member, so that a file belonging to a member nested
+   * inside this one is charged to that member's set instead of to this
+   * one. `packages/patterns/auth` sits inside `packages/patterns`, and a
+   * line of it belongs to one of the two rather than to both.
+   */
+  members: readonly string[];
+}
+
+/** What one measured set's report came to over its member's lines. */
+export interface MeasuredSetDebt {
+  /** Tracked source lines of the member nothing in the report covered. */
+  uncoveredLines: number;
+
+  /**
+   * How many of the member's files the report has a record for. Zero
+   * says the report measured nothing rather than that it covered
+   * nothing, which are different things and call for different
+   * treatment.
+   */
+  files: number;
+}
+
+/**
+ * What one measured set's report says about its member: the tracked
+ * source lines of `member` that the report has no covering record for,
+ * and how many of the member's files it has a record for at all.
+ *
+ * A file the report leaves out is charged by the same rule the
+ * repository-wide metric uses, which reads the absence as a file no test
+ * in this set loaded. That reading holds here whatever else the run did,
+ * because a measured set runs every one of its units.
+ */
+export async function collectMeasuredSetDebt(
+  options: MeasuredSetDebtOptions,
+): Promise<MeasuredSetDebt> {
+  const sourceFiles = await collectMemberSourceFiles(
+    options.rootDir,
+    options.member,
+    options.members,
+  );
+  const lcovCoverage = parseLcov(options.lcov);
+  let uncoveredLines = 0;
+  let files = 0;
+  for (const source of sourceFiles) {
+    const coverage = lcovCoverage.get(source.absolutePath);
+    if (coverage) files += 1;
+    uncoveredLines += coverage
+      ? countUncoveredProfileLines(coverage)
+      : await debtWithoutCoverageRecord(source);
+  }
+  return { uncoveredLines, files };
+}
+
+/** The tracked source files one workspace member owns. */
+async function collectMemberSourceFiles(
+  rootDir: string,
+  member: string,
+  members: readonly string[],
+): Promise<SourceFile[]> {
+  const owned = toPosix(member).replace(/^\.\//, "");
+  const nested = members
+    .map((other) => toPosix(other).replace(/^\.\//, ""))
+    .filter((other) => other.startsWith(`${owned}/`))
+    .map((other) => `${other}/`);
+  const files: SourceFile[] = [];
+  const fullRoot = path.join(rootDir, owned);
+  // A member the workspace declares always has a directory. Scoring an
+  // absent one as nothing uncovered would pass a gate over a name that
+  // measures nothing, which is the failure a count of zero cannot be
+  // told apart from.
+  if (!await existsDirectory(fullRoot)) {
+    throw new Error(`no directory for the workspace member ${owned}`);
+  }
+  for await (const file of walkFiles(fullRoot)) {
+    const relativePath = toPosix(path.relative(rootDir, file));
+    if (!isTrackedSourcePath(relativePath)) continue;
+    if (nested.some((prefix) => relativePath.startsWith(prefix))) continue;
+    const content = await Deno.readTextFile(file);
+    files.push({
+      absolutePath: path.normalize(file),
+      relativePath,
+      metricGroup: metricGroupFor(relativePath),
+      trackedLineCount: countTrackedSourceLines(content),
+    });
+  }
+  return files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}
+
 /**
  * Helper for `collectCoverageDebtMetricsFromLcov()`, which returns the debt
  * charged to a file the report has no record for. Three different things

--- a/tasks/post-main-report.ts
+++ b/tasks/post-main-report.ts
@@ -78,6 +78,7 @@ import {
 import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
 import type { Suite } from "./test-topology/suite.ts";
 import { census } from "./test-selection/census.ts";
+import { coverageGateFor, measuredSetName } from "./test-selection/coverage.ts";
 import { plan } from "./test-selection/plan.ts";
 import { fetchManifest, type ManifestFetch } from "./test-selection/store.ts";
 import type { Manifest, WithheldReason } from "./test-selection/manifest.ts";
@@ -597,6 +598,13 @@ export async function main(
     };
   }
 
+  // The same function the gate runs, over the same declarations, so the
+  // note about a rise and the gate that was supposed to catch it cannot
+  // disagree about which sets were gated.
+  const gate = coverageGateFor(
+    await (deps.topology ?? loadTopology)(),
+    changed,
+  );
   const input: ReportInput = {
     current,
     previous,
@@ -604,6 +612,10 @@ export async function main(
     coverage: await coverageOfRun(run.id, listedHere),
     coverageBefore: await coverageOfRun(previousRun.id, listedThere),
     touched: coverageGroupsForChangedFiles(changed),
+    coverageGate: {
+      reached: gate.reached.map(measuredSetName),
+      ran: gate.off === undefined,
+    },
     day: new Date().toISOString().slice(0, 10),
   };
   console.log(

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -1300,44 +1300,21 @@ describe("publish() reporting what no lane can hold", () => {
 });
 
 describe("the baselines a publish carries", () => {
-  const carried: CoverageBaseline[] = [{
-    suite: "workspace-unit",
-    member: "packages/bakery",
-    commit: "abc",
-    createdAt: "2026-09-09T00:00:00.000Z",
-    uncoveredLines: 7,
-  }];
   const now = new Date("2026-09-10T00:00:00.000Z");
 
-  it("brings the newest manifest's baselines forward", async () => {
-    let given: readonly CoverageBaseline[] | undefined;
-    const published = await liveBaselines(
-      now,
-      () =>
-        Promise.resolve({
-          manifest: { ...emptyManifest(), coverageBaselines: carried },
-        }),
-      (_now, known) => {
-        given = known;
-        return Promise.resolve([...known]);
-      },
+  /** A fetch answering a listing with nothing under the prefix. */
+  const empty: typeof globalThis.fetch = () =>
+    Promise.resolve(
+      new Response(
+        '<?xml version="1.0"?><ListBucketResult></ListBucketResult>',
+        { status: 200 },
+      ),
     );
-    expect(given).toEqual(carried);
-    expect(published).toEqual(carried);
-  });
 
-  it("brings nothing forward where there is no manifest to read", async () => {
+  it("carries nothing where there is no manifest to read", async () => {
     // The walk over recent runs is then the only source, which is what
-    // rebuilds the window over the publishes that follow.
-    let given: readonly CoverageBaseline[] | undefined;
-    await liveBaselines(
-      now,
-      () => Promise.resolve({ absent: "listing failed" }),
-      (_now, known) => {
-        given = known;
-        return Promise.resolve([]);
-      },
-    );
-    expect(given).toEqual([]);
+    // rebuilds the window over the publishes that follow. A publisher
+    // without a credential reads no runs, so this carries nothing.
+    expect(await liveBaselines(now, empty)).toEqual([]);
   });
 });

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -5,6 +5,7 @@ import {
   byDayThenName,
   dayPartitions,
   inputChoice,
+  liveBaselines,
   namingSurfaces,
   parseArgs,
   partitionOf,
@@ -31,6 +32,10 @@ import {
 import type { Suite } from "./test-topology/suite.ts";
 import { join } from "@std/path";
 import { stateObjectName } from "./test-selection/store.ts";
+import {
+  type CoverageBaseline,
+  emptyManifest,
+} from "./test-selection/manifest.ts";
 
 /**
  * A topology holding the one suite these cases record against. Supplied
@@ -1291,5 +1296,48 @@ describe("publish() reporting what no lane can hold", () => {
     expect(line).toBeDefined();
     expect(line).toContain("space > writes");
     expect(line).toContain("400.0s");
+  });
+});
+
+describe("the baselines a publish carries", () => {
+  const carried: CoverageBaseline[] = [{
+    suite: "workspace-unit",
+    member: "packages/bakery",
+    commit: "abc",
+    createdAt: "2026-09-09T00:00:00.000Z",
+    uncoveredLines: 7,
+  }];
+  const now = new Date("2026-09-10T00:00:00.000Z");
+
+  it("brings the newest manifest's baselines forward", async () => {
+    let given: readonly CoverageBaseline[] | undefined;
+    const published = await liveBaselines(
+      now,
+      () =>
+        Promise.resolve({
+          manifest: { ...emptyManifest(), coverageBaselines: carried },
+        }),
+      (_now, known) => {
+        given = known;
+        return Promise.resolve([...known]);
+      },
+    );
+    expect(given).toEqual(carried);
+    expect(published).toEqual(carried);
+  });
+
+  it("brings nothing forward where there is no manifest to read", async () => {
+    // The walk over recent runs is then the only source, which is what
+    // rebuilds the window over the publishes that follow.
+    let given: readonly CoverageBaseline[] | undefined;
+    await liveBaselines(
+      now,
+      () => Promise.resolve({ absent: "listing failed" }),
+      (_now, known) => {
+        given = known;
+        return Promise.resolve([]);
+      },
+    );
+    expect(given).toEqual([]);
   });
 });

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -32,10 +32,6 @@ import {
 import type { Suite } from "./test-topology/suite.ts";
 import { join } from "@std/path";
 import { stateObjectName } from "./test-selection/store.ts";
-import {
-  type CoverageBaseline,
-  emptyManifest,
-} from "./test-selection/manifest.ts";
 
 /**
  * A topology holding the one suite these cases record against. Supplied

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -53,6 +53,13 @@ const TOPOLOGY: Suite[] = [{
 
 const suites = () => Promise.resolve(TOPOLOGY);
 
+/**
+ * No coverage baselines. Reading real ones asks GitHub what its recent
+ * runs published, which is not a question a test of the fold should
+ * reach the network to answer.
+ */
+const noBaselines = () => Promise.resolve([]);
+
 /** The one unit that topology holds. */
 const UNIT = "packages/memory/test/space.test.ts";
 
@@ -378,13 +385,22 @@ describe("publish()", () => {
     // An absent aggregate is either a genuine first run or one that went
     // missing, and an incremental run cannot tell the two apart.
     const { store, created } = fakeStore(seed());
-    expect(await publish(["--days", "1"], store, NOW, suites)).toBe(1);
+    expect(await publish(["--days", "1"], store, NOW, suites, noBaselines))
+      .toBe(1);
     expect(created.size).toBe(0);
   });
 
   it("writes a manifest and a state from a bootstrap", async () => {
     const { store, created } = fakeStore(seed());
-    expect(await publish(["--bootstrap", "--days", "1"], store, NOW, suites))
+    expect(
+      await publish(
+        ["--bootstrap", "--days", "1"],
+        store,
+        NOW,
+        suites,
+        noBaselines,
+      ),
+    )
       .toBe(0);
     const names = [...created.keys()];
     const manifestName = names.find((name) => name.includes("/manifest-"));
@@ -426,6 +442,7 @@ describe("publish()", () => {
         store,
         NOW,
         () => Promise.resolve([]),
+        noBaselines,
       );
     } finally {
       console.log = log;
@@ -449,10 +466,16 @@ describe("publish()", () => {
     // topology does not account for.
     const objects = seed();
     const { store } = fakeStore(objects);
-    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      needsFile,
+      noBaselines,
+    );
     objects[CI(DAY, "3")] = object("c3", "pass", "2026-08-20T03:00:00.000Z");
     const lines = await saying(() =>
-      publish(["--days", "1"], store, NOW, needsFile)
+      publish(["--days", "1"], store, NOW, needsFile, noBaselines)
     );
     expect(lines).toContain(
       "1 of them were in this count at the last publish too",
@@ -465,11 +488,17 @@ describe("publish()", () => {
     // list replaced each run would call it new every time it did record.
     const objects = seed();
     const { store } = fakeStore(objects);
-    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
-    await publish(["--days", "1"], store, NOW, needsFile);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      needsFile,
+      noBaselines,
+    );
+    await publish(["--days", "1"], store, NOW, needsFile, noBaselines);
     objects[CI(DAY, "3")] = object("c3", "pass", "2026-08-20T03:00:00.000Z");
     const lines = await saying(() =>
-      publish(["--days", "1"], store, NOW, needsFile)
+      publish(["--days", "1"], store, NOW, needsFile, noBaselines)
     );
     expect(lines).toContain(
       "1 of them were in this count at the last publish too",
@@ -483,7 +512,13 @@ describe("publish()", () => {
     const laneKey = JSON.stringify(["gate", "ci", "ci-lane batch memory"]);
     const objects = seed();
     const { store, created } = fakeStore(objects);
-    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      needsFile,
+      noBaselines,
+    );
     const older = await newestState(created);
     objects[stateObjectName("2026-08-19", "01AAAA")] = JSON.stringify({
       ...older,
@@ -491,7 +526,7 @@ describe("publish()", () => {
     });
     created.clear();
     objects[CI(DAY, "3")] = object("c3", "pass", "2026-08-20T03:00:00.000Z");
-    await publish(["--days", "1"], store, NOW, needsFile);
+    await publish(["--days", "1"], store, NOW, needsFile, noBaselines);
     expect((await newestState(created)).unclaimed).not.toContain(laneKey);
   });
 
@@ -500,7 +535,13 @@ describe("publish()", () => {
     // a file a suite claims takes its identity out of it.
     const objects = seed();
     const { store, created } = fakeStore(objects);
-    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      needsFile,
+      noBaselines,
+    );
     objects[CI(DAY, "3")] = object(
       "c3",
       "pass",
@@ -508,7 +549,7 @@ describe("publish()", () => {
       "main",
       UNIT,
     );
-    await publish(["--days", "1"], store, NOW, needsFile);
+    await publish(["--days", "1"], store, NOW, needsFile, noBaselines);
     expect((await newestState(created)).unclaimed).toEqual([]);
   });
 
@@ -532,10 +573,16 @@ describe("publish()", () => {
       ),
     };
     const { store } = fakeStore(objects);
-    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      needsFile,
+      noBaselines,
+    );
     objects[CI(DAY, "3")] = object("c3", "pass", "2026-08-20T03:00:00.000Z");
     const lines = await saying(() =>
-      publish(["--days", "1"], store, NOW, needsFile)
+      publish(["--days", "1"], store, NOW, needsFile, noBaselines)
     );
     expect(lines).toContain(
       "none of them were in this count at the last publish",
@@ -548,10 +595,16 @@ describe("publish()", () => {
     // that did not move name the worst of theirs.
     const objects = seed();
     const { store } = fakeStore(objects);
-    await publish(["--bootstrap", "--days", "1"], store, NOW, needsFile);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      needsFile,
+      noBaselines,
+    );
     objects[CI(DAY, "3")] = object("c3", "pass", "2026-08-20T03:00:00.000Z");
     const lines = await saying(() =>
-      publish(["--days", "1"], store, NOW, needsFile)
+      publish(["--days", "1"], store, NOW, needsFile, noBaselines)
     );
     expect(lines).toContain(
       "those 1 were recorded by 1 surface(s): unit:memory 1",
@@ -566,7 +619,13 @@ describe("publish()", () => {
     // place and says nothing about whether that is falling.
     const { store } = fakeStore(seed());
     const lines = await saying(() =>
-      publish(["--bootstrap", "--days", "1"], store, NOW, needsFile)
+      publish(
+        ["--bootstrap", "--days", "1"],
+        store,
+        NOW,
+        needsFile,
+        noBaselines,
+      )
     );
     expect(lines).toContain("the topology has no unit for 1 identities");
     expect(lines).not.toContain("at the last publish");
@@ -591,6 +650,7 @@ describe("publish()", () => {
             reason: "the ON arm cannot run it yet",
           }],
         }]),
+      noBaselines,
     );
     const manifestName = [...created.keys()].find((name) =>
       name.includes("/manifest-")
@@ -626,6 +686,7 @@ describe("publish()", () => {
             ...TOPOLOGY[0]!,
             locate: () => ({ level: "suite" as const }),
           }]),
+        noBaselines,
       );
     } finally {
       console.log = log;
@@ -637,7 +698,13 @@ describe("publish()", () => {
 
   it("folds from the state it left rather than the objects again", async () => {
     const { store, created } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      suites,
+      noBaselines,
+    );
     const first = created.size;
     const readObjects: string[] = [];
     const watched: StoreAccess = {
@@ -647,7 +714,8 @@ describe("publish()", () => {
         return store.read(name);
       },
     };
-    expect(await publish(["--days", "1"], watched, NOW, suites)).toBe(0);
+    expect(await publish(["--days", "1"], watched, NOW, suites, noBaselines))
+      .toBe(0);
     expect(readObjects).toEqual([]);
     expect(created.size).toBeGreaterThan(first);
   });
@@ -661,13 +729,20 @@ describe("publish()", () => {
           ? Promise.reject(new Error("unreachable"))
           : store.list(prefix),
     };
-    expect(await publish(["--days", "1"], broken, NOW, suites)).toBe(1);
+    expect(await publish(["--days", "1"], broken, NOW, suites, noBaselines))
+      .toBe(1);
     expect(created.size).toBe(0);
   });
 
   it("refuses to publish from a window it could only partly read", async () => {
     const { store, created } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      suites,
+      noBaselines,
+    );
     const after = created.size;
     const broken: StoreAccess = {
       ...store,
@@ -677,7 +752,8 @@ describe("publish()", () => {
           ? store.list(prefix)
           : Promise.resolve([CI(DAY, "9")]),
     };
-    expect(await publish(["--days", "1"], broken, NOW, suites)).toBe(1);
+    expect(await publish(["--days", "1"], broken, NOW, suites, noBaselines))
+      .toBe(1);
     expect(created.size).toBe(after);
   });
 
@@ -688,6 +764,7 @@ describe("publish()", () => {
       store,
       NOW,
       suites,
+      noBaselines,
     );
     expect(code).toBe(0);
     expect(created.size).toBe(0);
@@ -701,6 +778,7 @@ describe("publish()", () => {
       anonymous,
       NOW,
       suites,
+      noBaselines,
     );
     expect(created.size).toBe(0);
     expect(code).toBe(0);
@@ -708,7 +786,9 @@ describe("publish()", () => {
 
   it("reports a malformed command line rather than publishing", async () => {
     const { store, created } = fakeStore(seed());
-    expect(await publish(["--nonsense"], store, NOW, suites)).toBe(2);
+    expect(await publish(["--nonsense"], store, NOW, suites, noBaselines)).toBe(
+      2,
+    );
     expect(created.size).toBe(0);
   });
 });
@@ -725,6 +805,7 @@ describe("publish() --out", () => {
         store,
         NOW,
         suites,
+        noBaselines,
       );
       expect(code).toBe(0);
       // A dry run creates nothing in the store, and the directory is how
@@ -757,6 +838,7 @@ describe("publish() --out", () => {
           store,
           NOW,
           suites,
+          noBaselines,
         ),
       ).toBe(0);
       expect((await Deno.stat(join(out, "manifest.json"))).isFile).toBe(true);
@@ -784,7 +866,15 @@ describe("publish() over a day that has been compacted", () => {
         return store.read(name);
       },
     };
-    expect(await publish(["--bootstrap", "--days", "1"], watched, NOW, suites))
+    expect(
+      await publish(
+        ["--bootstrap", "--days", "1"],
+        watched,
+        NOW,
+        suites,
+        noBaselines,
+      ),
+    )
       .toBe(0);
     expect(read).toEqual([ROLLUP]);
   });
@@ -796,7 +886,13 @@ describe("publish() over a day that has been compacted", () => {
       ...seed(),
       [ROLLUP]: object("c3", "fail", "2026-08-20T03:00:00.000Z"),
     }, { [DAY]: [ROLLUP] });
-    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      suites,
+      noBaselines,
+    );
     const asked: string[] = [];
     const watched: StoreAccess = {
       ...store,
@@ -805,7 +901,8 @@ describe("publish() over a day that has been compacted", () => {
         return store.rollupShards(day);
       },
     };
-    expect(await publish(["--days", "1"], watched, NOW, suites)).toBe(0);
+    expect(await publish(["--days", "1"], watched, NOW, suites, noBaselines))
+      .toBe(0);
     expect(asked).toEqual([]);
   });
 
@@ -824,7 +921,15 @@ describe("publish() over a day that has been compacted", () => {
     }, { [older]: [olderRollup] });
     // The first run's window holds only the newer day, so the older one
     // is a day the aggregate has never seen.
-    expect(await publish(["--bootstrap", "--days", "1"], store, NOW, suites))
+    expect(
+      await publish(
+        ["--bootstrap", "--days", "1"],
+        store,
+        NOW,
+        suites,
+        noBaselines,
+      ),
+    )
       .toBe(0);
     const read: string[] = [];
     const watched: StoreAccess = {
@@ -834,7 +939,8 @@ describe("publish() over a day that has been compacted", () => {
         return store.read(name);
       },
     };
-    expect(await publish(["--days", "2"], watched, NOW, suites)).toBe(0);
+    expect(await publish(["--days", "2"], watched, NOW, suites, noBaselines))
+      .toBe(0);
     expect(read).toContain(olderRollup);
     expect(read).not.toContain(CI(older, "9"));
   });
@@ -844,7 +950,13 @@ describe("publish() over a day that has been compacted", () => {
     // nothing in one of this format says by how much, so the pair that
     // has raw objects in the aggregate keeps taking raw ones.
     const { store } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      suites,
+      noBaselines,
+    );
     const read: string[] = [];
     const asked: string[] = [];
     const later: StoreAccess = {
@@ -860,7 +972,8 @@ describe("publish() over a day that has been compacted", () => {
         return store.read(name);
       },
     };
-    expect(await publish(["--days", "1"], later, NOW, suites)).toBe(0);
+    expect(await publish(["--days", "1"], later, NOW, suites, noBaselines))
+      .toBe(0);
     expect(read).not.toContain(ROLLUP);
     // Nor was the store asked: the aggregate already answers for the pair.
     expect(asked).toEqual([]);
@@ -884,7 +997,15 @@ describe("publish() over a day that has been compacted", () => {
         return store.read(name);
       },
     };
-    expect(await publish(["--bootstrap", "--days", "1"], watched, NOW, suites))
+    expect(
+      await publish(
+        ["--bootstrap", "--days", "1"],
+        watched,
+        NOW,
+        suites,
+        noBaselines,
+      ),
+    )
       .toBe(0);
     expect(read).toContain(ROLLUP);
     expect(read).toContain(local);
@@ -910,7 +1031,15 @@ describe("publish() over a day that has been compacted", () => {
           ? Promise.reject(new Error("that shard is gone"))
           : store.read(name),
     };
-    expect(await publish(["--bootstrap", "--days", "1"], broken, NOW, suites))
+    expect(
+      await publish(
+        ["--bootstrap", "--days", "1"],
+        broken,
+        NOW,
+        suites,
+        noBaselines,
+      ),
+    )
       .toBe(1);
     expect(created.size).toBe(0);
   });
@@ -951,7 +1080,15 @@ describe("publish() over a day that has been compacted", () => {
       );
       whole.add(shards.map((shard) => reportFromText(shard, objects[shard]!)));
       const { store, created } = fakeStore(objects, { [DAY]: shards });
-      expect(await publish(["--bootstrap", "--days", "1"], store, NOW, suites))
+      expect(
+        await publish(
+          ["--bootstrap", "--days", "1"],
+          store,
+          NOW,
+          suites,
+          noBaselines,
+        ),
+      )
         .toBe(0);
       const stateName = [...created.keys()].find((name) =>
         name.includes("/state/")
@@ -1002,7 +1139,15 @@ describe("publish() over a day that has been compacted", () => {
         }
       },
     };
-    expect(await publish(["--bootstrap", "--days", "1"], watched, NOW, suites))
+    expect(
+      await publish(
+        ["--bootstrap", "--days", "1"],
+        watched,
+        NOW,
+        suites,
+        noBaselines,
+      ),
+    )
       .toBe(0);
     expect(read).toEqual(shards);
     expect(peak).toBeLessThanOrEqual(SHARD_CHUNK);
@@ -1014,7 +1159,13 @@ describe("publish() over an aggregate it cannot make sense of", () => {
 
   it("refuses rather than starting again from nothing", async () => {
     const { store, created } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      suites,
+      noBaselines,
+    );
     const state = [...created.keys()].find((name) => name.includes("/state/"))!;
     const after = created.size;
     const broken: StoreAccess = {
@@ -1024,7 +1175,8 @@ describe("publish() over an aggregate it cannot make sense of", () => {
           ? Promise.resolve('{"schema":1,"nonsense":true}')
           : store.readText(name),
     };
-    expect(await publish(["--days", "1"], broken, NOW, suites)).toBe(1);
+    expect(await publish(["--days", "1"], broken, NOW, suites, noBaselines))
+      .toBe(1);
     expect(created.size).toBe(after);
   });
 });
@@ -1065,19 +1217,32 @@ describe("publish() over a store that answers badly", () => {
 
   it("refuses when the aggregate object will not read", async () => {
     const { store, created } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      suites,
+      noBaselines,
+    );
     const after = created.size;
     const broken: StoreAccess = {
       ...store,
       readText: () => Promise.reject(new Error("that object is gone")),
     };
-    expect(await publish(["--days", "1"], broken, NOW, suites)).toBe(1);
+    expect(await publish(["--days", "1"], broken, NOW, suites, noBaselines))
+      .toBe(1);
     expect(created.size).toBe(after);
   });
 
   it("refuses when the submissions cannot be listed", async () => {
     const { store, created } = fakeStore(seed());
-    await publish(["--bootstrap", "--days", "1"], store, NOW, suites);
+    await publish(
+      ["--bootstrap", "--days", "1"],
+      store,
+      NOW,
+      suites,
+      noBaselines,
+    );
     const after = created.size;
     const broken: StoreAccess = {
       ...store,
@@ -1086,7 +1251,8 @@ describe("publish() over a store that answers badly", () => {
           ? Promise.reject(new Error("the store is unreachable"))
           : store.list(prefix),
     };
-    expect(await publish(["--days", "1"], broken, NOW, suites)).toBe(1);
+    expect(await publish(["--days", "1"], broken, NOW, suites, noBaselines))
+      .toBe(1);
     expect(created.size).toBe(after);
   });
 });
@@ -1108,7 +1274,15 @@ describe("publish() reporting what no lane can hold", () => {
     const log = console.log;
     console.log = (...parts: unknown[]) => said.push(parts.join(" "));
     try {
-      expect(await publish(["--bootstrap", "--days", "1"], store, NOW, suites))
+      expect(
+        await publish(
+          ["--bootstrap", "--days", "1"],
+          store,
+          NOW,
+          suites,
+          noBaselines,
+        ),
+      )
         .toBe(0);
     } finally {
       console.log = log;

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -57,6 +57,7 @@ import {
 } from "./test-selection/build.ts";
 import { isLaneMeasurement } from "./lane-measurement.ts";
 import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
+import { publishableBaselines } from "./test-selection/baselines.ts";
 import type { Suite } from "./test-topology/suite.ts";
 import {
   manifestBody,
@@ -66,7 +67,11 @@ import {
   stateObjectName,
   statePrefix,
 } from "./test-selection/store.ts";
-import { serializeManifest } from "./test-selection/manifest.ts";
+import {
+  type CoverageBaseline,
+  serializeManifest,
+} from "./test-selection/manifest.ts";
+import { fetchManifest } from "./test-selection/store.ts";
 import { plan } from "./test-selection/plan.ts";
 import { LANE_BUDGET_SECONDS, LANES } from "./test-selection/policy.ts";
 
@@ -380,6 +385,20 @@ async function readAggregate(store: StoreAccess): Promise<AggregateRead> {
 }
 
 /**
+ * The coverage baselines the next manifest carries: what the newest one
+ * holds, brought forward, plus whatever the `main` runs since then
+ * published. Reading the previous manifest is one public read and is
+ * what keeps a publish from asking about every run in the window.
+ */
+async function liveBaselines(now: Date): Promise<CoverageBaseline[]> {
+  const previous = await fetchManifest({ at: now.toISOString() });
+  return await publishableBaselines(
+    now,
+    previous.manifest?.coverageBaselines ?? [],
+  );
+}
+
+/**
  * An access token for creating a manifest, when one is reachable. Only
  * the workflow has one: the publisher's identity is federated and pinned
  * to that workflow file, and it is the sole principal holding create on
@@ -400,6 +419,7 @@ export async function publish(
   store: StoreAccess = liveStore(storeBucket()),
   now: Date = new Date(),
   topology: () => Promise<readonly Suite[]> = () => loadTopology(),
+  baselines: (now: Date) => Promise<CoverageBaseline[]> = liveBaselines,
 ): Promise<number> {
   const options = parseArgs(args);
   if (options === undefined) {
@@ -602,6 +622,10 @@ export async function publish(
     commit,
     runs: runs.size,
   });
+  // What the coverage gate compares a pull request against. It comes from
+  // outside the fold, because the counts are published by the full run on
+  // `main` rather than recorded as tests.
+  manifest.coverageBaselines = await baselines(startedAt);
   manifest.unavailable = suites.flatMap((suite) =>
     suite.unavailable.map((entry) => ({
       suite: suite.id,

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -393,15 +393,16 @@ async function readAggregate(store: StoreAccess): Promise<AggregateRead> {
  */
 export async function liveBaselines(
   now: Date,
-  newest: (at: string) => Promise<ManifestFetch> = (at) =>
-    fetchManifest({ at }),
-  publishable: (
-    now: Date,
-    known: readonly CoverageBaseline[],
-  ) => Promise<CoverageBaseline[]> = publishableBaselines,
+  fetch?: typeof globalThis.fetch,
 ): Promise<CoverageBaseline[]> {
-  const previous = await newest(now.toISOString());
-  return await publishable(now, previous.manifest?.coverageBaselines ?? []);
+  const previous = await fetchManifest({
+    at: now.toISOString(),
+    ...(fetch === undefined ? {} : { fetch }),
+  });
+  return await publishableBaselines(
+    now,
+    previous.manifest?.coverageBaselines ?? [],
+  );
 }
 
 /**

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -62,6 +62,7 @@ import type { Suite } from "./test-topology/suite.ts";
 import {
   fetchManifest,
   manifestBody,
+  type ManifestFetch,
   manifestObjectName,
   manifestPrefix,
   newestAtOrBefore,
@@ -390,12 +391,17 @@ async function readAggregate(store: StoreAccess): Promise<AggregateRead> {
  * published. Reading the previous manifest is one public read and is
  * what keeps a publish from asking about every run in the window.
  */
-async function liveBaselines(now: Date): Promise<CoverageBaseline[]> {
-  const previous = await fetchManifest({ at: now.toISOString() });
-  return await publishableBaselines(
-    now,
-    previous.manifest?.coverageBaselines ?? [],
-  );
+export async function liveBaselines(
+  now: Date,
+  newest: (at: string) => Promise<ManifestFetch> = (at) =>
+    fetchManifest({ at }),
+  publishable: (
+    now: Date,
+    known: readonly CoverageBaseline[],
+  ) => Promise<CoverageBaseline[]> = publishableBaselines,
+): Promise<CoverageBaseline[]> {
+  const previous = await newest(now.toISOString());
+  return await publishable(now, previous.manifest?.coverageBaselines ?? []);
 }
 
 /**

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -62,7 +62,6 @@ import type { Suite } from "./test-topology/suite.ts";
 import {
   fetchManifest,
   manifestBody,
-  type ManifestFetch,
   manifestObjectName,
   manifestPrefix,
   newestAtOrBefore,

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -60,6 +60,7 @@ import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
 import { publishableBaselines } from "./test-selection/baselines.ts";
 import type { Suite } from "./test-topology/suite.ts";
 import {
+  fetchManifest,
   manifestBody,
   manifestObjectName,
   manifestPrefix,
@@ -71,7 +72,6 @@ import {
   type CoverageBaseline,
   serializeManifest,
 } from "./test-selection/manifest.ts";
-import { fetchManifest } from "./test-selection/store.ts";
 import { plan } from "./test-selection/plan.ts";
 import { LANE_BUDGET_SECONDS, LANES } from "./test-selection/policy.ts";
 

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -49,7 +49,14 @@ function suiteHolding(units: readonly string[]): Suite {
 }
 
 const TOPOLOGY: Suite[] = [
-  suiteHolding(["packages/memory/test/memory.test.ts"]),
+  {
+    ...suiteHolding(["packages/memory/test/memory.test.ts"]),
+    measured: [{
+      member: "packages/memory",
+      reachedBy: ["packages/memory/"],
+      units: ["packages/memory/test/memory.test.ts"],
+    }],
+  },
 ];
 
 describe("test-selection", () => {
@@ -227,41 +234,105 @@ describe("test-selection", () => {
 });
 
 describe("coverageLines()", () => {
-  it("names the baseline a member is gated against", () => {
+  const workspaceUnit = {
+    suite: "workspace-unit",
+    set: {
+      member: "packages/memory",
+      reachedBy: ["packages/memory/"],
+      units: ["packages/memory/one.test.ts", "packages/memory/two.test.ts"],
+    },
+  };
+
+  it("names the baseline a measured set is compared against", () => {
     const manifest = sampleManifest({
       coverageBaselines: [{
+        suite: "workspace-unit",
         member: "packages/memory",
         commit: "abcdef0",
-        day: "2026-08-20",
+        createdAt: "2026-08-20T00:00:00.000Z",
         uncoveredLines: 41,
       }],
     });
-    expect(coverageLines(manifest, ["packages/memory"])).toEqual([
-      "packages/memory  gated, against 41 uncovered lines at abcdef0",
+    expect(coverageLines(manifest, [workspaceUnit], [])).toEqual([
+      "workspace-unit/packages/memory  2 units, against 41 uncovered lines " +
+      "at abcdef0",
+    ]);
+    expect(
+      coverageLines(manifest, [{
+        suite: "workspace-unit",
+        set: { ...workspaceUnit.set, units: ["packages/memory/one.test.ts"] },
+      }], [])[0],
+    ).toContain("1 unit,");
+  });
+
+  it("keeps two sets over one member apart", () => {
+    const manifest = sampleManifest({
+      coverageBaselines: [
+        {
+          suite: "workspace-unit",
+          member: "packages/memory",
+          commit: "abcdef0",
+          createdAt: "2026-08-20T00:00:00.000Z",
+          uncoveredLines: 41,
+        },
+        {
+          suite: "memory-integration",
+          member: "packages/memory",
+          commit: "abcdef0",
+          createdAt: "2026-08-20T00:00:00.000Z",
+          uncoveredLines: 900,
+        },
+      ],
+    });
+    const lines = coverageLines(manifest, [
+      workspaceUnit,
+      { suite: "memory-integration", set: workspaceUnit.set },
+    ], []);
+    expect(lines[0]).toContain("41 uncovered lines");
+    expect(lines[1]).toContain("900 uncovered lines");
+  });
+
+  it("says so when a set has no baseline yet", () => {
+    const lines = coverageLines(sampleManifest(), [workspaceUnit], []);
+    expect(lines).toEqual([
+      "workspace-unit/packages/memory  2 units, against no baseline yet",
     ]);
   });
 
-  it("says so when a member has no baseline yet", () => {
-    const lines = coverageLines(sampleManifest(), ["packages/memory"]);
-    expect(lines).toEqual(["packages/memory  gated, against no baseline yet"]);
-  });
-
-  it("gives the reason for a member the gate leaves alone", () => {
+  it("gives the reason for a member that carries no set", () => {
     const member = [...EXCLUDED_FROM_COVERAGE_GATE.keys()][0]!;
-    const lines = coverageLines(sampleManifest(), [member]);
-    expect(lines[0]).toContain("not gated: ");
+    const lines = coverageLines(sampleManifest(), [], [member]);
+    expect(lines[0]).toContain("no measured set: ");
     expect(lines[0]).toContain(EXCLUDED_FROM_COVERAGE_GATE.get(member)!);
   });
 
-  it("reads a manifest that is missing the same as one with no baselines", () => {
-    const members = ["packages/memory", "packages/runner"];
-    expect(coverageLines(undefined, members))
-      .toEqual(coverageLines(sampleManifest(), members));
+  it("says a member outside the list has no Deno-only tests", () => {
+    const lines = coverageLines(sampleManifest(), [], ["packages/nowhere"]);
+    expect(lines[0]).toContain("no measured set: it has no Deno-only tests");
   });
 
-  it("pads every member to one width, so the column lines up", () => {
-    const lines = coverageLines(undefined, ["packages/a", "packages/longer"]);
-    const at = lines.map((line) => line.indexOf("gated"));
+  it("leaves a member that carries a set out of the ungated half", () => {
+    const lines = coverageLines(
+      sampleManifest(),
+      [workspaceUnit],
+      ["packages/memory"],
+    );
+    expect(lines).toHaveLength(1);
+  });
+
+  it("reads a manifest that is missing the same as one with no baselines", () => {
+    expect(coverageLines(undefined, [workspaceUnit], ["packages/runner"]))
+      .toEqual(
+        coverageLines(sampleManifest(), [workspaceUnit], ["packages/runner"]),
+      );
+  });
+
+  it("pads every name to one width, so the column lines up", () => {
+    const lines = coverageLines(undefined, [], [
+      "packages/a",
+      "packages/longer",
+    ]);
+    const at = lines.map((line) => line.indexOf("no measured set"));
     expect(at[0]).toBe(at[1]);
   });
 });
@@ -480,13 +551,21 @@ describe("dispatch()", () => {
     expect(result.out).toContain(DIALS[0]!.name);
   });
 
-  it("names the gated members, and carries on with no manifest", async () => {
+  it("names the measured sets, and carries on with no manifest", async () => {
     const result = await ran(["coverage"], {
       manifest: () => Promise.resolve(undefined),
     });
     expect(result.code).toBe(0);
-    expect(result.out).toContain("packages/memory");
+    expect(result.out).toContain("workspace-unit/packages/memory");
     expect(result.out).toContain("no baseline yet");
+  });
+
+  it("names a member that carries no set beside the sets", async () => {
+    const result = await ran(["coverage"], {
+      members: () => Promise.resolve(["packages/memory", "packages/runner"]),
+    });
+    expect(result.out).toContain("workspace-unit/packages/memory");
+    expect(result.out).toContain("no measured set: Its whole set is past");
   });
 
   it("stops when explain is given no identity, or a bad one", async () => {

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -33,6 +33,11 @@ import { fetchManifest } from "./test-selection/store.ts";
 import { capabilitiesBySuite, loadTopology } from "./test-topology.ts";
 import { type Suite, unavailableUnits } from "./test-topology/suite.ts";
 import { census } from "./test-selection/census.ts";
+import {
+  measuredSetName,
+  type MeasuredSetRef,
+  measuredSets,
+} from "./test-selection/coverage.ts";
 import type { Manifest } from "./test-selection/manifest.ts";
 import { plan } from "./test-selection/plan.ts";
 import { readWorkspaceMembers } from "./workspace-tests.ts";
@@ -109,26 +114,50 @@ export function dialLines(): string[] {
   return lines;
 }
 
-/** Each gated member and its baseline, as the lines `coverage` prints. */
+/**
+ * Each measured set and its baseline, then every workspace member that
+ * carries no set and the reason it does not.
+ *
+ * The two halves answer the two questions somebody brings here: what am I
+ * being compared against, and why is my package not gated.
+ */
 export function coverageLines(
   manifest: Manifest | undefined,
+  sets: readonly MeasuredSetRef[],
   members: readonly string[],
 ): string[] {
-  const width = Math.max(...members.map((member) => member.length));
-  const baselines = new Map(
-    (manifest?.coverageBaselines ?? []).map((base) => [base.member, base]),
+  const names = sets.map(measuredSetName);
+  const ungated = members.filter((member) =>
+    !sets.some((ref) => ref.set.member === member)
   );
-  return members.map((member) => {
-    const excluded = EXCLUDED_FROM_COVERAGE_GATE.get(member);
-    if (excluded !== undefined) {
-      return `${pad(member, width)}  not gated: ${excluded}`;
-    }
-    const baseline = baselines.get(member);
+  const width = Math.max(
+    1,
+    ...names.map((name) => name.length),
+    ...ungated.map((member) => member.length),
+  );
+  const baselines = new Map(
+    (manifest?.coverageBaselines ?? []).map((
+      base,
+    ) => [`${base.suite}/${base.member}`, base]),
+  );
+  const lines = sets.map((ref, index) => {
+    const name = names[index]!;
+    const baseline = baselines.get(name);
     const against = baseline === undefined
       ? "no baseline yet"
       : `${baseline.uncoveredLines} uncovered lines at ${baseline.commit}`;
-    return `${pad(member, width)}  gated, against ${against}`;
+    const units = ref.set.units.length;
+    return `${pad(name, width)}  ${units} ${units === 1 ? "unit" : "units"}, ` +
+      `against ${against}`;
   });
+  for (const member of ungated) {
+    const excluded = EXCLUDED_FROM_COVERAGE_GATE.get(member);
+    lines.push(
+      `${pad(member, width)}  no measured set: ` +
+        `${excluded ?? "it has no Deno-only tests"}`,
+    );
+  }
+  return lines;
 }
 
 /** The workspace members the coverage gate has an opinion about. */
@@ -492,10 +521,13 @@ export async function dispatch(
       return 0;
     case "coverage": {
       // The one mode that reads a manifest and carries on without one:
-      // which members are gated is a fact about the tree, and only the
-      // baseline each is measured against comes from a manifest.
+      // which sets exist is a fact about the tree, and only the baseline
+      // each is measured against comes from a manifest.
       const manifest = await sources.manifest();
-      for (const line of coverageLines(manifest, await sources.members())) {
+      const sets = measuredSets(await sources.topology());
+      for (
+        const line of coverageLines(manifest, sets, await sources.members())
+      ) {
         console.log(line);
       }
       return 0;

--- a/tasks/test-selection/baselines.test.ts
+++ b/tasks/test-selection/baselines.test.ts
@@ -234,6 +234,19 @@ describe("baselines", () => {
       expect(baselines[0]?.uncoveredLines).toBe(5);
     });
 
+    it("passes over a measured-set metric that names no member", async () => {
+      const baselines = await collectCoverageBaselines(
+        source([{ id: 1, commit: "abc", createdAt: daysAgo(1) }], {
+          1: {
+            [measuredSetCoverageMetric("workspace-unit")]: 5,
+            [measuredSetCoverageMetric("workspace-unit/packages/a")]: 7,
+          },
+        }),
+        NOW,
+      );
+      expect(baselines.map((base) => base.member)).toEqual(["packages/a"]);
+    });
+
     it("stops at a run whose report names no measured set", async () => {
       // Such a run measured a tree where nothing publishes one, and
       // every older run is such a tree too, so reading further costs an

--- a/tasks/test-selection/baselines.test.ts
+++ b/tasks/test-selection/baselines.test.ts
@@ -4,12 +4,14 @@ import {
   type BaselineRun,
   type BaselineSource,
   collectCoverageBaselines,
+  liveBaselineSource,
   publishableBaselines,
   splitMeasuredSet,
 } from "./baselines.ts";
 import {
   coverageMetricForGroup,
   measuredSetCoverageMetric,
+  PERF_METRICS_ARTIFACT_NAME,
 } from "../ci-check-lib.ts";
 import { LOCAL_COVERAGE_BASELINE_DAYS } from "./policy.ts";
 
@@ -277,6 +279,87 @@ describe("baselines", () => {
         NOW,
       );
       expect(baselines).toEqual([]);
+    });
+  });
+
+  describe("reading the repository's own runs and artifacts", () => {
+    /** One artifact, with only the fields the source reads. */
+    const artifact = (
+      over: Partial<{ id: number; name: string; expired: boolean }> = {},
+    ) => ({
+      id: 1,
+      name: PERF_METRICS_ARTIFACT_NAME,
+      expired: false,
+      created_at: "2026-09-09T00:00:00.000Z",
+      ...over,
+      // deno-lint-ignore no-explicit-any
+    } as any);
+
+    it("names each run by its commit and the moment it was created", async () => {
+      const source = liveBaselineSource({
+        list: () =>
+          Promise.resolve({
+            // deno-lint-ignore no-explicit-any
+            workflow_runs: [{
+              id: 7,
+              head_sha: "abc",
+              created_at: "2026-09-09T10:00:00Z",
+              // deno-lint-ignore no-explicit-any
+            }] as any,
+          }),
+      });
+      expect(await source.runs()).toEqual([
+        { id: 7, commit: "abc", createdAt: "2026-09-09T10:00:00Z" },
+      ]);
+    });
+
+    it("reads the uncovered count out of each metric the artifact holds", async () => {
+      const source = liveBaselineSource({
+        artifacts: () => Promise.resolve([artifact()]),
+        baseline: () =>
+          Promise.resolve({
+            metrics: new Map([["coverage-debt: tasks uncovered lines", {
+              uncoveredLines: 12,
+            }]]),
+          }),
+      });
+      expect([...(await source.metrics(7))!]).toEqual([
+        ["coverage-debt: tasks uncovered lines", 12],
+      ]);
+    });
+
+    it("passes over an artifact that has expired or is named otherwise", async () => {
+      const asked: number[] = [];
+      const source = liveBaselineSource({
+        artifacts: () =>
+          Promise.resolve([
+            artifact({ id: 2, expired: true }),
+            artifact({ id: 3, name: "something-else" }),
+          ]),
+        baseline: (id) => {
+          asked.push(id);
+          return Promise.resolve({ metrics: new Map() });
+        },
+      });
+      expect(await source.metrics(7)).toBeUndefined();
+      expect(asked).toEqual([]);
+    });
+
+    it("answers with nothing where the run's artifacts cannot be listed", async () => {
+      // A publish reads many runs, and one that cannot be read
+      // contributes no baseline rather than ending the publish.
+      const source = liveBaselineSource({
+        artifacts: () => Promise.reject(new Error("the interface said no")),
+      });
+      expect(await source.metrics(7)).toBeUndefined();
+    });
+
+    it("answers with nothing where the artifact cannot be parsed", async () => {
+      const source = liveBaselineSource({
+        artifacts: () => Promise.resolve([artifact()]),
+        baseline: () => Promise.resolve(null),
+      });
+      expect(await source.metrics(7)).toBeUndefined();
     });
   });
 

--- a/tasks/test-selection/baselines.test.ts
+++ b/tasks/test-selection/baselines.test.ts
@@ -214,6 +214,24 @@ describe("baselines", () => {
       expect(asked).toEqual([]);
     });
 
+    it("takes one commit's figures from the newest of its runs", async () => {
+      // A commit can carry more than one successful run. Two baselines
+      // at one commit would leave a comparison choosing between them by
+      // whichever was listed first.
+      const baselines = await collectCoverageBaselines(
+        source([
+          { id: 1, commit: "shared", createdAt: daysAgo(0.25) },
+          { id: 2, commit: "shared", createdAt: daysAgo(0.75) },
+        ], {
+          1: { [measuredSetCoverageMetric("workspace-unit/packages/a")]: 5 },
+          2: { [measuredSetCoverageMetric("workspace-unit/packages/a")]: 9 },
+        }),
+        NOW,
+      );
+      expect(baselines).toHaveLength(1);
+      expect(baselines[0]?.uncoveredLines).toBe(5);
+    });
+
     it("stops at a run whose report names no measured set", async () => {
       // Such a run measured a tree where nothing publishes one, and
       // every older run is such a tree too, so reading further costs an

--- a/tasks/test-selection/baselines.test.ts
+++ b/tasks/test-selection/baselines.test.ts
@@ -1,0 +1,306 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import {
+  type BaselineRun,
+  type BaselineSource,
+  collectCoverageBaselines,
+  publishableBaselines,
+  splitMeasuredSet,
+} from "./baselines.ts";
+import {
+  coverageMetricForGroup,
+  measuredSetCoverageMetric,
+} from "../ci-check-lib.ts";
+import { LOCAL_COVERAGE_BASELINE_DAYS } from "./policy.ts";
+
+const NOW = new Date("2026-09-09T12:00:00.000Z");
+
+/** A day inside or outside the window, as an ISO moment. */
+function daysAgo(days: number): string {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/** A source answering with exactly what a case describes. */
+function source(
+  runs: readonly BaselineRun[],
+  metrics: Record<number, Record<string, number>>,
+): BaselineSource {
+  return {
+    runs: () => Promise.resolve(runs),
+    metrics: (id) =>
+      Promise.resolve(
+        metrics[id] === undefined ? undefined : new Map(
+          Object.entries(metrics[id]!),
+        ),
+      ),
+  };
+}
+
+describe("baselines", () => {
+  describe("naming a measured set", () => {
+    it("splits at the first slash, however deep the member sits", () => {
+      expect(splitMeasuredSet("workspace-unit/packages/connectors/github"))
+        .toEqual({
+          suite: "workspace-unit",
+          member: "packages/connectors/github",
+        });
+    });
+
+    it("refuses a name with no member or no suite", () => {
+      expect(splitMeasuredSet("workspace-unit")).toBeUndefined();
+      expect(splitMeasuredSet("/packages/memory")).toBeUndefined();
+      expect(splitMeasuredSet("workspace-unit/")).toBeUndefined();
+    });
+  });
+
+  describe("the baselines a manifest carries", () => {
+    it("takes each run's measured-set figures against its commit", async () => {
+      const baselines = await collectCoverageBaselines(
+        source([{ id: 1, commit: "abc", createdAt: daysAgo(1) }], {
+          1: {
+            [measuredSetCoverageMetric("workspace-unit/packages/memory")]: 12,
+            [measuredSetCoverageMetric("runner-unit/packages/runner")]: 40,
+          },
+        }),
+        NOW,
+      );
+      expect(baselines).toEqual([
+        {
+          suite: "runner-unit",
+          member: "packages/runner",
+          commit: "abc",
+          createdAt: daysAgo(1),
+          uncoveredLines: 40,
+        },
+        {
+          suite: "workspace-unit",
+          member: "packages/memory",
+          commit: "abc",
+          createdAt: daysAgo(1),
+          uncoveredLines: 12,
+        },
+      ]);
+    });
+
+    it("leaves out a run older than the window", async () => {
+      const baselines = await collectCoverageBaselines(
+        source([
+          { id: 1, commit: "recent", createdAt: daysAgo(1) },
+          {
+            id: 2,
+            commit: "ancient",
+            createdAt: daysAgo(LOCAL_COVERAGE_BASELINE_DAYS + 1),
+          },
+        ], {
+          1: { [measuredSetCoverageMetric("workspace-unit/packages/a")]: 1 },
+          2: { [measuredSetCoverageMetric("workspace-unit/packages/a")]: 2 },
+        }),
+        NOW,
+      );
+      expect(baselines.map((base) => base.commit)).toEqual(["recent"]);
+    });
+
+    it("leaves out a run whose artifact says nothing", async () => {
+      const baselines = await collectCoverageBaselines(
+        source([{ id: 1, commit: "abc", createdAt: daysAgo(1) }], {}),
+        NOW,
+      );
+      expect(baselines).toEqual([]);
+    });
+
+    it("never reads a source group as a measured set", async () => {
+      const baselines = await collectCoverageBaselines(
+        source([{ id: 1, commit: "abc", createdAt: daysAgo(1) }], {
+          1: {
+            [coverageMetricForGroup("packages/memory")]: 900,
+            [coverageMetricForGroup("workspace")]: 90_000,
+          },
+        }),
+        NOW,
+      );
+      expect(baselines).toEqual([]);
+    });
+
+    it("keeps two suites over one member apart", async () => {
+      const baselines = await collectCoverageBaselines(
+        source([{ id: 1, commit: "abc", createdAt: daysAgo(1) }], {
+          1: {
+            [measuredSetCoverageMetric("workspace-unit/packages/memory")]: 12,
+            [measuredSetCoverageMetric("memory-e2e/packages/memory")]: 800,
+          },
+        }),
+        NOW,
+      );
+      expect(baselines.map((base) => [base.suite, base.uncoveredLines]))
+        .toEqual([
+          ["memory-e2e", 800],
+          ["workspace-unit", 12],
+        ]);
+    });
+
+    it("carries forward what the previous manifest held", async () => {
+      const known = [{
+        suite: "workspace-unit",
+        member: "packages/a",
+        commit: "earlier",
+        createdAt: daysAgo(2),
+        uncoveredLines: 7,
+      }];
+      const baselines = await collectCoverageBaselines(
+        source([{ id: 1, commit: "later", createdAt: daysAgo(1) }], {
+          1: { [measuredSetCoverageMetric("workspace-unit/packages/a")]: 5 },
+        }),
+        NOW,
+        known,
+      );
+      expect(baselines.map((base) => [base.commit, base.uncoveredLines]))
+        .toEqual([["later", 5], ["earlier", 7]]);
+    });
+
+    it("drops a carried baseline that has fallen out of the window", async () => {
+      const known = [{
+        suite: "workspace-unit",
+        member: "packages/a",
+        commit: "ancient",
+        createdAt: daysAgo(LOCAL_COVERAGE_BASELINE_DAYS + 1),
+        uncoveredLines: 7,
+      }];
+      expect(await collectCoverageBaselines(source([], {}), NOW, known))
+        .toEqual([]);
+    });
+
+    it("never reads a run a carried baseline already names", async () => {
+      // Reading one costs an artifact listing and a download, and the
+      // figure would be the same.
+      const asked: number[] = [];
+      const watching: BaselineSource = {
+        runs: () =>
+          Promise.resolve([{ id: 1, commit: "known", createdAt: daysAgo(1) }]),
+        metrics: (id) => {
+          asked.push(id);
+          return Promise.resolve(undefined);
+        },
+      };
+      await collectCoverageBaselines(watching, NOW, [{
+        suite: "workspace-unit",
+        member: "packages/a",
+        commit: "known",
+        createdAt: daysAgo(1),
+        uncoveredLines: 7,
+      }]);
+      expect(asked).toEqual([]);
+    });
+
+    it("stops at the first run past the window", async () => {
+      const asked: number[] = [];
+      const watching: BaselineSource = {
+        runs: () =>
+          Promise.resolve([
+            {
+              id: 1,
+              commit: "old",
+              createdAt: daysAgo(LOCAL_COVERAGE_BASELINE_DAYS + 1),
+            },
+            { id: 2, commit: "older", createdAt: daysAgo(1) },
+          ]),
+        metrics: (id) => {
+          asked.push(id);
+          return Promise.resolve(undefined);
+        },
+      };
+      // The listing is newest first, so nothing past the first run outside
+      // the window is worth asking about.
+      await collectCoverageBaselines(watching, NOW);
+      expect(asked).toEqual([]);
+    });
+
+    it("stops at a run whose report names no measured set", async () => {
+      // Such a run measured a tree where nothing publishes one, and
+      // every older run is such a tree too, so reading further costs an
+      // artifact download per run and finds nothing.
+      const asked: number[] = [];
+      const watching: BaselineSource = {
+        runs: () =>
+          Promise.resolve([
+            { id: 1, commit: "newer", createdAt: daysAgo(1) },
+            { id: 2, commit: "older", createdAt: daysAgo(2) },
+          ]),
+        metrics: (id) => {
+          asked.push(id);
+          return Promise.resolve(
+            new Map([[coverageMetricForGroup("workspace"), 90_000]]),
+          );
+        },
+      };
+      expect(await collectCoverageBaselines(watching, NOW)).toEqual([]);
+      expect(asked).toEqual([1]);
+    });
+
+    it("orders two runs of one day by the moment each was created", async () => {
+      const baselines = await collectCoverageBaselines(
+        source([
+          { id: 1, commit: "later", createdAt: daysAgo(0.25) },
+          { id: 2, commit: "earlier", createdAt: daysAgo(0.75) },
+        ], {
+          1: { [measuredSetCoverageMetric("workspace-unit/packages/a")]: 1 },
+          2: { [measuredSetCoverageMetric("workspace-unit/packages/a")]: 2 },
+        }),
+        NOW,
+      );
+      expect(baselines.map((base) => base.commit))
+        .toEqual(["later", "earlier"]);
+    });
+
+    it("passes over a run with an unreadable date", async () => {
+      const baselines = await collectCoverageBaselines(
+        source([{ id: 1, commit: "abc", createdAt: "not a date" }], {
+          1: { [measuredSetCoverageMetric("workspace-unit/packages/a")]: 1 },
+        }),
+        NOW,
+      );
+      expect(baselines).toEqual([]);
+    });
+  });
+
+  describe("what a publish carries", () => {
+    const known = [{
+      suite: "workspace-unit",
+      member: "packages/a",
+      commit: "earlier",
+      createdAt: daysAgo(1),
+      uncoveredLines: 7,
+    }];
+
+    it("carries what the last manifest held when it cannot read more", async () => {
+      // Switching the gate off for one publish would report every set
+      // as having nothing to compare against.
+      expect(
+        await publishableBaselines(NOW, known, source([], {}), undefined),
+      ).toEqual(known);
+      expect(await publishableBaselines(NOW, known, source([], {}), ""))
+        .toEqual(known);
+    });
+
+    it("carries what the last manifest held when the source throws", async () => {
+      const broken: BaselineSource = {
+        runs: () => Promise.reject(new Error("the interface said no")),
+        metrics: () => Promise.resolve(undefined),
+      };
+      expect(await publishableBaselines(NOW, known, broken, "a token"))
+        .toEqual(known);
+    });
+
+    it("adds what a run published to what it carried", async () => {
+      const baselines = await publishableBaselines(
+        NOW,
+        known,
+        source([{ id: 1, commit: "later", createdAt: daysAgo(0.5) }], {
+          1: { [measuredSetCoverageMetric("workspace-unit/packages/a")]: 5 },
+        }),
+        "a token",
+      );
+      expect(baselines.map((base) => base.commit))
+        .toEqual(["later", "earlier"]);
+    });
+  });
+});

--- a/tasks/test-selection/baselines.ts
+++ b/tasks/test-selection/baselines.ts
@@ -102,6 +102,11 @@ export async function collectCoverageBaselines(
     // a tree where nothing measures one. Every older run is such a tree
     // too, so there is nothing further back to read.
     if (sets.length === 0) break;
+    // A commit can carry more than one successful run. Its figures are
+    // taken from the newest of them and the rest are passed over, so a
+    // set never holds two baselines at one commit for a comparison to
+    // choose between.
+    carried.add(run.commit);
     for (const [set, uncoveredLines] of sets) {
       baselines.push({
         suite: set.suite,

--- a/tasks/test-selection/baselines.ts
+++ b/tasks/test-selection/baselines.ts
@@ -151,11 +151,29 @@ function measuredSetFigures(
  */
 const BASELINE_RUNS = 100;
 
+/** What the live source reaches for, so a test can hand it something. */
+export interface BaselineReads {
+  /** The runs a listing path names. */
+  list?: (path: string) => Promise<{ workflow_runs: WorkflowRun[] }>;
+
+  /** The artifacts one run left behind. */
+  artifacts?: (runId: number) => Promise<Artifact[]>;
+
+  /** What one artifact holds, or nothing where it cannot be read. */
+  baseline?: (
+    artifactId: number,
+  ) => Promise<{ metrics: Map<string, { uncoveredLines: number }> } | null>;
+}
+
 /** The runs and artifacts of the repository this is running in. */
-export function liveBaselineSource(): BaselineSource {
+export function liveBaselineSource(reads: BaselineReads = {}): BaselineSource {
+  const list = reads.list ??
+    ((path: string) => githubGet<{ workflow_runs: WorkflowRun[] }>(path));
+  const artifactsOf = reads.artifacts ?? fetchArtifactsForRun;
+  const baselineOf = reads.baseline ?? downloadAndParseCoverageBaseline;
   return {
     async runs() {
-      const response = await githubGet<{ workflow_runs: WorkflowRun[] }>(
+      const response = await list(
         workflowRunsPathForBaseline(BASELINE_RUNS),
       );
       return response.workflow_runs.map((run) => ({
@@ -167,7 +185,7 @@ export function liveBaselineSource(): BaselineSource {
     async metrics(runId: number) {
       let artifacts: Artifact[];
       try {
-        artifacts = await fetchArtifactsForRun(runId);
+        artifacts = await artifactsOf(runId);
       } catch {
         return undefined;
       }
@@ -177,7 +195,7 @@ export function liveBaselineSource(): BaselineSource {
         ),
       )[0];
       if (artifact === undefined) return undefined;
-      const parsed = await downloadAndParseCoverageBaseline(artifact.id);
+      const parsed = await baselineOf(artifact.id);
       if (parsed === null) return undefined;
       return new Map(
         [...parsed.metrics].map(([name, sample]) => [

--- a/tasks/test-selection/baselines.ts
+++ b/tasks/test-selection/baselines.ts
@@ -1,0 +1,213 @@
+/**
+ * Where a manifest's coverage baselines come from.
+ *
+ * A baseline is what one measured set counted at one `main` commit. The
+ * full run on `main` publishes those counts in its `perf-metrics`
+ * artifact, beside the repository-wide figure the dashboard reads, and
+ * this gathers the recent ones so a manifest carries them. The coverage
+ * gate then compares against data the newest manifest already holds,
+ * rather than downloading a run's artifacts at the barrier.
+ *
+ * Nothing here fails a publish. A run with no measured-set metrics
+ * contributes none, and a store that cannot be reached contributes none;
+ * a set with no baseline is reported by the gate rather than failed, so
+ * the worst an empty list costs is a pull request that is told there is
+ * nothing to compare it against.
+ */
+
+import {
+  type Artifact,
+  coverageMetricMeasuredSet,
+  downloadAndParseCoverageBaseline,
+  fetchArtifactsForRun,
+  githubGet,
+  newestArtifactsByName,
+  PERF_METRICS_ARTIFACT_NAME,
+  TOKEN,
+  type WorkflowRun,
+  workflowRunsPathForBaseline,
+} from "../ci-check-lib.ts";
+import type { CoverageBaseline } from "./manifest.ts";
+import { LOCAL_COVERAGE_BASELINE_DAYS } from "./policy.ts";
+
+/** One `main` run a baseline could come from. */
+export interface BaselineRun {
+  id: number;
+  commit: string;
+
+  /** When the run was created, ISO 8601. */
+  createdAt: string;
+}
+
+/** Where the runs and their published metrics come from. */
+export interface BaselineSource {
+  /** Successful pushes to the default branch, newest first. */
+  runs(): Promise<readonly BaselineRun[]>;
+
+  /** What one run published, by metric name, or nothing where it published none. */
+  metrics(runId: number): Promise<ReadonlyMap<string, number> | undefined>;
+}
+
+/**
+ * The measured set one metric names, split into its suite and its member.
+ *
+ * The name is the suite and the member joined by a slash, and a suite
+ * identifier holds no slash, so the first one separates them however deep
+ * the member sits.
+ */
+export function splitMeasuredSet(
+  name: string,
+): { suite: string; member: string } | undefined {
+  const at = name.indexOf("/");
+  if (at <= 0 || at === name.length - 1) return undefined;
+  return { suite: name.slice(0, at), member: name.slice(at + 1) };
+}
+
+/**
+ * The baselines a manifest should carry: the ones the previous manifest
+ * carried that are still inside `LOCAL_COVERAGE_BASELINE_DAYS`, plus the
+ * ones the runs since then published.
+ *
+ * Carried forward rather than read again, because reading one run's
+ * figures costs an artifact listing and a download, and a window of days
+ * holds more runs than a publisher should ask about every few hours. What
+ * is read is the runs whose commit no baseline names yet, which after the
+ * first publish is the handful since the last one.
+ *
+ * The window is what the gate can use: it takes the newest baseline the
+ * branch contains, so a branch based further back than the window finds
+ * none and is reported rather than failed.
+ */
+export async function collectCoverageBaselines(
+  source: BaselineSource,
+  now: Date,
+  known: readonly CoverageBaseline[] = [],
+): Promise<CoverageBaseline[]> {
+  const oldest = new Date(
+    now.getTime() - LOCAL_COVERAGE_BASELINE_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const baselines = known.filter((base) => base.createdAt >= oldest);
+  const carried = new Set(baselines.map((base) => base.commit));
+  for (const run of await source.runs()) {
+    const createdAt = new Date(run.createdAt);
+    if (Number.isNaN(createdAt.getTime())) continue;
+    // The listing is newest first, so the first run past the window is
+    // where the window ends.
+    if (createdAt.toISOString() < oldest) break;
+    if (carried.has(run.commit)) continue;
+    const metrics = await source.metrics(run.id);
+    if (metrics === undefined) continue;
+    const sets = measuredSetFigures(metrics);
+    // A run that published a report and named no measured set in it ran
+    // a tree where nothing measures one. Every older run is such a tree
+    // too, so there is nothing further back to read.
+    if (sets.length === 0) break;
+    for (const [set, uncoveredLines] of sets) {
+      baselines.push({
+        suite: set.suite,
+        member: set.member,
+        commit: run.commit,
+        createdAt: createdAt.toISOString(),
+        uncoveredLines,
+      });
+    }
+  }
+  return baselines.sort((a, b) =>
+    b.createdAt.localeCompare(a.createdAt) ||
+    a.suite.localeCompare(b.suite) || a.member.localeCompare(b.member)
+  );
+}
+
+/** The measured sets one run's metrics name, and what each counted. */
+function measuredSetFigures(
+  metrics: ReadonlyMap<string, number>,
+): [{ suite: string; member: string }, number][] {
+  const figures: [{ suite: string; member: string }, number][] = [];
+  for (const [name, uncoveredLines] of metrics) {
+    const set = coverageMetricMeasuredSet(name);
+    if (set === null) continue;
+    const split = splitMeasuredSet(set);
+    if (split === undefined) continue;
+    figures.push([split, uncoveredLines]);
+  }
+  return figures;
+}
+
+/**
+ * How many recent runs one listing asks for, which is GitHub's maximum
+ * for one page.
+ *
+ * It bounds how far one publish can catch up rather than how much
+ * history a manifest holds: what the window holds is built up by each
+ * publish carrying the previous manifest's baselines forward and adding
+ * the runs since. A busy day lands more runs than this, so a publisher
+ * that has been down for a day reaches back less far than the window
+ * until it has run a few times.
+ */
+const BASELINE_RUNS = 100;
+
+/** The runs and artifacts of the repository this is running in. */
+export function liveBaselineSource(): BaselineSource {
+  return {
+    async runs() {
+      const response = await githubGet<{ workflow_runs: WorkflowRun[] }>(
+        workflowRunsPathForBaseline(BASELINE_RUNS),
+      );
+      return response.workflow_runs.map((run) => ({
+        id: run.id,
+        commit: run.head_sha,
+        createdAt: run.created_at,
+      }));
+    },
+    async metrics(runId: number) {
+      let artifacts: Artifact[];
+      try {
+        artifacts = await fetchArtifactsForRun(runId);
+      } catch {
+        return undefined;
+      }
+      const artifact = newestArtifactsByName(
+        artifacts.filter((one) =>
+          one.name === PERF_METRICS_ARTIFACT_NAME && !one.expired
+        ),
+      )[0];
+      if (artifact === undefined) return undefined;
+      const parsed = await downloadAndParseCoverageBaseline(artifact.id);
+      if (parsed === null) return undefined;
+      return new Map(
+        [...parsed.metrics].map(([name, sample]) => [
+          name,
+          sample.uncoveredLines,
+        ]),
+      );
+    },
+  };
+}
+
+/**
+ * The baselines to publish, or the ones already published where the
+ * credential to read any more is absent. Reading a run's artifacts needs
+ * a token, and a publisher run without one still has a manifest worth
+ * creating; carrying what the previous manifest held keeps the gate
+ * working across such a run rather than switching it off for one.
+ */
+export async function publishableBaselines(
+  now: Date,
+  known: readonly CoverageBaseline[] = [],
+  source: BaselineSource = liveBaselineSource(),
+  token: string | undefined = TOKEN,
+): Promise<CoverageBaseline[]> {
+  if (token === undefined || token.length === 0) {
+    console.warn(
+      "test selection: no GitHub credential, so this manifest carries only " +
+        "the coverage baselines the last one did.",
+    );
+    return [...known];
+  }
+  try {
+    return await collectCoverageBaselines(source, now, known);
+  } catch (error) {
+    console.warn(`test selection: cannot read coverage baselines: ${error}`);
+    return [...known];
+  }
+}

--- a/tasks/test-selection/census.test.ts
+++ b/tasks/test-selection/census.test.ts
@@ -394,3 +394,116 @@ describe("what the tree says and the manifest does not", () => {
       .toEqual([UNMEASURED_COST_SECONDS, UNMEASURED_COST_SECONDS]);
   });
 });
+
+describe("what a measured set makes mandatory", () => {
+  const measured = suite({
+    id: "workspace-unit",
+    units: [
+      "packages/bakery/glaze.test.ts",
+      "packages/bakery/proof.test.ts",
+      "packages/cellar/rack.test.ts",
+    ],
+    measured: [{
+      member: "packages/bakery",
+      reachedBy: ["packages/bakery/"],
+      units: [
+        "packages/bakery/glaze.test.ts",
+        "packages/bakery/proof.test.ts",
+      ],
+    }],
+  });
+
+  const manifest = manifestOf([
+    {
+      unit: "packages/bakery/glaze.test.ts",
+      test: { k: "unit", s: "bakery", n: "glaze" },
+    },
+    {
+      unit: "packages/bakery/proof.test.ts",
+      test: { k: "unit", s: "bakery", n: "proof" },
+    },
+    {
+      unit: "packages/cellar/rack.test.ts",
+      test: { k: "unit", s: "bakery", n: "rack" },
+    },
+  ]);
+
+  it("requires every unit of a set the change reaches", () => {
+    const seen = census(
+      [measured],
+      manifest,
+      new Set(["packages/bakery/src/oven.ts"]),
+    );
+    expect([...seen.mandatory.values()]).toEqual([
+      "coverage-gate",
+      "coverage-gate",
+    ]);
+    expect(seen.coverage.sets).toHaveLength(1);
+  });
+
+  it("leaves a member the change did not reach alone", () => {
+    const seen = census(
+      [measured],
+      manifest,
+      new Set(["packages/bakery/src/oven.ts"]),
+    );
+    expect(
+      seen.mandatory.has(
+        testIdentityKey({ k: "unit", s: "bakery", n: "rack" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("says the change touched a test file rather than reached a set", () => {
+    // Both hold for a changed test file inside a measured set, and the
+    // diff naming the unit outright is the more exact answer.
+    const seen = census(
+      [measured],
+      manifest,
+      new Set(["packages/bakery/glaze.test.ts"]),
+    );
+    expect(
+      seen.mandatory.get(
+        testIdentityKey({ k: "unit", s: "bakery", n: "glaze" }),
+      ),
+    ).toBe("changed");
+    expect(
+      seen.mandatory.get(
+        testIdentityKey({ k: "unit", s: "bakery", n: "proof" }),
+      ),
+    ).toBe("coverage-gate");
+  });
+
+  it("requires nothing for a change that reaches no set", () => {
+    const seen = census([measured], manifest, new Set(["docs/README.md"]));
+    expect(seen.mandatory.size).toBe(0);
+    expect(seen.coverage.sets).toEqual([]);
+  });
+
+  it("requires nothing where the cap turned the gate off", () => {
+    const many = suite({
+      id: "workspace-unit",
+      units: [
+        "packages/a/one.test.ts",
+        "packages/b/one.test.ts",
+        "packages/c/one.test.ts",
+      ],
+      measured: ["a", "b", "c"].map((name) => ({
+        member: `packages/${name}`,
+        reachedBy: [`packages/${name}/`],
+        units: [`packages/${name}/one.test.ts`],
+      })),
+    });
+    const seen = census(
+      [many],
+      manifestOf(["a", "b", "c"].map((name) => ({
+        unit: `packages/${name}/one.test.ts`,
+        test: { k: "unit", s: "bakery", n: name },
+      }))),
+      new Set(["packages/a/x.ts", "packages/b/x.ts", "packages/c/x.ts"]),
+    );
+    expect(seen.mandatory.size).toBe(0);
+    expect(seen.coverage.off).toBeDefined();
+    expect(seen.coverage.reached).toHaveLength(3);
+  });
+});

--- a/tasks/test-selection/census.ts
+++ b/tasks/test-selection/census.ts
@@ -18,6 +18,11 @@ import {
   type Unit,
 } from "../test-topology/suite.ts";
 import {
+  coverageGateFor,
+  type CoverageGateSelection,
+  measuredUnitKeys,
+} from "./coverage.ts";
+import {
   emptyManifest,
   type Manifest,
   type ManifestEntry,
@@ -115,6 +120,15 @@ export interface Census {
    * arrives and still knows almost none of it.
    */
   unmeasured: number;
+
+  /**
+   * What the coverage gate decided about this change: the measured sets
+   * it runs whole and scores, everything the change reached, and the
+   * reason the gate is off where it is. Every consumer reads this rather
+   * than working the question out again, so the lane that measures and
+   * the job that scores cannot disagree about which sets are gated.
+   */
+  coverage: CoverageGateSelection;
 }
 
 /**
@@ -125,6 +139,11 @@ export interface Census {
  * spec requires of any consumer that selects which tests run. A selector
  * that never runs the unselected starves its own data, and a renamed test
  * is an unknown identity until an alias lands.
+ *
+ * The first rule is what the coverage gate rides on. A measured set the
+ * change reaches is a declaration saying the change touched what every
+ * one of its units covers, so its units are mandatory under the same rule
+ * and through the same declaration vocabulary rather than a second one.
  */
 export function census(
   suites: readonly Suite[],
@@ -154,6 +173,8 @@ export function census(
     const suite = key.slice(0, key.indexOf("\t"));
     costs.set(suite, [...costs.get(suite) ?? [], total]);
   }
+  const coverage = coverageGateFor(suites, changed);
+  const measured = measuredUnitKeys(suites, coverage);
   const entries: ManifestEntry[] = [];
   const mandatory = new Map<string, SelectionReason>();
   const taken = new Set<string>(
@@ -173,8 +194,12 @@ export function census(
     );
     for (const unit of suite.units) {
       if (unavailable.has(unit)) continue;
+      // The diff naming the unit outright is the more exact answer, so
+      // it is the reason reported where both hold.
       const reason: SelectionReason | undefined = touched.has(unit)
         ? "changed"
+        : measured.has(`${suite.id}\t${unit}`)
+        ? "coverage-gate"
         : undefined;
       const recorded = inUnit.get(`${suite.id}\t${unit}`);
       if (recorded === undefined) {
@@ -240,5 +265,6 @@ export function census(
     },
     mandatory,
     unmeasured,
+    coverage,
   };
 }

--- a/tasks/test-selection/coverage.test.ts
+++ b/tasks/test-selection/coverage.test.ts
@@ -197,6 +197,17 @@ describe("coverage", () => {
       expect([...measuredUnitKeys(suites, gate)]).toHaveLength(2);
     });
 
+    it("requires nothing of a suite this tree does not hold", () => {
+      // A manifest can name a suite a later tree dropped, and a unit of
+      // one cannot be placed by anything.
+      const suites = [suite("workspace-unit", [bakery])];
+      const gate = coverageGateFor(
+        suites,
+        new Set(["packages/bakery/oven.ts"]),
+      );
+      expect(measuredUnitKeys([], gate).size).toBe(0);
+    });
+
     it("requires nothing when the cap turned the gate off", () => {
       const many = Array.from(
         { length: LOCAL_COVERAGE_MAX_SETS + 1 },

--- a/tasks/test-selection/coverage.test.ts
+++ b/tasks/test-selection/coverage.test.ts
@@ -1,0 +1,237 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import {
+  coverageGateFor,
+  measuredMembersOf,
+  measuredSetDirectory,
+  measuredSetName,
+  measuredSets,
+  measuredUnitKeys,
+} from "./coverage.ts";
+import { LOCAL_COVERAGE_MAX_SETS } from "./policy.ts";
+import type { MeasuredSet, Suite } from "../test-topology/suite.ts";
+
+/** A suite carrying only what the coverage selection reads. */
+function suite(
+  id: string,
+  measured: MeasuredSet[],
+  unavailable: Suite["unavailable"] = [],
+): Suite {
+  return {
+    id,
+    recordSurfaces: [{ kind: "unit", scope: id }],
+    needs: [],
+    units: measured.flatMap((set) => set.units),
+    unavailable,
+    measured,
+    locate: () => undefined,
+    command: () => Promise.resolve([]),
+  };
+}
+
+const bakery: MeasuredSet = {
+  member: "packages/bakery",
+  reachedBy: ["packages/bakery/"],
+  units: ["packages/bakery/glaze.test.ts", "packages/bakery/proof.test.ts"],
+};
+
+const cellar: MeasuredSet = {
+  member: "packages/cellar",
+  reachedBy: ["packages/cellar/"],
+  units: ["packages/cellar/rack.test.ts"],
+};
+
+describe("coverage", () => {
+  describe("measured sets", () => {
+    it("lists every set the topology declares, suite then member", () => {
+      const suites = [suite("z-unit", [cellar]), suite("a-unit", [bakery])];
+      expect(measuredSets(suites).map(measuredSetName)).toEqual([
+        "a-unit/packages/bakery",
+        "z-unit/packages/cellar",
+      ]);
+    });
+
+    it("lists nothing for a suite that declares nothing", () => {
+      const bare = suite("bare", []);
+      delete (bare as { measured?: unknown }).measured;
+      expect(measuredSets([bare])).toEqual([]);
+    });
+
+    it("names a directory that a member's own slashes cannot break", () => {
+      const nested: MeasuredSet = {
+        member: "packages/connectors/github",
+        reachedBy: ["packages/connectors/github/"],
+        units: ["packages/connectors/github/issue.test.ts"],
+      };
+      const ref = measuredSets([suite("workspace-unit", [nested])])[0]!;
+      expect(measuredSetDirectory(ref))
+        .toBe("workspace-unit/packages__connectors__github");
+    });
+
+    it("leaves out a set nothing in this configuration runs", () => {
+      // Scoring it would score whatever some other lane left in the
+      // directory, since nothing would be required to run the set.
+      const suites = [suite(
+        "workspace-unit",
+        [bakery],
+        bakery.units.map(
+          (unit) => ({ unit, reason: "this configuration cannot run it" }),
+        ),
+      )];
+      expect(measuredSets(suites)).toEqual([]);
+    });
+
+    it("keeps a set some of whose units this configuration runs", () => {
+      const suites = [suite("workspace-unit", [bakery], [{
+        unit: bakery.units[0]!,
+        reason: "this configuration cannot run it",
+      }])];
+      expect(measuredSets(suites)).toHaveLength(1);
+    });
+  });
+
+  describe("the coverage gate's selection", () => {
+    it("reaches a set through the paths it declares", () => {
+      const suites = [suite("workspace-unit", [bakery, cellar])];
+      const gate = coverageGateFor(
+        suites,
+        new Set(["packages/bakery/src/oven.ts"]),
+      );
+      expect(gate.sets.map(measuredSetName))
+        .toEqual(["workspace-unit/packages/bakery"]);
+      expect(gate.off).toBeUndefined();
+    });
+
+    it("reaches nothing where the change is somewhere else", () => {
+      const suites = [suite("workspace-unit", [bakery, cellar])];
+      const gate = coverageGateFor(suites, new Set(["docs/README.md"]));
+      expect(gate.sets).toEqual([]);
+      expect(gate.reached).toEqual([]);
+      expect(gate.off).toBeUndefined();
+    });
+
+    it("keeps two suites over one member apart", () => {
+      const other: MeasuredSet = {
+        ...bakery,
+        units: ["packages/bakery/e2e.ts"],
+      };
+      const suites = [
+        suite("workspace-unit", [bakery]),
+        suite("bakery-integration", [other]),
+      ];
+      const gate = coverageGateFor(
+        suites,
+        new Set(["packages/bakery/src/oven.ts"]),
+      );
+      expect(gate.sets.map(measuredSetName)).toEqual([
+        "bakery-integration/packages/bakery",
+        "workspace-unit/packages/bakery",
+      ]);
+    });
+
+    it("turns the gate off past the cap, and says what it reached", () => {
+      const many = Array.from(
+        { length: LOCAL_COVERAGE_MAX_SETS + 1 },
+        (_, index): MeasuredSet => ({
+          member: `packages/p${index}`,
+          reachedBy: [`packages/p${index}/`],
+          units: [`packages/p${index}/one.test.ts`],
+        }),
+      );
+      const suites = [suite("workspace-unit", many)];
+      const changed = new Set(many.map((set) => `${set.member}/src/main.ts`));
+      const gate = coverageGateFor(suites, changed);
+      expect(gate.sets).toEqual([]);
+      expect(gate.reached).toHaveLength(LOCAL_COVERAGE_MAX_SETS + 1);
+      expect(gate.off).toContain(
+        `${LOCAL_COVERAGE_MAX_SETS + 1} measured sets`,
+      );
+    });
+
+    it("still gates a change that reaches exactly the cap", () => {
+      const suites = [suite("workspace-unit", [bakery, cellar])];
+      const gate = coverageGateFor(
+        suites,
+        new Set(["packages/bakery/src/oven.ts", "packages/cellar/src/rack.ts"]),
+      );
+      expect(gate.sets).toHaveLength(2);
+      expect(gate.off).toBeUndefined();
+    });
+
+    it("makes every unit of a gated set mandatory", () => {
+      const suites = [suite("workspace-unit", [bakery, cellar])];
+      const gate = coverageGateFor(
+        suites,
+        new Set(["packages/bakery/oven.ts"]),
+      );
+      expect([...measuredUnitKeys(suites, gate)].sort()).toEqual([
+        "workspace-unit\tpackages/bakery/glaze.test.ts",
+        "workspace-unit\tpackages/bakery/proof.test.ts",
+      ]);
+    });
+
+    it("leaves a unit the suite declares unavailable out of the mandatory set", () => {
+      const suites = [suite("workspace-unit", [bakery], [{
+        unit: "packages/bakery/proof.test.ts",
+        reason: "it needs an oven nobody has",
+      }])];
+      const gate = coverageGateFor(
+        suites,
+        new Set(["packages/bakery/oven.ts"]),
+      );
+      expect([...measuredUnitKeys(suites, gate)]).toEqual([
+        "workspace-unit\tpackages/bakery/glaze.test.ts",
+      ]);
+    });
+
+    it("keeps a unit whose unavailability names one leaf", () => {
+      const suites = [suite("workspace-unit", [bakery], [{
+        unit: "packages/bakery/proof.test.ts",
+        leafName: "rises twice",
+        reason: "it is slow on this configuration",
+      }])];
+      const gate = coverageGateFor(
+        suites,
+        new Set(["packages/bakery/oven.ts"]),
+      );
+      expect([...measuredUnitKeys(suites, gate)]).toHaveLength(2);
+    });
+
+    it("requires nothing when the cap turned the gate off", () => {
+      const many = Array.from(
+        { length: LOCAL_COVERAGE_MAX_SETS + 1 },
+        (_, index): MeasuredSet => ({
+          member: `packages/p${index}`,
+          reachedBy: [`packages/p${index}/`],
+          units: [`packages/p${index}/one.test.ts`],
+        }),
+      );
+      const suites = [suite("workspace-unit", many)];
+      const gate = coverageGateFor(
+        suites,
+        new Set(many.map((set) => `${set.member}/src/main.ts`)),
+      );
+      expect(measuredUnitKeys(suites, gate).size).toBe(0);
+    });
+
+    it("names the members one suite measures", () => {
+      const suites = [
+        suite("workspace-unit", [bakery, cellar]),
+        suite("runner-unit", [{
+          member: "packages/runner",
+          reachedBy: ["packages/runner/"],
+          units: ["packages/runner/one.test.ts"],
+        }]),
+      ];
+      const gate = coverageGateFor(
+        suites,
+        new Set(["packages/bakery/oven.ts", "packages/runner/src/run.ts"]),
+      );
+      expect([...measuredMembersOf(gate, "workspace-unit")])
+        .toEqual(["packages/bakery"]);
+      expect([...measuredMembersOf(gate, "runner-unit")])
+        .toEqual(["packages/runner"]);
+      expect([...measuredMembersOf(gate, "nothing-unit")]).toEqual([]);
+    });
+  });
+});

--- a/tasks/test-selection/coverage.ts
+++ b/tasks/test-selection/coverage.ts
@@ -1,0 +1,139 @@
+/**
+ * Which measured sets a change reaches, and what each of them is called
+ * on disk.
+ *
+ * A measured set is one suite's units over one workspace member's lines.
+ * Everything about the coverage gate starts here: the lanes read this to
+ * decide what to run whole and what to turn coverage on for, and the job
+ * that joins the lanes reads the same function over the same diff rather
+ * than trusting what a lane reported.
+ */
+
+import {
+  coverageMemberDirectory,
+  type MeasuredSet,
+  reachedByChange,
+  type Suite,
+  unavailableUnits,
+} from "../test-topology/suite.ts";
+import { LOCAL_COVERAGE_MAX_SETS } from "./policy.ts";
+
+/** One measured set, and the suite that declared it. */
+export interface MeasuredSetRef {
+  suite: string;
+  set: MeasuredSet;
+}
+
+/**
+ * Every measured set the topology declares that this configuration can
+ * run, in a stable order.
+ *
+ * A set every one of whose units the suite declares unavailable is left
+ * out. Keeping it would mean scoring a set nothing was required to run,
+ * so the count would be whatever some other lane happened to leave in
+ * the directory.
+ */
+export function measuredSets(
+  suites: readonly Suite[],
+): MeasuredSetRef[] {
+  const sets: MeasuredSetRef[] = [];
+  for (const suite of suites) {
+    const unavailable = unavailableUnits(suite);
+    for (const set of suite.measured ?? []) {
+      if (set.units.every((unit) => unavailable.has(unit))) continue;
+      sets.push({ suite: suite.id, set });
+    }
+  }
+  return sets.sort((a, b) =>
+    a.suite.localeCompare(b.suite) || a.set.member.localeCompare(b.set.member)
+  );
+}
+
+/** Where one measured set's coverage profiles and report live. */
+export function measuredSetDirectory(ref: MeasuredSetRef): string {
+  return `${ref.suite}/${coverageMemberDirectory(ref.set.member)}`;
+}
+
+/** How a measured set is named in a summary or a metric. */
+export function measuredSetName(ref: MeasuredSetRef): string {
+  return `${ref.suite}/${ref.set.member}`;
+}
+
+/** What the coverage gate decided about one change. */
+export interface CoverageGateSelection {
+  /** The sets the gate runs and scores. Empty where it does not run. */
+  sets: MeasuredSetRef[];
+
+  /**
+   * Every set the change reached, whether or not the gate runs. The cap
+   * below turns the gate off without changing what the change reached,
+   * and a summary that could not say what it reached would leave nobody
+   * able to tell a capped change from an untouched one.
+   */
+  reached: MeasuredSetRef[];
+
+  /** Why the gate did not run, where it did not. */
+  off?: string;
+}
+
+/**
+ * Which measured sets a change reaches, and whether the gate runs.
+ *
+ * The gate is off entirely past the cap rather than off for some of the
+ * sets: gating two of the four a change reached would mean quietly
+ * ignoring the other two. A cliff is also predictable, so an author can
+ * tell from the diff whether the gate applies without knowing what any
+ * set's tests cost.
+ */
+export function coverageGateFor(
+  suites: readonly Suite[],
+  changed: ReadonlySet<string>,
+): CoverageGateSelection {
+  const reached = measuredSets(suites)
+    .filter((ref) => reachedByChange(ref.set.reachedBy, changed));
+  if (reached.length > LOCAL_COVERAGE_MAX_SETS) {
+    return {
+      sets: [],
+      reached,
+      off: `the change reaches ${reached.length} measured sets, more than ` +
+        `the ${LOCAL_COVERAGE_MAX_SETS} a gated change may reach`,
+    };
+  }
+  return { sets: reached, reached };
+}
+
+/**
+ * The units one selection makes mandatory, as `suite\tunit` keys.
+ *
+ * A unit the suite declares unavailable is left out: it does not run, so
+ * requiring it would place an identity no invocation would execute.
+ */
+export function measuredUnitKeys(
+  suites: readonly Suite[],
+  selection: CoverageGateSelection,
+): Set<string> {
+  const bySuite = new Map(suites.map((suite) => [suite.id, suite]));
+  const keys = new Set<string>();
+  for (const ref of selection.sets) {
+    const suite = bySuite.get(ref.suite);
+    if (suite === undefined) continue;
+    const unavailable = unavailableUnits(suite);
+    for (const unit of ref.set.units) {
+      if (unavailable.has(unit)) continue;
+      keys.add(`${ref.suite}\t${unit}`);
+    }
+  }
+  return keys;
+}
+
+/** The members one suite measures under a selection. */
+export function measuredMembersOf(
+  selection: CoverageGateSelection,
+  suiteId: string,
+): Set<string> {
+  return new Set(
+    selection.sets
+      .filter((ref) => ref.suite === suiteId)
+      .map((ref) => ref.set.member),
+  );
+}

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -111,7 +111,9 @@ describe("plan", () => {
       expect(taken?.reason).toBe("changed");
     });
 
-    it("runs a mandatory identity once, whatever its repeat count", () => {
+    it("keeps the repeats of an identity the coverage gate pulled in", () => {
+      // Measuring a set is not a reason to run one of its tests fewer
+      // times than a lane that never measured it would have.
       const manifest = sampleManifest({
         entries: entries(3, () => ({ repeats: 3 })),
       });
@@ -121,7 +123,107 @@ describe("plan", () => {
       ]]);
       const result = run(manifest, { mandatory });
       const taken = selected(result).find((s) => s.entry.test.n === "case 0");
-      expect(taken?.repeats).toBe(1);
+      expect(taken?.repeats).toBe(3);
+    });
+
+    it("charges a lane for every run of a repeated mandatory identity", () => {
+      const manifest = sampleManifest({
+        entries: entries(1, () => ({ cost: 10, repeats: 3 })),
+      });
+      const once = run(
+        sampleManifest({ entries: entries(1, () => ({ cost: 10 })) }),
+        {
+          mandatory: new Map([[
+            testIdentityKey(manifest.entries[0]!.test),
+            "coverage-gate" as const,
+          ]]),
+        },
+      );
+      const thrice = run(manifest, {
+        mandatory: new Map([[
+          testIdentityKey(manifest.entries[0]!.test),
+          "coverage-gate" as const,
+        ]]),
+      });
+      const load = (result: ReturnType<typeof run>) =>
+        result.lanes.reduce((total, lane) => total + lane.projectedSeconds, 0);
+      expect(load(thrice)).toBeGreaterThan(load(once));
+    });
+
+    it("keeps the repeats of an identity the change edited", () => {
+      // A test the change edits is one of the two routes an excluded
+      // identity reaches a lane by, and the count is what makes it prove
+      // itself there.
+      const manifest = sampleManifest({
+        entries: entries(3, () => ({ repeats: 3 })),
+      });
+      const mandatory = new Map([[
+        testIdentityKey(manifest.entries[0]!.test),
+        "changed" as const,
+      ]]);
+      const result = run(manifest, { mandatory });
+      const taken = selected(result).find((s) => s.entry.test.n === "case 0");
+      expect(taken?.repeats).toBe(3);
+    });
+
+    it("keeps the repeats of every identity of the full run", () => {
+      const manifest = sampleManifest({
+        entries: entries(3, () => ({ repeats: 3 })),
+      });
+      const result = run(manifest, { policy: "everything" });
+      expect(selected(result).map((s) => s.repeats)).toEqual([3, 3, 3]);
+    });
+
+    it("gives up a mandatory identity's runs until they fit a lane", () => {
+      // All of one identity's runs go in one lane, so a lane cannot be
+      // added to make room for them, and one observation beats none.
+      const manifest = sampleManifest({
+        entries: entries(1, () => ({ cost: 100, repeats: 3 })),
+      });
+      const result = run(manifest, {
+        mandatory: new Map([[
+          testIdentityKey(manifest.entries[0]!.test),
+          "coverage-gate" as const,
+        ]]),
+        budgetSeconds: 250,
+      });
+      expect(selected(result)[0]?.repeats).toBe(2);
+    });
+
+    it("places a mandatory identity no lane can hold, and says so", () => {
+      // Mandatory means mandatory. Leaving it out would report a pass
+      // over a test that never ran, where placing it produces a lane
+      // that runs long and a figure saying by how much.
+      const manifest = sampleManifest({
+        entries: entries(1, () => ({ cost: 1000, repeats: 3 })),
+      });
+      const key = testIdentityKey(manifest.entries[0]!.test);
+      const result = run(manifest, {
+        mandatory: new Map([[key, "coverage-gate" as const]]),
+        budgetSeconds: 10,
+      });
+      expect(selected(result).map((s) => testIdentityKey(s.entry.test)))
+        .toEqual([key]);
+      // Down to once, and never to nothing.
+      expect(selected(result)[0]?.repeats).toBe(1);
+      expect(result.overBudgetSeconds).toBeGreaterThan(0);
+      // The list of work no lane can hold names the discretionary
+      // identities alone, so nothing reads a required one as dropped.
+      expect(result.unschedulable).toEqual([]);
+    });
+
+    it("never leaves a mandatory identity out, whatever it costs", () => {
+      // Every identity is mandatory here, and each costs more than a
+      // lane's whole budget.
+      const manifest = sampleManifest({
+        entries: entries(4, () => ({ cost: 5000, repeats: 2 })),
+      });
+      const result = run(manifest, {
+        mandatory: everything(manifest),
+        budgetSeconds: 10,
+      });
+      expect(selected(result)).toHaveLength(4);
+      expect(result.unschedulable).toEqual([]);
     });
 
     it("says by how much the mandatory set alone overran", () => {

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -438,6 +438,7 @@ export function plan(input: PlanInput): Plan {
     key: string;
     reason: SelectionReason;
     entry: ManifestEntry;
+    runs: number;
     cost: number;
   }[] = [];
   for (const [key, reason] of requiredOf) {
@@ -463,6 +464,12 @@ export function plan(input: PlanInput): Plan {
       key,
       reason,
       entry,
+      // How many times an item runs is what its share asks for, and
+      // nothing else decides it. A repeat catches a test disagreeing
+      // with itself, which is worth the same whether the item was
+      // chosen, edited, pulled in by the coverage gate, or required
+      // because the run is the whole corpus.
+      runs: entry.repeats,
       cost: loneCost(manifest, input, entry),
     });
   }
@@ -475,20 +482,31 @@ export function plan(input: PlanInput): Plan {
   // decides only where the work lands. The key breaks ties, so two
   // identities costing the same are ordered the same way in every lane.
   required.sort((a, b) =>
-    b.cost - a.cost || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0)
+    b.cost * b.runs - a.cost * a.runs ||
+    (a.key < b.key ? -1 : a.key > b.key ? 1 : 0)
   );
 
-  for (const { key, reason, entry } of required) {
-    // Mandatory work runs once. A repeat covers nothing a measured run
-    // did not, and this pass is the one allowed to put a lane past its
-    // budget: it takes a lane that can hold the work where there is one,
-    // and the lane it leaves shortest where there is not.
-    const spots = spotsFor(input, lanes, entry, 1, laneBudget, bound);
-    // Every lane is a candidate for work that fits in none of them, and
-    // there is at least one lane, so there is always a shortest.
-    const spot = spots.fitting ?? spots.shortest!;
+  for (const { key, reason, entry, runs } of required) {
+    // An identity that would be repeated but fits nowhere runs fewer
+    // times first, down to once, the way the discretionary passes do.
+    // All of one identity's runs go in one lane, so a lane cannot be
+    // added to make room for them.
+    let taking: { spot: Spot; runs: number } | undefined;
+    for (let count = runs; count >= 1 && taking === undefined; count--) {
+      const spot = spotsFor(input, lanes, entry, count, laneBudget, bound)
+        .fitting;
+      if (spot !== undefined) taking = { spot, runs: count };
+    }
+    // This pass is the one allowed to put a lane past its budget: where
+    // one run of it fits in no lane, it goes in the lane it leaves
+    // shortest. Every lane is a candidate for such work, and there is at
+    // least one lane, so there is always a shortest.
+    const chosen = taking ?? {
+      spot: spotsFor(input, lanes, entry, 1, laneBudget, bound).shortest!,
+      runs: 1,
+    };
     taken.add(key);
-    place(input, spot, entry, reason, 1);
+    place(input, chosen.spot, entry, reason, chosen.runs);
   }
   const mandatoryLoad = laneLoad(lanes);
   // A mandatory set larger than the whole run's budget leaves some lane

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -190,6 +190,7 @@ function loneCost(
   manifest: Manifest,
   input: PlanInput,
   entry: ManifestEntry,
+  repeats = 1,
 ): number {
   return marginalCost(
     manifest,
@@ -203,7 +204,7 @@ function loneCost(
       load: 0,
     },
     entry,
-    1,
+    repeats,
   );
 }
 
@@ -470,7 +471,12 @@ export function plan(input: PlanInput): Plan {
       // chosen, edited, pulled in by the coverage gate, or required
       // because the run is the whole corpus.
       runs: entry.repeats,
-      cost: loneCost(manifest, input, entry),
+      // What an empty lane would pay for every one of those runs. The
+      // setup and overheads a lane opens are paid once however many
+      // times the item runs, so multiplying one run's whole figure
+      // would charge them again per repeat and order the pass by a cost
+      // no lane pays.
+      cost: loneCost(manifest, input, entry, entry.repeats),
     });
   }
 
@@ -482,8 +488,7 @@ export function plan(input: PlanInput): Plan {
   // decides only where the work lands. The key breaks ties, so two
   // identities costing the same are ordered the same way in every lane.
   required.sort((a, b) =>
-    b.cost * b.runs - a.cost * a.runs ||
-    (a.key < b.key ? -1 : a.key > b.key ? 1 : 0)
+    b.cost - a.cost || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0)
   );
 
   for (const { key, reason, entry, runs } of required) {

--- a/tasks/test-selection/policy.ts
+++ b/tasks/test-selection/policy.ts
@@ -164,13 +164,17 @@ export const SUITE_FLAKE_PRIOR_RATE = 0.02;
 /** Uncovered lines a change must add before the comment mentions it. */
 export const COVERAGE_COMMENT_LINES = 25;
 
-/** Seconds past which a covered package's measured set is reported. */
+/** Seconds past which a measured set's units are reported as expensive. */
 export const LOCAL_COVERAGE_MAX_SECONDS = 30;
 
-/** Covered packages a change may touch and still be gated. */
-export const LOCAL_COVERAGE_MAX_PACKAGES = 2;
+/** Measured sets a change may reach and still be gated. */
+export const LOCAL_COVERAGE_MAX_SETS = 2;
 
-/** Days of per-package coverage baselines a manifest carries. */
+/**
+ * How old a measured set's coverage baseline may be and still be
+ * published. A publisher keeps one measured within this many days of the
+ * moment it publishes, and drops the rest.
+ */
 export const LOCAL_COVERAGE_BASELINE_DAYS = 7;
 
 /** Weeks of rising debt before the coverage tile goes amber. */
@@ -254,11 +258,11 @@ export const RENAME_SUGGESTIONS = 5;
 export const ALIAS_GATE_MIN_CATCHES: number | undefined = undefined;
 
 /**
- * Workspace members the per-package coverage gate does not cover, each
- * with the reason it is here. A list rather than a rule that measures
- * each package and decides, because such a rule can take a package's gate
- * away for a change nobody meant as a change to coverage, and a gate that
- * silently stops gating is worse than no gate.
+ * Workspace members that carry no measured set, each with the reason it
+ * is here. A list rather than a rule that measures each member and
+ * decides, because such a rule can take a member's gate away for a change
+ * nobody meant as a change to coverage, and a gate that silently stops
+ * gating is worse than no gate.
  */
 export const EXCLUDED_FROM_COVERAGE_GATE: ReadonlyMap<string, string> = new Map(
   [
@@ -671,19 +675,19 @@ export const DIALS: readonly Dial[] = [
     unit: "seconds",
     setBy: "chosen",
     why:
-      "Up when too many packages are reported as expensive for the report to " +
-      "be worth reading; down when one is quietly eating a lane. Nothing is " +
+      "Up when too many sets are reported as expensive for the report to be " +
+      "worth reading; down when one is quietly eating a lane. Nothing is " +
       "excluded either way; it only decides what the summary mentions.",
   },
   {
-    name: "LOCAL_COVERAGE_MAX_PACKAGES",
-    value: LOCAL_COVERAGE_MAX_PACKAGES,
-    unit: "packages",
+    name: "LOCAL_COVERAGE_MAX_SETS",
+    value: LOCAL_COVERAGE_MAX_SETS,
+    unit: "measured sets",
     setBy: "chosen",
     why:
       "Up when broader changes should still be gated and the run can afford " +
-      "their packages' whole test sets; down when sweeping changes are " +
-      "crowding lanes.",
+      "those sets' whole unit lists; down when sweeping changes are crowding " +
+      "lanes.",
   },
   {
     name: "EXCLUDED_FROM_COVERAGE_GATE",
@@ -692,8 +696,8 @@ export const DIALS: readonly Dial[] = [
     setBy: "chosen",
     why:
       "Not a quantity. A line comes off when a package fits the run's budget " +
-      "or gains a Deno-only half, which turns its gate on. A line goes on " +
-      "when a package's own tests stop being what covers it.",
+      "or gains a Deno-only half, which gives it a measured set. A line goes " +
+      "on when a package's own tests stop being what covers it.",
   },
   {
     name: "LOCAL_COVERAGE_BASELINE_DAYS",
@@ -701,9 +705,9 @@ export const DIALS: readonly Dial[] = [
     unit: "days",
     setBy: "chosen",
     why:
-      "Up when branches based further back are being reported for want of an " +
-      "ancestor baseline; down when the manifest carries more history than " +
-      "anybody reads.",
+      "Up when branches based further back are being reported for want of a " +
+      "baseline they contain; down when the manifest carries more history " +
+      "than anybody reads.",
   },
   {
     name: "COVERAGE_TREND_WEEKS",

--- a/tasks/test-selection/report.test.ts
+++ b/tasks/test-selection/report.test.ts
@@ -14,9 +14,9 @@ import {
   firstFailures,
   flakyNewTests,
   MAIN_REPORT_MARKER,
+  measuredSetRises,
   nameSimilarity,
   outcomesOf,
-  packageRises,
   partsOf,
   type PullRequestView,
   renames,
@@ -33,7 +33,7 @@ import {
 import {
   COVERAGE_COMMENT_LINES,
   EXCLUDED_FROM_COVERAGE_GATE,
-  LOCAL_COVERAGE_MAX_PACKAGES,
+  LOCAL_COVERAGE_MAX_SETS,
   RENAME_SIMILARITY,
 } from "./policy.ts";
 
@@ -74,10 +74,14 @@ function figures(
 /** An own-tests figure set: a package measured by only its own tests. */
 function ownTests(
   entries: readonly (readonly [string, number])[],
+  suite = "workspace-unit",
 ): CoverageFigures {
   return new Map(
     entries.map(([member, lines]) =>
-      [`coverage-debt: ${member} own-tests uncovered lines`, lines] as const
+      [
+        `coverage-debt: measured set ${suite}/${member} uncovered lines`,
+        lines,
+      ] as const
     ),
   );
 }
@@ -129,6 +133,7 @@ function input(partial: Partial<ReportInput> = {}): ReportInput {
     coverage: new Map(),
     coverageBefore: new Map(),
     touched: new Set(),
+    coverageGate: { reached: [], ran: true },
     day: "2026-09-07",
     ...partial,
   };
@@ -396,31 +401,60 @@ describe("report", () => {
     });
   });
 
-  describe("packageRises()", () => {
+  describe("measuredSetRises()", () => {
     const gated = "packages/memory";
     const excluded = [...EXCLUDED_FROM_COVERAGE_GATE.keys()][0]!;
-    const overTheCap = new Set(
-      Array.from(
-        { length: LOCAL_COVERAGE_MAX_PACKAGES + 1 },
-        (_, index) => `packages/gated-${index}`,
+    /** The gate having run over exactly these sets. */
+    const over = (...members: string[]) => ({
+      reached: members.map((member) => `workspace-unit/${member}`),
+      ran: true,
+    });
+    const overTheCap = {
+      reached: Array.from(
+        { length: LOCAL_COVERAGE_MAX_SETS + 1 },
+        (_, index) => `workspace-unit/packages/gated-${index}`,
       ),
-    );
+      ran: false,
+    };
 
-    it("names the cap when the change touched more packages than it allows", () => {
-      const rises = packageRises(input({
+    it("names the cap when the change reached more sets than it allows", () => {
+      const rises = measuredSetRises(input({
         coverageBefore: ownTests([[gated, 10]]),
         coverage: ownTests([[gated, 14]]),
-        touched: overTheCap,
+        touched: new Set([gated]),
+        coverageGate: overTheCap,
       }));
       expect(rises[0]?.route).toBe("over-the-cap");
-      expect(rises[0]?.touched).toBe(LOCAL_COVERAGE_MAX_PACKAGES + 1);
+      expect(rises[0]?.touched).toBe(LOCAL_COVERAGE_MAX_SETS + 1);
+    });
+
+    // Two sets over one member count twice against the cap, because the
+    // cap is what the gate applies and the gate counts sets. Counting
+    // members here would say the gate ran when it did not.
+    it("counts a set rather than a member against the cap", () => {
+      const rises = measuredSetRises(input({
+        coverageBefore: ownTests([[gated, 10]]),
+        coverage: ownTests([[gated, 14]]),
+        touched: new Set([gated]),
+        coverageGate: {
+          reached: [
+            `workspace-unit/${gated}`,
+            `memory-e2e/${gated}`,
+            `memory-browser/${gated}`,
+          ],
+          ran: false,
+        },
+      }));
+      expect(rises[0]?.route).toBe("over-the-cap");
+      expect(rises[0]?.touched).toBe(3);
     });
 
     it("names the exclusion list, with its reason", () => {
-      const rises = packageRises(input({
+      const rises = measuredSetRises(input({
         coverageBefore: ownTests([[excluded, 10]]),
         coverage: ownTests([[excluded, 14]]),
         touched: new Set([excluded]),
+        coverageGate: over(),
       }));
       expect(rises[0]?.route).toBe("excluded");
       expect(rises[0]?.reason).toBe(EXCLUDED_FROM_COVERAGE_GATE.get(excluded));
@@ -430,19 +464,21 @@ describe("report", () => {
     // list whatever else the change touched, so the cap cannot be the
     // route that let its rise through.
     it("names the exclusion list even when the cap was also passed", () => {
-      const rises = packageRises(input({
+      const rises = measuredSetRises(input({
         coverageBefore: ownTests([[excluded, 10]]),
         coverage: ownTests([[excluded, 14]]),
-        touched: overTheCap,
+        touched: new Set([excluded]),
+        coverageGate: overTheCap,
       }));
       expect(rises[0]?.route).toBe("excluded");
     });
 
-    it("names the change when it did not touch the risen package", () => {
-      const rises = packageRises(input({
+    it("names the change when it did not reach the risen set", () => {
+      const rises = measuredSetRises(input({
         coverageBefore: ownTests([[gated, 10]]),
         coverage: ownTests([[gated, 14]]),
         touched: new Set(["tasks"]),
+        coverageGate: over(),
       }));
       expect(rises[0]?.route).toBe("elsewhere");
     });
@@ -451,10 +487,11 @@ describe("report", () => {
     // landed anyway. That is the two measurements disagreeing, and saying
     // the change did not touch the package would be false.
     it("says the measurements disagree when the gate did run", () => {
-      const rises = packageRises(input({
+      const rises = measuredSetRises(input({
         coverageBefore: ownTests([[gated, 10]]),
         coverage: ownTests([[gated, 14]]),
         touched: new Set([gated]),
+        coverageGate: over(gated),
       }));
       expect(rises[0]?.route).toBe("gated");
     });
@@ -463,14 +500,14 @@ describe("report", () => {
     // compare against, and calling its first figure a rise would report
     // every package the moment it gains a gate.
     it("says nothing about a package the run before did not measure", () => {
-      expect(packageRises(input({
+      expect(measuredSetRises(input({
         coverage: ownTests([[gated, 14]]),
         touched: new Set(["tasks"]),
       }))).toEqual([]);
     });
 
     it("says nothing about a package that did not rise", () => {
-      expect(packageRises(input({
+      expect(measuredSetRises(input({
         coverageBefore: ownTests([[gated, 10]]),
         coverage: both(ownTests([[gated, 10]]), figures([["workspace", 900]])),
       }))).toEqual([]);
@@ -479,17 +516,20 @@ describe("report", () => {
     // Both metrics carry the same package name, and only the own-tests
     // one is the quantity the per-package gate compares.
     it("reads the own-tests figure and not the whole run's figure", () => {
-      expect(packageRises(input({
+      expect(measuredSetRises(input({
         coverageBefore: figures([[gated, 10]]),
         coverage: figures([[gated, 400]]),
       }))).toEqual([]);
     });
 
-    it("counts only covered packages against the cap", () => {
-      const rises = packageRises(input({
+    it("counts only the sets the gate reached", () => {
+      // An excluded member carries no set, so touching every one of them
+      // reaches nothing and the gate ran over an empty selection.
+      const rises = measuredSetRises(input({
         coverageBefore: ownTests([[gated, 10]]),
         coverage: ownTests([[gated, 14]]),
         touched: new Set([...EXCLUDED_FROM_COVERAGE_GATE.keys()]),
+        coverageGate: over(),
       }));
       expect(rises[0]?.route).toBe("elsewhere");
     });
@@ -1070,7 +1110,7 @@ describe("report", () => {
       expect(body).toContain("somewhere else in the repository");
     });
 
-    it("names the exclusion list's reason and the packages counted", () => {
+    it("names the exclusion list's reason and the sets counted", () => {
       const excluded = [...EXCLUDED_FROM_COVERAGE_GATE.keys()][0]!;
       const body = renderReport(
         buildReport(input({
@@ -1080,6 +1120,14 @@ describe("report", () => {
             "packages/html",
             "tasks",
           ]),
+          coverageGate: {
+            reached: [
+              "workspace-unit/packages/memory",
+              "workspace-unit/packages/ui",
+              "workspace-unit/packages/html",
+            ],
+            ran: false,
+          },
           coverageBefore: ownTests([[excluded, 10], ["packages/memory", 4]]),
           coverage: ownTests([[excluded, 14], ["packages/memory", 9]]),
         })),
@@ -1087,7 +1135,7 @@ describe("report", () => {
       )!;
       expect(body).toContain("The list gives the reason:");
       expect(body).toContain(EXCLUDED_FROM_COVERAGE_GATE.get(excluded));
-      expect(body).toContain("The change touched 3 covered packages.");
+      expect(body).toContain("The change reached 3 measured sets.");
     });
 
     it("says the coverage note is not a failure", () => {

--- a/tasks/test-selection/report.ts
+++ b/tasks/test-selection/report.ts
@@ -35,14 +35,14 @@ import {
 } from "@commonfabric/test-support/records";
 import {
   coverageMetricGroupName,
-  ownTestsCoverageMember,
+  coverageMetricMeasuredSet,
 } from "../ci-check-lib.ts";
 import type { WithheldReason } from "./manifest.ts";
 import {
   COVERAGE_COMMENT_LINES,
   EXCLUDED_FROM_COVERAGE_GATE,
   FLAKE_WINDOW_DAYS,
-  LOCAL_COVERAGE_MAX_PACKAGES,
+  LOCAL_COVERAGE_MAX_SETS,
   RENAME_MARGIN,
   RENAME_SIMILARITY,
   RENAME_SUGGESTIONS,
@@ -196,24 +196,29 @@ export interface CoverageRise {
   groups: Array<{ group: string; from: number; to: number }>;
 }
 
-/** Which route let a package's rise reach the default branch. */
-export type PackageRoute =
+/** Which route let a measured set's rise reach the default branch. */
+export type MeasuredSetRoute =
   | "excluded"
   | "over-the-cap"
   | "elsewhere"
   | "gated";
 
-/** A rise in one covered package's own-tests number. */
-export interface PackageRise {
+/** A rise in one measured set's number. */
+export interface MeasuredSetRise {
+  /** The suite and the member the set pairs, as one name. */
+  set: string;
+
+  /** The workspace member whose lines rose. */
   member: string;
+
   from: number;
   to: number;
-  route: PackageRoute;
+  route: MeasuredSetRoute;
 
   /** Present for `excluded`: the reason the exclusion list gives. */
   reason?: string;
 
-  /** Present for `over-the-cap`: how many covered packages were touched. */
+  /** Present for `over-the-cap`: how many measured sets were reached. */
   touched?: number;
 }
 
@@ -238,7 +243,7 @@ export interface RenameSuggestion {
 export interface Report {
   firstFailures: FirstFailure[];
   coverageRise?: CoverageRise;
-  packageRises: PackageRise[];
+  measuredSetRises: MeasuredSetRise[];
   flakyNewTests: FlakyNewTest[];
   renames: RenameSuggestion[];
 }
@@ -247,7 +252,7 @@ export interface Report {
 export function reportIsEmpty(report: Report): boolean {
   return report.firstFailures.length === 0 &&
     report.coverageRise === undefined &&
-    report.packageRises.length === 0 &&
+    report.measuredSetRises.length === 0 &&
     report.flakyNewTests.length === 0 &&
     report.renames.length === 0;
 }
@@ -275,6 +280,14 @@ export interface ReportInput {
 
   /** The source groups this change touched. */
   touched: ReadonlySet<string>;
+
+  /**
+   * The measured sets the change reached, and whether the coverage gate
+   * ran over them. Worked out from the declarations by the same function
+   * the gate runs, so the note and the gate cannot come to different
+   * answers about which sets were gated.
+   */
+  coverageGate: { reached: readonly string[]; ran: boolean };
 
   /** The day the comment is written, which dates an alias line. */
   day: string;
@@ -375,15 +388,15 @@ export function groupFigures(figures: CoverageFigures): Map<string, number> {
 }
 
 /**
- * Every covered package's own-tests figure: its source measured by only
- * its own tests. A run measures the whole of this however much of the
- * corpus it ran, which is what makes it the one per-package figure worth
+ * Every measured set's figure: one member's source measured by one
+ * suite's tests alone. A run measures the whole of this however much of
+ * the corpus it ran, which is what makes it the one figure worth
  * comparing between two runs.
  */
-export function ownTestsFigures(
+export function measuredSetFigures(
   figures: CoverageFigures,
 ): Map<string, number> {
-  return figuresNamed(figures, ownTestsCoverageMember);
+  return figuresNamed(figures, coverageMetricMeasuredSet);
 }
 
 function figuresNamed(
@@ -430,61 +443,52 @@ export function coverageRise(input: ReportInput): CoverageRise | undefined {
   return { from: before, to: after, groups };
 }
 
-/** The covered packages a change touched, which is what the cap counts. */
-export function coveredPackagesTouched(
-  touched: ReadonlySet<string>,
-): string[] {
-  return [...touched]
-    .filter((group) =>
-      group.startsWith("packages/") && !EXCLUDED_FROM_COVERAGE_GATE.has(group)
-    )
-    .sort();
-}
-
 /**
- * Each covered package whose own-tests number rose, and what let the
- * rise past the per-package gate.
+ * Each measured set whose number rose, and what let the rise past the
+ * coverage gate.
  *
  * Three of the four are the ways a rise reaches the default branch with
  * the gate never having had an opinion, and they call for different
  * things: nothing, a look at the exclusion list, and a look at the
  * change respectively. The fourth is the state where the gate did
- * measure the package and passed it, which means the two measurements
+ * measure the set and passed it, which means the two measurements
  * disagree and is worth saying plainly rather than describing as one of
  * the other three.
  */
-export function packageRises(input: ReportInput): PackageRise[] {
+export function measuredSetRises(input: ReportInput): MeasuredSetRise[] {
   // A change that touched no source at all could not have moved which
-  // lines any package's own tests reach, and the figures move a little
-  // between runs on their own.
+  // lines any set's tests reach, and the figures move a little between
+  // runs on their own.
   if (input.touched.size === 0) return [];
-  const before = ownTestsFigures(input.coverageBefore);
-  const after = ownTestsFigures(input.coverage);
-  const touched = coveredPackagesTouched(input.touched);
-  const rises: PackageRise[] = [];
-  for (const [member, lines] of after) {
-    const was = before.get(member);
+  const before = measuredSetFigures(input.coverageBefore);
+  const after = measuredSetFigures(input.coverage);
+  const { reached, ran } = input.coverageGate;
+  const rises: MeasuredSetRise[] = [];
+  for (const [set, lines] of after) {
+    const was = before.get(set);
     if (was === undefined || lines <= was) continue;
-    // The exclusion list is asked first, because a package on it is one
-    // the gate would not have measured whatever else the change touched.
+    const member = set.slice(set.indexOf("/") + 1);
+    // The exclusion list is asked first, because a member on it carries
+    // no set the gate would have measured whatever else was reached.
     const excluded = EXCLUDED_FROM_COVERAGE_GATE.get(member);
-    const rise: PackageRise = {
+    const rise: MeasuredSetRise = {
+      set,
       member,
       from: was,
       to: lines,
       route: excluded !== undefined
         ? "excluded"
-        : touched.length > LOCAL_COVERAGE_MAX_PACKAGES
+        : !ran && reached.length > 0
         ? "over-the-cap"
-        : touched.includes(member)
+        : ran && reached.includes(set)
         ? "gated"
         : "elsewhere",
     };
-    if (rise.route === "over-the-cap") rise.touched = touched.length;
+    if (rise.route === "over-the-cap") rise.touched = reached.length;
     if (rise.route === "excluded") rise.reason = excluded;
     rises.push(rise);
   }
-  return rises.sort((a, b) => a.member < b.member ? -1 : 1);
+  return rises.sort((a, b) => a.set < b.set ? -1 : 1);
 }
 
 /**
@@ -673,7 +677,7 @@ export function buildReport(input: ReportInput): Report {
   return {
     firstFailures: firstFailures(input),
     ...(rise === undefined ? {} : { coverageRise: rise }),
-    packageRises: packageRises(input),
+    measuredSetRises: measuredSetRises(input),
     flakyNewTests: flakyNewTests(input),
     renames: renames(input),
   };
@@ -732,18 +736,19 @@ const SELECTION_PROSE: Record<ReportedSelection, string> = {
     "nothing to say about whether it ran this test.",
 };
 
-/** What the comment says about each route past the per-package gate. */
-const ROUTE_PROSE: Record<PackageRoute, string> = {
-  excluded: "The package is on `EXCLUDED_FROM_COVERAGE_GATE`, so nothing " +
-    "gates it. The exclusion list is what to look at.",
-  "over-the-cap": "The change touched more covered packages than " +
-    `\`LOCAL_COVERAGE_MAX_PACKAGES\` (${LOCAL_COVERAGE_MAX_PACKAGES}) ` +
-    "allows, so the per-package gate did not run at all. There is nothing " +
+/** What the comment says about each route past the coverage gate. */
+const ROUTE_PROSE: Record<MeasuredSetRoute, string> = {
+  excluded: "The member is on `EXCLUDED_FROM_COVERAGE_GATE`, so it carries " +
+    "no measured set and nothing gates it. The exclusion list is what to " +
+    "look at.",
+  "over-the-cap": "The change reached more measured sets than " +
+    `\`LOCAL_COVERAGE_MAX_SETS\` (${LOCAL_COVERAGE_MAX_SETS}) ` +
+    "allows, so the coverage gate did not run at all. There is nothing " +
     "to do about the gate; the rise itself is the thing to look at.",
-  elsewhere: "The change did not touch this package, so the gate had " +
-    "nothing to compare and something elsewhere moved which lines the " +
-    "package's own tests reach. The change is what to look at.",
-  gated: "The gate measured this package on the pull request and passed " +
+  elsewhere: "The change did not touch this member, so the gate had " +
+    "nothing to compare and something elsewhere moved which lines this " +
+    "set's tests reach. The change is what to look at.",
+  gated: "The gate measured this set on the pull request and passed " +
     "it, so the two measurements disagree. That is worth looking at on " +
     "its own, before the rise.",
 };
@@ -823,25 +828,25 @@ export function renderReport(
     }
   }
 
-  if (report.packageRises.length > 0) {
+  if (report.measuredSetRises.length > 0) {
     out.push("");
-    out.push("### A covered package's own tests reach less than they did");
+    out.push("### A measured set reaches less of its package than it did");
     out.push("");
     out.push(
-      "The per-package coverage gate exists to catch this before it lands. " +
-        "It did not, and this is why.",
+      "The coverage gate exists to catch this before it lands. It did not, " +
+        "and this is why.",
     );
-    for (const rise of report.packageRises) {
+    for (const rise of report.measuredSetRises) {
       out.push("");
       out.push(
-        `- \`${rise.member}\`: ${rise.from} to ${rise.to} uncovered lines. ` +
+        `- \`${rise.set}\`: ${rise.from} to ${rise.to} uncovered lines. ` +
           ROUTE_PROSE[rise.route],
       );
       if (rise.reason !== undefined) {
         out.push(`  The list gives the reason: ${rise.reason}`);
       }
       if (rise.touched !== undefined) {
-        out.push(`  The change touched ${rise.touched} covered packages.`);
+        out.push(`  The change reached ${rise.touched} measured sets.`);
       }
     }
   }

--- a/tasks/test-topology/patterns.test.ts
+++ b/tasks/test-topology/patterns.test.ts
@@ -211,7 +211,7 @@ describe("the pattern and package suites", () => {
       },
     );
     expect(invocation!.env?.DENO_COVERAGE_DIR).toBe(
-      "/cov/pattern-integration-patterns",
+      "/cov/packages__patterns",
     );
   });
 

--- a/tasks/test-topology/suite.test.ts
+++ b/tasks/test-topology/suite.test.ts
@@ -5,6 +5,7 @@ import {
   SKIP_LIST_VARIABLE,
 } from "@commonfabric/test-support/records";
 import {
+  coverageMemberDirectory,
   fileSuite,
   unavailableFrom,
   unavailableLeaves,
@@ -300,5 +301,25 @@ describe("two parts of one suite under one scope", () => {
         file: "packages/oven/b.test.ts",
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("naming a member's coverage directory", () => {
+  it("stands a slash up as a separator a directory name can hold", () => {
+    expect(coverageMemberDirectory("packages/connectors/github"))
+      .toBe("packages__connectors__github");
+  });
+
+  it("names the same directory whether or not the member leads with ./", () => {
+    expect(coverageMemberDirectory("./packages/memory"))
+      .toBe(coverageMemberDirectory("packages/memory"));
+  });
+
+  it("refuses a member whose own name holds the separator", () => {
+    // Two members would otherwise share one directory, and their
+    // coverage would be added together with nothing saying so.
+    expect(() => coverageMemberDirectory("packages/one__two")).toThrow(
+      "cannot be measured",
+    );
   });
 });

--- a/tasks/test-topology/suite.ts
+++ b/tasks/test-topology/suite.ts
@@ -106,11 +106,22 @@ export interface CommandContext {
   outputDir: string;
 
   /**
-   * Where coverage profiles go, one directory per workspace member.
+   * Where coverage profiles go. A suite writes one directory under it
+   * per workspace member, named by {@link coverageMemberDirectory}, so
+   * that what one member's tests reached is converted on its own.
    * Absent where this batch is not being measured, which is every batch
-   * outside the per-package coverage gate and the full run.
+   * outside the coverage gate and the full run.
    */
   coverageDir?: string;
+
+  /**
+   * The workspace members to measure, where only some of them are. A
+   * member outside the set runs unmeasured, because coverage costs time
+   * and nothing reads a profile no measured set is scored from. Absent
+   * means every member this batch runs, which is what the full run asks
+   * for.
+   */
+  measuredMembers?: ReadonlySet<string>;
 
   /**
    * Where a producer that writes a coverage report of its own puts it.
@@ -184,6 +195,14 @@ export interface Suite {
    */
   unitsForChange?(changed: ReadonlySet<string>): readonly Unit[];
 
+  /**
+   * What this suite's coverage is gated on: one entry per workspace
+   * member whose lines a subset of these units is scored over. Absent
+   * where nothing here is measured, which is every suite whose runner
+   * writes no coverage profile.
+   */
+  measured?: readonly MeasuredSet[];
+
   /** Whether a record belongs to one of this suite's units, or to it. */
   locate(record: LocatableRecord): Location | undefined;
 
@@ -216,6 +235,77 @@ export interface Suite {
  * budget forever.
  */
 export type ReachedBy = readonly string[];
+
+/**
+ * One suite's units over one workspace member's lines, measured together
+ * and gated together.
+ *
+ * The pair is the unit of the coverage gate because it is the one
+ * measurement selection cannot skew: run every unit here and what those
+ * tests reached in that member is complete, whatever was chosen anywhere
+ * else in the run. Two sets over one member are two numbers and are never
+ * added together, since a line one suite covers says nothing about
+ * whether the other does.
+ */
+export interface MeasuredSet {
+  /** The workspace member whose lines are counted, repository-relative. */
+  member: string;
+
+  /**
+   * The paths a change reaches this set by. Reaching it makes every unit
+   * below mandatory, which is the same declaration vocabulary that
+   * reaches a unit no diff can name, so one mechanism answers "what did
+   * this change touch" wherever the question comes up.
+   */
+  reachedBy: ReachedBy;
+
+  /** Every unit that measures it. */
+  units: readonly Unit[];
+}
+
+/**
+ * The directory one member's coverage profiles go in, under whatever
+ * directory a batch was given. Derived rather than declared, so that the
+ * suite writing the profiles and the conversion reading them cannot
+ * disagree about where they are.
+ *
+ * A member already holding the separator is refused rather than encoded,
+ * because two members would then share one directory and their coverage
+ * would be added together silently. No member in the tree has such a
+ * name, and the refusal is what keeps that from becoming a measurement
+ * nobody can explain.
+ */
+export function coverageMemberDirectory(member: string): string {
+  const path = member.replace(/^\.\//, "");
+  if (path.includes("__")) {
+    throw new Error(
+      `the workspace member ${path} cannot be measured: its name holds ` +
+        `the separator that stands for a slash in a coverage directory, ` +
+        `so it would share a directory with another member`,
+    );
+  }
+  return path.replaceAll("/", "__");
+}
+
+/**
+ * Where an invocation over `member` writes its coverage profiles, or
+ * nothing where it writes none. A batch with no coverage directory
+ * measures nothing, and one measuring only some members measures none of
+ * the others.
+ *
+ * The directory rather than a yes or no, so that a caller cannot ask
+ * whether it is measuring and then build the path from a directory the
+ * answer said nothing about.
+ */
+export function measuringInto(
+  context: Pick<CommandContext, "coverageDir" | "measuredMembers">,
+  member: string,
+): string | undefined {
+  if (context.coverageDir === undefined) return undefined;
+  const normalized = member.replace(/^\.\//, "");
+  if (context.measuredMembers?.has(normalized) === false) return undefined;
+  return path.join(context.coverageDir, coverageMemberDirectory(normalized));
+}
 
 /**
  * Whether one entry names a path. `**\/` stands for any run of
@@ -422,6 +512,9 @@ export interface FileSuiteOptions {
    * batch is measured.
    */
   patternCoverage?: boolean;
+
+  /** What this suite's coverage is gated on, where anything is. */
+  measured?: readonly MeasuredSet[];
 }
 
 /**
@@ -453,6 +546,7 @@ export function fileSuite(options: FileSuiteOptions): Suite {
     needs: options.needs,
     units,
     unavailable,
+    ...(options.measured === undefined ? {} : { measured: options.measured }),
 
     locate(record) {
       if (!claimsIdentity(surfaces, record.test)) return undefined;
@@ -500,9 +594,8 @@ export function fileSuite(options: FileSuiteOptions): Suite {
           await writeSkipList(skipListPath, skips);
           env[SKIP_LIST_VARIABLE] = skipListPath;
         }
-        if (context.coverageDir !== undefined) {
-          env.DENO_COVERAGE_DIR = path.join(context.coverageDir, slug);
-        }
+        const measuring = measuringInto(context, part.packageDir);
+        if (measuring !== undefined) env.DENO_COVERAGE_DIR = measuring;
         if (
           options.patternCoverage === true &&
           context.patternCoverageDir !== undefined

--- a/tasks/test-topology/unit.test.ts
+++ b/tasks/test-topology/unit.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "@std/testing/bdd";
 import { SKIP_LIST_VARIABLE } from "@commonfabric/test-support/records";
 import { loadUnitSuites } from "./unit.ts";
 import type { Suite } from "./suite.ts";
+import { EXCLUDED_FROM_COVERAGE_GATE } from "../test-selection/policy.ts";
 
 /** A workspace holding the members a case describes. */
 async function workspace(
@@ -308,8 +309,8 @@ describe("running a member that cannot be handed a subset", () => {
     expect(made.length).toBe(2);
     expect(made.some((i) => i.command.includes("browser-test"))).toBe(true);
     // Each member's profiles go somewhere of their own, which is what
-    // lets the per-package figures be added up afterwards.
-    expect(made[0]!.env?.DENO_COVERAGE_DIR).toBe("/cov/bakery");
+    // keeps one measured set's number out of another's.
+    expect(made[0]!.env?.DENO_COVERAGE_DIR).toBe("/cov/packages__bakery");
   });
 
   it("locates a browser record on the half that produced it", async () => {
@@ -392,5 +393,224 @@ describe("what the unit suites decline to claim", () => {
     expect(
       suite.locate({ test: { k: "browser", s: "bakery", n: "bakes" } }),
     ).toEqual({ level: "unit", unit: "packages/bakery#browser-test" });
+  });
+});
+
+describe("the measured sets a unit suite declares", () => {
+  it("gives a member one set over its own files", async () => {
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: { test: "deno test test/*.test.ts" },
+        files: ["test/glaze.test.ts", "test/proof.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    expect(suite.measured).toEqual([{
+      member: "packages/bakery",
+      reachedBy: ["packages/bakery/"],
+      units: [
+        "packages/bakery/test/glaze.test.ts",
+        "packages/bakery/test/proof.test.ts",
+      ],
+    }]);
+  });
+
+  it("gives a member whose task runs whole a set over that one unit", async () => {
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: { test: "deno run -A test/run-tests.ts" },
+        files: ["test/glaze.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    expect(suite.measured?.[0]?.units).toEqual(["packages/bakery"]);
+  });
+
+  it("covers a member added to the workspace with no other edit", async () => {
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: { test: "deno test test/glaze.test.ts" },
+        files: ["test/glaze.test.ts"],
+      },
+      "./packages/cellar": {
+        tasks: { test: "deno test test/rack.test.ts" },
+        files: ["test/rack.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    expect(suite.measured?.map((set) => set.member))
+      .toEqual(["packages/bakery", "packages/cellar"]);
+  });
+
+  it("covers a member at whatever depth it sits", async () => {
+    const root = await workspace({
+      "./packages/connectors/github": {
+        tasks: { test: "deno test test/issue.test.ts" },
+        files: ["test/issue.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    expect(suite.measured?.[0]?.member).toBe("packages/connectors/github");
+  });
+
+  it("leaves a nested member's tree out of the outer member's reach", async () => {
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: { test: "deno test test/shape.test.ts" },
+        files: ["test/shape.test.ts"],
+      },
+      "./packages/bakery/cellar": {
+        tasks: { test: "deno test test/rack.test.ts" },
+        files: ["test/rack.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    const outer = suite.measured?.find((set) =>
+      set.member === "packages/bakery"
+    );
+    expect(outer?.reachedBy).toEqual([
+      "packages/bakery/",
+      "!packages/bakery/cellar/",
+    ]);
+  });
+
+  it("leaves a member on the exclusion list without a set", async () => {
+    const excluded = [...EXCLUDED_FROM_COVERAGE_GATE.keys()]
+      .find((member) => !member.includes("/", "packages/".length))!;
+    const root = await workspace({
+      [`./${excluded}`]: {
+        tasks: { test: "deno test test/one.test.ts" },
+        files: ["test/one.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    expect(suite.measured).toBeUndefined();
+  });
+
+  it("leaves a member outside packages/ without a set", async () => {
+    const root = await workspace({
+      "./tools/bakery": {
+        tasks: { test: "deno test test/one.test.ts" },
+        files: ["test/one.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    expect(suite.measured).toBeUndefined();
+  });
+
+  it("measures a member's Deno-only half and never its browser unit", async () => {
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: {
+          "deno-test": "deno test test/glaze.test.ts",
+          "browser-test": "deno run -A ../deno-web-test/cli.ts oven.test.ts",
+          test: "deno task deno-test && deno task browser-test",
+        },
+        files: ["test/glaze.test.ts", "oven.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    expect(suite.units).toContain("packages/bakery#browser-test");
+    expect(suite.measured?.[0]?.units)
+      .toEqual(["packages/bakery/test/glaze.test.ts"]);
+  });
+
+  it("leaves a member with only a browser half without a set", async () => {
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: {
+          "browser-test": "deno run -A ../deno-web-test/cli.ts oven.test.ts",
+        },
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    expect(suite.measured).toBeUndefined();
+  });
+});
+
+describe("where a unit suite writes its coverage profiles", () => {
+  it("names a directory for the member, under the batch's directory", async () => {
+    const root = await workspace({
+      "./packages/connectors/github": {
+        tasks: { test: "deno test test/issue.test.ts" },
+        files: ["test/issue.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    const [invocation] = await suite.command(
+      [{ unit: "packages/connectors/github/test/issue.test.ts", skip: [] }],
+      {
+        root,
+        outputDir: "/out",
+        spoolDir: "/spool",
+        coverageDir: "/cov",
+      },
+    );
+    expect(invocation?.env?.DENO_COVERAGE_DIR)
+      .toBe("/cov/packages__connectors__github");
+  });
+
+  it("writes nothing for a member the run is not measuring", async () => {
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: { test: "deno test test/glaze.test.ts" },
+        files: ["test/glaze.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    const [invocation] = await suite.command(
+      [{ unit: "packages/bakery/test/glaze.test.ts", skip: [] }],
+      {
+        root,
+        outputDir: "/out",
+        spoolDir: "/spool",
+        coverageDir: "/cov",
+        measuredMembers: new Set(["packages/cellar"]),
+      },
+    );
+    expect(invocation?.env?.DENO_COVERAGE_DIR).toBeUndefined();
+  });
+
+  it("keeps the browser half out of the member's measured directory", async () => {
+    // The browser unit is not one of the set's units, so what it reached
+    // must not move the set's number: a lane that happened to select it
+    // would otherwise measure something a lane that did not would miss.
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: {
+          "deno-test": "deno test test/glaze.test.ts",
+          "browser-test": "deno run -A ../deno-web-test/cli.ts oven.test.ts",
+          test: "deno task deno-test && deno task browser-test",
+        },
+        files: ["test/glaze.test.ts", "oven.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    const made = await suite.command(
+      [
+        { unit: "packages/bakery/test/glaze.test.ts", skip: [] },
+        { unit: "packages/bakery#browser-test", skip: [] },
+      ],
+      { root, outputDir: "/out", spoolDir: "/spool", coverageDir: "/cov" },
+    );
+    const browser = made.find((one) => one.command.includes("browser-test"))!;
+    const deno = made.find((one) => !one.command.includes("browser-test"))!;
+    expect(deno.env?.DENO_COVERAGE_DIR).toBe("/cov/packages__bakery");
+    expect(browser.env?.DENO_COVERAGE_DIR).toBeUndefined();
+  });
+
+  it("writes nothing at all where the batch is not being measured", async () => {
+    const root = await workspace({
+      "./packages/bakery": {
+        tasks: { test: "deno test test/glaze.test.ts" },
+        files: ["test/glaze.test.ts"],
+      },
+    });
+    const suite = workspaceUnit(await loadUnitSuites(root));
+    const [invocation] = await suite.command(
+      [{ unit: "packages/bakery/test/glaze.test.ts", skip: [] }],
+      { root, outputDir: "/out", spoolDir: "/spool" },
+    );
+    expect(invocation?.env?.DENO_COVERAGE_DIR).toBeUndefined();
   });
 });

--- a/tasks/test-topology/unit.ts
+++ b/tasks/test-topology/unit.ts
@@ -26,6 +26,8 @@ import {
   type Invocation,
   type LocatableRecord,
   type Location,
+  type MeasuredSet,
+  measuringInto,
   recordingArguments,
   type RecordSurface,
   skipListOf,
@@ -34,6 +36,7 @@ import {
   writeSkipList,
 } from "./suite.ts";
 import type { CapabilityId } from "../ci-capabilities.ts";
+import { EXCLUDED_FROM_COVERAGE_GATE } from "../test-selection/policy.ts";
 
 /** The member the runner suite owns; every other member is the other one. */
 const RUNNER_MEMBER = "./packages/runner";
@@ -135,6 +138,46 @@ function wholeUnit(member: Member): string {
 }
 
 /**
+ * The measured set one member carries, or nothing where it carries none.
+ *
+ * A set holds the units of the member's Deno-only half and never its
+ * browser unit, so that adding a test needing a browser costs a member
+ * nothing here. The browser unit therefore writes no coverage into the
+ * set's directory either: it is not one of the set's units, so counting
+ * what it reached would make the set's number depend on whether a lane
+ * selected it.
+ *
+ * The paths that reach the set are the member's own tree, less the trees
+ * of any member nested inside it, which belong to that member's set
+ * instead.
+ */
+function measuredSetOf(
+  member: Member,
+  members: readonly Member[],
+): MeasuredSet | undefined {
+  const memberPath = wholeUnit(member);
+  // The gate is over `packages/`. `tasks` is one coverage group rather
+  // than a tree of them, and `scripts` is outside coverage accounting.
+  if (!memberPath.startsWith("packages/")) return undefined;
+  if (EXCLUDED_FROM_COVERAGE_GATE.has(memberPath)) return undefined;
+  const units = member.files.length > 0
+    ? member.files
+    : member.denoHalf
+    ? [memberPath]
+    : [];
+  if (units.length === 0) return undefined;
+  const nested = members
+    .map(wholeUnit)
+    .filter((other) => other.startsWith(`${memberPath}/`))
+    .map((other) => `!${other}/`);
+  return {
+    member: memberPath,
+    reachedBy: [`${memberPath}/`, ...nested],
+    units,
+  };
+}
+
+/**
  * Builds a suite over a set of members. The two unit suites differ only
  * in which members they hold and what they are called, so they are one
  * implementation with two callers.
@@ -174,6 +217,9 @@ function unitSuite(
   }
 
   const sources = members.flatMap((member) => member.browserFiles);
+  const measured = members
+    .map((member) => measuredSetOf(member, members))
+    .filter((set): set is MeasuredSet => set !== undefined);
 
   return {
     id,
@@ -182,6 +228,7 @@ function unitSuite(
     units,
     unavailable: [],
     ...(sources.length === 0 ? {} : { sources }),
+    ...(measured.length === 0 ? {} : { measured }),
 
     locate(record: LocatableRecord): Location | undefined {
       if (!claimsIdentity({ recordSurfaces }, record.test)) return undefined;
@@ -223,11 +270,17 @@ function unitSuite(
       for (const [member, group] of byMember) {
         const memberDir = path.resolve(context.root, member.memberPath);
         const slug = member.scope.replaceAll("/", "__");
-        const env: Record<string, string> = { ENV: "test", ...member.run?.env };
-        if (context.coverageDir !== undefined) {
-          env.DENO_COVERAGE_DIR = path.join(context.coverageDir, slug);
-        }
         const whole = wholeUnit(member);
+        const env: Record<string, string> = { ENV: "test", ...member.run?.env };
+        // Only the Deno-only half writes into the member's measured-set
+        // directory. The browser unit is not one of the set's units, so
+        // its profiles would make the set's number depend on whether a
+        // lane happened to select it, which is the one thing the set
+        // exists to rule out.
+        const measured = measuringInto(context, whole);
+        const denoEnv = measured === undefined
+          ? env
+          : { ...env, DENO_COVERAGE_DIR: measured };
         const files: UnitRequest[] = [];
         let runsWhole = false;
         let runsBrowser = false;
@@ -245,7 +298,7 @@ function unitSuite(
             command: [Deno.execPath(), "task", member.denoTestTask],
             cwd: memberDir,
             env: {
-              ...env,
+              ...denoEnv,
               ...await skipEnv(context, slug, group),
             },
           });
@@ -267,7 +320,7 @@ function unitSuite(
               ),
             ],
             cwd: memberDir,
-            env: { ...env, ...await skipEnv(context, slug, files) },
+            env: { ...denoEnv, ...await skipEnv(context, slug, files) },
             junit: [{
               path: junitPath,
               kind: "unit",

--- a/tasks/write-coverage-lcov.ts
+++ b/tasks/write-coverage-lcov.ts
@@ -224,18 +224,21 @@ export async function copyUnlaunchedMembers(
   );
 }
 
-async function main(): Promise<void> {
-  const [profileDir, outputPath] = Deno.args;
-  if (!profileDir || !outputPath) {
-    console.error(
-      "Usage: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts <profile-dir> <output.lcov>",
-    );
-    Deno.exit(2);
-  }
-
-  // Ahead of every path below, each of which returns or exits: the record says
-  // what the report does not cover, so a report written without it says more
-  // than the run measured.
+/**
+ * Converts every coverage profile under `profileDir` into one LCOV report
+ * at `outputPath`, and says whether the report accounts for everything
+ * the profiles named.
+ *
+ * A report is written whatever the outcome, so a caller collecting it as
+ * a build artifact still finds one to collect and reads the outcome from
+ * the answer rather than from the file.
+ */
+export async function writeLcovReport(
+  profileDir: string,
+  outputPath: string,
+): Promise<{ ok: boolean }> {
+  // Ahead of every path below: the record says what the report does not
+  // cover, so a report written without it says more than the run measured.
   await copyUnlaunchedMembers(profileDir, outputPath);
 
   const profileFiles = await collectCoverageProfileFiles(profileDir);
@@ -244,7 +247,7 @@ async function main(): Promise<void> {
       outputPath,
       `No coverage profile files found in ${profileDir}`,
     );
-    return;
+    return { ok: true };
   }
 
   const removedEmptyProfiles = await removeEmptyCoverageProfiles(profileFiles);
@@ -260,7 +263,7 @@ async function main(): Promise<void> {
       outputPath,
       `No non-empty coverage profile files remain in ${profileDir}`,
     );
-    return;
+    return { ok: true };
   }
 
   await Deno.mkdir(path.dirname(outputPath), { recursive: true });
@@ -297,9 +300,6 @@ async function main(): Promise<void> {
   };
 
   if (!result.success) {
-    // An output file is left behind whatever the outcome, so a caller that
-    // collects the report as a build artifact still finds one to collect and
-    // reads the outcome from this step.
     await writeEmptyLcovFile(outputPath);
 
     // `deno coverage` leaves test files out of a report by design, so profiles
@@ -313,7 +313,7 @@ async function main(): Promise<void> {
       console.warn(
         `deno coverage found nothing to report in ${profileDir}; wrote empty LCOV report to ${outputPath}.`,
       );
-      return;
+      return { ok: true };
     }
 
     console.error(
@@ -321,7 +321,7 @@ async function main(): Promise<void> {
     );
     if (lost.length > 0) reportLostFiles();
     console.error(stderr.trim());
-    Deno.exit(1);
+    return { ok: false };
   }
 
   await Deno.writeTextFile(
@@ -334,10 +334,22 @@ async function main(): Promise<void> {
   if (lost.length > 0) {
     console.error(`Wrote the LCOV report that did convert to ${outputPath}.`);
     reportLostFiles();
-    Deno.exit(1);
+    return { ok: false };
   }
 
   console.log(`Wrote LCOV coverage report to ${outputPath}`);
+  return { ok: true };
+}
+
+async function main(): Promise<void> {
+  const [profileDir, outputPath] = Deno.args;
+  if (!profileDir || !outputPath) {
+    console.error(
+      "Usage: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts <profile-dir> <output.lcov>",
+    );
+    Deno.exit(2);
+  }
+  if (!(await writeLcovReport(profileDir, outputPath)).ok) Deno.exit(1);
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
PROBLEM

Choosing which tests a change runs breaks a gate on the repository's whole coverage number: a change that runs a fifth of the test time measures a fifth of the coverage, so the two sides of the comparison stop being the same thing. The plan replaced that with a gate over a package's own tests, stated as one number per package. That is wrong wherever two suites reach one package's lines: merging what `pattern-unit` and `pattern-integration` covered lets either suite pay the other's debt down, and merging what `packages/memory`'s tests covered in `packages/piece` credits `packages/piece` with lines nothing in it tests. On the default branch the collision is live rather than hypothetical, since `package-integration` and `workspace-unit` both measure `packages/shell` and `packages/runtime-client`.

Nothing was built either way. `SelectionReason` carried a `coverage-gate` value nothing produced, `CommandContext.coverageDir` had no setter, and the manifest's `coverageBaselines` had no writer.

SOLUTION

The gated thing is a measured set: one suite's units over one workspace member's lines. A suite declares its sets, each naming the member whose lines it counts, the units that measure it, and the paths a change reaches it by; reaching one makes every unit of the set mandatory, through the declaration vocabulary the rest of selection already uses. Profiles go in a directory named for the suite and the member, and a set's count is converted from that directory alone, so no suite's coverage can move another's number and a member's browser half, which is not one of the set's units, writes nowhere near it.

A lane turns coverage on for the members it is scoring and no others, and converts every profile directory it wrote into one report. `tasks/coverage-gate.ts` joins the reports per set, scores each over its member's own tree, and compares against the baseline measured at the newest default-branch commit the branch holds. Five states report rather than fail: no baseline the branch holds, no report, a set nothing measured, a report naming no line of the member, and a run with a failing test.

`LOCAL_COVERAGE_MAX_SETS` bounds what a change is forced to run, and nothing else. Whether a number may be compared against the baseline turns on whether the set ran whole, so a set the cap left unforced that some run measured anyway is still scored, and a change labelled `ci: full` measures every set in the repository.

The full run measures every set, which is where the baselines come from, and its reports merge into the repository-wide figure as before. Nothing about coverage fails a run on the default branch.

DESIGN DISCUSSION

Which baseline is newest comes from git: the gate reads the branch's own history back from the tip and takes the first of a set's baseline commits it meets. Run times are a different order — a re-run of an older commit is created after the run of a newer one — and the tree a rise is measured against is what the branch's history orders. Reading back from the tip also costs the distance to the answer, where asking about each commit in turn costs a question per commit and the window holds a week of them.

Measuring a set does not change how often anything runs, and neither does anything else: an identity runs the count its share asks for whatever put it in the lane and whichever run it is. Two things follow. A batch carries a run count per unit rather than one for the batch, so one flaky unit in a set of eighty-three does not run every other unit of that suite again. And the mandatory pass gives up runs until what is left fits a lane, down to one, since all of one identity's runs go in one lane and no lane can be added to make room for them.

Down to once and never to nothing. A mandatory identity is placed whatever it costs, the lane runs long and says by how much, and the list of work no lane can hold names the discretionary identities alone. The contract now states that, because the alternative is a run reporting a pass over a test it decided not to run.

The workflows are unchanged, so nothing here runs yet: the lanes that would upload the reports do not exist. What each half will have to do is in the plan's checklist, including that the gate's checkout has to hold the commits the baselines name.

The publisher fills the manifest's baselines from the `perf-metrics` artifact of each default-branch run it has not read, carrying the previous manifest's forward for the rest of the window and stopping at the first run whose report names no measured set. That is two API calls a publish until the producing half lands.
`.github/workflows/test-selection.yml` gains `actions: read` for it.

`ACCEPT_COVERAGE_DEBT` now also accepts a workspace member deeper than a coverage source group, which this gate reads and the repository-wide ratchet passes over; a name neither of them measures fails here, and two markers naming one thing are refused. `LOCAL_COVERAGE_MAX_PACKAGES` becomes `LOCAL_COVERAGE_MAX_SETS`, since what it caps is measured sets. `workflowRunsPathForBaseline` moves to `ci-check-lib.ts`, beside the repository and workflow names it is built from, so the two readers of recent default-branch runs cannot come to different lists.

Two things the extra runs still want are their own pieces of work, and the plan carries both. The independence flag would let a repeated identity be skipped in its file's own invocation and run alone, so its siblings go back to running once; it is declared in the manifest and nothing writes it. And the rule that an excluded test's failure does not fail the run is what keeps those runs from turning the default branch red more often than one run of it does.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

