### PR TITLE
fix(cf-harness): the audit pins the flow-label rung AUD-15a expects

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -2307,6 +2307,12 @@ conforming states and the ordering rules of
 [`docs/specs/cfc-enforcement-matrix.md`](../../docs/specs/cfc-enforcement-matrix.md),
 each rule carrying the clause it turns on.
 
+AUD-15a's expected flow-label rung is a constant of the audit the same way,
+pinned at compile time to `MAX_ENFORCEMENT_CFC_OPTIONS` through a type-only
+import that reads no value out of the runner: a recorded run keeps one verdict,
+and a bundle that moves off that rung fails `deno task check` where the move is
+made rather than re-grading the corpus in silence.
+
 Every check carries the clauses it rests on and an exact quote from each, both
 printed with the finding and included in `--json`, **and how it rests on them**.
 A citation is `required-by` when the clause states the requirement the check

--- a/packages/cf-harness/audit/checks/posture.ts
+++ b/packages/cf-harness/audit/checks/posture.ts
@@ -27,6 +27,7 @@ import type {
   CfcPostureProvenance,
   CfcPostureReport,
 } from "@commonfabric/runner/cfc";
+import type { MAX_ENFORCEMENT_CFC_OPTIONS } from "@commonfabric/runner";
 
 import type { HarnessCfcPolicySnapshot } from "../../src/contracts/cfc-policy-snapshot.ts";
 import type { HarnessFabricSessionCfcPosture } from "../../src/run-state.ts";
@@ -360,6 +361,27 @@ const defaultModeDrift: AuditCheck = {
   },
 };
 
+/**
+ * The flow-label rung a run claiming the max-enforcement bundle is held to.
+ *
+ * A record carries the rung the run resolved and the name of the bundle it
+ * claimed, never the rung that bundle asserted, so the audit carries the
+ * second one. This rung moves when this line is edited and at no other time,
+ * which is what keeps a verdict on an already-recorded artifact from turning
+ * over as the runner's bundle moves.
+ *
+ * The pin is what makes moving it a decision. It reads no value out of the
+ * runner: `satisfies` fails `deno check` when the bundle sets a different
+ * rung or stops setting one, so the move surfaces where it is made rather
+ * than as an audit that quietly grades the corpus by a new rule.
+ *
+ * `persist` is the strongest rung of `CfcFlowLabelsMode`, which is what makes
+ * the inequality below read as `falsifiedBy` states it — weaker than the
+ * bundle asserts, rather than merely different from it.
+ */
+const EXPECTED_MAX_ENFORCEMENT_FLOW_LABELS =
+  "persist" satisfies typeof MAX_ENFORCEMENT_CFC_OPTIONS["cfcFlowLabels"];
+
 const defaultDialDrift: AuditCheck = {
   id: "AUD-15a",
   title: "default-sourced dial drift",
@@ -386,12 +408,13 @@ const defaultDialDrift: AuditCheck = {
       };
     }
     if (
-      posture.flowLabelsSource === "default" && posture.flowLabels !== "persist"
+      posture.flowLabelsSource === "default" &&
+      posture.flowLabels !== EXPECTED_MAX_ENFORCEMENT_FLOW_LABELS
     ) {
       return {
         verdict: "fail",
         message:
-          `this run's flow-label dial came from a default and landed at \`${posture.flowLabels}\`, while the max-enforcement bundle it claims asserts \`persist\``,
+          `this run's flow-label dial came from a default and landed at \`${posture.flowLabels}\`, while the max-enforcement bundle it claims asserts \`${EXPECTED_MAX_ENFORCEMENT_FLOW_LABELS}\``,
         evidence: [{
           artifact: "run-state.json",
           pointer: "fabricSessionCfc.flowLabelsSource",


### PR DESCRIPTION
PROBLEM

The audit check AUD-15a wrote `persist` twice: once as the rung below which it fails a run claiming the max-enforcement posture bundle, and once inside the message saying what that bundle asserts. Both restate `MAX_ENFORCEMENT_CFC_OPTIONS.cfcFlowLabels` in the runner's presets, and nothing tied any of the three together. The two copies inside the check could part from one another with every test still green, and the message could go on telling an operator that the bundle asserts a rung the bundle no longer sets.

SOLUTION

The rung becomes one named constant, and stays written down rather than read from the bundle. AUD-15a grades an artifact some earlier run recorded, under whatever the bundle asserted then; resolving the rung from the runner would decide a fixed artifact's verdict by whichever checkout the audit happens to run from. A type-only import pins the two instead: `satisfies` fails `deno task check` when the bundle sets a different rung or stops setting one, so moving the rung is a decision taken where the move is made, and no value crosses into the audit at run time.

DESIGN DISCUSSION

The opposite answer is right one layer down. A harness projecting the posture of a session whose runtime it is about to build must read the bundle, because the projection and the runtime have to give one answer; `presetCfcOptions` is exported for exactly that, and `cfc-posture.ts` uses it. An audit reads someone else's finished record, so the same argument reverses.

The audit already draws this line without stating it. It imports types, the dial ladders, and `cfcEnforcementStrictness` from the runner — the vocabulary a record is written in — and, outside its own tests, no setting. Settings are stated in the audit: `matrix.ts` restates the enforcement matrix, `profiles/max-enforcement.json` the expected posture. Each is paired with something that notices divergence, `citation-drift.test.ts` for the matrix and `expected-posture.test.ts` for the profile, and the `satisfies` clause is that pairing for this rung.

AUD-15a's failing branch is unreachable for a record this harness writes: a session naming the bundle records `flowLabelsSource: "posture"`, never `"default"`. Every run it can fail was written by an older harness or a foreign writer, which is the case where the audit is least entitled to substitute today's code for the run's.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

