### PR TITLE
Split two packages' test tasks into a Deno half and a browser half

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -35,9 +35,10 @@ A test that needs a real browser but not a running product goes in a
 package that splits its tests this way matches the pattern twice: once as an
 `--ignore` that keeps the file out of plain `deno test` discovery, and once as
 the argument list handed to `deno-web-test`. Both are globs, so there is no list
-to add the file to. `packages/dashboard` spreads the pair across a runner script
-and the task that runner calls, which changes where they are written and not
-what they match.
+to add the file to. `packages/ui` and `packages/iframe-sandbox` write the two
+halves as separate `deno-test` and `browser-test` tasks, and
+`packages/dashboard` spreads the pair across a runner script and the task that
+runner calls. Where the pair is written changes; what it matches does not.
 
 Two things break it, and the second is what makes the first hard to notice.
 

--- a/packages/iframe-sandbox/deno.jsonc
+++ b/packages/iframe-sandbox/deno.jsonc
@@ -2,9 +2,16 @@
   // Dependency guide: ../../docs/development/DEPENDENCIES.md
   "name": "@commonfabric/iframe-sandbox",
   "tasks": {
+    "test": {
+      "dependencies": [
+        "deno-test",
+        "browser-test"
+      ]
+    },
     // The `*.browser.test.ts` name is what routes a file: the glob keeps it
     // out of the plain `deno test` run and hands it to the browser runner.
-    "test": "deno test --allow-read --ignore='**/*.browser.test.ts' && deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts **/*.browser.test.ts"
+    "deno-test": "deno test --allow-read --ignore='**/*.browser.test.ts'",
+    "browser-test": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts **/*.browser.test.ts"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/packages/ui/deno.jsonc
+++ b/packages/ui/deno.jsonc
@@ -5,9 +5,16 @@
   },
   "tasks": {
     "bundle": "../../scripts/bundle.ts src/index.ts",
+    "test": {
+      "dependencies": [
+        "deno-test",
+        "browser-test"
+      ]
+    },
     // The `*.browser.test.ts` name is what routes a file: the glob keeps it
     // out of the plain `deno test` run and hands it to the browser runner.
-    "test": "deno test --allow-env --allow-ffi --allow-read --allow-write --allow-run --ignore='**/*.browser.test.ts' && deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts **/*.browser.test.ts"
+    "deno-test": "deno test --allow-env --allow-ffi --allow-read --allow-write --allow-run --ignore='**/*.browser.test.ts'",
+    "browser-test": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts **/*.browser.test.ts"
   },
   "imports": {
     // Dependency guide: ../../docs/development/DEPENDENCIES.md

--- a/tasks/test-topology/unit.ts
+++ b/tasks/test-topology/unit.ts
@@ -118,7 +118,7 @@ async function readMember(
     // the browser unit is one unit rather than one per file. The same
     // paths the task names, read without its ignores, so the difference
     // is what an ignore took out rather than what the task never looked
-    // at. No member in the tree has that shape yet.
+    // at.
     const everything = new Set(
       (await memberTestFiles(memberDir, { ...tasks.denoTest, ignores: [] }))
         .map(relative),

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -218,15 +218,17 @@ const INTERNALLY_SHARDED_PACKAGES: Record<
 //
 // A task carrying a shell metacharacter puts the appended flag somewhere
 // other than the test command: `api` chains a type-performance benchmark
-// after its tests, and `patterns` and `ui` run two test commands each, so
-// the flag would reach only the last one.
+// after its tests, and `patterns` runs two test commands, so the flag
+// would reach only the last one. A member that names its halves as
+// separate tasks has no `test` command at all, and takes neither flag for
+// the same reason a dependencies-only task does not.
 //
 // A task that runs a script cannot show what the script does with the
 // flags it is handed. The members listed here route through a runner that
 // forwards them to one `deno test`. The runners that do not appear here
 // keep their leaves out: `cli` runs three `deno test` invocations per
-// slice, which would each overwrite the file, and `dashboard`, `identity`,
-// and `iframe-sandbox` drive browser harnesses that record through the
+// slice, which would each overwrite the file, and `dashboard` and
+// `identity` drive browser harnesses that record through the
 // deno-web-test reporter instead.
 const FLAG_FORWARDING_RUNNERS = new Set([
   "./packages/connectors/agents/host",


### PR DESCRIPTION
PROBLEM

`packages/ui` and `packages/iframe-sandbox` run their Deno tests and their browser tests from one shell command:

    "test": "deno test ... --ignore='**/*.browser.test.ts' &&
             deno run ... deno-web-test/cli.ts **/*.browser.test.ts"

Nothing can address either half on its own. The test topology reads a task carrying `&&` as a task it cannot take apart, so each package is one unit that runs whole: no run can be pointed at one of its test files, there is no browser unit, and the files only the browser runs are claimed by the whole-member unit rather than by anything that says what runs them. Coverage from the two halves lands in one directory.

SOLUTION

Each package's `test` task becomes an object depending on `deno-test` and `browser-test`, which is the shape `packages/static` already writes. The two command lines move into those two tasks unchanged, so the same tests run, and `deno task test` in either package still runs both halves.

The topology already reads `deno-test` where a member names one, so this is an edit to two manifests. `packages/ui` goes from one unit to sixty-six, sixty-five of them its own test files and the last its browser half; `packages/iframe-sandbox` goes from one to eight. The files only the browser half runs, ten and three, are accounted for as the unit suite's sources, which is the path `readMember()` was written for and nothing in the tree had taken until now.

Three comments that described the old shape are corrected, in `tasks/workspace-tests.ts`, `tasks/test-topology/unit.ts`, and `.claude/rules/tests.md`.

DESIGN DISCUSSION

Deno runs a task's dependencies together, so `deno task test` in these packages now runs the two halves at the same time rather than the Deno half first, and both halves run even when one fails. `&&` stopped at the first failure. The output carries a `[deno-test]` or `[browser-test]` prefix per line, as `packages/static` has all along.

Whether an appended `--junit-path` reaches a member's leaf is unchanged. A task carrying a shell metacharacter was refused because the flag would land past the `&&`, and a task defined by its dependencies carries no command line to append to, so both shapes are refused, each for its own reason.

The checklist item in `docs/plans/pull-request-test-selection.md` that covers this also asks `tasks/workspace-tests.ts` to give a member's `deno-test` task a coverage directory separate from the rest of its `test` task, so the item stays open. The per-suite coverage gate being written separately measures a set's coverage from a directory named for the suite and the member, which is a different place to make that separation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

