### PR TITLE
Keep index member setup inputs opaque

### DIFF
--- a/docs/features/collection-indexes.md
+++ b/docs/features/collection-indexes.md
@@ -112,6 +112,12 @@ confirmations are ignored.
 
 ## Work and limitations
 
+Member setup watches retain Cell references to the selector result, source
+element, shared descriptor, and maintenance records. Each member resolves its
+selector and reads the concrete maintenance slots it needs; setting up one member
+does not materialize every bucket through its input schema. Selector reads remain
+reactive, including omitted keys.
+
 Membership reconciliation scans source occurrence identities. `groupBy` writes
 one member entry and uses a cached occurrence order to locate its published
 slot. Unchanged slots retain their original source links. Copying the order and

--- a/packages/runner/src/builtins/collection-index-member.ts
+++ b/packages/runner/src/builtins/collection-index-member.ts
@@ -49,20 +49,26 @@ export function collectionIndexMember(
   const index = inputs.key("index").resolveAsCell();
   return Object.assign((tx: IExtendedStorageTransaction) => {
     const args = inputs.withTx(tx);
-    const extracted = args.key("extracted");
+    const extracted = args.key("extracted").resolveAsCell()
+      .asSchema<CollectionIndexMemberInput["extracted"]>(undefined);
     const cellKey = extracted.key("isCell").get();
     if (cellKey === undefined) return;
     const value = cellKey
       ? extracted.key("value").asSchema({ asCell: ["cell"] }).get()
       : extracted.key("value").get();
+    // Maintenance reads concrete slots behind the opaque setup references.
     maintainCollectionIndexMembership(
       tx,
-      args.key("state").resolveAsCell(),
-      args.key("index").resolveAsCell(),
+      args.key("state").resolveAsCell().asSchema<CollectionIndexMembership>(
+        undefined,
+      ),
+      args.key("index").resolveAsCell().asSchema<MaintainedCollectionIndex>(
+        undefined,
+      ),
       args.key("mode").get(),
       args.key("occurrence").get(),
       resolveCollectionKey(runtime, tx, value),
-      args.key("element").resolveAsCell(),
+      args.key("element").resolveAsCell().asSchema<unknown>(undefined),
     );
     sendResult(tx, true);
   }, {

--- a/packages/runner/src/builtins/collection-index.ts
+++ b/packages/runner/src/builtins/collection-index.ts
@@ -55,7 +55,26 @@ function getMemberPattern() {
         type: "ref",
         implementation: "collectionIndexMember",
       })(input),
-    { type: "object", additionalProperties: true },
+    {
+      type: "object",
+      properties: {
+        extracted: { asCell: ["cell"], type: "unknown" },
+        element: { asCell: ["cell"], type: "unknown" },
+        // Setup watches retain shared addresses without traversing every bucket.
+        state: { asCell: ["cell"], type: "unknown" },
+        index: { asCell: ["cell"], type: "unknown" },
+        occurrence: { type: "string" },
+        mode: { enum: ["group", "key"] },
+      },
+      required: [
+        "extracted",
+        "element",
+        "state",
+        "index",
+        "occurrence",
+        "mode",
+      ],
+    },
     true,
   );
 }


### PR DESCRIPTION
## Why

The maintained lunch-poll migration in #7336 exposes excessive setup work at 1,184 votes: its headless initial render times out under CI coverage, and a same-tree local run exhausted the JavaScript heap. Each index member's unrestricted input schema can traverse its shared index and maintenance graph. This follow-up to #7323 makes those inputs explicit reference boundaries.

## What Changed

Give member-pattern inputs Cell-bearing schemas for the selector result, original element, index descriptor, and maintenance state. Resolve each reference before applying its internal value view, so pending and omitted selectors, primitive versus Cell keys, and original element identity remain intact. Document the setup/read boundary in the live index guide.

## Test plan

- All 13 index suites / 59 steps pass, including omitted selectors, mixed and cross-space keys, scoped maintenance, missing buckets, joins, and recovery.
- Combined with the exact poll candidate from #7336, the existing 1,184-vote scenario passes both assertions normally in 108,585 ms and with coverage in 131,590 ms. The existing 180,000 ms action limit and default heap are unchanged. The poll source is only a validation input and is not included in this PR.
- At 296 votes, the same allocation/CPU profiling protocol records 28,207 ms for the control and 18,800 ms for the candidate. Sampled cumulative allocation drops from 20,009 to 15,116 MiB; these totals include collected objects and are not retained-heap measurements. This is a bounded diagnostic comparison, not a general latency guarantee.
- Full runner: 1,458 tests / 9,244 steps. All 46 type groups, 600 documentation examples, repository formatting/lint, and conflict-marker checks pass.
- The combined poll candidate passes all 93 assertions, unchanged 4,857 / 958 / 224 read budgets, and fresh two-browser voting in both client and server execution modes.

The existing large poll scenario guards the motivating regression.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

