### PR TITLE
fix(patterns): the profile picker's default badge compares the row's list entry, not the map parameter

### DIFF
--- a/packages/patterns/system/profile-picker.tsx
+++ b/packages/patterns/system/profile-picker.tsx
@@ -8,6 +8,7 @@ import {
   Writable,
 } from "commonfabric";
 import ProfileCreate, {
+  profileLinkListSchema,
   profileLinkSchema,
   setDefaultProfile,
   setMruProfile,
@@ -56,6 +57,12 @@ type ProfilePickerInput = {
 // `homeSpace` guards the degenerate case: the `profiles` / `defaultProfile` /
 // `mru` container links live in the home space, so an unmaterialized / invalid
 // entry that still resolves into the home space must never match.
+//
+// Both sides must be link CELLS: the default read as a cell ref, and the row's
+// profile re-read from the `profiles` list by index. The map callback's element
+// parameter is not usable for this — inside a `computed` it is the opaque
+// reference, not a cell, so it carries no link and every row compared as "not
+// the default" (the badge never lit; 2026-09-11, the estuary profile preflight).
 //
 // Uses `getAsNormalizedFullLink().space` via the `as any` escape hatch — the
 // pattern-facing surface has no typed space accessor (precedent:
@@ -110,7 +117,7 @@ export default pattern<
         style={{ padding: "8px" }}
       >
         <h3 style={{ margin: 0, fontSize: "14px" }}>Your profiles</h3>
-        {profiles.map((p) => (
+        {profiles.map((p, i) => (
           <cf-hstack gap="2" align="center">
             <div style={{ flex: "1" }}>
               {
@@ -122,14 +129,22 @@ export default pattern<
             </div>
             {ifElse(
               computed(() => {
-                // Read the default link as a cell REF (asCell) so a cross-space
-                // profile not yet loaded here doesn't collapse to `undefined`,
-                // then match by the profile's own SPACE (CT-1843) — `equals`
-                // returns false cross-space (different entity id + scope).
+                // Read the default link and this row's list entry as cell REFS
+                // (asCell) so a cross-space profile not yet loaded here doesn't
+                // collapse to `undefined`, then match by the profile's own
+                // SPACE (CT-1843) — `equals` returns false cross-space
+                // (different entity id + scope). The entry comes from the list
+                // by index, not from `p`: see sameProfileCell.
+                const entries = ((profiles as any).asSchema(
+                  profileLinkListSchema(),
+                ).get() ?? []) as unknown[];
+                const entry = entries[i as any];
                 const def = (defaultProfile as any).asSchema(
                   profileLinkSchema(),
                 ).get();
-                return def ? sameProfileCell(def, p, homeSpace) : false;
+                return def && entry
+                  ? sameProfileCell(def, entry, homeSpace)
+                  : false;
               }),
               <span style={{ color: "#0a7", fontSize: "12px" }}>default</span>,
               <cf-button

--- a/packages/runner/test/profile-picker-default-badge.test.ts
+++ b/packages/runner/test/profile-picker-default-badge.test.ts
@@ -1,0 +1,158 @@
+import { expect } from "@std/expect";
+import { fromFileUrl } from "@std/path";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { Identity } from "@commonfabric/identity";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+
+// Runs the shipped `profile-picker.tsx` and reads the badge it renders per
+// row. Each profile lives in its own space, as `ProfileHome.inSpace()` puts
+// it, and the home's `defaultProfile` links to one of them — the shape the
+// home Profile tab shows. The row for the default must say "default"; every
+// other row offers "Set default".
+//
+// The pin exists because the badge compared the default link against the map
+// callback's element parameter, which inside a `computed` is the opaque
+// reference and carries no link, so no row ever matched: a user who clicked
+// "Set default" kept seeing "Set default", reload or not (2026-09-11).
+
+const signer = await Identity.fromPassphrase("profile-picker default badge");
+const home = signer.did();
+const spaceA = (await Identity.fromPassphrase("profile-picker badge profile a"))
+  .did();
+const spaceB = (await Identity.fromPassphrase("profile-picker badge profile b"))
+  .did();
+
+const sysDir = fromFileUrl(new URL("../../patterns/system/", import.meta.url));
+const read = (name: string) => Deno.readTextFileSync(sysDir + name);
+const PROGRAM: RuntimeProgram = {
+  main: "/profile-picker.tsx",
+  files: [
+    { name: "/profile-picker.tsx", contents: read("profile-picker.tsx") },
+    { name: "/profile-create.tsx", contents: read("profile-create.tsx") },
+    { name: "/profile-home.tsx", contents: read("profile-home.tsx") },
+  ],
+};
+
+/** The string leaves of a rendered VNode tree, in document order. */
+function textLeaves(node: unknown, out: string[] = [], depth = 0): string[] {
+  if (depth > 40 || node === null || node === undefined) return out;
+  if (typeof node === "string") {
+    out.push(node);
+    return out;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) textLeaves(child, out, depth + 1);
+    return out;
+  }
+  if (typeof node === "object" && "children" in node) {
+    textLeaves((node as { children: unknown }).children, out, depth + 1);
+  }
+  return out;
+}
+
+/** The badge text of each profile row: "default" or "Set default". */
+function rowBadges(ui: unknown): string[] {
+  return textLeaves(ui).filter((leaf) =>
+    leaf === "default" || leaf === "Set default"
+  );
+}
+
+describe("profile-picker default badge", () => {
+  let manager: EmulatedStorageManager;
+  let rt: Runtime;
+
+  beforeEach(() => {
+    manager = EmulatedStorageManager.emulate({ as: signer });
+    rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+    });
+  });
+  afterEach(async () => {
+    await rt.dispose({ closeStorage: false });
+    await manager.close();
+  });
+
+  async function renderPicker(
+    cause: string,
+    defaultProfile: "a" | "b" | undefined,
+  ): Promise<string[]> {
+    let tx = rt.edit();
+    rt.getCell(spaceA, "profile", undefined, tx).set({
+      name: "Ada",
+      initialNameApplied: "Ada",
+    });
+    await tx.commit();
+    tx = rt.edit();
+    rt.getCell(spaceB, "profile", undefined, tx).set({
+      name: "Alan",
+      initialNameApplied: "Alan",
+    });
+    await tx.commit();
+
+    tx = rt.edit();
+    const pattern = await rt.patternManager.compilePattern(PROGRAM, {
+      space: home,
+      tx,
+    });
+    const a = rt.getCell(spaceA, "profile", undefined, tx);
+    const b = rt.getCell(spaceB, "profile", undefined, tx);
+    const resultCell = rt.getCell<Record<string, unknown>>(
+      home,
+      cause,
+      undefined,
+      tx,
+    );
+    const result = rt.run(
+      tx,
+      // deno-lint-ignore no-explicit-any
+      pattern as any,
+      {
+        profiles: [a, b],
+        defaultProfile: defaultProfile === "a"
+          ? a
+          : defaultProfile === "b"
+          ? b
+          : undefined,
+        mru: [],
+      },
+      resultCell,
+    );
+    rt.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await result.pull();
+    await rt.idle();
+    await result.pull();
+    try {
+      // deno-lint-ignore no-explicit-any
+      return rowBadges(result.key("$UI" as any).get());
+    } finally {
+      rt.runner.stop(resultCell);
+    }
+  }
+
+  it("lights the badge on the row of the default profile only", async () => {
+    // The default on the SECOND row: an identity mix-up between rows, or a
+    // comparison that matches every row, both fail here.
+    expect(await renderPicker("picker badge default b", "b")).toEqual([
+      "Set default",
+      "default",
+    ]);
+  });
+
+  it("lights the first row when it is the default", async () => {
+    expect(await renderPicker("picker badge default a", "a")).toEqual([
+      "default",
+      "Set default",
+    ]);
+  });
+
+  it("offers Set default on every row when no default is set", async () => {
+    expect(await renderPicker("picker badge no default", undefined)).toEqual([
+      "Set default",
+      "Set default",
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Finding 1 of the Stage 0 estuary profile preflight (2026-09-11): the home Profile tab kept showing **Set default** for the profile the user had just made the default, reload or not, with clean browser logs and the stored default resolving correctly.

## Root cause (reproduced with the shipped pattern)

The home Profile tab *is* `profile-picker.tsx` (`home.tsx` instantiates it with the home's `profiles` / `defaultProfile` / `mru`). Its badge is `ifElse(computed(() => sameProfileCell(def, p, homeSpace)), "default", "Set default")`, comparing the default link and the row's profile by the profile's own space (CT-1843).

The right-hand side is the map callback's element parameter `p`. Inside a `computed`, `p` is the opaque reference, not a cell — it is function-typed, has no `getAsNormalizedFullLink`, no `get`, no keys — so `linkSpace(p)` is `undefined` and the comparison is `false` for every row. The left-hand side is fine: reading `defaultProfile` as a cell ref resolves into the profile's space.

Measured by compiling and running the real picker in a runner probe (two profiles in their own spaces, default on one): with the shipped code both rows render "Set default"; a constant `true` or a `computed(() => true)` condition renders "default", so `ifElse` and map-scoped computeds work; `typeof p === "function"` inside the computed; the list read as link cells resolves into the profile space and the map callback's index parameter is a plain number there.

Nothing pinned the badge — `home-profile.test.ts` clicks the trusted Set-default action but never asserts the badge afterwards.

## The fix

`profiles.map((p, i) => …)`: the row's profile is re-read from the `profiles` list by index as a link cell (`profileLinkListSchema`), the same kind of read the default link gets, and the two are compared by space as before. The home-space guard is unchanged.

## Tests

`packages/runner/test/profile-picker-default-badge.test.ts` runs the shipped picker with Ada and Alan in their own spaces: default on the second row → `["Set default", "default"]`; default on the first → `["default", "Set default"]`; no default → both "Set default". Against the unmodified picker the two default cases fail and the no-default case passes.

Gates: `deno task check`, lint, fmt; toolshed `patterns-identity-parity` (endpoint == worker compile of the picker); patterns system unit tests; `cf test` on `home`, `profile-create`, `profile-home` (25/25); runner wish + profile pattern tests.

## Notes

- Estuary serves system patterns from its own tree, so the tab lights only after deploy.
- Companion to #7354 (the cold `cf wish` lookup, finding 2 of the same report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

