### PR TITLE
fix(runner): UI-contract discovery follows a direct `cid:` reference

### DIFF
--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -159,52 +159,43 @@ const trustRequirementsFromContract = (
   };
 };
 
-/**
- * The refs a branch of the walk has followed, keyed by the document each was
- * read in. A local `#/…` pointer names a definition of the document it sits
- * in, so the same pointer read in another document is another ref; an
- * embedded or external ref names its document wherever it sits, so those
- * share one key. A ref met twice under one key is a cycle.
- */
-type FollowedRefs = Map<object, Set<string>>;
-
-const DOCUMENT_REFS: object = {};
-
-const followedRefsKey = (ref: string, root: JSONSchema | undefined): object =>
-  ref.startsWith("#") && isObjectOrArray(root) ? root : DOCUMENT_REFS;
-
-const copyFollowedRefs = (followed: FollowedRefs): FollowedRefs => {
-  const copy: FollowedRefs = new Map();
-  for (const [key, refs] of followed) copy.set(key, new Set(refs));
-  return copy;
-};
-
 // Follow a `$ref` of any form the runtime resolves — a local pointer, an
 // embedded schema, or an external `cid:` document — one chain at a time. The
-// schema comes back as it is where it carries no ref, where the ref closes a
-// cycle, or where it resolves to nothing.
+// resolver guards the chain; `seenRefs`, the refs this branch of the walk has
+// followed, guards the descent, where a recursive document reaches its own
+// ref again below the body it resolved to. The schema comes back as it is
+// where it carries no ref, where the ref closes a cycle, or where it resolves
+// to nothing.
 const followSchemaRef = (
   schema: JSONSchema | undefined,
   root: JSONSchema | undefined,
-  followed: FollowedRefs,
+  seenRefs: Set<string>,
 ): JSONSchema | undefined => {
   if (!isObjectOrArray(schema) || typeof schema.$ref !== "string") {
     return schema;
   }
   const ref = schema.$ref;
-  const key = followedRefsKey(ref, root);
-  let refs = followed.get(key);
-  if (refs?.has(ref)) return schema;
-  if (refs === undefined) {
-    refs = new Set();
-    followed.set(key, refs);
-  }
-  refs.add(ref);
+  if (seenRefs.has(ref)) return schema;
+  seenRefs.add(ref);
   return ContextualFlowControl.resolveSchemaRefs(
     schema,
     isObjectOrArray(root) ? root : schema,
   ) ?? schema;
 };
+
+// The seen refs to carry below a resolution. A resolution that enters another
+// document — its root is not the one the ref was read in — leaves the local
+// pointers followed so far behind: each named a definition of the document
+// being left, and the same pointer in the new document is another ref. An
+// embedded or external ref names its document wherever it sits, and stays.
+const seenRefsBelow = (
+  seenRefs: Set<string>,
+  root: JSONSchema | undefined,
+  resolvedRoot: JSONSchema,
+): Set<string> =>
+  resolvedRoot === root
+    ? seenRefs
+    : new Set([...seenRefs].filter((ref) => !ref.startsWith("#")));
 
 // The root a resolved ref's target resolves against: its own document where
 // the ref's chain ended in another one — a definition body that is an
@@ -222,14 +213,19 @@ const resolvedRootFor = (
 const uiContractFromSchemaInternal = (
   schema: JSONSchema | undefined,
   root: JSONSchema | undefined,
-  followed: FollowedRefs,
+  seenRefs: Set<string>,
 ): UiContract | undefined => {
-  const resolvedSchema = followSchemaRef(schema, root, followed);
+  const resolvedSchema = followSchemaRef(schema, root, seenRefs);
   if (resolvedSchema !== schema && schema !== undefined) {
+    const resolvedRoot = resolvedRootFor(
+      schema,
+      resolvedSchema ?? schema,
+      root,
+    );
     return uiContractFromSchemaInternal(
       resolvedSchema,
-      resolvedRootFor(schema, resolvedSchema ?? schema, root),
-      followed,
+      resolvedRoot,
+      seenRefsBelow(seenRefs, root, resolvedRoot),
     );
   }
   if (
@@ -266,22 +262,27 @@ const uiContractFromSchemaInternal = (
 export const uiContractFromSchema = (
   schema: JSONSchema | undefined,
 ): UiContract | undefined =>
-  uiContractFromSchemaInternal(schema, schema, new Map());
+  uiContractFromSchemaInternal(schema, schema, new Set());
 
 const uiContractsFromSchemaInternal = (
   schema: JSONSchema | undefined,
   root: JSONSchema | undefined,
   path: string[],
-  followed: FollowedRefs,
+  seenRefs: Set<string>,
 ): UiContractEntry[] => {
-  const branchRefs = copyFollowedRefs(followed);
+  const branchRefs = new Set(seenRefs);
   const resolvedSchema = followSchemaRef(schema, root, branchRefs);
   if (resolvedSchema !== schema && schema !== undefined) {
+    const resolvedRoot = resolvedRootFor(
+      schema,
+      resolvedSchema ?? schema,
+      root,
+    );
     return uiContractsFromSchemaInternal(
       resolvedSchema,
-      resolvedRootFor(schema, resolvedSchema ?? schema, root),
+      resolvedRoot,
       path,
-      branchRefs,
+      seenRefsBelow(branchRefs, root, resolvedRoot),
     );
   }
   if (!isObjectOrArray(resolvedSchema)) {
@@ -293,7 +294,7 @@ const uiContractsFromSchemaInternal = (
   const contract = uiContractFromSchemaInternal(
     resolvedSchema,
     childRoot,
-    new Map(),
+    new Set(),
   );
   if (contract !== undefined) {
     entries.push(
@@ -327,7 +328,7 @@ const uiContractsFromSchemaInternal = (
           definition as JSONSchema,
           definition as JSONSchema,
           [],
-          new Map(),
+          new Set(),
         )
       )
       .map((entry) => entry.contract);
@@ -343,7 +344,7 @@ const uiContractsFromSchemaInternal = (
           child as JSONSchema,
           childRoot,
           [...path, key],
-          followed,
+          seenRefs,
         ),
       );
     }
@@ -360,7 +361,7 @@ const uiContractsFromSchemaInternal = (
         child as JSONSchema,
         childRoot,
         path,
-        followed,
+        seenRefs,
       ),
     );
   }
@@ -380,7 +381,7 @@ const uiContractsFromSchemaInternal = (
         resolvedSchema.items as JSONSchema,
         childRoot,
         [...path, "*"],
-        followed,
+        seenRefs,
       ),
     );
   }
@@ -392,7 +393,7 @@ const uiContractsFromSchemaInternal = (
           resolvedSchema.prefixItems[index] as JSONSchema,
           childRoot,
           [...path, String(index)],
-          followed,
+          seenRefs,
         ),
       );
     }
@@ -404,7 +405,7 @@ const uiContractsFromSchemaInternal = (
 export const uiContractsFromSchema = (
   schema: JSONSchema | undefined,
 ): UiContractEntry[] =>
-  uiContractsFromSchemaInternal(schema, schema, [], new Map());
+  uiContractsFromSchemaInternal(schema, schema, [], new Set());
 
 export const trustedEventProvenanceMatchesUiContract = (
   provenance: unknown,

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -159,25 +159,51 @@ const trustRequirementsFromContract = (
   };
 };
 
-const resolveLocalSchemaRef = (
+/**
+ * The refs a branch of the walk has followed, keyed by the document each was
+ * read in. A local `#/…` pointer names a definition of the document it sits
+ * in, so the same pointer read in another document is another ref; an
+ * embedded or external ref names its document wherever it sits, so those
+ * share one key. A ref met twice under one key is a cycle.
+ */
+type FollowedRefs = Map<object, Set<string>>;
+
+const DOCUMENT_REFS: object = {};
+
+const followedRefsKey = (ref: string, root: JSONSchema | undefined): object =>
+  ref.startsWith("#") && isObjectOrArray(root) ? root : DOCUMENT_REFS;
+
+const copyFollowedRefs = (followed: FollowedRefs): FollowedRefs => {
+  const copy: FollowedRefs = new Map();
+  for (const [key, refs] of followed) copy.set(key, new Set(refs));
+  return copy;
+};
+
+// Follow a `$ref` of any form the runtime resolves — a local pointer, an
+// embedded schema, or an external `cid:` document — one chain at a time. The
+// schema comes back as it is where it carries no ref, where the ref closes a
+// cycle, or where it resolves to nothing.
+const followSchemaRef = (
   schema: JSONSchema | undefined,
   root: JSONSchema | undefined,
-  seenRefs: Set<string>,
+  followed: FollowedRefs,
 ): JSONSchema | undefined => {
   if (!isObjectOrArray(schema) || typeof schema.$ref !== "string") {
     return schema;
   }
   const ref = schema.$ref;
-  if (!ref.startsWith("#/") || seenRefs.has(ref)) {
-    return schema;
+  const key = followedRefsKey(ref, root);
+  let refs = followed.get(key);
+  if (refs?.has(ref)) return schema;
+  if (refs === undefined) {
+    refs = new Set();
+    followed.set(key, refs);
   }
-  seenRefs.add(ref);
-
-  if (!isObjectOrArray(root)) {
-    return schema;
-  }
-
-  return ContextualFlowControl.resolveSchemaRefs(schema, root) ?? schema;
+  refs.add(ref);
+  return ContextualFlowControl.resolveSchemaRefs(
+    schema,
+    isObjectOrArray(root) ? root : schema,
+  ) ?? schema;
 };
 
 // The root a resolved ref's target resolves against: its own document where
@@ -196,14 +222,14 @@ const resolvedRootFor = (
 const uiContractFromSchemaInternal = (
   schema: JSONSchema | undefined,
   root: JSONSchema | undefined,
-  seenRefs: Set<string>,
+  followed: FollowedRefs,
 ): UiContract | undefined => {
-  const resolvedSchema = resolveLocalSchemaRef(schema, root, seenRefs);
+  const resolvedSchema = followSchemaRef(schema, root, followed);
   if (resolvedSchema !== schema && schema !== undefined) {
     return uiContractFromSchemaInternal(
       resolvedSchema,
       resolvedRootFor(schema, resolvedSchema ?? schema, root),
-      seenRefs,
+      followed,
     );
   }
   if (
@@ -240,16 +266,16 @@ const uiContractFromSchemaInternal = (
 export const uiContractFromSchema = (
   schema: JSONSchema | undefined,
 ): UiContract | undefined =>
-  uiContractFromSchemaInternal(schema, schema, new Set());
+  uiContractFromSchemaInternal(schema, schema, new Map());
 
 const uiContractsFromSchemaInternal = (
   schema: JSONSchema | undefined,
   root: JSONSchema | undefined,
   path: string[],
-  seenRefs: Set<string>,
+  followed: FollowedRefs,
 ): UiContractEntry[] => {
-  const branchRefs = new Set(seenRefs);
-  const resolvedSchema = resolveLocalSchemaRef(schema, root, branchRefs);
+  const branchRefs = copyFollowedRefs(followed);
+  const resolvedSchema = followSchemaRef(schema, root, branchRefs);
   if (resolvedSchema !== schema && schema !== undefined) {
     return uiContractsFromSchemaInternal(
       resolvedSchema,
@@ -267,7 +293,7 @@ const uiContractsFromSchemaInternal = (
   const contract = uiContractFromSchemaInternal(
     resolvedSchema,
     childRoot,
-    new Set(),
+    new Map(),
   );
   if (contract !== undefined) {
     entries.push(
@@ -301,7 +327,7 @@ const uiContractsFromSchemaInternal = (
           definition as JSONSchema,
           definition as JSONSchema,
           [],
-          new Set(),
+          new Map(),
         )
       )
       .map((entry) => entry.contract);
@@ -317,7 +343,7 @@ const uiContractsFromSchemaInternal = (
           child as JSONSchema,
           childRoot,
           [...path, key],
-          seenRefs,
+          followed,
         ),
       );
     }
@@ -334,7 +360,7 @@ const uiContractsFromSchemaInternal = (
         child as JSONSchema,
         childRoot,
         path,
-        seenRefs,
+        followed,
       ),
     );
   }
@@ -354,7 +380,7 @@ const uiContractsFromSchemaInternal = (
         resolvedSchema.items as JSONSchema,
         childRoot,
         [...path, "*"],
-        seenRefs,
+        followed,
       ),
     );
   }
@@ -366,7 +392,7 @@ const uiContractsFromSchemaInternal = (
           resolvedSchema.prefixItems[index] as JSONSchema,
           childRoot,
           [...path, String(index)],
-          seenRefs,
+          followed,
         ),
       );
     }
@@ -378,7 +404,7 @@ const uiContractsFromSchemaInternal = (
 export const uiContractsFromSchema = (
   schema: JSONSchema | undefined,
 ): UiContractEntry[] =>
-  uiContractsFromSchemaInternal(schema, schema, [], new Set());
+  uiContractsFromSchemaInternal(schema, schema, [], new Map());
 
 export const trustedEventProvenanceMatchesUiContract = (
   provenance: unknown,

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -13,7 +13,11 @@ import {
   ContextualFlowControl,
   resolveExternalRootRefForStructure,
 } from "./cfc.ts";
-import { cfcSchemaResolvedRoot } from "./cfc/schema-refs.ts";
+import {
+  cfcSchemaResolvedRoot,
+  resolveCfcSchemaRefRoot,
+} from "./cfc/schema-refs.ts";
+import { isEmbeddedCfcSchemaRef } from "./embedded-schemas.ts";
 import type { RuntimeProgram } from "./harness/types.ts";
 import { resolveLink } from "./link-resolution.ts";
 import { isSigilLink, linkPathSegmentToCellPathSegment } from "./link-types.ts";
@@ -164,10 +168,15 @@ export function schemaWithScopedLinkRequiredsRelaxed(
     structuralRoot = structural;
   } else {
     // A local reference resolves against the document root, the rule every
-    // CFC schema walker applies; a `$defs` below that root is inert.
+    // CFC schema walker applies; a `$defs` below that root is inert. An
+    // embedded reference (the renderer's vnode schema among them) is a
+    // document of its own, and the root moves into it.
     structuralRoot = root ?? structural;
     const ref = (structural as { $ref?: unknown }).$ref;
-    if (typeof ref === "string" && ref.startsWith("#")) {
+    if (
+      typeof ref === "string" &&
+      (ref.startsWith("#") || isEmbeddedCfcSchemaRef(ref))
+    ) {
       const resolved = ContextualFlowControl.resolveSchemaRefs(
         structural as Parameters<
           typeof ContextualFlowControl.resolveSchemaRefs
@@ -175,8 +184,11 @@ export function schemaWithScopedLinkRequiredsRelaxed(
         structuralRoot,
       );
       if (!isObjectOrArray(resolved)) return schema;
+      structuralRoot = cfcSchemaResolvedRoot(
+        resolved,
+        resolveCfcSchemaRefRoot(structural, structuralRoot),
+      );
       structural = resolved;
-      structuralRoot = cfcSchemaResolvedRoot(structural, structuralRoot);
     }
   }
 

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -381,6 +381,97 @@ describe("CFC UI contract matching", () => {
       release();
     }
   });
+
+  it("resolves a contract from a direct `cid:` reference", () => {
+    const release = acquireSchemaRegistryLease();
+    try {
+      const document = trustedPatternUiActionSchema as unknown as JSONSchema;
+      const hash = internSchemaAsTaggedHashString(document);
+      registerSchemaDocument(hash, document);
+      const reference = { $ref: `cid:${hash}` } as unknown as JSONSchema;
+      const contract = {
+        helper: "UiAction",
+        action: "SubmitDirectCommand",
+        trustedPattern: "TrustedDirectCommandSurface",
+        requiredEventIntegrity: ["TrustedDirectCommandSurface"],
+      };
+
+      expect(uiContractFromSchema(reference)).toEqual(contract);
+      expect(uiContractsFromSchema(reference)).toEqual([{
+        path: [],
+        contract,
+      }]);
+    } finally {
+      release();
+    }
+  });
+
+  it("resolves a direct `cid:` document's descendants against that document's $defs", () => {
+    const release = acquireSchemaRegistryLease();
+    try {
+      const document = {
+        type: "object",
+        properties: { action: { $ref: "#/$defs/Action" } },
+        $defs: { Action: trustedPatternUiActionSchema },
+      } as unknown as JSONSchema;
+      const hash = internSchemaAsTaggedHashString(document);
+      registerSchemaDocument(hash, document);
+
+      const contracts = uiContractsFromSchema(
+        { $ref: `cid:${hash}` } as unknown as JSONSchema,
+      );
+
+      expect(contracts).toEqual([{
+        path: ["action"],
+        contract: {
+          helper: "UiAction",
+          action: "SubmitDirectCommand",
+          trustedPattern: "TrustedDirectCommandSurface",
+          requiredEventIntegrity: ["TrustedDirectCommandSurface"],
+        },
+      }]);
+    } finally {
+      release();
+    }
+  });
+
+  it("follows a local pointer inside an external document that the referring document also used", () => {
+    // Both documents name a `Panel` definition. The outer one was followed on
+    // the way in; the external document's `#/$defs/Panel` is another ref,
+    // read in another document, not a cycle.
+    const release = acquireSchemaRegistryLease();
+    try {
+      const document = {
+        type: "object",
+        properties: { action: { $ref: "#/$defs/Panel" } },
+        $defs: { Panel: trustedPatternUiActionSchema },
+      } as unknown as JSONSchema;
+      const hash = internSchemaAsTaggedHashString(document);
+      registerSchemaDocument(hash, document);
+
+      const contracts = uiContractsFromSchema({
+        $ref: "#/$defs/Panel",
+        $defs: {
+          Panel: {
+            type: "object",
+            properties: { inner: { $ref: `cid:${hash}` } },
+          },
+        },
+      } as unknown as JSONSchema);
+
+      expect(contracts).toEqual([{
+        path: ["inner", "action"],
+        contract: {
+          helper: "UiAction",
+          action: "SubmitDirectCommand",
+          trustedPattern: "TrustedDirectCommandSurface",
+          requiredEventIntegrity: ["TrustedDirectCommandSurface"],
+        },
+      }]);
+    } finally {
+      release();
+    }
+  });
 });
 
 describe("CFC trusted UI event enforcement", () => {

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -472,6 +472,53 @@ describe("CFC UI contract matching", () => {
       release();
     }
   });
+
+  it("resolves one definition name in two external documents to each document's own", () => {
+    // `Panel` is a submit action in one document and a disclosure in the
+    // other. Read as siblings, and read with the second nested inside the
+    // first, each document's `#/$defs/Panel` names its own definition.
+    const release = acquireSchemaRegistryLease();
+    try {
+      const submit = {
+        helper: "UiAction",
+        action: "SubmitDirectCommand",
+        trustedPattern: "TrustedDirectCommandSurface",
+        requiredEventIntegrity: ["TrustedDirectCommandSurface"],
+      };
+      const disclosure = { helper: "UiDisclosure", kind: "Secret" };
+      const disclosing = {
+        type: "object",
+        properties: { action: { $ref: "#/$defs/Panel" } },
+        $defs: { Panel: { type: "string", ifc: { uiContract: disclosure } } },
+      } as unknown as JSONSchema;
+      const disclosingHash = internSchemaAsTaggedHashString(disclosing);
+      registerSchemaDocument(disclosingHash, disclosing);
+      const submitting = {
+        type: "object",
+        properties: {
+          action: { $ref: "#/$defs/Panel" },
+          next: { $ref: `cid:${disclosingHash}` },
+        },
+        $defs: { Panel: trustedPatternUiActionSchema },
+      } as unknown as JSONSchema;
+      const submittingHash = internSchemaAsTaggedHashString(submitting);
+      registerSchemaDocument(submittingHash, submitting);
+
+      expect(uiContractsFromSchema({
+        type: "object",
+        properties: {
+          a: { $ref: `cid:${submittingHash}` },
+          b: { $ref: `cid:${disclosingHash}` },
+        },
+      } as unknown as JSONSchema)).toEqual([
+        { path: ["a", "action"], contract: submit },
+        { path: ["a", "next", "action"], contract: disclosure },
+        { path: ["b", "action"], contract: disclosure },
+      ]);
+    } finally {
+      release();
+    }
+  });
 });
 
 describe("CFC trusted UI event enforcement", () => {

--- a/packages/runner/test/scoped-link-whole-object-read.test.ts
+++ b/packages/runner/test/scoped-link-whole-object-read.test.ts
@@ -413,6 +413,51 @@ describe("whole-object read over a session-scoped link", () => {
     }
   });
 
+  it("relaxes a required behind an embedded schema reference", async () => {
+    // The renderer's vnode schema is an embedded document, and a schema that
+    // is a bare reference to it carries no structure of its own. The
+    // relaxation resolves through the reference into that document, where
+    // `name` is required, and drops it when the stored `name` is a
+    // session-scoped link.
+    const vnodeReference = {
+      $ref: "https://commonfabric.org/schemas/vnode.json",
+    } as unknown as JSONSchema;
+
+    const tx = writerRt.edit();
+    const name = writerRt.getCell<string>(
+      space,
+      "vnode-session-name",
+      { type: "string" } as const,
+      tx,
+      "session",
+    );
+    name.set("writer-session-only");
+    const container = writerRt.getCell(
+      space,
+      "vnode-container",
+      vnodeReference,
+      tx,
+    );
+    container.set({ type: "vnode", name, props: {} } as never);
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+    await writerStorage.synced();
+
+    const { rt, close } = freshReader();
+    try {
+      const cell = rt.getCell(space, "vnode-container", vnodeReference);
+      await cell.pull();
+      const relaxed = schemaWithScopedLinkRequiredsRelaxed(
+        vnodeReference,
+        cell.getRaw(),
+        cell as unknown as Cell<unknown>,
+      ) as { required?: string[] };
+      expect(relaxed.required).toEqual(["type", "props"]);
+    } finally {
+      await close();
+    }
+  });
+
   it("multi-hop: scope declared one redirect hop deep is detected (the real piece-result shape)", async () => {
     // Live pieces don't put the scope on the first link: result.prop links
     // (scope "space") to an intermediate doc whose VALUE is the


### PR DESCRIPTION
## Summary

Fixes CT-2301. `uiContractsFromSchema()` resolved only a `#/` pointer at a ref site and returned a site whose ref was `cid:` untouched, so a schema that was an external reference at its top level, or at a property, contributed no contract, and trusted-event verification could omit a requirement the referenced document declared. A `cid:` reached through a local definition already worked, because the chain resolver follows the external hop; only a ref that was `cid:` at the site itself was skipped.

## Change

`packages/runner/src/cfc/ui-contract.ts`:

- `resolveLocalSchemaRef` becomes `followSchemaRef` and follows any ref the runtime resolves: a local pointer, an embedded schema, or an external `cid:` document. The root moves with the resolution through `resolvedRootFor`, as before, so descendants of the external document resolve their `#/$defs/<name>` refs against that document.
- Cycle tracking stays a flat per-branch set of ref strings, guarding the descent while the resolver guards each chain. A resolution whose root is not the one the ref was read in has entered another document, and the local pointers followed so far are left behind there, since each named a definition of the document being left; embedded and external refs stay. A `cid:` document cannot contain its own hash and the embedded schemas reference only themselves, so a walk enters a document once and this is the whole of what document-awareness needs.

No live document describes contract discovery, so no docs change.

`packages/runner/src/piece-helpers.ts`, the same shape of gap one step over: `schemaWithScopedLinkRequiredsRelaxed` resolved a `cid:` reference at the root and a `#` pointer below it, and left an embedded reference such as the renderer's vnode schema unresolved, so a value whose schema is a bare reference to that document kept every `required` the document declares even where the stored member is a narrower-scoped link. The relaxation's fallback now follows an embedded reference as it does an external one, with the root moving into the embedded document. The shared `resolveExternalRootRefForStructure` helper is left as it is, since its other callers include link rewriting.

## Tests

`packages/runner/test/cfc-ui-contract.test.ts`, matching the ticket's acceptance criteria:

- a direct `cid:` reference yields the document's root contract, from both `uiContractFromSchema` and `uiContractsFromSchema`;
- a direct `cid:` document's descendants resolve `#/$defs/Action` against that document;
- the same pointer name used in the referring document and inside the external document is followed in both;
- one definition name defined differently in two external documents resolves to each document's own, read as siblings and nested.

The first three fail on main's module and pass on the fix.

`packages/runner/test/scoped-link-whole-object-read.test.ts`: a container whose schema is a bare reference to the vnode schema stores a `name` that is a session-scoped link; from a fresh reader the relaxed `required` is `["type", "props"]`. Fails on main's module, passes on the fix.

## Verification

The ui-contract file passes at 38 steps, the relaxation file at 20 and the other piece-helpers and structural-ref files at 74, the other CFC test files (commit preparation, cid schema verify, structural ref resolution, agent tool input integrity, cfc) at 126 steps, `deno task check` completes, and `deno fmt --check` and `deno lint` are clean on the touched files. #7350 touches the storage read-through and a doc comment in `schema-decompose.ts` and does not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fdDsLuSJEz98iJCAvqv71
