### PR TITLE
Visit shared downstream paths once per scheduler wake check

### DIFF
--- a/packages/runner/src/scheduler/dependency-graph.ts
+++ b/packages/runner/src/scheduler/dependency-graph.ts
@@ -346,13 +346,22 @@ export function groupReadsByEntity(
   return readsByEntity;
 }
 
+/** Returns whether `to` is reachable from `from`, including itself. */
 export function hasDependentPath(
   dependentsByAction: WeakMap<Action, Set<Action>>,
   from: Action,
   to: Action,
 ): boolean {
-  const visited = new Set<Action>([from]);
-  const pending = [from];
+  return reachesDependent(dependentsByAction, [from], to);
+}
+
+/** Traverses the union of the seed nodes' downstream edges once per query. */
+function reachesDependent(
+  dependentsByAction: WeakMap<Action, Set<Action>>,
+  pending: Action[],
+  to: Action,
+): boolean {
+  const visited = new Set(pending);
 
   while (pending.length > 0) {
     const current = pending.pop()!;
@@ -374,8 +383,8 @@ export function hasDependentPath(
  * True when an invalid/never-ran node is transitively upstream of `action`.
  *
  * Seed from the maintained invalid-node set rather than walking `action`'s
- * whole upstream cone. {@link hasDependentPath} supplies the cycle-safe
- * downstream reachability check over the canonical writer-to-reader edges.
+ * whole upstream cone. Shared downstream paths are visited once per query,
+ * including when several invalid nodes feed the same reader.
  * `action` itself is excluded: a resubscribe records a run that just completed,
  * so callers use this to decide whether newly-live upstream work needs a wake.
  */
@@ -383,15 +392,11 @@ export function hasInvalidUpstream(
   state: Pick<DependencyGraphState, "dependents" | "nodes">,
   action: Action,
 ): boolean {
+  const pending: Action[] = [];
   for (const candidate of state.nodes.getInvalidNodes()) {
-    if (
-      candidate !== action &&
-      hasDependentPath(state.dependents, candidate, action)
-    ) {
-      return true;
-    }
+    if (candidate !== action) pending.push(candidate);
   }
-  return false;
+  return reachesDependent(state.dependents, pending, action);
 }
 
 export function collectDirectWritersForLog(state: {

--- a/packages/runner/test/scheduler/has-invalid-upstream.test.ts
+++ b/packages/runner/test/scheduler/has-invalid-upstream.test.ts
@@ -1,0 +1,74 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { hasInvalidUpstream } from "../../src/scheduler/dependency-graph.ts";
+import { NodeRegistry } from "../../src/scheduler/node-record.ts";
+import type { Action } from "../../src/scheduler/types.ts";
+
+/** Counts graph lookups so the shared-cone bound is independent of timing. */
+class CountingEdges extends WeakMap<Action, Set<Action>> {
+  #reads = 0;
+
+  /** Number of downstream adjacency lists requested. */
+  get reads(): number {
+    return this.#reads;
+  }
+
+  /** Returns a node's downstream edges and records the lookup. */
+  override get(action: Action): Set<Action> | undefined {
+    this.#reads++;
+    return super.get(action);
+  }
+}
+
+describe("hasInvalidUpstream()", () => {
+  it("returns true for an invalid or never-run transitive writer", () => {
+    const nodes = new NodeRegistry();
+    const writer: Action = () => {};
+    const middle: Action = () => {};
+    const reader: Action = () => {};
+    const dependents = new WeakMap<Action, Set<Action>>([
+      [writer, new Set([middle])],
+      [middle, new Set([reader])],
+    ]);
+    nodes.register(writer, "computation");
+    expect(hasInvalidUpstream({ nodes, dependents }, reader)).toBe(true);
+    nodes.setStatus(writer, "clean");
+    expect(hasInvalidUpstream({ nodes, dependents }, reader)).toBe(false);
+    nodes.setStatus(writer, "invalid");
+    expect(hasInvalidUpstream({ nodes, dependents }, reader)).toBe(true);
+  });
+
+  it("excludes the reader itself even when it belongs to a cycle", () => {
+    const nodes = new NodeRegistry();
+    const reader: Action = () => {};
+    const other: Action = () => {};
+    const dependents = new WeakMap<Action, Set<Action>>([
+      [reader, new Set([other])],
+      [other, new Set([reader])],
+    ]);
+    nodes.register(reader, "computation");
+    expect(hasInvalidUpstream({ nodes, dependents }, reader)).toBe(false);
+    nodes.register(other, "computation");
+    expect(hasInvalidUpstream({ nodes, dependents }, reader)).toBe(true);
+  });
+
+  it("visits a shared downstream cone at most once across invalid writers", () => {
+    const nodes = new NodeRegistry();
+    const dependents = new CountingEdges();
+    const writers: Action[] = Array.from({ length: 64 }, () => () => {});
+    const chain: Action[] = Array.from({ length: 64 }, () => () => {});
+    const unreachable: Action = () => {};
+    for (const writer of writers) {
+      nodes.register(writer, "computation");
+      dependents.set(writer, new Set([chain[0]]));
+    }
+    for (let i = 0; i < chain.length; i++) {
+      dependents.set(chain[i], new Set([chain[(i + 1) % chain.length]]));
+    }
+    expect(hasInvalidUpstream({ nodes, dependents }, unreachable)).toBe(false);
+    expect(dependents.reads).toBeLessThanOrEqual(writers.length + chain.length);
+    dependents.get(chain.at(-1)!)!.add(unreachable);
+    expect(hasInvalidUpstream({ nodes, dependents }, unreachable)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Large maintained indexes make many scheduler nodes live together. The resubscription wake check searches downstream from every invalid node independently, revisiting shared paths and allocating a visited set for each seed. This contributes to the remaining 1,184-vote CI timeout in #7336 after #7372; that poll remains unmerged.

## What Changed

Search the union of invalid nodes' downstream paths once per wake check. The query still excludes the action itself as a seed, follows canonical dependency edges through clean nodes, and handles cycles. The single-source reachability API uses the same traversal.

## Test plan

A deterministic shared-cone test fails against the unchanged code with 4,160 graph lookups versus a bound of 128, and passes with the change. Other cases cover invalid/never-run/clean status transitions and self-exclusion in cycles.

On the exact failed CI merge's poll workload, both functional assertions pass. Matched CPU-profile runs measured 90,368 ms before and 83,856 ms after; graph traversal self time fell from 4,248 ms to 1,960 ms. Scheduler action executions are unchanged at 9,269. An instrumented coverage run also passes both assertions in 123,709 ms; a separate coverage run under heavier concurrent validation timed out, so this is not a CI acceptance claim. The full runner package passes 1,463 tests / 9,303 steps. All 46 type-check groups, repository formatting, lint, and antagonistic review pass. Current-head CI and actual clean Cubic review are required before merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

