### PR TITLE
test(runner): the served compile suite holds at the strict CFC rung

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -686,6 +686,21 @@ The strict-only delta is:
     the parent link a write traverses — which is tracked separately.
     `cfc-runtime-owned-store-wiring.test.ts` pins both spellings, so the
     refused half flips visibly the day that lands.
+
+    The claim reaches a child only from a parent that carries one, and the
+    case where none does is worth stating because the refusal it produces
+    names a document no author wrote down. A child anchored out of an
+    ordinary authored store is measured against its own ceiling: the
+    residency clause, plus what the schema describing the parent's value at
+    the anchored position declares, which the child carries. Only a
+    declaration at that position covers it. The anchoring write lands at the
+    child's root, so an `ifc` on a field of the element leaves the write
+    uncovered, and the misfit reads `at /` rather than naming the field the
+    clause was written for. Where the parent declares nothing there, a write
+    carrying a label into the child is refused at the child's id, and that id
+    is a hash of the parent and the path, so nothing recovers the parent from
+    it: what the message establishes is that some document holds a piece of
+    another document's value. The same test file pins the four outcomes.
   - **How far it reaches inside that document.** Every path the
     transaction writes there, not only the paths setup wrote: the marker
     names the store, and the declaration is a statement about the store.

--- a/packages/runner/test/builtins/compile-and-run-served.test.ts
+++ b/packages/runner/test/builtins/compile-and-run-served.test.ts
@@ -7,8 +7,10 @@ import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value"
 import type { BuiltInCompileAndRunParams } from "commonfabric";
 
 import { compileAndRun } from "../../src/builtins/compile-and-run.ts";
+import { enrollRuntimeOwnedStore } from "../../src/builtins/runtime-owned-store.ts";
 import type { Cell } from "../../src/cell.ts";
 import { readStoredCfcMetadata } from "../../src/cfc/metadata.ts";
+import type { CfcEnforcementMode } from "../../src/cfc/types.ts";
 import { RUNNER_ACCEPTANCE_EFFECT_KIND } from "../../src/executor/runner-acceptance.ts";
 import {
   stampWaveRunContext,
@@ -44,6 +46,7 @@ type Outputs = {
 async function fixture(
   servingPosture: boolean,
   cfcFlowLabels: "off" | "persist" = "off",
+  cfcEnforcementMode: CfcEnforcementMode = "enforce-explicit",
 ) {
   const identity = await Identity.fromPassphrase("served compile unit");
   const storage = StorageManager.emulate({ as: identity });
@@ -53,6 +56,7 @@ async function fixture(
     experimental: { serverExecution: true },
     servingPosture,
     cfcFlowLabels,
+    cfcEnforcementMode,
   });
   const space = identity.did();
   const inputs = runtime.getCell<BuiltInCompileAndRunParams<any>>(
@@ -60,6 +64,28 @@ async function fixture(
     "inputs",
   );
   const parent = runtime.getCell(space, "parent");
+  // A program's bytes live in a cell of the piece that names them — its
+  // argument document, or one of the internal documents its result projects —
+  // and the runner enrolls each of those as a store the runtime owns. This
+  // cell stands in for that document, so it carries the same claim.
+  //
+  // The claim decides a verdict once the source carries a label. `run()` puts
+  // the program in through `Cell.set`, which gives a plain object sitting in
+  // an array a document of its own, so `files[0]` is split out into a child
+  // whose id derives from this one's; §8.12.5 route 2 reaches that child
+  // through this document's claim, and without it the child is a store no
+  // piece owns and no schema declares. That write shape has no production
+  // counterpart: a builtin's inputs arrive in an immutable `data:` document
+  // that nothing writes to, and a node's output reaches its binding without
+  // anchoring anything.
+  //
+  // The enrollment is deliberately not transactional, so this transaction
+  // carries it and nothing else.
+  {
+    const enrollment = runtime.edit();
+    enrollRuntimeOwnedStore(enrollment, parent, inputs);
+    enrollment.abort("Enrollment recorded");
+  }
   const publication = runtime.getCellFromLink<unknown>({
     ...runtime.getCell(space, "compile-publication").getAsNormalizedFullLink(),
     scope: "user",
@@ -116,6 +142,22 @@ async function fixture(
 const PROGRAM: RuntimeProgram = {
   main: "/main.tsx",
   files: [{ name: "/main.tsx", contents: "export default 1;" }],
+};
+
+/**
+ * A compilation the case settles by hand.
+ *
+ * The rejection carries a handler from the moment the compilation exists. A
+ * case that throws before settling its own compilation still runs the
+ * `finally` that rejects it, and that rejection is then the promise's first
+ * settlement with nobody awaiting it. The unhandled rejection aborts the
+ * module: the cases after it never run, and the failure that caused it can go
+ * unreported with them.
+ */
+const deferredCompilation = <T>(): PromiseWithResolvers<T> => {
+  const deferred = Promise.withResolvers<T>();
+  deferred.promise.catch(() => {});
+  return deferred;
 };
 
 describe("compile-and-run-served", () => {
@@ -184,7 +226,7 @@ describe("compile-and-run-served", () => {
 
   it("launches at commit and keeps one unresolved request through repeated runs", async () => {
     const f = await fixture(true);
-    const compilation = Promise.withResolvers<never>();
+    const compilation = deferredCompilation<never>();
     let launches = 0;
     f.runtime.patternManager.compileOrGetPattern = () => {
       launches++;
@@ -293,9 +335,94 @@ describe("compile-and-run-served", () => {
     }
   });
 
+  it("compiles a program whose source carries a confidentiality label", async () => {
+    // The companion to the ceiling case above: the same labeled program,
+    // released rather than refused, so the path past the sink gate is covered
+    // too. Setup reads the labeled source, so its flow join carries that
+    // caveat and every store the setup transaction fills is measured against
+    // it; each is a store the runtime owns, so §8.12.5 route 2 declares the
+    // join on it and the compiler is handed the program.
+    const signer = await Identity.fromPassphrase("compile labeled source");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      ...MAX_ENFORCEMENT_CFC_OPTIONS,
+      cfcEnforcementMode: "enforce-strict",
+      // The sink releases ungated here; the ceiling case covers the gate.
+      cfcSinkMaxConfidentiality: {},
+      experimental: { serverExecution: true },
+      servingPosture: true,
+    });
+    let launches = 0;
+    runtime.patternManager.compileOrGetPattern = () => {
+      launches++;
+      return Promise.reject(new Error("labeled source compiler failure"));
+    };
+    const refusals: unknown[] = [];
+    const refused = Promise.withResolvers<void>();
+    refused.promise.catch(() => {});
+    runtime.scheduler.onError((error) => {
+      refusals.push(error);
+      refused.resolve();
+    });
+    const { pattern, Cell: BuilderCell, compileAndRun: compile } =
+      createTrustedBuilder(runtime).commonfabric;
+    const parent = pattern<Record<string, never>>(() => {
+      const contents = BuilderCell.of("export default 1;", {
+        type: "string",
+        ifc: {
+          confidentiality: [{
+            type: "https://commonfabric.org/cfc/atom/Caveat",
+            kind: "https://commonfabric.org/cfc/concepts/prompt-influence",
+            source: "of:compile-labeled-source",
+          }],
+        },
+      });
+      return compile({
+        main: "/main.tsx",
+        files: [{ name: "/main.tsx", contents }],
+      });
+    });
+    try {
+      const tx = runtime.edit();
+      const result = runtime.getCell(
+        signer.did(),
+        "compile-labeled-result",
+        parent.resultSchema,
+        tx,
+      );
+      runtime.run(tx, parent, {}, result);
+      runtime.prepareTxForCommit(tx);
+      expect((await tx.commit()).error).toBeUndefined();
+      // Either outcome ends the wait. A refused write never reaches the
+      // result cell, so waiting on that cell alone would hang on exactly the
+      // regression these assertions are written to name; the scheduler
+      // reports the refusal, and a run that reaches the compiler reports
+      // nothing.
+      await Promise.race([
+        waitForCellValue<{ pending: boolean; error?: string }>(
+          runtime,
+          result,
+          (value) => value?.error !== undefined,
+        ),
+        refused.promise,
+      ]);
+      await runtime.settled();
+      expect(refusals.map(String).join("\n")).not.toContain("writer-fit");
+      expect(launches).toBe(1);
+      const value = result.get() as { pending: boolean; error?: string };
+      expect(value.pending).toBe(false);
+      expect(value.error).toContain("labeled source compiler failure");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("reissues a recovered compilation before consulting the process cache", async () => {
     const f = await fixture(true);
-    const compilation = Promise.withResolvers<never>();
+    const compilation = deferredCompilation<never>();
     const spaces: unknown[] = [];
     f.runtime.patternManager.compileOrGetPattern = (_input, space) => {
       spaces.push(space);
@@ -324,7 +451,7 @@ describe("compile-and-run-served", () => {
 
   it("reissues a recovered pending request after its sealed wave is withdrawn", async () => {
     const f = await fixture(true);
-    const compilation = Promise.withResolvers<never>();
+    const compilation = deferredCompilation<never>();
     let launches = 0;
     f.runtime.patternManager.compileOrGetPattern = () => {
       launches++;
@@ -433,7 +560,7 @@ describe("compile-and-run-served", () => {
     const child = createTrustedBuilder(f.runtime).commonfabric.pattern(
       () => ({ answer: 1 }),
     );
-    const compilation = Promise.withResolvers<typeof child>();
+    const compilation = deferredCompilation<typeof child>();
     f.runtime.patternManager.compileOrGetPattern = () => compilation.promise;
     try {
       expect(await f.run(PROGRAM)).toBe(true);
@@ -475,7 +602,7 @@ describe("compile-and-run-served", () => {
       const child = createTrustedBuilder(f.runtime).commonfabric.pattern(
         () => ({ answer: 1 }),
       );
-      const compilation = Promise.withResolvers<typeof child>();
+      const compilation = deferredCompilation<typeof child>();
       f.runtime.patternManager.compileOrGetPattern = () => compilation.promise;
       f.runtime.patternManager.getCompiledPatternForProgramSync = () => child;
       try {
@@ -530,7 +657,7 @@ describe("compile-and-run-served", () => {
 
   it("ignores a superseded completion and reports its retirement", async () => {
     const f = await fixture(true);
-    const compilation = Promise.withResolvers<never>();
+    const compilation = deferredCompilation<never>();
     const events: string[] = [];
     f.runtime.effectMemoObserver = (event) => events.push(event.kind);
     f.runtime.patternManager.compileOrGetPattern = () => compilation.promise;
@@ -552,7 +679,7 @@ describe("compile-and-run-served", () => {
 
   it("settles an accepted request after a newer sealed request is withdrawn", async () => {
     const f = await fixture(true);
-    const compilation = Promise.withResolvers<never>();
+    const compilation = deferredCompilation<never>();
     let completion: Promise<unknown> | undefined;
     let launches = 0;
     f.runtime.asyncWorkObserver = (work) => completion = work;
@@ -619,8 +746,8 @@ describe("compile-and-run-served", () => {
   });
 
   it("inherits source labels added while an accepted compile is pending", async () => {
-    const f = await fixture(true, "persist");
-    const compilation = Promise.withResolvers<never>();
+    const f = await fixture(true, "persist", "enforce-strict");
+    const compilation = deferredCompilation<never>();
     f.runtime.patternManager.compileOrGetPattern = () => compilation.promise;
 
     /** Replaces the source's metadata while preserving the program bytes. */

--- a/packages/runner/test/cfc-runtime-owned-store-wiring.test.ts
+++ b/packages/runner/test/cfc-runtime-owned-store-wiring.test.ts
@@ -429,4 +429,121 @@ describe("runtime-owned-store enrollment wiring", () => {
       expect(refused.error?.message).toContain('"anchor-field-2"');
     });
   });
+
+  describe("an element anchored inside a store no piece owns", () => {
+    // The other half of the same split. A child inherits the runtime-owned
+    // claim only from a parent that carries one, so a child of an ordinary
+    // authored document is measured against what the schema describing the
+    // parent's value at the anchored position declares. The refusal names the
+    // child, at an id no author wrote down, and lands at the child's root
+    // whatever the declaration sits on inside the element.
+
+    /** The holder these cases write their list into, under `schema`. */
+    const holder = (name: string, schema: JSONSchema) =>
+      runtime.getCell<{ items: { note: string }[] }>(space, name, schema);
+
+    /** A list schema whose ELEMENT declares `clauses`, where any are given. */
+    const listSchema = (...clauses: string[]): JSONSchema => ({
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { note: { type: "string" } },
+            ...(clauses.length > 0
+              ? { ifc: { confidentiality: clauses } }
+              : {}),
+          },
+        },
+      },
+    } as JSONSchema);
+
+    /** Put what `sourceName` carries into `target`'s list, anchoring it. */
+    const writeElement = async (
+      target: ReturnType<typeof holder>,
+      sourceName: string,
+    ) => {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-strict");
+      const source = runtime.getCell(space, sourceName, undefined, tx);
+      const raw = source.getRaw() as { secret?: string };
+      target.withTx(tx).set({ items: [{ note: `${raw.secret}/anchored` }] });
+      tx.prepareCfc();
+      return await tx.commit();
+    };
+
+    it("refuses one whose parent declares nothing", async () => {
+      await seedSecret("unowned-bare", "unowned-bare-clause");
+      const refused = await writeElement(
+        holder("wiring-unowned-bare", listSchema()),
+        "unowned-bare",
+      );
+      expect(refused.error?.message).toContain(
+        "writer-fit confidentiality misfit",
+      );
+      expect(refused.error?.message).toContain('"unowned-bare-clause"');
+    });
+
+    it("admits one the element's own declaration covers", async () => {
+      await seedSecret("unowned-covered", "unowned-covered-clause");
+      const committed = await writeElement(
+        holder(
+          "wiring-unowned-covered",
+          listSchema("unowned-covered-clause"),
+        ),
+        "unowned-covered",
+      );
+      expect(committed.error).toBeUndefined();
+    });
+
+    it("refuses one the element declares a different clause for", async () => {
+      await seedSecret("unowned-other", "unowned-other-clause");
+      const refused = await writeElement(
+        holder(
+          "wiring-unowned-other",
+          listSchema("some-other-clause"),
+        ),
+        "unowned-other",
+      );
+      expect(refused.error?.message).toContain(
+        "writer-fit confidentiality misfit",
+      );
+      expect(refused.error?.message).toContain('"unowned-other-clause"');
+    });
+
+    it("refuses one declared on a field rather than on the element", async () => {
+      // The anchoring write lands at the child's ROOT, so a declaration one
+      // level in does not cover it, and the misfit says `at /` rather than
+      // naming the field the clause was written for.
+      await seedSecret("unowned-field", "unowned-field-clause");
+      const fieldDeclared: JSONSchema = {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                note: {
+                  type: "string",
+                  ifc: { confidentiality: ["unowned-field-clause"] },
+                },
+              },
+            },
+          },
+        },
+      } as JSONSchema;
+      const refused = await writeElement(
+        holder("wiring-unowned-field", fieldDeclared),
+        "unowned-field",
+      );
+      expect(refused.error?.message).toContain(
+        "writer-fit confidentiality misfit",
+      );
+      expect(refused.error?.message).toContain("at /");
+      expect(refused.error?.message).not.toContain("at /note");
+      expect(refused.error?.message).toContain('"unowned-field-clause"');
+    });
+  });
 });


### PR DESCRIPTION
PROBLEM

At `cfcEnforcementMode: enforce-strict` with `cfcFlowLabels: persist`, the last case of the served compile suite is refused at commit, and the document the refusal names is none that the builtin mints:

    CFC enforcement rejected commit: relevant transaction was not
    prepared: writer-fit confidentiality misfit for
    of:fid1:m_M4IOTll6RnL01HPGLV8xJjej_iQ4B1yyQHTQfrqgs at /
    (canWrite, section 8.12.4): "initial-source-label"

The case also hides that refusal. Its body throws before settling its own compilation, the `finally` rejects that compilation with nobody awaiting it, and the unhandled rejection aborts the module.

SOLUTION

The refused document is the one anchoring splits out of the fixture's input cell. `Cell.set` gives a plain object sitting in an array a document of its own, so writing the program back moves `files[0]` into a document whose id derives from the input document's. `anchorValueAsEntity` carries a runtime-owned claim from the parent to that child, and the fixture's input cell carries none, so the child is a store no piece owns and no schema declares. A program's bytes live in a cell of the piece that names them, which the runner enrolls, so the fixture enrolls its own, and the case runs at the rung that refused it. A second case covers the shape end to end: a pattern whose source cell carries a caveat compiles. Four more, in the enrollment wiring suite, pin what a child of a parent carrying no claim is measured against. Each compilation is handed out with a rejection handler already attached.

DESIGN DISCUSSION

The five state documents `compileAndRun` registers through `ownedCell` are not what the refusal was about. All five take section 8.12.5 route 2 in that same transaction, and so do the sink request's own stores; the fixture's input document was the only writer-fit measurement in the suite that reached a refusal. A misfit naming an anchored child is hard to read, because the id in the message belongs to no line of code.

`docs/specs/cfc-enforcement-matrix.md` section 4 said how ownership reaches an anchored document from a parent that carries the claim, and left the other case unwritten. It now says what a child of an ordinary authored store is measured against: the residency clause, plus what the schema declares at the anchored position, and only at that position — a declaration one level in leaves the write uncovered, because the anchoring write lands at the child's root. The four new cases pin all of it.

Neither new case waits on a value alone. A refused write never reaches the result cell, so a wait for one would hang on exactly the regression the assertions are written to name; the compile case races that wait against the scheduler's first reported error, which a passing run never reports.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

