### PR TITLE
perf(piece): avoid loading source code for pattern refs

### DIFF
--- a/packages/cli/test/piece-discovery-reads.test.ts
+++ b/packages/cli/test/piece-discovery-reads.test.ts
@@ -4,7 +4,7 @@ import { expect } from "@std/expect";
 import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { createSession, Identity } from "@commonfabric/identity";
 import type { Cell } from "@commonfabric/runner";
-import { Runtime } from "@commonfabric/runner";
+import { parseLink, Runtime, sourceDocKey } from "@commonfabric/runner";
 import {
   EmulatedStorageManager,
   newLoopbackServer,
@@ -100,6 +100,9 @@ interface ColdDiscovery<T> {
   /** The collection documents the reader's replica held once every load it
    * registered had been answered. Empty is the property under test. */
   itemsHeld: string[];
+
+  /** Whether discovery loaded the authored entry's content-addressed code. */
+  sourceCodeHeld: boolean;
 }
 
 /**
@@ -169,6 +172,17 @@ async function readsOfColdDiscovery<T>(
       PROGRAM as never,
       { space },
     );
+    const patternRef = writerRuntime.patternManager.getArtifactEntryRef(
+      compiled,
+    )!;
+    const sourceRecord = writerRuntime.getCell(
+      space,
+      sourceDocKey(patternRef.identity),
+    );
+    const sourceCodeUri = parseLink(
+      (sourceRecord.getRaw() as { code?: unknown } | undefined)?.code,
+      sourceRecord,
+    )?.id;
 
     // One document per member, each holding a value of its own, handed to the
     // pattern as cells so the piece's result reaches them through links.
@@ -233,8 +247,10 @@ async function readsOfColdDiscovery<T>(
     const itemsHeld = itemUris.filter((uri) =>
       provider.get?.(uri) !== undefined
     );
+    const sourceCodeHeld = sourceCodeUri !== undefined &&
+      provider.get?.(sourceCodeUri) !== undefined;
 
-    return { result, syncs, itemsHeld };
+    return { result, syncs, itemsHeld, sourceCodeHeld };
   } finally {
     await release();
   }
@@ -295,7 +311,7 @@ describe("piece discovery reads", () => {
   });
 
   it("lists the verb without syncing under the declared result type", async () => {
-    const { result, syncs, itemsHeld } = await readsOfColdDiscovery((
+    const discovery = await readsOfColdDiscovery((
       pieces,
       piece,
       space,
@@ -307,6 +323,7 @@ describe("piece discovery reads", () => {
         space,
       }, { loadPieces: () => Promise.resolve(pieces as never) })
     );
+    const { result, syncs, itemsHeld } = discovery;
 
     // The listing is the whole point of paying anything at all, so it is
     // asserted beside the reads: a discovery that syncs nothing and lists
@@ -322,12 +339,13 @@ describe("piece discovery reads", () => {
     });
 
     expect(itemsHeld).toEqual([]);
+    expect(discovery.sourceCodeHeld).toBe(false);
     expect(syncs.filter((sync) => isDeclaredResultType(sync.schema)))
       .toEqual([]);
   });
 
   it("describes the piece without syncing under the declared result type", async () => {
-    const { result, syncs, itemsHeld } = await readsOfColdDiscovery((
+    const discovery = await readsOfColdDiscovery((
       pieces,
       piece,
       space,
@@ -339,6 +357,7 @@ describe("piece discovery reads", () => {
         space,
       }, { loadPieces: () => Promise.resolve(pieces as never) })
     );
+    const { result, syncs, itemsHeld } = discovery;
 
     // `describe`'s STATE section comes from the compiled pattern, not from a
     // projection of the piece, so it names every non-callable property of the
@@ -354,6 +373,7 @@ describe("piece discovery reads", () => {
     ]);
 
     expect(itemsHeld).toEqual([]);
+    expect(discovery.sourceCodeHeld).toBe(false);
     expect(syncs.filter((sync) => isDeclaredResultType(sync.schema)))
       .toEqual([]);
   });

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -3853,14 +3853,14 @@ export class PieceController<T = unknown> {
     if (trackedSource !== undefined) source.origin = trackedSource;
 
     try {
-      const program = await this.#pieces.runtime.patternManager
-        .getPatternSourceProgramByIdentity(
+      const entry = await this.#pieces.runtime.patternManager
+        .getPatternSourceEntryByIdentity(
           ref.identity,
           this.#pieces.getSpace(),
         );
-      return program?.main === undefined
+      return entry === undefined
         ? { ...ref, source }
-        : { ...ref, source: { ...source, entry: program.main } };
+        : { ...ref, source: { ...source, entry } };
     } catch {
       // The content pointer remains useful even if the source closure is
       // unavailable or unreadable in this space.

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1824,18 +1824,18 @@ describe("piece pull materialization", () => {
       source: { ref: `cf:pattern:${identityRef.identity}` },
     };
     const originalLookup = runtime.patternManager
-      .getPatternSourceProgramByIdentity.bind(runtime.patternManager);
+      .getPatternSourceEntryByIdentity.bind(runtime.patternManager);
 
     try {
-      runtime.patternManager.getPatternSourceProgramByIdentity = () =>
+      runtime.patternManager.getPatternSourceEntryByIdentity = () =>
         Promise.resolve(undefined);
       expect(await controller.getPatternRef()).toEqual(contentOnlyRef);
 
-      runtime.patternManager.getPatternSourceProgramByIdentity = () =>
+      runtime.patternManager.getPatternSourceEntryByIdentity = () =>
         Promise.reject(new Error("source unavailable"));
       expect(await controller.getPatternRef()).toEqual(contentOnlyRef);
     } finally {
-      runtime.patternManager.getPatternSourceProgramByIdentity = originalLookup;
+      runtime.patternManager.getPatternSourceEntryByIdentity = originalLookup;
     }
   });
 

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -755,6 +755,12 @@ export const SOURCE_DOC_SCHEMA = {
   $ref: "#/$defs/sourceDoc",
 } as const satisfies JSONSchema;
 
+/** Read a source record's filename without following its source closure. */
+export const SOURCE_DOC_ENTRY_SCHEMA = {
+  type: "object",
+  properties: { filename: { type: "string" } },
+} as const satisfies JSONSchema;
+
 /**
  * Flat source-document write schema. Only delegation metadata receives the
  * runtime-minted compiler attestation: source code/imports remain

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -33,6 +33,7 @@ import {
   planCompileCacheWriteChunks,
   recordUndeclarablePolicyStore,
   ROOT_LINK_SPECIFIER,
+  SOURCE_DOC_ENTRY_SCHEMA,
   type SourceDoc,
   sourceDocKey,
   stageModuleDelegations,
@@ -3532,6 +3533,29 @@ export class PatternManager {
       ...(sourceRoots.length === 0 ? {} : { sourceRoots }),
       ...(dataFiles.length === 0 ? {} : { dataFiles }),
     };
+  }
+
+  /** Read a stored pattern's entry filename without loading its source closure. */
+  async getPatternSourceEntryByIdentity(
+    entryIdentity: string,
+    space: MemorySpace,
+  ): Promise<string | undefined> {
+    const readTx = this.#runtime.edit();
+    try {
+      const entry = this.#runtime.getCell(
+        space,
+        sourceDocKey(entryIdentity),
+        SOURCE_DOC_ENTRY_SCHEMA,
+        readTx,
+      );
+      await entry.sync();
+      const value = entry.get();
+      return isObjectOrArray(value) && typeof value.filename === "string"
+        ? value.filename
+        : undefined;
+    } finally {
+      readTx.abort?.("get-pattern-source-entry read complete");
+    }
   }
 
   /**


### PR DESCRIPTION
Summary
- Add a filename-only schema for source entry records.
- Use it in PieceController.getPatternRef so callers do not follow the authored code CID or import closure just to report the entry filename.
- Cover both cf piece verbs and cf piece describe with a cold-replica regression.

The compiled-pattern read is intentionally unchanged: verb enumeration still needs the result graph produced by evaluating that module.

Tests
- deno fmt --check
- deno lint
- deno task check
- packages/cli/test/piece-discovery-reads.test.ts (4 steps)
- packages/piece/test/pull-materialization.test.ts (142 steps)