### PR TITLE
feat(data-model): `value-visit` descends into a `FabricInstance` through its codec

### DIFF
--- a/packages/data-model/src/value-visit/BaseValueVisitor.ts
+++ b/packages/data-model/src/value-visit/BaseValueVisitor.ts
@@ -98,7 +98,7 @@ export abstract class BaseValueVisitor<
   ): BaselineVisitResult<ResultType>;
 
   /** @inheritDoc */
-  abstract visitedFabricPlainObject(
+  abstract visitedFabricPlainObjectEntry(
     container: FabricPlainObject,
     key: DomainFor<DomainExtra>,
     value: DomainFor<DomainExtra>,

--- a/packages/data-model/src/value-visit/BaseValueVisitor.ts
+++ b/packages/data-model/src/value-visit/BaseValueVisitor.ts
@@ -92,6 +92,12 @@ export abstract class BaseValueVisitor<
   ): BaselineVisitResult<ResultType>;
 
   /** @inheritDoc */
+  abstract visitedFabricInstance(
+    instance: FabricInstance,
+    state: FabricValue,
+  ): BaselineVisitResult<ResultType>;
+
+  /** @inheritDoc */
   abstract visitedMapping(
     container: FabricPlainObject | FabricInstance,
     key: DomainFor<DomainExtra>,

--- a/packages/data-model/src/value-visit/BaseValueVisitor.ts
+++ b/packages/data-model/src/value-visit/BaseValueVisitor.ts
@@ -98,7 +98,7 @@ export abstract class BaseValueVisitor<
   ): BaselineVisitResult<ResultType>;
 
   /** @inheritDoc */
-  abstract visitedMapping(
+  abstract visitedFabricPlainObject(
     container: FabricPlainObject,
     key: DomainFor<DomainExtra>,
     value: DomainFor<DomainExtra>,

--- a/packages/data-model/src/value-visit/BaseValueVisitor.ts
+++ b/packages/data-model/src/value-visit/BaseValueVisitor.ts
@@ -78,14 +78,14 @@ export abstract class BaseValueVisitor<
   ): DispatchingVisitorResult<DomainExtra, ResultType>;
 
   /** @inheritDoc */
-  abstract visitedArrayElement(
+  abstract visitedFabricArrayElement(
     array: FabricArray,
     index: number,
     value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType>;
 
   /** @inheritDoc */
-  abstract visitedArrayGap(
+  abstract visitedFabricArrayGap(
     array: FabricArray,
     start: number,
     count: number,

--- a/packages/data-model/src/value-visit/BaseValueVisitor.ts
+++ b/packages/data-model/src/value-visit/BaseValueVisitor.ts
@@ -99,7 +99,7 @@ export abstract class BaseValueVisitor<
 
   /** @inheritDoc */
   abstract visitedMapping(
-    container: FabricPlainObject | FabricInstance,
+    container: FabricPlainObject,
     key: DomainFor<DomainExtra>,
     value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType>;

--- a/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
+++ b/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
@@ -91,7 +91,7 @@ export abstract class ContainerIteratingValueVisitor<
   }
 
   /** @inheritDoc */
-  visitedMapping(
+  visitedFabricPlainObject(
     _container: FabricPlainObject,
     _key: DomainFor<DomainExtra>,
     _value: DomainFor<DomainExtra>,

--- a/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
+++ b/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
@@ -23,10 +23,13 @@ import {
  * * `FabricInstance` -- _the_ state value (it only has the one).
  * * `FabricPlainObject`s -- values only.
  *
- * The implementation includes a definition for all container-specific `visit()`
- * methods, which all return `DO_RECURSE_VALUES` (per the above description),
- * and also implements no-op (empty) `visited*()` methods. Every other method of
- * the interface remains `abstract`.
+ * The implementation includes a definition for all container-specific
+ * `visit*()` methods, which all return `DO_RECURSE_VALUES` (per the above
+ * description), and also implements no-op (empty) `visited*()` methods. Every
+ * other method of the interface remains `abstract`. The `visit*()` method
+ * implementations are intended to make it easy to override implementations
+ * selectively, by overriding `visitFabricContainer()` to return
+ * `DO_VISIT_SUBTYPE` and then whatever specific subtypes need to be altered.
  */
 export abstract class ContainerIteratingValueVisitor<
   DomainExtra = never,

--- a/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
+++ b/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
@@ -91,7 +91,7 @@ export abstract class ContainerIteratingValueVisitor<
   }
 
   /** @inheritDoc */
-  visitedFabricPlainObject(
+  visitedFabricPlainObjectEntry(
     _container: FabricPlainObject,
     _key: DomainFor<DomainExtra>,
     _value: DomainFor<DomainExtra>,

--- a/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
+++ b/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
@@ -93,7 +93,7 @@ export abstract class ContainerIteratingValueVisitor<
 
   /** @inheritDoc */
   visitedMapping(
-    _container: FabricPlainObject | FabricInstance,
+    _container: FabricPlainObject,
     _key: DomainFor<DomainExtra>,
     _value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType> {

--- a/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
+++ b/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
@@ -84,6 +84,14 @@ export abstract class ContainerIteratingValueVisitor<
   }
 
   /** @inheritDoc */
+  visitedFabricInstance(
+    _instance: FabricInstance,
+    _state: FabricValue,
+  ): BaselineVisitResult<ResultType> {
+    return undefined;
+  }
+
+  /** @inheritDoc */
   visitedMapping(
     _container: FabricPlainObject | FabricInstance,
     _key: DomainFor<DomainExtra>,

--- a/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
+++ b/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
@@ -10,9 +10,7 @@ import { BaseValueVisitor } from "./BaseValueVisitor.ts";
 import {
   type BaselineVisitResult,
   type DispatchingVisitorResult,
-  DO_RECURSE_KEYS_VALUES,
   DO_RECURSE_VALUES,
-  DO_VISIT_SUBTYPE,
   type DomainFor,
   type LeafVisitorResult,
 } from "./interface.ts";
@@ -21,13 +19,14 @@ import {
  * Visitor which handles all containers by requesting that the engine iterate
  * over their contents. Recursion is as follows:
  *
- * * `FabricArray` -- all elements.
- * * `FabricInstance` -- keys and values.
+ * * `FabricArray` -- all elements (values).
+ * * `FabricInstance` -- _the_ state value (it only has the one).
  * * `FabricPlainObject`s -- values only.
  *
  * The implementation includes a definition for all container-specific `visit()`
- * methods per the above description, and also implements no-op (empty)
- * `visited*()` methods. Every other method of the interface remains `abstract`.
+ * methods, which all return `DO_RECURSE_VALUES` (per the above description),
+ * and also implements no-op (empty) `visited*()` methods. Every other method of
+ * the interface remains `abstract`.
  */
 export abstract class ContainerIteratingValueVisitor<
   DomainExtra = never,
@@ -48,7 +47,7 @@ export abstract class ContainerIteratingValueVisitor<
   visitFabricInstance(
     _value: FabricInstance,
   ): LeafVisitorResult<DomainExtra, ResultType> {
-    return DO_RECURSE_KEYS_VALUES;
+    return DO_RECURSE_VALUES;
   }
 
   /** @inheritDoc */
@@ -62,7 +61,7 @@ export abstract class ContainerIteratingValueVisitor<
   visitFabricContainer(
     _value: FabricContainerValue,
   ): DispatchingVisitorResult<DomainExtra, ResultType> {
-    return DO_VISIT_SUBTYPE;
+    return DO_RECURSE_VALUES;
   }
 
   /** @inheritDoc */

--- a/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
+++ b/packages/data-model/src/value-visit/ContainerIteratingValueVisitor.ts
@@ -68,7 +68,7 @@ export abstract class ContainerIteratingValueVisitor<
   }
 
   /** @inheritDoc */
-  visitedArrayElement(
+  visitedFabricArrayElement(
     _array: FabricArray,
     _index: number,
     _value: DomainFor<DomainExtra>,
@@ -77,7 +77,7 @@ export abstract class ContainerIteratingValueVisitor<
   }
 
   /** @inheritDoc */
-  visitedArrayGap(
+  visitedFabricArrayGap(
     _array: FabricArray,
     _start: number,
     _count: number,

--- a/packages/data-model/src/value-visit/NopValueVisitor.ts
+++ b/packages/data-model/src/value-visit/NopValueVisitor.ts
@@ -118,7 +118,7 @@ export class NopValueVisitor<DomainExtra = never, ResultType = FabricValue>
   }
 
   /** @inheritDoc */
-  visitedFabricPlainObject(
+  visitedFabricPlainObjectEntry(
     _container: FabricPlainObject,
     _key: DomainFor<DomainExtra>,
     _value: DomainFor<DomainExtra>,

--- a/packages/data-model/src/value-visit/NopValueVisitor.ts
+++ b/packages/data-model/src/value-visit/NopValueVisitor.ts
@@ -92,7 +92,7 @@ export class NopValueVisitor<DomainExtra = never, ResultType = FabricValue>
   }
 
   /** @inheritDoc */
-  visitedArrayElement(
+  visitedFabricArrayElement(
     _array: FabricArray,
     _index: number,
     _value: DomainFor<DomainExtra>,
@@ -101,7 +101,7 @@ export class NopValueVisitor<DomainExtra = never, ResultType = FabricValue>
   }
 
   /** @inheritDoc */
-  visitedArrayGap(
+  visitedFabricArrayGap(
     _array: FabricArray,
     _start: number,
     _count: number,

--- a/packages/data-model/src/value-visit/NopValueVisitor.ts
+++ b/packages/data-model/src/value-visit/NopValueVisitor.ts
@@ -118,7 +118,7 @@ export class NopValueVisitor<DomainExtra = never, ResultType = FabricValue>
   }
 
   /** @inheritDoc */
-  visitedMapping(
+  visitedFabricPlainObject(
     _container: FabricPlainObject,
     _key: DomainFor<DomainExtra>,
     _value: DomainFor<DomainExtra>,

--- a/packages/data-model/src/value-visit/NopValueVisitor.ts
+++ b/packages/data-model/src/value-visit/NopValueVisitor.ts
@@ -119,7 +119,7 @@ export class NopValueVisitor<DomainExtra = never, ResultType = FabricValue>
 
   /** @inheritDoc */
   visitedMapping(
-    _container: FabricPlainObject | FabricInstance,
+    _container: FabricPlainObject,
     _key: DomainFor<DomainExtra>,
     _value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType> {

--- a/packages/data-model/src/value-visit/NopValueVisitor.ts
+++ b/packages/data-model/src/value-visit/NopValueVisitor.ts
@@ -110,6 +110,14 @@ export class NopValueVisitor<DomainExtra = never, ResultType = FabricValue>
   }
 
   /** @inheritDoc */
+  visitedFabricInstance(
+    _instance: FabricInstance,
+    _state: FabricValue,
+  ): BaselineVisitResult<ResultType> {
+    return undefined;
+  }
+
+  /** @inheritDoc */
   visitedMapping(
     _container: FabricPlainObject | FabricInstance,
     _key: DomainFor<DomainExtra>,

--- a/packages/data-model/src/value-visit/VisitInProgress.ts
+++ b/packages/data-model/src/value-visit/VisitInProgress.ts
@@ -185,10 +185,16 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
           }
 
           default: {
+            // deno-coverage-ignore-start
+
+            // This is a defense-in-depth protection against bugs in this
+            // submodule: `containerTag` is typed as exactly the three cases
+            // above, so nothing else can reach here.
             throw new Error(
               `Shouldn't happen: Got unrecognized \`containerTag\`: \`${result.containerTag}\``,
             );
           }
+            // deno-coverage-ignore-stop
         }
       }
 

--- a/packages/data-model/src/value-visit/VisitInProgress.ts
+++ b/packages/data-model/src/value-visit/VisitInProgress.ts
@@ -518,7 +518,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         // TODO(danfuzz): When we have a non-`mainResult` visit-result type,
         // we'll want to pass the result value(s) from the visits immediately
         // above instead of the original `key` and `value`.
-        const result = vis.visitedMapping(container, key, value);
+        const result = vis.visitedMapping(plainObj, key, value);
         if (result?.type === "mainResult") {
           return result;
         }

--- a/packages/data-model/src/value-visit/VisitInProgress.ts
+++ b/packages/data-model/src/value-visit/VisitInProgress.ts
@@ -180,7 +180,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
           }
 
           case VALUE_TAGS.Object: {
-            return this.#iterateMap(result);
+            return this.#iterateFabricPlainObject(result);
           }
 
           default: {
@@ -480,10 +480,12 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   }
 
   /**
-   * Iterates over all the elements in a map-like value, in response to a
+   * Iterates over all the entries in a `FabricPlainObject`, in response to a
    * `recurse` result.
    */
-  #iterateMap(result: RecurseOfForm): BaselineVisitResult<ResultType> {
+  #iterateFabricPlainObject(
+    result: RecurseOfForm,
+  ): BaselineVisitResult<ResultType> {
     const { container, doKeys, doValues } = result;
     const plainObj = container as FabricPlainObject;
     const vis = this.#visitor;

--- a/packages/data-model/src/value-visit/VisitInProgress.ts
+++ b/packages/data-model/src/value-visit/VisitInProgress.ts
@@ -399,7 +399,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
         if (idxNumber !== (lastIdx + 1)) {
           // There's a gap just before this element.
-          const result = vis.visitedArrayGap(
+          const result = vis.visitedFabricArrayGap(
             array,
             lastIdx + 1,
             idxNumber - lastIdx - 1,
@@ -419,8 +419,8 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
         // TODO(danfuzz): When we have a non-`mainResult` visit-result type,
         // we'll want to pass the result value from `elemResult` into
-        // `visitedArrayElement()` and not the original `element`.
-        const result = vis.visitedArrayElement(array, idxNumber, element);
+        // `visitedFabricArrayElement()` and not the original `element`.
+        const result = vis.visitedFabricArrayElement(array, idxNumber, element);
         if (result?.type === "mainResult") {
           return result;
         }
@@ -428,7 +428,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
       if (array.length !== (lastIdx + 1)) {
         // There's a gap at the end of the array.
-        const result = vis.visitedArrayGap(
+        const result = vis.visitedFabricArrayGap(
           array,
           lastIdx + 1,
           array.length - lastIdx - 1,

--- a/packages/data-model/src/value-visit/VisitInProgress.ts
+++ b/packages/data-model/src/value-visit/VisitInProgress.ts
@@ -497,12 +497,12 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       return undefined;
     }
 
-    const mappings = Object.entries(plainObj);
+    const entries = Object.entries(plainObj);
 
     this.#stack.push(plainObj);
 
     try {
-      for (const [key, value] of mappings) {
+      for (const [key, value] of entries) {
         if (doKeys) {
           const keyResult = this.#visitValue(key);
           if (keyResult?.type === "mainResult") {

--- a/packages/data-model/src/value-visit/VisitInProgress.ts
+++ b/packages/data-model/src/value-visit/VisitInProgress.ts
@@ -520,7 +520,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         // TODO(danfuzz): When we have a non-`mainResult` visit-result type,
         // we'll want to pass the result value(s) from the visits immediately
         // above instead of the original `key` and `value`.
-        const result = vis.visitedFabricPlainObject(plainObj, key, value);
+        const result = vis.visitedFabricPlainObjectEntry(plainObj, key, value);
         if (result?.type === "mainResult") {
           return result;
         }

--- a/packages/data-model/src/value-visit/VisitInProgress.ts
+++ b/packages/data-model/src/value-visit/VisitInProgress.ts
@@ -173,15 +173,15 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       case "recurseOf": {
         switch (result.containerTag) {
           case VALUE_TAGS.Array: {
-            return this.#iterateArray(result);
+            return this.#recurseFabricArray(result);
           }
 
           case VALUE_TAGS.FabricInstance: {
-            return this.#iterateFabricInstance(result);
+            return this.#recurseFabricInstance(result);
           }
 
           case VALUE_TAGS.Object: {
-            return this.#iterateFabricPlainObject(result);
+            return this.#recurseFabricPlainObject(result);
           }
 
           default: {
@@ -366,7 +366,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    * Recurses into a `FabricArray`, iterating over all its elements, in response
    * to a `recurse` result.
    */
-  #iterateArray(result: RecurseOfForm): BaselineVisitResult<ResultType> {
+  #recurseFabricArray(result: RecurseOfForm): BaselineVisitResult<ResultType> {
     const { container, doValues } = result;
     const array = container as FabricArray;
     const vis = this.#visitor;
@@ -443,7 +443,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    * recursion consists of a single sub-value visit, of the instance's state,
    * per its normal codec.
    */
-  #iterateFabricInstance(
+  #recurseFabricInstance(
     result: RecurseOfForm,
   ): BaselineVisitResult<ResultType> {
     const { container, doValues } = result;
@@ -484,7 +484,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
    * Recurses into a `FabricPlainObject`, iterating over all its entries, in
    * response to a `recurse` result.
    */
-  #iterateFabricPlainObject(
+  #recurseFabricPlainObject(
     result: RecurseOfForm,
   ): BaselineVisitResult<ResultType> {
     const { container, doKeys, doValues } = result;

--- a/packages/data-model/src/value-visit/VisitInProgress.ts
+++ b/packages/data-model/src/value-visit/VisitInProgress.ts
@@ -50,8 +50,9 @@ type VisitSubtypeOfForm<DomainExtra> = {
 /**
  * Similar to `VisitSubtypeOfForm`, but for `recurse`. Unlike that one, though,
  * this one is _always_ propagated in the engine after getting a plain `recurse`
- * result, on the theory that if we're going to iterate the one extra allocation
- * is small potatoes, and it keeps the code a wee bit simpler.
+ * result, on the theory that if we're going to recurse -- a relatively
+ * heavyweight operation -- the one extra allocation is small potatoes, and it
+ * keeps the code a wee bit simpler.
  */
 type RecurseOfForm = {
   readonly type: "recurseOf";
@@ -362,8 +363,8 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   }
 
   /**
-   * Iterates over all the elements in an array, in response to a `recurse`
-   * result.
+   * Recurses into a `FabricArray`, iterating over all its elements, in response
+   * to a `recurse` result.
    */
   #iterateArray(result: RecurseOfForm): BaselineVisitResult<ResultType> {
     const { container, doValues } = result;
@@ -438,7 +439,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   }
 
   /**
-   * Recurses on a `FabricInstance`, in response to a `recurse` result. The
+   * Recurses into a `FabricInstance`, in response to a `recurse` result. The
    * recursion consists of a single sub-value visit, of the instance's state,
    * per its normal codec.
    */
@@ -480,8 +481,8 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   }
 
   /**
-   * Iterates over all the entries in a `FabricPlainObject`, in response to a
-   * `recurse` result.
+   * Recurses into a `FabricPlainObject`, iterating over all its entries, in
+   * response to a `recurse` result.
    */
   #iterateFabricPlainObject(
     result: RecurseOfForm,

--- a/packages/data-model/src/value-visit/VisitInProgress.ts
+++ b/packages/data-model/src/value-visit/VisitInProgress.ts
@@ -2,6 +2,7 @@ import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { IndexTrackingStack } from "@commonfabric/utils/index-tracking-stack";
 import { type Primitive } from "@commonfabric/utils/types";
 
+import { codecOf, NULL_LIVE_ENVIRONMENT } from "@/codec-common/index.ts";
 import { isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import {
   type FabricArray,
@@ -169,9 +170,25 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       }
 
       case "recurseOf": {
-        return (result.containerTag === VALUE_TAGS.Array)
-          ? this.#iterateArray(result)
-          : this.#iterateMap(result);
+        switch (result.containerTag) {
+          case VALUE_TAGS.Array: {
+            return this.#iterateArray(result);
+          }
+
+          case VALUE_TAGS.FabricInstance: {
+            return this.#iterateFabricInstance(result);
+          }
+
+          case VALUE_TAGS.Object: {
+            return this.#iterateMap(result);
+          }
+
+          default: {
+            throw new Error(
+              `Shouldn't happen: Got unrecognized \`containerTag\`: \`${result.containerTag}\``,
+            );
+          }
+        }
       }
 
       default: {
@@ -421,14 +438,54 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
   }
 
   /**
+   * Recurses on a `FabricInstance`, in response to a `recurse` result. The
+   * recursion consists of a single sub-value visit, of the instance's state,
+   * per its normal codec.
+   */
+  #iterateFabricInstance(
+    result: RecurseOfForm,
+  ): BaselineVisitResult<ResultType> {
+    const { container, doValues } = result;
+    const instance = container as FabricInstance;
+    const vis = this.#visitor;
+
+    if (!doValues) {
+      // `result` represents a no-op `recurse`. Though pointless, nothing
+      // prevents a client from returning it as a visit result, so just handle
+      // it gracefully here.
+      return undefined;
+    }
+
+    const state = codecOf(instance).encode(instance, NULL_LIVE_ENVIRONMENT);
+    this.#stack.push(instance);
+
+    try {
+      const stateResult = this.#visitValue(state);
+      if (stateResult?.type === "mainResult") {
+        return stateResult;
+      }
+
+      // TODO(danfuzz): When we have a non-`mainResult` visit-result type, we'll
+      // want to pass the result value from the visits immediately above instead
+      // of the original `state`.
+      const result = vis.visitedFabricInstance(instance, state);
+      if (result?.type === "mainResult") {
+        return result;
+      }
+
+      return undefined;
+    } finally {
+      this.#stack.popExpect(instance);
+    }
+  }
+
+  /**
    * Iterates over all the elements in a map-like value, in response to a
    * `recurse` result.
    */
   #iterateMap(result: RecurseOfForm): BaselineVisitResult<ResultType> {
-    const { container: looseTypedContainer, containerTag, doKeys, doValues } =
-      result;
-    const container =
-      looseTypedContainer as (FabricInstance | FabricPlainObject);
+    const { container, doKeys, doValues } = result;
+    const plainObj = container as FabricPlainObject;
     const vis = this.#visitor;
 
     if (!(doKeys || doValues)) {
@@ -438,15 +495,9 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
       return undefined;
     }
 
-    const mappings = (containerTag === VALUE_TAGS.Object)
-      ? Object.entries(container)
-      : (() => {
-        // TODO(danfuzz): This is where we finally need to sort out
-        // `FabricInstance` iteration.
-        throw new Error("`FabricInstance` not yet visitable");
-      })();
+    const mappings = Object.entries(plainObj);
 
-    this.#stack.push(container);
+    this.#stack.push(plainObj);
 
     try {
       for (const [key, value] of mappings) {
@@ -475,7 +526,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
 
       return undefined;
     } finally {
-      this.#stack.popExpect(container);
+      this.#stack.popExpect(plainObj);
     }
   }
 

--- a/packages/data-model/src/value-visit/VisitInProgress.ts
+++ b/packages/data-model/src/value-visit/VisitInProgress.ts
@@ -518,7 +518,7 @@ export class VisitInProgress<DomainExtra = never, ResultType = FabricValue> {
         // TODO(danfuzz): When we have a non-`mainResult` visit-result type,
         // we'll want to pass the result value(s) from the visits immediately
         // above instead of the original `key` and `value`.
-        const result = vis.visitedMapping(plainObj, key, value);
+        const result = vis.visitedFabricPlainObject(plainObj, key, value);
         if (result?.type === "mainResult") {
           return result;
         }

--- a/packages/data-model/src/value-visit/interface.ts
+++ b/packages/data-model/src/value-visit/interface.ts
@@ -315,12 +315,12 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
   ): BaselineVisitResult<ResultType>;
 
   /**
-   * Indicates that `FabricPlainObject` was just visited. This method is called
-   * as a result of the visitor returning a `recurse` result for a visited
-   * `FabricPlainObject` and is called _after_ the object itself was directly
-   * visited.
+   * Indicates that `FabricPlainObject` entry was just visited. This method is
+   * called as a result of the visitor returning a `recurse` result for a
+   * visited `FabricPlainObject` and is called _after_ the entry's key and/or
+   * value were directly visited.
    */
-  visitedFabricPlainObject(
+  visitedFabricPlainObjectEntry(
     container: FabricPlainObject,
     key: DomainFor<DomainExtra>,
     value: DomainFor<DomainExtra>,

--- a/packages/data-model/src/value-visit/interface.ts
+++ b/packages/data-model/src/value-visit/interface.ts
@@ -304,6 +304,17 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
   ): BaselineVisitResult<ResultType>;
 
   /**
+   * Indicates that the instance state of a `FabricInstance` was just visited.
+   * This method is called as a result of the visitor returning a `recurse`
+   * result for a visited `FabricInstance` and is called _after_ the element
+   * itself was directly visited.
+   */
+  visitedFabricInstance(
+    instance: FabricInstance,
+    state: FabricValue,
+  ): BaselineVisitResult<ResultType>;
+
+  /**
    * Indicates that a container mapping was just visited. This method is called
    * as a result of the visitor returning a `recurse` result for a visited
    * container and is called _after_ the mapping itself was directly visited.

--- a/packages/data-model/src/value-visit/interface.ts
+++ b/packages/data-model/src/value-visit/interface.ts
@@ -37,7 +37,7 @@ export type MainResultForm<ResultType> = {
  * A `recurse` form. This is returned by visitor methods which visit containers.
  * This tells the visitor engine that it should recursively visit the contents
  * of the container, such that each visited item is known by the engine to be
- * contained by the container which is being iterated over. The two `boolean`
+ * contained by the container which is being recursed into. The two `boolean`
  * properties indicate whether the container's keys and/or values are to be
  * recursed over. `doKeys` is ignored in a context where there is no key.
  *

--- a/packages/data-model/src/value-visit/interface.ts
+++ b/packages/data-model/src/value-visit/interface.ts
@@ -290,12 +290,12 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
    * This method is called as a result of the visitor returning a `recurse`
    * result for a visited array and is called during iteration as gaps are
    * encountered. The sequencing of this call is meant to mirror
-   * `visitedFabricArrayElement()`, but since there is nothing to recurse on (it's a
-   * gap, not any actual values), there is no regular `visitValue()` call which
-   * immediately precedes it (hence the visit was "nominal"). `start` is the
-   * start index of the gap (integer `>= 0`), and `count` is the number of holes
-   * in the gap (integer `>= 1`). This method is called as a result of the
-   * visitor returning a `recurse` result for a visited array.
+   * `visitedFabricArrayElement()`, but since there is nothing to recurse on
+   * (it's a gap, not any actual values), there is no regular `visitValue()`
+   * call which immediately precedes it (hence the visit was "nominal"). `start`
+   * is the start index of the gap (integer `>= 0`), and `count` is the number
+   * of holes in the gap (integer `>= 1`). This method is called as a result of
+   * the visitor returning a `recurse` result for a visited array.
    */
   visitedFabricArrayGap(
     array: FabricArray,

--- a/packages/data-model/src/value-visit/interface.ts
+++ b/packages/data-model/src/value-visit/interface.ts
@@ -320,7 +320,7 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
    * container and is called _after_ the mapping itself was directly visited.
    */
   visitedMapping(
-    container: FabricPlainObject | FabricInstance,
+    container: FabricPlainObject,
     key: DomainFor<DomainExtra>,
     value: DomainFor<DomainExtra>,
   ): BaselineVisitResult<ResultType>;

--- a/packages/data-model/src/value-visit/interface.ts
+++ b/packages/data-model/src/value-visit/interface.ts
@@ -279,7 +279,7 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
    * a result of the visitor returning a `recurse` result for a visited array
    * and is called _after_ the element itself was directly visited.
    */
-  visitedArrayElement(
+  visitedFabricArrayElement(
     array: FabricArray,
     index: number,
     value: DomainFor<DomainExtra>,
@@ -290,14 +290,14 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
    * This method is called as a result of the visitor returning a `recurse`
    * result for a visited array and is called during iteration as gaps are
    * encountered. The sequencing of this call is meant to mirror
-   * `visitedArrayElement()`, but since there is nothing to recurse on (it's a
+   * `visitedFabricArrayElement()`, but since there is nothing to recurse on (it's a
    * gap, not any actual values), there is no regular `visitValue()` call which
    * immediately precedes it (hence the visit was "nominal"). `start` is the
    * start index of the gap (integer `>= 0`), and `count` is the number of holes
    * in the gap (integer `>= 1`). This method is called as a result of the
    * visitor returning a `recurse` result for a visited array.
    */
-  visitedArrayGap(
+  visitedFabricArrayGap(
     array: FabricArray,
     start: number,
     count: number,

--- a/packages/data-model/src/value-visit/interface.ts
+++ b/packages/data-model/src/value-visit/interface.ts
@@ -306,8 +306,8 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
   /**
    * Indicates that the instance state of a `FabricInstance` was just visited.
    * This method is called as a result of the visitor returning a `recurse`
-   * result for a visited `FabricInstance` and is called _after_ the element
-   * itself was directly visited.
+   * result for a visited `FabricInstance` and is called _after_ the instance's
+   * state was directly visited.
    */
   visitedFabricInstance(
     instance: FabricInstance,

--- a/packages/data-model/src/value-visit/interface.ts
+++ b/packages/data-model/src/value-visit/interface.ts
@@ -315,11 +315,12 @@ export interface ValueVisitor<DomainExtra = never, ResultType = FabricValue> {
   ): BaselineVisitResult<ResultType>;
 
   /**
-   * Indicates that a container mapping was just visited. This method is called
+   * Indicates that `FabricPlainObject` was just visited. This method is called
    * as a result of the visitor returning a `recurse` result for a visited
-   * container and is called _after_ the mapping itself was directly visited.
+   * `FabricPlainObject` and is called _after_ the object itself was directly
+   * visited.
    */
-  visitedMapping(
+  visitedFabricPlainObject(
     container: FabricPlainObject,
     key: DomainFor<DomainExtra>,
     value: DomainFor<DomainExtra>,

--- a/packages/data-model/test/value-visit/ContainerIteratingValueVisitor.test.ts
+++ b/packages/data-model/test/value-visit/ContainerIteratingValueVisitor.test.ts
@@ -5,9 +5,7 @@ import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import {
   ContainerIteratingValueVisitor,
   type DispatchingVisitorResult,
-  DO_RECURSE_KEYS_VALUES,
   DO_RECURSE_VALUES,
-  DO_VISIT_SUBTYPE,
   type LeafVisitorResult,
 } from "@/value-visit";
 
@@ -32,8 +30,10 @@ describe("ContainerIteratingValueVisitor", () => {
 
   describe("instance members", () => {
     describe("visitFabricContainer()", () => {
-      it("returns `DO_VISIT_SUBTYPE`", () => {
-        expect(new Iterating().visitFabricContainer([])).toBe(DO_VISIT_SUBTYPE);
+      it("returns `DO_RECURSE_VALUES`, without subtype dispatch", () => {
+        expect(new Iterating().visitFabricContainer([])).toBe(
+          DO_RECURSE_VALUES,
+        );
       });
     });
 
@@ -52,11 +52,11 @@ describe("ContainerIteratingValueVisitor", () => {
     });
 
     describe("visitFabricInstance()", () => {
-      it("returns `DO_RECURSE_KEYS_VALUES`", () => {
+      it("returns `DO_RECURSE_VALUES`", () => {
         const instance = new FabricMap(new Map());
 
         expect(new Iterating().visitFabricInstance(instance)).toBe(
-          DO_RECURSE_KEYS_VALUES,
+          DO_RECURSE_VALUES,
         );
       });
     });
@@ -67,6 +67,8 @@ describe("ContainerIteratingValueVisitor", () => {
 
         expect(vis.visitedArrayElement([1], 0, 1)).toBeUndefined();
         expect(vis.visitedArrayGap([], 0, 1)).toBeUndefined();
+        expect(vis.visitedFabricInstance(new FabricMap(new Map()), {}))
+          .toBeUndefined();
         expect(vis.visitedFabricPlainObjectEntry({}, "k", 1)).toBeUndefined();
       });
     });

--- a/packages/data-model/test/value-visit/ContainerIteratingValueVisitor.test.ts
+++ b/packages/data-model/test/value-visit/ContainerIteratingValueVisitor.test.ts
@@ -67,7 +67,7 @@ describe("ContainerIteratingValueVisitor", () => {
 
         expect(vis.visitedArrayElement([1], 0, 1)).toBeUndefined();
         expect(vis.visitedArrayGap([], 0, 1)).toBeUndefined();
-        expect(vis.visitedMapping({}, "k", 1)).toBeUndefined();
+        expect(vis.visitedFabricPlainObject({}, "k", 1)).toBeUndefined();
       });
     });
   });

--- a/packages/data-model/test/value-visit/ContainerIteratingValueVisitor.test.ts
+++ b/packages/data-model/test/value-visit/ContainerIteratingValueVisitor.test.ts
@@ -67,7 +67,7 @@ describe("ContainerIteratingValueVisitor", () => {
 
         expect(vis.visitedArrayElement([1], 0, 1)).toBeUndefined();
         expect(vis.visitedArrayGap([], 0, 1)).toBeUndefined();
-        expect(vis.visitedFabricPlainObject({}, "k", 1)).toBeUndefined();
+        expect(vis.visitedFabricPlainObjectEntry({}, "k", 1)).toBeUndefined();
       });
     });
   });

--- a/packages/data-model/test/value-visit/ContainerIteratingValueVisitor.test.ts
+++ b/packages/data-model/test/value-visit/ContainerIteratingValueVisitor.test.ts
@@ -65,8 +65,8 @@ describe("ContainerIteratingValueVisitor", () => {
       it("return `undefined`", () => {
         const vis = new Iterating();
 
-        expect(vis.visitedArrayElement([1], 0, 1)).toBeUndefined();
-        expect(vis.visitedArrayGap([], 0, 1)).toBeUndefined();
+        expect(vis.visitedFabricArrayElement([1], 0, 1)).toBeUndefined();
+        expect(vis.visitedFabricArrayGap([], 0, 1)).toBeUndefined();
         expect(vis.visitedFabricInstance(new FabricMap(new Map()), {}))
           .toBeUndefined();
         expect(vis.visitedFabricPlainObjectEntry({}, "k", 1)).toBeUndefined();

--- a/packages/data-model/test/value-visit/NopValueVisitor.test.ts
+++ b/packages/data-model/test/value-visit/NopValueVisitor.test.ts
@@ -21,7 +21,7 @@ describe("NopValueVisitor", () => {
     expect(vis.visitValue(1)).toBeUndefined();
     expect(vis.visitedArrayElement([1], 0, 1)).toBeUndefined();
     expect(vis.visitedArrayGap([], 0, 1)).toBeUndefined();
-    expect(vis.visitedMapping({}, "k", 1)).toBeUndefined();
+    expect(vis.visitedFabricPlainObject({}, "k", 1)).toBeUndefined();
   });
 
   it("completes a visit of a nested value without descending", () => {

--- a/packages/data-model/test/value-visit/NopValueVisitor.test.ts
+++ b/packages/data-model/test/value-visit/NopValueVisitor.test.ts
@@ -21,7 +21,7 @@ describe("NopValueVisitor", () => {
     expect(vis.visitValue(1)).toBeUndefined();
     expect(vis.visitedArrayElement([1], 0, 1)).toBeUndefined();
     expect(vis.visitedArrayGap([], 0, 1)).toBeUndefined();
-    expect(vis.visitedFabricPlainObject({}, "k", 1)).toBeUndefined();
+    expect(vis.visitedFabricPlainObjectEntry({}, "k", 1)).toBeUndefined();
   });
 
   it("completes a visit of a nested value without descending", () => {

--- a/packages/data-model/test/value-visit/NopValueVisitor.test.ts
+++ b/packages/data-model/test/value-visit/NopValueVisitor.test.ts
@@ -19,8 +19,8 @@ describe("NopValueVisitor", () => {
     expect(vis.visitNonFabricValue(new Date(0))).toBeUndefined();
     expect(vis.visitPrimitive(1, "number")).toBeUndefined();
     expect(vis.visitValue(1)).toBeUndefined();
-    expect(vis.visitedArrayElement([1], 0, 1)).toBeUndefined();
-    expect(vis.visitedArrayGap([], 0, 1)).toBeUndefined();
+    expect(vis.visitedFabricArrayElement([1], 0, 1)).toBeUndefined();
+    expect(vis.visitedFabricArrayGap([], 0, 1)).toBeUndefined();
     expect(vis.visitedFabricInstance(instance, {})).toBeUndefined();
     expect(vis.visitedFabricPlainObjectEntry({}, "k", 1)).toBeUndefined();
   });

--- a/packages/data-model/test/value-visit/NopValueVisitor.test.ts
+++ b/packages/data-model/test/value-visit/NopValueVisitor.test.ts
@@ -21,6 +21,7 @@ describe("NopValueVisitor", () => {
     expect(vis.visitValue(1)).toBeUndefined();
     expect(vis.visitedArrayElement([1], 0, 1)).toBeUndefined();
     expect(vis.visitedArrayGap([], 0, 1)).toBeUndefined();
+    expect(vis.visitedFabricInstance(instance, {})).toBeUndefined();
     expect(vis.visitedFabricPlainObjectEntry({}, "k", 1)).toBeUndefined();
   });
 

--- a/packages/data-model/test/value-visit/Recorder.ts
+++ b/packages/data-model/test/value-visit/Recorder.ts
@@ -151,7 +151,7 @@ export class Recorder extends ContainerIteratingValueVisitor<unknown, unknown> {
     return this.onNonFabric ? this.onNonFabric(value) : undefined;
   }
 
-  override visitedArrayElement(
+  override visitedFabricArrayElement(
     array: FabricArray,
     index: number,
     value: unknown,
@@ -162,7 +162,7 @@ export class Recorder extends ContainerIteratingValueVisitor<unknown, unknown> {
       : undefined;
   }
 
-  override visitedArrayGap(
+  override visitedFabricArrayGap(
     array: FabricArray,
     start: number,
     count: number,

--- a/packages/data-model/test/value-visit/Recorder.ts
+++ b/packages/data-model/test/value-visit/Recorder.ts
@@ -168,12 +168,12 @@ export class Recorder extends ContainerIteratingValueVisitor<unknown, unknown> {
     return this.onVisitedGap ? this.onVisitedGap(start, count) : undefined;
   }
 
-  override visitedFabricPlainObject(
+  override visitedFabricPlainObjectEntry(
     container: FabricPlainObject | FabricInstance,
     key: unknown,
     value: unknown,
   ): BaselineVisitResult<unknown> {
-    this.events.push(["visitedFabricPlainObject", container, key, value]);
+    this.events.push(["visitedFabricPlainObjectEntry", container, key, value]);
     return this.onVisitedMapping
       ? this.onVisitedMapping(key, value)
       : undefined;

--- a/packages/data-model/test/value-visit/Recorder.ts
+++ b/packages/data-model/test/value-visit/Recorder.ts
@@ -66,6 +66,10 @@ export class Recorder extends ContainerIteratingValueVisitor<unknown, unknown> {
     value: unknown,
   ) => BaselineVisitResult<unknown>;
   onVisitedGap?: (start: number, count: number) => BaselineVisitResult<unknown>;
+  onVisitedInstance?: (
+    instance: FabricInstance,
+    state: unknown,
+  ) => BaselineVisitResult<unknown>;
   onVisitedMapping?: (
     key: unknown,
     value: unknown,
@@ -126,11 +130,10 @@ export class Recorder extends ContainerIteratingValueVisitor<unknown, unknown> {
   override visitFabricInstance(
     value: FabricInstance,
   ): LeafVisitorResult<unknown, unknown> {
-    // Unlike the other container hooks, this one does not defer to the
-    // superclass by default: the engine cannot yet iterate an instance, so
-    // the default here is to stop.
     this.events.push(["instance", value]);
-    return this.onInstance ? this.onInstance(value) : undefined;
+    return this.onInstance
+      ? this.onInstance(value)
+      : super.visitFabricInstance(value);
   }
 
   override visitPrimitive(
@@ -166,6 +169,16 @@ export class Recorder extends ContainerIteratingValueVisitor<unknown, unknown> {
   ): BaselineVisitResult<unknown> {
     this.events.push(["visitedGap", array, start, count]);
     return this.onVisitedGap ? this.onVisitedGap(start, count) : undefined;
+  }
+
+  override visitedFabricInstance(
+    instance: FabricInstance,
+    state: unknown,
+  ): BaselineVisitResult<unknown> {
+    this.events.push(["visitedInstance", instance, state]);
+    return this.onVisitedInstance
+      ? this.onVisitedInstance(instance, state)
+      : undefined;
   }
 
   override visitedFabricPlainObjectEntry(

--- a/packages/data-model/test/value-visit/Recorder.ts
+++ b/packages/data-model/test/value-visit/Recorder.ts
@@ -168,12 +168,12 @@ export class Recorder extends ContainerIteratingValueVisitor<unknown, unknown> {
     return this.onVisitedGap ? this.onVisitedGap(start, count) : undefined;
   }
 
-  override visitedMapping(
+  override visitedFabricPlainObject(
     container: FabricPlainObject | FabricInstance,
     key: unknown,
     value: unknown,
   ): BaselineVisitResult<unknown> {
-    this.events.push(["visitedMapping", container, key, value]);
+    this.events.push(["visitedFabricPlainObject", container, key, value]);
     return this.onVisitedMapping
       ? this.onVisitedMapping(key, value)
       : undefined;

--- a/packages/data-model/test/value-visit/Recorder.ts
+++ b/packages/data-model/test/value-visit/Recorder.ts
@@ -3,8 +3,8 @@
  * call it receives, and builders for the result forms a test hands back.
  *
  * The recorder dispatches every value to its subtype method and recurses into
- * containers the way `ContainerIteratingValueVisitor` does by default, so a test
- * that wants the default walk sets nothing, and one that wants a different
+ * containers the way `ContainerIteratingValueVisitor` does by default, so a
+ * test that wants the default walk sets nothing, and one that wants a different
  * decision at one hook assigns the matching `on*` property.
  */
 
@@ -31,9 +31,9 @@ export type Event = [name: string, ...args: unknown[]];
 
 /**
  * Visitor that dispatches every value to its subtype method, recurses into
- * containers the way `ContainerIteratingValueVisitor` does by default, and records
- * each call it receives. Each hook can be overridden per test by assigning the
- * matching `on*` property.
+ * containers the way `ContainerIteratingValueVisitor` does by default, and
+ * records each call it receives. Each hook can be overridden per test by
+ * assigning the matching `on*` property.
  */
 export class Recorder extends ContainerIteratingValueVisitor<unknown, unknown> {
   readonly events: Event[] = [];

--- a/packages/data-model/test/value-visit/VisitInProgress.test.ts
+++ b/packages/data-model/test/value-visit/VisitInProgress.test.ts
@@ -305,9 +305,10 @@ describe("VisitInProgress", () => {
           const object = { a: 1, b: 2 };
 
           expect(visit(object, rec)).toEqual(mainResult("first"));
-          expect(rec.events.filter((e) => e[0] === "visitedFabricPlainObject")).toEqual([
-            ["visitedFabricPlainObject", object, "a", 1],
-          ]);
+          expect(rec.events.filter((e) => e[0] === "visitedFabricPlainObject"))
+            .toEqual([
+              ["visitedFabricPlainObject", object, "a", 1],
+            ]);
           expect(rec.events.map((e) => e[1])).not.toContain(2);
         });
 
@@ -416,7 +417,9 @@ describe("VisitInProgress", () => {
             const object = { a: 1 };
 
             visit(object, rec);
-            expect(rec.events.filter((e) => e[0] === "visitedFabricPlainObject"))
+            expect(
+              rec.events.filter((e) => e[0] === "visitedFabricPlainObject"),
+            )
               .toEqual([
                 ["visitedFabricPlainObject", object, "a", 1],
               ]);

--- a/packages/data-model/test/value-visit/VisitInProgress.test.ts
+++ b/packages/data-model/test/value-visit/VisitInProgress.test.ts
@@ -188,7 +188,7 @@ describe("VisitInProgress", () => {
           ]);
         });
 
-        it("reports the original element, not its replacement, to `visitedArrayElement()`", () => {
+        it("reports the original element, not its replacement, to `visitedFabricArrayElement()`", () => {
           const rec = new Recorder();
           rec.onValue = (v) => (v === "x") ? replace(42) : DO_VISIT_SUBTYPE;
           const array = ["x"];
@@ -288,7 +288,7 @@ describe("VisitInProgress", () => {
       });
 
       describe("`mainResult` results", () => {
-        it("ends the visit from `visitedArrayElement()`, skipping later elements", () => {
+        it("ends the visit from `visitedFabricArrayElement()`, skipping later elements", () => {
           const rec = new Recorder();
           rec.onVisitedElement = (i) =>
             (i === 1) ? mainResult("at 1") : undefined;
@@ -329,7 +329,7 @@ describe("VisitInProgress", () => {
           expect(rec.names).not.toContain("visitedFabricPlainObjectEntry");
         });
 
-        it("ends the visit from `visitedArrayGap()`, for a gap before an element", () => {
+        it("ends the visit from `visitedFabricArrayGap()`, for a gap before an element", () => {
           const rec = new Recorder();
           rec.onVisitedGap = () => mainResult("gap");
 
@@ -338,7 +338,7 @@ describe("VisitInProgress", () => {
           expect(rec.names).not.toContain("visitedElement");
         });
 
-        it("ends the visit from `visitedArrayGap()`, for a gap at the end", () => {
+        it("ends the visit from `visitedFabricArrayGap()`, for a gap at the end", () => {
           const rec = new Recorder();
           rec.onVisitedGap = () => mainResult("gap");
 

--- a/packages/data-model/test/value-visit/VisitInProgress.test.ts
+++ b/packages/data-model/test/value-visit/VisitInProgress.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import { FabricError } from "@/fabric-instances/FabricError.ts";
+import { FabricLink } from "@/fabric-instances/FabricLink.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { type FabricContainerValue, type FabricValue } from "@/interface.ts";
@@ -96,6 +98,7 @@ describe("VisitInProgress", () => {
 
         it("passes a `FabricInstance` through `visitFabricContainer()` to `visitFabricInstance()`", () => {
           const rec = new Recorder();
+          rec.onInstance = () => undefined;
           const instance = new FabricMap(new Map([["k", 1]]));
 
           visit(instance, rec);
@@ -305,7 +308,9 @@ describe("VisitInProgress", () => {
           const object = { a: 1, b: 2 };
 
           expect(visit(object, rec)).toEqual(mainResult("first"));
-          expect(rec.events.filter((e) => e[0] === "visitedFabricPlainObjectEntry"))
+          expect(
+            rec.events.filter((e) => e[0] === "visitedFabricPlainObjectEntry"),
+          )
             .toEqual([
               ["visitedFabricPlainObjectEntry", object, "a", 1],
             ]);
@@ -418,7 +423,9 @@ describe("VisitInProgress", () => {
 
             visit(object, rec);
             expect(
-              rec.events.filter((e) => e[0] === "visitedFabricPlainObjectEntry"),
+              rec.events.filter((e) =>
+                e[0] === "visitedFabricPlainObjectEntry"
+              ),
             )
               .toEqual([
                 ["visitedFabricPlainObjectEntry", object, "a", 1],
@@ -488,13 +495,116 @@ describe("VisitInProgress", () => {
             /Cannot use `recurse` result with non-container: /,
           );
         });
+      });
 
-        it("throws for a `recurse` on a `FabricInstance`", () => {
+      describe("`FabricInstance` recursion", () => {
+        // `FabricLink` and `FabricError` are the fixtures because their
+        // codecs are real. A link's state is its payload, the very object,
+        // which makes the sequence easy to state; an error's state is built
+        // fresh on each encode and can hold a `cause`, which is what a cycle
+        // through an instance needs.
+
+        it("visits the state under the instance, then reports both to `visitedFabricInstance()`", () => {
           const rec = new Recorder();
-          rec.onInstance = () => DO_RECURSE_KEYS_VALUES;
+          const payload = { id: "fid1:abc" };
+          const link = new FabricLink(payload);
+
+          expect(visit(link, rec)).toBeUndefined();
+          expect(rec.events).toEqual([
+            ["value", link],
+            ["container", link],
+            ["instance", link],
+            ["value", payload],
+            ["container", payload],
+            ["object", payload],
+            ["value", "fid1:abc"],
+            ["primitive", "fid1:abc", "string"],
+            ["visitedFabricPlainObjectEntry", payload, "id", "fid1:abc"],
+            ["visitedInstance", link, payload],
+          ]);
+        });
+
+        it("visits the state its codec encodes", () => {
+          const rec = new Recorder();
+          const error = new FabricError({
+            type: "TypeError",
+            message: "boom",
+            stack: undefined,
+            cause: undefined,
+          });
+
+          visit(error, rec);
+          expect(rec.events.filter((e) => e[0] === "visitedInstance")).toEqual([
+            ["visitedInstance", error, {
+              type: "TypeError",
+              name: null,
+              message: "boom",
+            }],
+          ]);
+          expect(rec.events.filter((e) => e[0] === "primitive")).toEqual([
+            ["primitive", "TypeError", "string"],
+            ["primitive", null, "null"],
+            ["primitive", "boom", "string"],
+          ]);
+        });
+
+        it("reports a cycle through an instance at the instance", () => {
+          const holder: Record<string, unknown> = {};
+          const error = new FabricError({
+            type: "Error",
+            message: "m",
+            stack: undefined,
+            cause: holder as FabricValue,
+          });
+          holder.err = error;
+
+          const rec = new Recorder();
+
+          visit(error, rec);
+          expect(rec.events.filter((e) => e[0] === "cycle")).toEqual([
+            ["cycle", error, 0, 3],
+          ]);
+        });
+
+        it("ends the visit from inside the state, before `visitedFabricInstance()`", () => {
+          const rec = new Recorder();
+          rec.onPrimitive = (v) =>
+            (v === "boom") ? mainResult("found") : undefined;
+          const error = new FabricError({
+            type: "Error",
+            message: "boom",
+            stack: undefined,
+            cause: undefined,
+          });
+
+          expect(visit(error, rec)).toEqual(mainResult("found"));
+          expect(rec.names).not.toContain("visitedInstance");
+        });
+
+        it("ends the visit from `visitedFabricInstance()`", () => {
+          const rec = new Recorder();
+          rec.onVisitedInstance = () => mainResult("after");
+          const link = new FabricLink({ id: "fid1:abc" });
+
+          expect(visit([link, 1], rec)).toEqual(mainResult("after"));
+          expect(rec.events.map((e) => e[1])).not.toContain(1);
+        });
+
+        it("iterates nothing for `DO_RECURSE_KEYS` on an instance", () => {
+          const rec = new Recorder();
+          rec.onInstance = () => DO_RECURSE_KEYS;
+          const link = new FabricLink({ id: "fid1:abc" });
+
+          visit(link, rec);
+          expect(rec.names).not.toContain("visitedInstance");
+          expect(rec.names).not.toContain("primitive");
+        });
+
+        it("throws from the codec for an instance whose codec is a stub", () => {
+          const rec = new Recorder();
           const instance = new FabricMap(new Map());
 
-          expect(() => visit(instance, rec)).toThrow(/not yet visitable/);
+          expect(() => visit(instance, rec)).toThrow(/not yet implemented/);
         });
       });
 

--- a/packages/data-model/test/value-visit/VisitInProgress.test.ts
+++ b/packages/data-model/test/value-visit/VisitInProgress.test.ts
@@ -61,9 +61,9 @@ describe("VisitInProgress", () => {
             ["object", inner],
             ["value", null],
             ["primitive", null, "null"],
-            ["visitedFabricPlainObject", inner, "b", null],
+            ["visitedFabricPlainObjectEntry", inner, "b", null],
             ["visitedElement", array, 1, inner],
-            ["visitedFabricPlainObject", root, "a", array],
+            ["visitedFabricPlainObjectEntry", root, "a", array],
           ]);
         });
 
@@ -299,15 +299,15 @@ describe("VisitInProgress", () => {
           expect(rec.events.map((e) => e[1])).not.toContain(30);
         });
 
-        it("ends the visit from `visitedFabricPlainObject()`, skipping later mappings", () => {
+        it("ends the visit from `visitedFabricPlainObjectEntry()`, skipping later mappings", () => {
           const rec = new Recorder();
           rec.onVisitedMapping = () => mainResult("first");
           const object = { a: 1, b: 2 };
 
           expect(visit(object, rec)).toEqual(mainResult("first"));
-          expect(rec.events.filter((e) => e[0] === "visitedFabricPlainObject"))
+          expect(rec.events.filter((e) => e[0] === "visitedFabricPlainObjectEntry"))
             .toEqual([
-              ["visitedFabricPlainObject", object, "a", 1],
+              ["visitedFabricPlainObjectEntry", object, "a", 1],
             ]);
           expect(rec.events.map((e) => e[1])).not.toContain(2);
         });
@@ -321,7 +321,7 @@ describe("VisitInProgress", () => {
           expect(rec.events.filter((e) => e[0] === "primitive")).toEqual([
             ["primitive", "a", "string"],
           ]);
-          expect(rec.names).not.toContain("visitedFabricPlainObject");
+          expect(rec.names).not.toContain("visitedFabricPlainObjectEntry");
         });
 
         it("ends the visit from `visitedArrayGap()`, for a gap before an element", () => {
@@ -410,7 +410,7 @@ describe("VisitInProgress", () => {
           ]);
         });
 
-        it("reports each mapping to `visitedFabricPlainObject()` whichever of keys or values is recursed", () => {
+        it("reports each mapping to `visitedFabricPlainObjectEntry()` whichever of keys or values is recursed", () => {
           for (const form of [DO_RECURSE_KEYS, DO_RECURSE_VALUES]) {
             const rec = new Recorder();
             rec.onPlainObject = () => form;
@@ -418,10 +418,10 @@ describe("VisitInProgress", () => {
 
             visit(object, rec);
             expect(
-              rec.events.filter((e) => e[0] === "visitedFabricPlainObject"),
+              rec.events.filter((e) => e[0] === "visitedFabricPlainObjectEntry"),
             )
               .toEqual([
-                ["visitedFabricPlainObject", object, "a", 1],
+                ["visitedFabricPlainObjectEntry", object, "a", 1],
               ]);
           }
         });
@@ -445,7 +445,7 @@ describe("VisitInProgress", () => {
 
           visit({ a: 1 }, rec);
           expect(rec.names).not.toContain("primitive");
-          expect(rec.names).not.toContain("visitedFabricPlainObject");
+          expect(rec.names).not.toContain("visitedFabricPlainObjectEntry");
         });
 
         it("honors a `recurse` returned directly from `visitValue()`, without subtype dispatch", () => {

--- a/packages/data-model/test/value-visit/VisitInProgress.test.ts
+++ b/packages/data-model/test/value-visit/VisitInProgress.test.ts
@@ -61,9 +61,9 @@ describe("VisitInProgress", () => {
             ["object", inner],
             ["value", null],
             ["primitive", null, "null"],
-            ["visitedMapping", inner, "b", null],
+            ["visitedFabricPlainObject", inner, "b", null],
             ["visitedElement", array, 1, inner],
-            ["visitedMapping", root, "a", array],
+            ["visitedFabricPlainObject", root, "a", array],
           ]);
         });
 
@@ -299,14 +299,14 @@ describe("VisitInProgress", () => {
           expect(rec.events.map((e) => e[1])).not.toContain(30);
         });
 
-        it("ends the visit from `visitedMapping()`, skipping later mappings", () => {
+        it("ends the visit from `visitedFabricPlainObject()`, skipping later mappings", () => {
           const rec = new Recorder();
           rec.onVisitedMapping = () => mainResult("first");
           const object = { a: 1, b: 2 };
 
           expect(visit(object, rec)).toEqual(mainResult("first"));
-          expect(rec.events.filter((e) => e[0] === "visitedMapping")).toEqual([
-            ["visitedMapping", object, "a", 1],
+          expect(rec.events.filter((e) => e[0] === "visitedFabricPlainObject")).toEqual([
+            ["visitedFabricPlainObject", object, "a", 1],
           ]);
           expect(rec.events.map((e) => e[1])).not.toContain(2);
         });
@@ -320,7 +320,7 @@ describe("VisitInProgress", () => {
           expect(rec.events.filter((e) => e[0] === "primitive")).toEqual([
             ["primitive", "a", "string"],
           ]);
-          expect(rec.names).not.toContain("visitedMapping");
+          expect(rec.names).not.toContain("visitedFabricPlainObject");
         });
 
         it("ends the visit from `visitedArrayGap()`, for a gap before an element", () => {
@@ -409,16 +409,16 @@ describe("VisitInProgress", () => {
           ]);
         });
 
-        it("reports each mapping to `visitedMapping()` whichever of keys or values is recursed", () => {
+        it("reports each mapping to `visitedFabricPlainObject()` whichever of keys or values is recursed", () => {
           for (const form of [DO_RECURSE_KEYS, DO_RECURSE_VALUES]) {
             const rec = new Recorder();
             rec.onPlainObject = () => form;
             const object = { a: 1 };
 
             visit(object, rec);
-            expect(rec.events.filter((e) => e[0] === "visitedMapping"))
+            expect(rec.events.filter((e) => e[0] === "visitedFabricPlainObject"))
               .toEqual([
-                ["visitedMapping", object, "a", 1],
+                ["visitedFabricPlainObject", object, "a", 1],
               ]);
           }
         });
@@ -442,7 +442,7 @@ describe("VisitInProgress", () => {
 
           visit({ a: 1 }, rec);
           expect(rec.names).not.toContain("primitive");
-          expect(rec.names).not.toContain("visitedMapping");
+          expect(rec.names).not.toContain("visitedFabricPlainObject");
         });
 
         it("honors a `recurse` returned directly from `visitValue()`, without subtype dispatch", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

## Summary

The `value-visit` engine can now descend into a `FabricInstance`. A `recurse` on an instance pushes the instance onto the cycle stack, encodes it through its own codec to its state, visits that state as a single sub-value, and then reports `visitedFabricInstance(instance, state)`. The codec is thereby the one definition of an instance's contents for the visitor, the same definition the hash walk and the wire use, and no per-class traversal protocol is needed. This was the half of the generalized value walk left open when the module first landed. The submodule remains **work in progress and not for use yet**: it is still unexported from the package, and the prose and links that introduce it to consumers follow once it is ready to be used.

## What changed

* **Instance descent** in `VisitInProgress`: `#recurseFabricInstance()` does the encode, the stacked visit of the state, and the callback. Only `doValues` is meaningful for an instance, since its state is one value; `ContainerIteratingValueVisitor` returns `DO_RECURSE_VALUES` for it and says so. The instance is on the stack while its state is visited, so a cycle that runs through an instance is caught at the instance even though each encode produces a fresh state object.
* **`visitedFabricInstance(instance, state)`** joins the `visited*()` family on the interface, `BaseValueVisitor`, `NopValueVisitor`, and `ContainerIteratingValueVisitor`.
* **Renames for consistency with the recognized types:** `visitedMapping()` becomes `visitedFabricPlainObjectEntry()`, whose `container` parameter narrows to `FabricPlainObject` now that an instance never reaches it; `visitedArrayElement()` and `visitedArrayGap()` become `visitedFabricArrayElement()` and `visitedFabricArrayGap()`; the engine's iteration methods follow.
* **`ContainerIteratingValueVisitor.visitFabricContainer()`** returns `DO_RECURSE_VALUES` directly rather than dispatching to the subtype methods, and the class doc says how a subclass gets per-subtype behavior: override `visitFabricContainer()` to return `DO_VISIT_SUBTYPE`, then override the subtype it wants.

A consequence worth knowing: a `FabricMap`'s keys will arrive as elements of whatever its codec's state is, not as `visitedFabricPlainObjectEntry()` calls with the map's own keys. A visitor that wants a map's semantics overrides `visitFabricInstance()`, which has the instance in hand. `FabricMap` and `FabricSet` still have stub codecs, so recursing into either throws "not yet implemented" from the codec rather than from the engine.

## Tests

129 cases across the six files, up from 122. The descent cases use `FabricLink` and `FabricError`, whose codecs are real: a link's state is its payload, the very object, which makes the full event sequence easy to state; an error's state is built fresh on each encode and can hold a `cause`, which is what a cycle through an instance needs. They pin: the state visited under the instance and then reported with it; the state being what the codec encodes; a cycle through an instance reported at the instance; a `mainResult` from inside the state and from the callback; a keys-only `recurse` iterating nothing; and the stub codecs' throw. The engine's unrecognized-tag arm is typed unreachable and carries the coverage marker the file uses for its other defense-in-depth branches, keeping `src/value-visit/` at 100% line coverage.

No test-identity aliases are recorded for the renamed hooks, for the same reason as the two earlier splits: these tests are a day old.

## Authorship

A collaboration between @danfuzz and an agent (Fable 5.1): the descent tactic, its implementation, and the renames are @danfuzz's; the review that caught the per-entry hook's naming and a type error, the tests, and the rewraps are the agent's.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

