### PR TITLE
fix(html): refresh attributes in headless rendered output

### DIFF
--- a/packages/html/src/mock-doc.ts
+++ b/packages/html/src/mock-doc.ts
@@ -71,9 +71,7 @@ function renderOptionsFromDoc(document: globalThis.Document): RenderOptions {
       } else {
         attrValue = `${value}`;
       }
-      if (!el.attribs[key]) {
-        el.attribs[key] = attrValue;
-      }
+      el.attribs[key] = attrValue;
     },
   };
 }

--- a/packages/html/test/in-process-attributes.test.ts
+++ b/packages/html/test/in-process-attributes.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { renderInProcess } from "../src/in-process.ts";
+import { MockDoc } from "../src/mock-doc.ts";
+
+describe("in-process-attributes", () => {
+  it("reflects successive property values on the same rendered element", async () => {
+    const signer = await Identity.fromPassphrase("in-process attributes");
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: StorageManager.emulate({ as: signer }),
+    });
+    const mock = new MockDoc('<div id="root"></div>');
+    const container = mock.document.getElementById("root")!;
+    let render: ReturnType<typeof renderInProcess> | undefined;
+    try {
+      const tx = runtime.edit();
+      const vdom = runtime.getCell<unknown>(
+        signer.did(),
+        "attributes",
+        undefined,
+        tx,
+      );
+      vdom.set({
+        type: "vnode",
+        name: "span",
+        props: { "aria-label": "green vote", style: "color: green" },
+        children: ["V"],
+      });
+      await tx.commit();
+      render = renderInProcess(container, vdom, {
+        document: mock.document,
+        setProp: mock.renderOptions.setProp,
+      });
+      await runtime.idle();
+      render.flush();
+      const element = container.firstChild;
+      expect(element).toBeDefined();
+      expect(element).not.toBeNull();
+      expect(container.innerHTML).toBe(
+        '<span aria-label="green vote" style="color: green">V</span>',
+      );
+
+      for (const color of ["yellow", "green"]) {
+        const update = runtime.edit();
+        vdom.withTx(update).key("props").set({
+          "aria-label": `${color} vote`,
+          style: `color: ${color}`,
+        });
+        await update.commit();
+        await runtime.idle();
+        render.flush();
+        expect(container.firstChild).toBe(element);
+        expect(container.innerHTML).toBe(
+          `<span aria-label="${color} vote" style="color: ${color}">V</span>`,
+        );
+      }
+    } finally {
+      render?.cancel();
+      await runtime.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Why

The #7155 poll-copy rehearsal found that headless HTML kept a vote's old label and string style after the vote committed. `MockDoc` only assigned an ordinary attribute when its existing value was falsy, so a mounted `cf view` could report stale attributes while the browser updated correctly. This also prevented a reliable comparison of the two measurement rigs after #7336.

## What changed

Always replace ordinary attribute values in the mock document's property setter. Add a reactive in-process rendering test that changes a vote from green to yellow and back, checks the serialized label and style, and verifies the element was retained.

## Test plan

- Regression fails without the setter fix and passes with it.
- Full HTML package: 28 tests / 287 steps pass; the final focused regression passes. Repository formatting/lint and all 46 type-check groups pass.
- A serial rehearsal on the isolated local poll copy passes with the corrected adapter: headless and browser both report 220 accesses across 29 completed scheduler runs. Local data stays outside this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

