### PR TITLE
docs: close computation-cost rehearsal and plan lazy fast-follow

### DIFF
--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -4,6 +4,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Audits and reports
 
+- [Representative lunch-poll copy rehearsal](development/performance/2026-09-12-representative-lunch-poll-rehearsal.md) — two isolated migration passes, authored-data preservation, matched browser/headless read counts, graph and timing tradeoffs, bounded clock churn, and the Q9 fast-follow decision.
+
 - [Index maintenance phase counts](development/performance/2026-09-11-index-maintenance-phases.md) — completed action-body counts for both index types across membership edits, key edits and lookup retargeting at three sizes.
 
 - [Demand-driven index enumeration](development/performance/2026-09-11-demanded-index-enumeration.md) — 2026-09-11: 512-row lookup and enumeration measurements, skewed-bucket costs, and the unresolved mixed-key representation boundary.
@@ -263,3 +265,6 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 ## The retired tutorial site
 
 - [tutorials/](tutorials/) — the complete MyST source of the retired docs.commontools.dev site: nine chapters, example code and images, and the build scaffolding, entered at [index.md](tutorials/index.md). Its state chapters and LLM tour teach the retired `cell()` API.
+
+- [Pattern computation cost implementation](plans/pattern-computation-cost-implementation.md) — executed #7155 sequence, copy-based acceptance, explicit B3a deferral, and D1/D2 handoff.
+- [Pattern computation cost design](plans/pattern-computation-cost.md) — original #7155 proposal, executed scope and separately tracked remaining lazy-materialization work.

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -80,6 +80,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Executed plans and work orders
 
+- [Pattern computation cost implementation](plans/pattern-computation-cost-implementation.md) — executed #7155 sequence, copy-based acceptance, explicit B3a deferral, and D1/D2 handoff.
+
 - [server-pattern-verbs-seed.md](plans/server-pattern-verbs-seed.md) — the seed that recorded the ruled 2026-08-24 direction for the pattern lifecycle verbs as server calls, executed September 2026 for `upload` and `instantiate`, which run on the space's serving runtime under `EXPERIMENTAL_SERVER_EXECUTION` with `cf` requesting them, while `setsrc` stays client-side because a source update's module authority needs a transaction that commits to storage itself; the live contract is `docs/features/server-pattern-lifecycle.md`.
 - [read-cost-budgets.md](plans/read-cost-budgets.md) — completed A3 plan for opt-in pattern-test read budgets, transaction-attempt coverage, failure diagnostics, and executable pass/fail demonstrations; shipped in #7257, September 2026.
 
@@ -124,6 +126,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 - [topics-board-migration-2026-08-28.md](topics-board-migration-2026-08-28.md) — the Stage B migration of the Estuary Topics board and its 125 topics: why the board moved FIRST and the children-first rule inverts when the parent's demand is what changed, that reversal through the source log is refused in both directions so recovery means restoring content, and the failures only the live run produced — every laptop run dying 4-6 minutes in on a different entity, per-row cost rising and never recovering after each transport error, and a partial apply reporting success.
 
 ## Shipped or superseded designs and decision records
+
+- [Pattern computation cost design](plans/pattern-computation-cost.md) — original #7155 proposal, executed scope and separately tracked remaining lazy-materialization work.
 
 - [Collection indexes and keyed lookup](plans/collection-index-contract.md) — 2026-09-10: executed B1/B2 semantics and acceptance contract for grouping, unique-key lookup, tagged enumeration, left joins, and maintenance measurements.
 
@@ -265,6 +269,3 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 ## The retired tutorial site
 
 - [tutorials/](tutorials/) — the complete MyST source of the retired docs.commontools.dev site: nine chapters, example code and images, and the build scaffolding, entered at [index.md](tutorials/index.md). Its state chapters and LLM tour teach the retired `cell()` API.
-
-- [Pattern computation cost implementation](plans/pattern-computation-cost-implementation.md) — executed #7155 sequence, copy-based acceptance, explicit B3a deferral, and D1/D2 handoff.
-- [Pattern computation cost design](plans/pattern-computation-cost.md) — original #7155 proposal, executed scope and separately tracked remaining lazy-materialization work.

--- a/docs/history/development/performance/2026-09-12-representative-lunch-poll-rehearsal.md
+++ b/docs/history/development/performance/2026-09-12-representative-lunch-poll-rehearsal.md
@@ -1,0 +1,179 @@
+---
+status: historical
+created: 2026-09-12
+archived: 2026-09-12
+reason: "Representative lunch-poll copy rehearsal and matched headless/browser measurements for design #7155."
+---
+
+# Representative lunch-poll copy rehearsal
+
+This record covers an isolated copy of the representative lunch poll. It does
+not authorize or describe an update to the live poll. The source was supplied by
+the operator as a consistent SQLite snapshot; all pattern reads, source updates,
+profile creation, and test votes used the local copy.
+
+## Source and isolation
+
+Snapshot: `team-lunch-rehearsal-20260912T001622Z.sqlite`, 4,379,738,112 bytes.
+SHA-256: `b9d2940775106e203252f857094cbe5a2525fe27671d92ac6c92527a8664fd0b`. The
+original file was preserved. `cf space clone` established a pristine copy and a
+manifest of 105,230 scoped fingerprints, with no unhashable or ambiguous
+entities. Generated cells were excluded by the clone tool's normal contract.
+
+The server bound to loopback, used a dedicated writable memory directory, and
+printed its rehearsal-clone banner. Server execution was explicitly disabled in
+toolshed, shell and probe processes. A fresh local identity and disabled local
+ACL enforcement allowed exercising the copy without an operator key. These
+conditions test content migration and client execution; they do not test
+production access control, hosting, network latency, or concurrent users.
+
+The snapshot contained 14 options, 9 participants, 76 votes, and no visits.
+Seventy-two votes carried September 8 UTC timestamps, two September 10, and two
+September 11. The poll's local-calendar filter was kept intact. During the
+September 11 America/Los_Angeles rehearsal, two original votes were visible. One
+local test profile joined and cast one vote, giving matched measurement inputs
+of 14 options, 10 participants, 77 stored votes and three current-day votes. No
+original timestamps or profile links were rewritten.
+
+Nine original participant profiles referenced nine home spaces absent from the
+snapshot. Their badges displayed unresolved-profile fallbacks. Stored roster
+names and vote identities remained available; a profile created through the
+local UI supplied the test voter's cross-space profile. This is explicit partial
+linked-profile coverage, not a full copy of every participant's home.
+
+## Compared programs and measurement boundary
+
+The deployed compiled module identity was
+`pzofRLPO9pT6Mwguyr8rrjpN-jRss_KgJJME3C464Y4`. Source recovered from the local
+copy used scan-based tallying. The candidate was the maintained-group poll
+reviewed at `76097f0cc6a4112291d02d902cad688b5e46501f` and merged in #7336. Both
+arms used that fixed runtime revision. All eight authored test entries were
+supplied with each candidate source update; there were no attached data files.
+All 93 authored assertions passed before the first apply.
+
+The browser kept the poll's cards and summary mounted. The headless rig used the
+same worker reconciler and DOM applicator in process, with `MockDoc` as the
+document. A stale-attribute defect in that adapter was reproduced by a
+regression test and corrected before accepting headless samples. Both source
+arms used the same corrected adapter. Runtime error logs and the rendered
+local-voter swatch were checked after each operation.
+
+Setup and two warmup color changes were outside measurement. One green-to-yellow
+vote collected completed reactive-body counters in the executing runtime. These
+counters exclude handler and commit-preparation reads. Successful and failed
+event-commit markers were recorded separately; they are not all storage
+transactions. A subsequent yellow-to-green vote ran with accounting disabled.
+The headless call awaited its handler commit and reactive/storage settlement;
+the browser timer included trusted-click readiness, protocol, DOM and view
+settlement. Their elapsed times are different end-to-end boundaries, not an
+isolated measurement of worker-message overhead.
+
+## Results
+
+The second pass ran the following operations serially on matched inputs:
+
+| Rig/source          | Body runs | Accesses | Maximum body | Link crossings | Event commits | Graph nodes | Graph edges | Elapsed ms |
+| ------------------- | --------- | -------- | ------------ | -------------- | ------------- | ----------- | ----------- | ---------- |
+| Browser, deployed   | 39        | 629      | 84           | 418            | 2             | 2,300       | 5,026       | 139.07     |
+| Headless, deployed  | 39        | 629      | 84           | 418            | 1             | 2,255       | 4,938       | 235.81     |
+| Browser, candidate  | 29        | 220      | 139          | 382            | 2             | 2,477       | 6,067       | 160.49     |
+| Headless, candidate | 29        | 220      | 139          | 382            | 1             | 2,466       | 6,084       | 148.86     |
+
+Reactive-body accesses fell about 65%, while the maximum body increased from 84
+to 139 and the graph grew. Graph snapshots include the whole mounted runtime,
+including shell and home subscriptions. The elapsed values are single samples:
+the browser candidate was slower and the headless candidate faster. They do not
+establish a uniform latency improvement. Browser and headless body counters
+matched within each source arm. Browser dispatch passes through the row wrapper;
+headless dispatch calls the bound vote handler directly, explaining the
+different event-commit boundaries.
+
+The browser's 14 rendered options and three current-day swatches matched across
+source arms, with no runtime errors. These observations do not reproduce or
+explain the design's historical approximate 45 ms versus 550 ms deployment
+comparison; that estimate remains unconfirmed in the accepted local-copy scope.
+
+The earlier synthetic profile-location comparison in #7340 separately held 74
+votes and the runtime fixed while moving voter profiles between the poll space
+and a dedicated profile space. Both browser variants reported 134 runs, 1,016
+accesses, 896 link traversals and two successful event commits. That experiment
+isolates profile location within its own cohort. Its absolute counts are not
+comparable to this three-current-vote snapshot or to another runtime revision.
+
+The budget fixtures demand and release VDOM for each render window, whereas
+these mounted rigs retain their subscriptions. Their rematerialization limits
+and completed-attempt totals are a separate measurement from continuously
+mounted reactive-body counts. Fewer measured reads alone does not establish a
+latency improvement or eliminate index initialization and maintenance cost.
+
+## Preservation and repeatability
+
+Both source checks and both updates passed compatibility acceptance without an
+incompatibility override. The update receipts were
+`ac63c62f-4c6e-4ec5-b4f1-4ce80e396fad` and
+`c79efac9-1f38-47f3-9ed6-5f2326ccb7c2`. Before the second pass, strict reset
+verification restored all 105,230 scoped fingerprints, with zero changed,
+removed, or added entities and the original commit/revision counts. The original
+100 authored entities also matched their saved hashes.
+
+In the second pass, all 102 prepared authored entities matched immediately after
+migration and after the final observation. Preparing the local test participant
+and vote changed only the original input root among the original 100 entities;
+original option, user, and vote entities remained unchanged. Whole-store
+verification reported migration acceptance, an intact pristine baseline, zero
+removed, 45 changed, and 930 added entities, with no ambiguous or unhashable
+entities. Its changed free cells had the same audited categories as pass one.
+The strict pristine verdict is intentionally false after migration; the
+migration verdict and authored-data hashes answer separate questions.
+
+The first migration preserved all 102 authored entities checked immediately
+before and after apply. Whole-store verification reported zero removed entities,
+45 changed and 867 added, with the pristine baseline intact. Its 21 changed free
+cells were audited: 18 compilation records, one clock, one rendered VNode, and
+one derived link. The authored-data comparison is necessary because a
+whole-store migration verdict cannot distinguish a clobber from an intended
+result rewrite.
+
+An explicitly bounded churn observation showed five consecutive zero-commit
+one-minute buckets from 00:43 through 00:47 UTC after the initial migration and
+browser checks. Later diagnostic operations were separate writes. No sustained
+write plateau appeared in that observed quiet interval. The server was stopped
+before reset so the second pass could not use an unlinked database.
+
+## Scope remaining
+
+The second pass kept a settled browser mounted from 01:25:10 through 01:31:34
+UTC. Its bounded churn observation recorded two commits and two revisions in the
+01:30 bucket, and zero commits in the surrounding observed minute buckets. Both
+writes were reconstructed and verified as the five-minute clock value
+`1789176600000`. The observer closed after explicit settlement with no runtime
+errors. No sustained write plateau appeared in this interval.
+
+[PR #7391](https://github.com/commontoolsinc/labs/pull/7391) fixes the headless
+adapter's attribute replacement, merged as
+`b3f7972f245dd6ad2e2276aeae17c1f110c3cc80` after clean antagonistic and Cubic
+reviews and 69 successful or intentionally skipped checks. The first CI attempt
+hit the existing 1,184-vote render limit in a harness that discards DOM
+operations and does not call this adapter. One diagnostic rerun passed with
+unchanged limits. The negative regression failed against the stale setter; the
+corrected HTML suite passed 28 tests and 287 steps.
+
+## Q9 decision and consequences
+
+Mike approved a separate lazy-materialization fast-follow on September 12 UTC.
+The [follow-up plan](../../../plans/lazy-materialization-fast-follow.md) owns
+handler investigation/integration, rollout evidence, flag retirement, and
+remeasurement in stages F0–F5. This allows the collection implementation and
+copy-based acceptance to close without claiming those runtime stages are done.
+
+The alternatives were to expand #7155 into those behavioral and rollout changes,
+or leave them deferred without an execution sequence. The separate plan retains
+explicit dependencies and acceptance criteria while avoiding both scope
+expansion and an untracked handler exception. Handler work and lift-flag
+retirement can proceed independently unless contract investigation establishes a
+dependency.
+
+The live poll remains unchanged. Any live update still requires operator
+coordination and its own rollback preparation. The D1/D2 handoff does not claim
+handler integration or flag retirement; those remain pending in the separate
+plan.

--- a/docs/history/development/performance/2026-09-pattern-read-accounting.md
+++ b/docs/history/development/performance/2026-09-pattern-read-accounting.md
@@ -9,7 +9,7 @@ reason: "First-batch read-accounting measurements and generic reduction baseline
 
 Measured against base commit `16de7e0c87` with the uncommitted read-accounting
 implementation, using Deno 2.9.4 on macOS arm64. This record covers A1/A2 and
-the available portion of A0 in `docs/plans/pattern-computation-cost.md`.
+the available portion of A0 in `docs/history/plans/pattern-computation-cost.md`.
 It does not establish a speedup for an incremental aggregate: those operators
 are not implemented by this batch.
 

--- a/docs/history/features/2026-09-11-index-key-enumeration-decision.md
+++ b/docs/history/features/2026-09-11-index-key-enumeration-decision.md
@@ -8,7 +8,7 @@ reason: "Accepted Q7 API decision; records context, consequences, and alternativ
 # Mixed index key enumeration decision
 
 Mike approved explicit tagged enumeration on September 11, 2026, resolving Q7
-of the [computation-cost implementation plan](../../plans/pattern-computation-cost-implementation.md).
+of the [computation-cost implementation plan](../plans/pattern-computation-cost-implementation.md).
 This records an accepted design decision, not completed implementation or test
 acceptance. The [archived contract](../plans/collection-index-contract.md) tracks
 implementation requirements.

--- a/docs/history/plans/pattern-computation-cost-implementation.md
+++ b/docs/history/plans/pattern-computation-cost-implementation.md
@@ -1,11 +1,18 @@
+---
+status: historical
+created: 2026-09-10
+archived: 2026-09-12
+reason: "Executed #7155 scope; B3a deferred and D1/D2 transferred to a separate fast-follow."
+---
+
 # Pattern computation cost: implementation sequence
 
 Status: instrumentation, read budgets, named aggregates, reactive row repairs,
 collection indexes, tagged key enumeration, and left lookup joins are delivered.
 [PR #7323](https://github.com/commontoolsinc/labs/pull/7323) publishes the index
 producers and join acceptance;
-[PR #7362](https://github.com/commontoolsinc/labs/pull/7362) publishes the separate
-maintenance-phase measurements. Both passed CI and review before merge.
+[PR #7362](https://github.com/commontoolsinc/labs/pull/7362) publishes the
+separate maintenance-phase measurements. Both passed CI and review before merge.
 [PR #7372](https://github.com/commontoolsinc/labs/pull/7372) bounds index member
 setup reads, and [PR #7385](https://github.com/commontoolsinc/labs/pull/7385)
 bounds shared downstream traversal in scheduler wake checks. The repository
@@ -13,11 +20,13 @@ lunch poll uses maintained per-option groups and tighter updated-render budgets
 in [PR #7336](https://github.com/commontoolsinc/labs/pull/7336). The execution
 dashboard records validation and publication status.
 
-A5/B6 still require a comparison against an isolated snapshot copy of the
-representative poll. Local-copy evidence does not establish production hosting,
-network, or concurrent-user performance. D1/D2 track the remaining
-lazy-materialization work under its own plan and require a new baseline when
-that dependency changes.
+A5/B6 acceptance is recorded in the
+[representative-copy report](../development/performance/2026-09-12-representative-lunch-poll-rehearsal.md).
+Two migration passes preserved authored data and matched rendered content. The
+report separates reduced update reads from graph growth and mixed timings;
+production latency and the historical deployment ratio remain unconfirmed. Q9
+transfers D1/D2 execution to the
+[lazy-materialization fast-follow](../../plans/lazy-materialization-fast-follow.md).
 The live poll is untouched.
 
 This tracker executes the design in
@@ -27,8 +36,8 @@ scope; this document owns dependencies, implementation slices, acceptance
 checks, and the next task. Keep the A–E identifiers aligned with the design. Its
 reported durations and access estimates are hypotheses until reproduced here.
 
-The [execution dashboard](../../tools/implementation-progress/README.md) shows
-delivery state, review gates, outstanding questions, and observable demos.
+The [execution dashboard](../../../tools/implementation-progress/README.md)
+shows delivery state, review gates, outstanding questions, and observable demos.
 Checked items below mean implemented and validated; the dashboard separately
 records whether they have landed. Keep both current at implementation
 milestones.
@@ -77,7 +86,7 @@ replacement advice requires a shipped replacement.
       points.
 - [x] Create the full implementation sequence with explicit acceptance gates.
 - [x] Reconcile D3 with the current implementation: `getSnapshotMemo()` in
-      [extended-storage-transaction.ts](../../packages/runner/src/storage/extended-storage-transaction.ts)
+      [extended-storage-transaction.ts](../../../packages/runner/src/storage/extended-storage-transaction.ts)
       selects separate memos by epoch and ambient metadata. D3 must verify
       isolation and measure reuse, rather than assume scoped memoization is
       absent.
@@ -98,9 +107,9 @@ replacement advice requires a shipped replacement.
         Disable idempotency verification before using test durations as
         performance evidence, following the performance-investigation skill.
 - [x] **A1a — Define the initial accounting contract.** See
-      [read accounting](../features/read-accounting.md). Reactive action bodies
-      are the initial boundary; event dispatch and commit work must be added
-      before claiming whole-step budget coverage.
+      [read accounting](../../features/read-accounting.md). Reactive action
+      bodies are the initial boundary; event dispatch and commit work must be
+      added before claiming whole-step budget coverage.
   - [x] Define proxy access events, actual link crossings, distinct documents
         identified by replica document object, and registered dependencies.
         Specify repeated reads, missing values, enumeration, shallow reads, and
@@ -114,8 +123,8 @@ replacement advice requires a shipped replacement.
 - [x] **A1b — Implement reactive-action accounting at the operations it
       measures.**
   - [x] Extend `ActionStats` and scheduler recording in
-        [telemetry.ts](../../packages/runner/src/telemetry.ts) and
-        [timing.ts](../../packages/runner/src/scheduler/timing.ts).
+        [telemetry.ts](../../../packages/runner/src/telemetry.ts) and
+        [timing.ts](../../../packages/runner/src/scheduler/timing.ts).
   - [x] Trace both query-result and schema-backed lazy reads before placing
         proxy counters. Count link crossings in the actual resolution and schema
         traversal paths, without counting the same crossing twice.
@@ -127,11 +136,11 @@ replacement advice requires a shipped replacement.
   - [x] Verify disabled accounting allocates no per-read counter state and
         performs no document-set maintenance; measure its overhead against an
         uninstrumented control. See the
-        [disabled-probe measurement](../history/development/performance/2026-09-10-read-accounting-probes.md);
+        [disabled-probe measurement](../development/performance/2026-09-10-read-accounting-probes.md);
         the result is limited to that workload and does not claim zero overhead.
 - [x] **A2 — Expose attributed reactive-action counts.**
   - [x] Extend per-step output in
-        [test-runner.ts](../../packages/cli/lib/test-runner.ts), sorting by
+        [test-runner.ts](../../../packages/cli/lib/test-runner.ts), sorting by
         access deltas and retaining run counts and authored `src`.
   - [x] Keep builtin/coordinator work visible when no authored site exists. The
         CLI aggregates completed-run events, including removed actions. Avoid
@@ -145,15 +154,15 @@ replacement advice requires a shipped replacement.
         estimates. A0 is complete only after this pass.
 
 See the
-[controlled baseline](../history/development/performance/2026-09-10-lunch-poll-read-baseline.md)
+[controlled baseline](../development/performance/2026-09-10-lunch-poll-read-baseline.md)
 for the fixture, command, execution posture, and counts. No pattern-test
 durations are used as performance evidence.
 
 ## 3–4. Defend and calibrate measurements: A3–A5
 
 - [x] **A3 — Add opt-in pattern-test budgets.** The
-      [budget contract](../features/read-accounting.md#pattern-test-budgets) defines the surface, execution
-      coverage, and pass/fail demo.
+      [budget contract](../../features/read-accounting.md#pattern-test-budgets)
+      defines the surface, execution coverage, and pass/fail demo.
   - [x] Define the test declaration and diagnostics for per-action-run and
         per-step-through-settle limits, with separate initialization limits.
   - [x] Include every execution in a step, including builtins, coordinators,
@@ -163,53 +172,53 @@ durations are used as performance evidence.
         individually cheap runs exceeding the step budget. Verify unbudgeted
         tests preserve their behavior.
 - [x] **A4 — Add the read-side benchmark.**
-  - [x] Follow [BENCHMARKS.md](../development/BENCHMARKS.md); measure one vote
-        settling with its tally on screen across declared collection sizes.
+  - [x] Follow [BENCHMARKS.md](../../development/BENCHMARKS.md); measure one
+        vote settling with its tally on screen across declared collection sizes.
   - [x] Preserve the existing write-burst benchmark as a separate workload.
         Record reads, runs, commits, and timing in
         [PR #7261](https://github.com/commontoolsinc/labs/pull/7261).
   - [x] Add read-count regression limits in
         [PR #7282](https://github.com/commontoolsinc/labs/pull/7282): all six
-        functional assertions and render limits pass at 74, 296, and 1,184 votes.
-        Benchmark timing remains a reported trend.
-- [ ] **A5 — Explain probe/product differences.**
-  - [ ] Compare matched inputs in the headless probe and browser, varying worker
+        functional assertions and render limits pass at 74, 296, and 1,184
+        votes. Benchmark timing remains a reported trend.
+- [x] **A5 — Compare probe/product boundaries within accepted copy scope.**
+  - [x] Compare matched inputs in the headless probe and browser, varying worker
         boundary and single-space/cross-space voter links separately.
-  - [ ] Record client/server execution posture, demanded surfaces, counters, and
+  - [x] Record client/server execution posture, demanded surfaces, counters, and
         timings from the process that performs the work.
-  - [ ] Confirm the explanation against an isolated snapshot copy of the
+  - [x] Validate the comparison against an isolated snapshot copy of the
         representative poll. Record the snapshot, source revision, and linked
         profile coverage. Keep production hosting, network conditions, and
         concurrent live-user behavior outside the resulting performance claim.
 
 The representative-poll comparison uses the
-[local clone rehearsal procedure](../development/space-clone-rehearsal.md).
+[local clone rehearsal procedure](../../development/space-clone-rehearsal.md).
 Acquire a consistent snapshot, inventory cross-space profile dependencies,
 record a pristine baseline and the current-day vote filter, and compare the
 candidate on the clone. Verify preserved authored inputs and correct rendered
 behavior separately from generated results. The copy has its own local server
-and writable database; test votes and edits stay there. Live poll updates require
-separate coordination.
+and writable database; test votes and edits stay there. Live poll updates
+require separate coordination.
 
 ### Validation evidence for the A3 slice
 
 [PR #7257](https://github.com/commontoolsinc/labs/pull/7257) implements the
 checked A3 acceptance items.
-[Read-accounting tests](../../packages/runner/test/read-accounting.test.ts)
+[Read-accounting tests](../../../packages/runner/test/read-accounting.test.ts)
 cover transaction ownership, aborted attempts, queued preflight setup failures,
 fan-out, and asynchronous writebacks. The
-[budget collector tests](../../packages/cli/test/read-budgets.test.ts) cover
-exact boundaries, total/per-run separation, and action/attempt attribution.
-The [CLI budget fixtures](../../packages/cli/test/test-runner-read-budgets.test.ts)
+[budget collector tests](../../../packages/cli/test/read-budgets.test.ts) cover
+exact boundaries, total/per-run separation, and action/attempt attribution. The
+[CLI budget fixtures](../../../packages/cli/test/test-runner-read-budgets.test.ts)
 exercise declarations, functional-failure preservation, rejected initialization
 settlement without restarting it, render enforcement, many cheap runs, and one
 expensive run.
 
-Compiler acceptance also covers stored fields named after Cell methods,
-optional Cell handles, and whole-value reads passed to helpers. The generated
-call-center integration and pinned default-app vintage replay pass with complete
-stored shapes preserved. Full affected-package validation and all 69 CI gates
-passed before merge, with clean Cubic and antagonistic reviews.
+Compiler acceptance also covers stored fields named after Cell methods, optional
+Cell handles, and whole-value reads passed to helpers. The generated call-center
+integration and pinned default-app vintage replay pass with complete stored
+shapes preserved. Full affected-package validation and all 69 CI gates passed
+before merge, with clean Cubic and antagonistic reviews.
 
 ## 5, 10. Repair incremental correctness: C1–C4
 
@@ -226,37 +235,38 @@ passed before merge, with clean Cubic and antagonistic reviews.
   - [x] Verify rendered rows after reconnect.
 
   The
-  [independent-replica probes](../../packages/patterns/integration/reactive-vote-rows.test.ts)
+  [independent-replica probes](../../../packages/patterns/integration/reactive-vote-rows.test.ts)
   assert nested-filter membership and derived tally updates. The
-  [browser tests](../../packages/patterns/integration/reactive-vote-rows-browser.test.ts)
+  [browser tests](../../../packages/patterns/integration/reactive-vote-rows-browser.test.ts)
   cover same-space and cross-space profiles, remote colors, profile-only edits,
   membership additions, removal/restoration, ranking changes, and nested mapped
   swatches. Removal checks pin the empty row, absence of nested swatches,
-  reordering, and exactly one swatch after restoring the same keyed vote. A fresh
-  browser reader first materializes a vote and renamed profile after both were
-  changed remotely, then observes further edits while subscribed. Cross-space
-  profiles are created in a separate transaction and edited directly in their
-  own space. Headless result reads explicitly pull data, so browser rendering
-  owns the passive-update check. The optional browser reconnect mode closes
-  live reader sockets around color, profile, and removal writes; all four
+  reordering, and exactly one swatch after restoring the same keyed vote. A
+  fresh browser reader first materializes a vote and renamed profile after both
+  were changed remotely, then observes further edits while subscribed.
+  Cross-space profiles are created in a separate transaction and edited directly
+  in their own space. Headless result reads explicitly pull data, so browser
+  rendering owns the passive-update check. The optional browser reconnect mode
+  closes live reader sockets around color, profile, and removal writes; all four
   nested/mapped and same/cross-space cases pass. The
-  [repeatable relay procedure](../development/TESTING.md#browser-row-reconnect-acceptance)
+  [repeatable relay procedure](../../development/TESTING.md#browser-row-reconnect-acceptance)
   keeps the writer connected and asserts that each outage closes live sockets.
-  The [reconnect probe](../../packages/patterns/integration/reactive-vote-rows-reconnect.test.ts)
+  The
+  [reconnect probe](../../../packages/patterns/integration/reactive-vote-rows-reconnect.test.ts)
   closes the reader's storage sockets while the writer changes membership and
   profiles. Ordinary memory queries wait for session restoration before
-  constructing their requests. This guards the handshake-to-session interval;
-  a subsequent disconnect during request issue remains a separate boundary.
-  These synthetic probes cover repository behavior. Live poll changes require
+  constructing their requests. This guards the handshake-to-session interval; a
+  subsequent disconnect during request issue remains a separate boundary. These
+  synthetic probes cover repository behavior. Live poll changes require
   coordination with Mike.
 
-  C3 records the mutable inline element used when resolving a nested array to
-  a content-addressed snapshot. The
-  [cell callback regression](../../packages/runner/test/cell-callbacks.test.ts)
+  C3 records the mutable inline element used when resolving a nested array to a
+  content-addressed snapshot. The
+  [cell callback regression](../../../packages/runner/test/cell-callbacks.test.ts)
   verifies updates after initial demand settles and confirms that changing a
   neighboring inline element causes no rerun. The fix and its validation are
-  recorded in [PR #7265](https://github.com/commontoolsinc/labs/pull/7265).
-  C3's complete acceptance also includes the client and serving cases below.
+  recorded in [PR #7265](https://github.com/commontoolsinc/labs/pull/7265). C3's
+  complete acceptance also includes the client and serving cases below.
 
   To record synthetic browser evidence with a local test server, set `API_URL`
   and `FRONTEND_URL`, then run:
@@ -269,21 +279,21 @@ passed before merge, with clean Cubic and antagonistic reviews.
   four cases. Live poll access requires coordination with Mike.
 
 - [x] **C2 — Repair partial materialization.** Complete inputs are covered by
-      C1's cold-browser, remote insertion/removal, and reconnect acceptance.
-      The session-restoration query repair is merged in #7308; rendered
-      reconnect acceptance is merged in #7312. The same-space and cross-space
-      fixtures verify complete vote and profile inputs on first demand, after
-      membership changes, and after two reader outages. No additional
-      materialization change is required for these reproductions. Disconnects
-      during request issue remain the separate boundary stated above; C3's
-      producer-identity and rerun checks are tracked independently.
+      C1's cold-browser, remote insertion/removal, and reconnect acceptance. The
+      session-restoration query repair is merged in #7308; rendered reconnect
+      acceptance is merged in #7312. The same-space and cross-space fixtures
+      verify complete vote and profile inputs on first demand, after membership
+      changes, and after two reader outages. No additional materialization
+      change is required for these reproductions. Disconnects during request
+      issue remain the separate boundary stated above; C3's producer-identity
+      and rerun checks are tracked independently.
 - [x] **C3 — Repair remote row invalidation.** Client and serving-host
       acceptance verify correct derived values, stable normalized output links
       and producer identities, and no execution of the untouched row producer
       after edits to each of two linked rows. The
-      [client case](../../packages/patterns/integration/reactive-vote-rows.test.ts)
+      [client case](../../../packages/patterns/integration/reactive-vote-rows.test.ts)
       uses independent worker replicas and merged in #7329. The
-      [serving-loop case](../../packages/runner/test/executor-serving-loop.test.ts)
+      [serving-loop case](../../../packages/runner/test/executor-serving-loop.test.ts)
       observes the actual serving runtime and waits for the authored input
       watermark; a client diagnostic graph does not contain those actions.
       Serving acceptance is published in
@@ -292,21 +302,23 @@ passed before merge, with clean Cubic and antagonistic reviews.
       voter maps use the scoped callback-child repair. Repository acceptance
       includes 93 assertions, unchanged A4 budgets at all three sizes, and
       concurrent two-browser voting. The
-      [acceptance record](../history/development/performance/2026-09-11-reactive-lunch-rows.md)
+      [acceptance record](../development/performance/2026-09-11-reactive-lunch-rows.md)
       states measurement limits. B5's operator migration remains separate;
       deployed poll updates require coordination with Mike.
 
 ## 6–9. Complete the collection algebra: B1–B4
 
 - [x] **B1 contract — Specify `groupBy` and `keyBy` separately.** The
-      [executed index contract](../history/plans/collection-index-contract.md)
-      records semantic decisions and acceptance tests, agreed in
+      [executed index contract](collection-index-contract.md) records semantic
+      decisions and acceptance tests, agreed in
       [PR #7294](https://github.com/commontoolsinc/labs/pull/7294). Typed lookup
       landed in [PR #7304](https://github.com/commontoolsinc/labs/pull/7304);
-      producers landed in [PR #7323](https://github.com/commontoolsinc/labs/pull/7323);
+      producers landed in
+      [PR #7323](https://github.com/commontoolsinc/labs/pull/7323);
       initialization and maintenance counts are validated separately in
-      [PR #7362](https://github.com/commontoolsinc/labs/pull/7362), with 12 cases
-      and 96 phases. Source-size and affected-bucket costs remain explicit.
+      [PR #7362](https://github.com/commontoolsinc/labs/pull/7362), with 12
+      cases and 96 phases. Source-size and affected-bucket costs remain
+      explicit.
   - [x] Key domain and equality, including resolved link identity and
         retargeting a key link without editing its containing element.
   - [x] Duplicate-key handling that remains deterministic for unordered input;
@@ -315,21 +327,21 @@ passed before merge, with clean Cubic and antagonistic reviews.
         surface, and identity across removal/reinsertion.
   - [x] Mixed primitive/Cell enumeration API decision (Q7): explicit tagged
         entries, preserving homogeneous `keys()` usage. The
-        [decision record](../history/features/2026-09-11-index-key-enumeration-decision.md)
+        [decision record](../features/2026-09-11-index-key-enumeration-decision.md)
         records consequences and alternatives.
   - [x] Implement tagged enumeration and verify authored output acceptance,
         lookup round trips, cross-space identities, and durable resume. The
-        [authored consumer tests](../../packages/runner/test/collection-index-key-entries.test.ts)
+        [authored consumer tests](../../../packages/runner/test/collection-index-key-entries.test.ts)
         exercise both producer modes with equal-valued primitive and Cell keys;
         stored-descriptor recovery preserves lookup-only demand behavior.
   - [x] Bound invalidation to affected keys; state initialization, update,
         lookup, and storage complexity.
-- [x] **B2 contract — Specify lookup and join.** The index contract defines
-      a left lookup join, unmatched rows, deterministic duplicate matches,
-      left occurrence ordering, link retargeting, and owned cleanup.
-- [x] **B1 implementation — Build grouping and unique-key indexing.**
-      PR #7323 carries the implementation and runner acceptance; PR #7362
-      supplies the separate phase-count probe. Both PRs passed delivery gates.
+- [x] **B2 contract — Specify lookup and join.** The index contract defines a
+      left lookup join, unmatched rows, deterministic duplicate matches, left
+      occurrence ordering, link retargeting, and owned cleanup.
+- [x] **B1 implementation — Build grouping and unique-key indexing.** PR #7323
+      carries the implementation and runner acceptance; PR #7362 supplies the
+      separate phase-count probe. Both PRs passed delivery gates.
   - [x] Reuse collection element-identity/reconciliation rules from existing
         builtins; cover primitives, linked elements, and inline values.
   - [x] Wire builtin registration, replayability, `Cell` methods and reactive
@@ -357,11 +369,11 @@ passed before merge, with clean Cubic and antagonistic reviews.
 - [x] **B4 — Document contracts and complexity with each operator.** Update
       public doc comments, pattern-author documentation, and executable examples
       in the same slice that ships the API. The aggregate portion is documented
-      in [collection aggregates](../features/collection-aggregates.md); index
+      in [collection aggregates](../../features/collection-aggregates.md); index
       semantics and current costs are documented in
-      [collection indexes](../features/collection-indexes.md). Measured scale
-      acceptance is recorded in PR #7362; join documentation and acceptance tests
-      are in PR #7323. Both PRs passed CI and review before merge.
+      [collection indexes](../../features/collection-indexes.md). Measured scale
+      acceptance is recorded in PR #7362; join documentation and acceptance
+      tests are in PR #7323. Both PRs passed CI and review before merge.
 
 **Deferred B3a:** Reconsider restricted append folds only after B1–B3 ship and a
 remaining use case justifies them. Requires a separate contract excluding
@@ -370,22 +382,22 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 ## 11. Validate the motivating pattern: B5–B6
 
 - [x] **B5 — Rewrite `tallyOptions` using the shipped operators.**
-      [PR #7336](https://github.com/commontoolsinc/labs/pull/7336) uses maintained
-      per-option vote groups. Authored pattern tests and two-browser acceptance
-      cover ranking, profile identity, and viewer-specific behavior with client
-      and server execution. The 1,184-vote coverage case keeps its existing
-      action limit and default heap.
-- [x] Add measured per-run and steady-state step budgets for the hot path.
-      PR #7336 limits the 74-vote fixture to 6,000 initial-render accesses,
-      1,100 updated-render accesses, and 300 accesses per reactive body. The
-      local combined run measured 4,857 / 958 / 224. The scan control passes
+      [PR #7336](https://github.com/commontoolsinc/labs/pull/7336) uses
+      maintained per-option vote groups. Authored pattern tests and two-browser
+      acceptance cover ranking, profile identity, and viewer-specific behavior
+      with client and server execution. The 1,184-vote coverage case keeps its
+      existing action limit and default heap.
+- [x] Add measured per-run and steady-state step budgets for the hot path. PR
+      #7336 limits the 74-vote fixture to 6,000 initial-render accesses, 1,100
+      updated-render accesses, and 300 accesses per reactive body. The local
+      combined run measured 4,857 / 958 / 224. The scan control passes
       functional assertions and the initial-render limit at 3,176 accesses. It
-      fails the 300-access per-body limit in both render windows (360 each)
-      and the 1,100-access updated-render limit (1,240). Maintained groups use
-      more initial-render accesses (4,857 versus 3,176) and fewer updated-render
-      accesses (958 versus 1,240); this is an update-work bound, not a total-cost
-      or latency claim.
-- [ ] **B6 — Measure savings and maintenance together.** Compare the same
+      fails the 300-access per-body limit in both render windows (360 each) and
+      the 1,100-access updated-render limit (1,240). Maintained groups use more
+      initial-render accesses (4,857 versus 3,176) and fewer updated-render
+      accesses (958 versus 1,240); this is an update-work bound, not a
+      total-cost or latency claim.
+- [x] **B6 — Measure savings and maintenance together.** Compare the same
       operation before/after on both probe and browser rigs, then validate with
       the representative poll copy after A5. Report accesses, runs, nodes,
       commits, durations, and any omitted cross-space dependencies. Do not call
@@ -396,14 +408,15 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
 
 - [x] **E1 — Measure identical `computed` and `lift` collection loops** under
       current defaults and compare declared read width and access counts. The
-      [reproducible comparison](../history/development/performance/2026-09-11-computed-lift-collection-loops.md)
-      validates three forms at 32, 128, and 512 linked rows, including unread-field
-      edits. The dashboard tracks publication and review status.
+      [reproducible comparison](../development/performance/2026-09-11-computed-lift-collection-loops.md)
+      validates three forms at 32, 128, and 512 linked rows, including
+      unread-field edits. The dashboard tracks publication and review status.
 - [x] **E2 — Publish the measured advice** where pattern authors encounter
       collections, `computed`, and `lift`. Explain nested-scan cost and use only
       available operators in replacement examples. The
-      [computed/lift guide](../common/concepts/computed/computed.md#collection-loop-cost)
-      and [collection guide](../features/collection-aggregates.md#choosing-a-collection-computation)
+      [computed/lift guide](../../common/concepts/computed/computed.md#collection-loop-cost)
+      and
+      [collection guide](../../features/collection-aggregates.md#choosing-a-collection-computation)
       explain lazy read width, repeated scans, explicit cell receivers, numeric
       contract differences, and measurement limits. The author index links both;
       dashboard publication status remains separate.
@@ -411,56 +424,55 @@ whole-array access and mutable accumulator aliasing; no active checkbox here.
       collector. Test recognizable nested reactive scans and negative cases
       involving plain arrays and unrelated scopes; inspect warning volume across
       authored patterns before shipping. Escalation to error requires separate
-      evidence about false positives.
-      The [diagnostic acceptance report](../history/development/performance/2026-09-11-nested-collection-scan-diagnostic.md)
+      evidence about false positives. The
+      [diagnostic acceptance report](../development/performance/2026-09-11-nested-collection-scan-diagnostic.md)
       records the focused cases, full transformer suite, and all five distinct
       findings across 413 pattern entries. Publication and review remain visible
       in the dashboard.
-- [ ] **D1 — Follow the remaining lazy-materialization work** in its
-      [own plan](lazy-cell-materialization.md), including handlers and flag
-      removal. Keep implementation ownership there.
-- [ ] **D2 — Re-run the A baseline when that dependency changes** and separate
-      reduced access count from reduced per-access cost.
-- [x] **D3 — Verify scoped snapshot memoization and measure its effect.**
-      The snapshot-memo suite passes 41 steps, including combined epoch/metadata
-      label-view isolation. The benchmark verifies one metadata read across
-      74, 296, and 1,184 requests in each scope. The
-      [verification report](../history/development/performance/2026-09-10-scoped-snapshot-memo.md)
+- [x] **D1 — Transfer remaining lazy-materialization execution** to the
+      [separate fast-follow plan](../../plans/lazy-materialization-fast-follow.md),
+      as approved in Q9. F1/F2 own handlers; F3/F4 own rollout and flag
+      retirement. These behaviors are not implemented by this handoff.
+- [x] **D2 — Transfer conditional remeasurement** to F0/F5 of that plan. Repeat
+      the A baseline when its dependency changes, separating access count from
+      per-access cost. This checks off the approved handoff, not a future
+      measurement that has already run.
+- [x] **D3 — Verify scoped snapshot memoization and measure its effect.** The
+      snapshot-memo suite passes 41 steps, including combined epoch/metadata
+      label-view isolation. The benchmark verifies one metadata read across 74,
+      296, and 1,184 requests in each scope. The
+      [verification report](../development/performance/2026-09-10-scoped-snapshot-memo.md)
       records the control and measurement limits.
 
 ## 14. Validation and closeout
 
-- [ ] Each code slice runs relevant focused tests plus the touched packages'
+- [x] Each code slice runs relevant focused tests plus the touched packages'
       test tasks, repo-wide `deno fmt --check`, `deno lint`, and
       `deno task
       check`. Pattern changes also run authoritative
       `deno task cfcheck`.
-- [ ] Browser-launching checks on macOS run outside the sandbox. Follow
-      [TESTING.md](../development/TESTING.md) and event-driven waiting rules.
-- [ ] Run applicable independent gates: documentation examples, history index,
+- [x] Browser-launching checks on macOS run outside the sandbox. Follow
+      [TESTING.md](../../development/TESTING.md) and event-driven waiting rules.
+- [x] Run applicable independent gates: documentation examples, history index,
       conflict markers, package cycles, and any changed CLI surface,
       experimental options, skills, or transformer fixtures.
-- [ ] Review every implementation slice through the `cf-review` skill; attach
+- [x] Review every implementation slice through the `cf-review` skill; attach
       the exact validation scope and unresolved limitations.
-- [ ] Confirm every active stage has evidence, keep deferred work explicit,
+- [x] Confirm every active stage has evidence, keep deferred work explicit,
       update live feature/author docs, and archive the completed tracker
-      following [the documentation lifecycle](../README.md).
+      following [the documentation lifecycle](../../README.md).
 
 ## Accounting measurement record
 
 The
-[probe comparison](../history/development/performance/2026-09-10-read-accounting-probes.md)
+[probe comparison](../development/performance/2026-09-10-read-accounting-probes.md)
 records the measurement method and its limits. The current accounting contract
 and regression surfaces are documented in
-[read accounting](../features/read-accounting.md).
+[read accounting](../../features/read-accounting.md).
 
-## Next task
+## Follow-up
 
-Obtain the representative poll URL and a consistent snapshot for A5/B6, then
-serve an isolated local copy and inventory its linked-profile dependencies.
-Keep the live poll unchanged. The
-[lazy-materialization plan](lazy-cell-materialization.md) owns its remaining
-handler and rollout stages. Track its changes under D1 and rerun the motivating
-baseline under D2 when they land. The execution dashboard
-records the outstanding coordination questions and preserves the synthetic
-74-, 296-, and 1,184-vote evidence with its measurement limits.
+The
+[lazy-materialization fast-follow](../../plans/lazy-materialization-fast-follow.md)
+owns remaining execution and conditional remeasurement. B3a remains deferred.
+Any live poll update requires separate operator coordination.

--- a/docs/history/plans/pattern-computation-cost.md
+++ b/docs/history/plans/pattern-computation-cost.md
@@ -1,10 +1,26 @@
+---
+status: historical
+created: 2026-09-09
+archived: 2026-09-12
+reason: "Executed #7155 scope; B3a deferred and D1/D2 transferred to a separate fast-follow."
+---
+
+Execution closed with the
+[implementation record](pattern-computation-cost-implementation.md) and
+[representative-copy report](../development/performance/2026-09-12-representative-lunch-poll-rehearsal.md).
+B3a remains explicitly deferred. Q9 transfers remaining D1/D2 execution to the
+[lazy-materialization fast-follow](../../plans/lazy-materialization-fast-follow.md).
+The proposal below records the original design, not a claim that deferred stages
+shipped or historical deployment timings were reproduced.
+
 # Making pattern computation cost declarable and visible
 
 A pattern author can write a derivation that reads a thousand documents. The
 single-runtime pattern test runner exposes that work through per-action read
-counts. Named aggregates maintain linked single-row updates incrementally;
-keyed collection operations and opt-in test budgets remain the next steps. This plan gives expensive collection operations an incremental form and
-makes their cost visible before they ship.
+counts. Named aggregates maintain linked single-row updates incrementally; keyed
+collection operations and opt-in test budgets remain the next steps. This plan
+gives expensive collection operations an incremental form and makes their cost
+visible before they ship.
 
 It is deliberately not a proposal to hand execution planning to the compiler.
 The reasoning for that boundary is under
@@ -21,8 +37,8 @@ Mark a parent checkbox complete only after all of its child checks pass.
 
 A1 and A2 provide read accounting and generic `reduce` baselines. B3 provides
 named aggregates on explicit Cell/Writable array inputs, with contracts in
-[collection aggregates](../features/collection-aggregates.md). The
-[aggregate comparison](../history/development/performance/2026-09-incremental-aggregates.md)
+[collection aggregates](../../features/collection-aggregates.md). The
+[aggregate comparison](../development/performance/2026-09-incremental-aggregates.md)
 covers initialization, single-row updates, scheduler runs, and total read work
 at 10, 100, and 1,000 elements. Timings include maintenance and commits and
 record the startup cost and machine-load limitations alongside update savings.
@@ -32,12 +48,14 @@ collection-algebra priority.
 A0's specified headless command is measured, but it does not reproduce the
 reported 74-vote deployed workload. Keep the deployed figures unconfirmed until
 the representative workload and probe/deployed comparison in A4/A5 are ready.
-The [first-batch measurement record](../history/development/performance/2026-09-pattern-read-accounting.md)
+The
+[first-batch measurement record](../development/performance/2026-09-pattern-read-accounting.md)
 contains the observed headless counts and the aggregate baseline matrix.
 
 ## Problem
 
-The vote path in [`packages/patterns/lunch-poll/main.tsx`](../../packages/patterns/lunch-poll/main.tsx)
+The vote path in
+[`packages/patterns/lunch-poll/main.tsx`](../../../packages/patterns/lunch-poll/main.tsx)
 is the worked example. `tallyOptions` is a group-by over votes joined against a
 roster, hand-written as nested scans: for each of the options it filters the
 whole vote list, then filters that result three more times by vote color, then
@@ -45,16 +63,16 @@ resolves each voter through a linear `find` over the roster. Every one of those
 element and property reads goes through a reactive query proxy, so each is a
 link resolution rather than a property load.
 
-Figures reported from the current investigation, reconstructed by hand from a
-V8 profile and a reading of the code, pending reconfirmation under Stage A0:
+Figures reported from the current investigation, reconstructed by hand from a V8
+profile and a reading of the code, pending reconfirmation under Stage A0:
 
-| Quantity | Reported |
-| --- | --- |
-| Wall clock per vote | ~1.15 s |
-| Tally derivation, single run | ~550 ms |
-| Tally proxy accesses, single run at 74 votes | ~2,600 |
-| Per-option card derivation, per run | ~30 ms, over 14 runs |
-| Per-proxy-access cost | ~0.2 to 0.8 ms |
+| Quantity                                     | Reported             |
+| -------------------------------------------- | -------------------- |
+| Wall clock per vote                          | ~1.15 s              |
+| Tally derivation, single run                 | ~550 ms              |
+| Tally proxy accesses, single run at 74 votes | ~2,600               |
+| Per-option card derivation, per run          | ~30 ms, over 14 runs |
+| Per-proxy-access cost                        | ~0.2 to 0.8 ms       |
 
 The tally figure decomposes as 14 options times 74 votes for the per-option
 filter, three more color filters over each option's votes, then up to 8 roster
@@ -70,11 +88,12 @@ proxy accesses and link resolutions separately rather than reporting one number.
 Three properties of the system produce that, and each needs a different repair.
 
 **The algebra has no middle.** `map`, `filter`, and `flatMap` have incremental
-builtins under [`packages/runner/src/builtins/`](../../packages/runner/src/builtins/)
-that key elements by normalized link address and reuse per-element runs across
+builtins under
+[`packages/runner/src/builtins/`](../../../packages/runner/src/builtins) that
+key elements by normalized link address and reuse per-element runs across
 changes. `reduce` has none — its doc comment on
-[`packages/runner/src/cell.ts`](../../packages/runner/src/cell.ts) records that
-it re-runs the whole reduction when any element changes — and there is no
+[`packages/runner/src/cell.ts`](../../../packages/runner/src/cell.ts) records
+that it re-runs the whole reduction when any element changes — and there is no
 `groupBy`, no `keyBy`, no join, and no read-side index. A tally is a group-by
 and a join. Neither has a declarative spelling, so it is written as scans.
 
@@ -103,23 +122,27 @@ than competing with them.
 
 - **Incremental collection builtins.** `map`, `filter`, `flatMap` and their
   `WithPattern` forms, registered in
-  [`packages/runner/src/builtins/index.ts`](../../packages/runner/src/builtins/index.ts).
+  [`packages/runner/src/builtins/index.ts`](../../../packages/runner/src/builtins/index.ts).
   `map.ts` documents the element-identity rules every new operator must follow.
 - **A declarative query surface.** The SQLite builtin ships;
-  [`docs/specs/sqlite-builtin/`](../specs/sqlite-builtin/README.md) is as-built,
-  with its remaining phases and open questions recorded there. Any proposal for
-  a new declarative layer should first say why that one is not the vehicle.
-- **Per-access cost work.** [Lazy cell materialization](lazy-cell-materialization.md)
-  is the plan that owns the constant this plan multiplies against. It is on by
-  default behind `lazyMaterialization`; its remaining stages include the handler
-  path and flag removal. This plan adds no work there and depends on it.
-- **Per-step counters.** `deno task cf test <file> --verbose --stats-threshold 0`
-  prints per-step timing and per-action run deltas from
-  [`packages/cli/lib/test-runner.ts`](../../packages/cli/lib/test-runner.ts).
+  [`docs/specs/sqlite-builtin/`](../../specs/sqlite-builtin/README.md) is
+  as-built, with its remaining phases and open questions recorded there. Any
+  proposal for a new declarative layer should first say why that one is not the
+  vehicle.
+- **Per-access cost work.**
+  [Lazy cell materialization](../../plans/lazy-cell-materialization.md) is the
+  plan that owns the constant this plan multiplies against. It is on by default
+  behind `lazyMaterialization`; its remaining stages include the handler path
+  and flag removal. This plan adds no work there and depends on it.
+- **Per-step counters.**
+  `deno task cf test <file> --verbose --stats-threshold 0` prints per-step
+  timing and per-action run deltas from
+  [`packages/cli/lib/test-runner.ts`](../../../packages/cli/lib/test-runner.ts).
 - **Read-width feedback.** `deno task cf check <file> --show-transformed` shows
   the emitted input schema, whose size is a usable proxy for how much a
   derivation declared it would read.
-- **A write-side benchmark.** [`packages/patterns/integration/lunch-poll-vote-burst.bench.ts`](../../packages/patterns/integration/lunch-poll-vote-burst.bench.ts)
+- **A write-side benchmark.**
+  [`packages/patterns/integration/lunch-poll-vote-burst.bench.ts`](../../../packages/patterns/integration/lunch-poll-vote-burst.bench.ts)
   measures a hundred-vote burst to settle. It exercises the write path; the read
   path this plan targets needs its own.
 
@@ -128,12 +151,12 @@ than competing with them.
 It does not build a cost-based optimizer that chooses an execution strategy for
 arbitrary authored TypeScript.
 
-Planners work where there is a closed algebra and statistics to plan against. Authored pattern bodies are neither. More importantly, an optimizer
-answers the complaint that motivates this work — an author cannot predict what
-their code costs — by removing the author's choice rather than informing it,
-which relocates the surprise into a plan the author can neither see nor
-override. The tracks below keep the choice with the author and make it a choice
-they can see.
+Planners work where there is a closed algebra and statistics to plan against.
+Authored pattern bodies are neither. More importantly, an optimizer answers the
+complaint that motivates this work — an author cannot predict what their code
+costs — by removing the author's choice rather than informing it, which
+relocates the surprise into a plan the author can neither see nor override. The
+tracks below keep the choice with the author and make it a choice they can see.
 
 Track B adds operators whose cost is a documented property of the operator. The
 author says what the result is and the runtime owns how it is maintained, with
@@ -154,9 +177,10 @@ only one that helps patterns nobody rewrites. Do it first.
 
 - [ ] **A0. Reconfirm the baseline.** Reproduce the table above with
       `deno task cf test packages/patterns/lunch-poll/main.test.tsx --verbose
-      --stats-threshold 0 --no-idempotency-check`, disabling verification before quoting
-      any duration, per the instrument notes in
-      [`skills/perf-investigation/SKILL.md`](../../skills/perf-investigation/SKILL.md).
+      --stats-threshold 0 --no-idempotency-check`,
+      disabling verification before quoting any duration, per the instrument
+      notes in
+      [`skills/perf-investigation/SKILL.md`](../../../skills/perf-investigation/SKILL.md).
       Record counts, not milliseconds, as the durable baseline.
 - [x] **A1. Count accesses per action run.** Add read accounting to
       `ActionStats` in `packages/runner/src/telemetry.ts`, accumulated the way
@@ -188,7 +212,7 @@ only one that helps patterns nobody rewrites. Do it first.
       Reports cover assertion, render, and settle steps as well as actions;
       initialization is separate. Totals collect completion events, including
       actions absent from the final graph snapshot. The
-      [CLI reference](../../packages/cli/README.md#pattern-test-read-costs)
+      [CLI reference](../../../packages/cli/README.md#pattern-test-read-costs)
       defines each counter and its boundary.
 - [ ] **A3. Give a pattern test a budget.** Opt-in per pattern, not a
       repository-wide gate, so a pattern can defend its own hot path the way a
@@ -208,8 +232,9 @@ only one that helps patterns nobody rewrites. Do it first.
 - [ ] **A4. Add the read-side benchmark.** A lunch-poll benchmark for the cost
       of one vote settling with the tally on screen, sibling to the existing
       write-side burst benchmark, so Track B and Track C changes have something
-      to move. Follow [`docs/development/BENCHMARKS.md`](../development/BENCHMARKS.md)
-      for the shape rather than copying the burst file.
+      to move. Follow
+      [`docs/development/BENCHMARKS.md`](../../development/BENCHMARKS.md) for
+      the shape rather than copying the burst file.
 - [ ] **A5. Settle the probe-versus-deployed discrepancy.** The headless probe
       `packages/patterns/tools/lunch-poll-diagnose.ts` runs at the same
       `enforce-explicit` posture as the deployed board, and its tally at 70
@@ -241,10 +266,10 @@ reconciliation; follow their keying rules rather than inventing new ones.
 - [ ] **B1. `groupBy` and `keyBy` are two operators, not one.** They differ in
       arity and therefore in every edge case, so settle both contracts before
       either is built. `groupBy` maps a key to a collection of elements and is
-      what the tally needs; `keyBy` maps a key to at most one element and is what
-      the roster lookup needs. Both maintain the index incrementally: an element
-      changing its key moves, and consumers of untouched keys do not re-run.
-      Together they are the read-side counterpart to `elementById`.
+      what the tally needs; `keyBy` maps a key to at most one element and is
+      what the roster lookup needs. Both maintain the index incrementally: an
+      element changing its key moves, and consumers of untouched keys do not
+      re-run. Together they are the read-side counterpart to `elementById`.
 
       Decide and write down, before implementation:
 
@@ -274,8 +299,8 @@ reconciliation; follow their keying rules rather than inventing new ones.
       `find((x) => x.id === k)`, `find((u) => equals(u.profile, p))`, and
       `some((x) => x.id === k)`. The nested form
       `filter((a) => !current.some((b) => b === a))` is a set difference written
-      as a quadratic scan, and appears several times. Keep this stage as the next collection-algebra priority after the initial
-      aggregate comparison.
+      as a quadratic scan, and appears several times. Keep this stage as the
+      next collection-algebra priority after the initial aggregate comparison.
 - [x] **B3. Named aggregates, not a general incremental `reduce`.** A survey of
       the authored patterns finds 33 `reduce` call sites, of which the large
       majority are a sum, and the rest an average (a sum over a count), an
@@ -353,7 +378,7 @@ reconciliation; follow their keying rules rather than inventing new ones.
 - [ ] **B4. State each operator's cost in its documentation.** An operator whose
       complexity is not written down is one an author has to measure. The
       per-change cost belongs in the doc comment and in
-      [`docs/common/concepts/`](../common/README.md).
+      [`docs/common/concepts/`](../../common/README.md).
 - [ ] **B5. Rewrite `tallyOptions` on the new operators** and record the
       before-and-after access counts from Track A in this plan.
 - [ ] **B6. Measure maintenance cost against savings, on the deployed board and
@@ -419,14 +444,14 @@ constant is what every other track multiplies against, and operators layered
 over a sub-millisecond access are still one large collection away from a slow
 interaction.
 
-- [ ] **D1. Track [lazy cell materialization](lazy-cell-materialization.md)
+- [ ] **D1. Track
+      [lazy cell materialization](../../plans/lazy-cell-materialization.md)
       through flag removal**, including the handler path it lists as
       deliberately deferred.
 - [ ] **D2. Re-run the Track A baseline after each stage of it lands**, so the
       per-access improvement is attributed rather than assumed.
-- [ ] **D3. Audit and measure the scoped snapshot memo.**
-      `getSnapshotMemo()` in
-      [`packages/runner/src/storage/extended-storage-transaction.ts`](../../packages/runner/src/storage/extended-storage-transaction.ts)
+- [ ] **D3. Audit and measure the scoped snapshot memo.** `getSnapshotMemo()` in
+      [`packages/runner/src/storage/extended-storage-transaction.ts`](../../../packages/runner/src/storage/extended-storage-transaction.ts)
       maintains separate memos by read epoch and ambient metadata identity.
       Child-view label derivation in `deriveDereferenceLabelView` uses an
       ambient-read-meta scope. Measure reuse within these scopes with Track A's
@@ -438,12 +463,12 @@ interaction.
 
 Independent of every other track, cheap, and worth doing this week.
 
-- [ ] **E1. Give the `computed` and `lift` recommendation a cost dimension,
-      once it is measured.**
-      [`docs/common/concepts/computed/computed.md`](../common/concepts/computed/computed.md)
+- [ ] **E1. Give the `computed` and `lift` recommendation a cost dimension, once
+      it is measured.**
+      [`docs/common/concepts/computed/computed.md`](../../common/concepts/computed/computed.md)
       recommends `computed()` as almost always better and treats `lift()` purely
-      as a reuse mechanism. Cost appears nowhere in that recommendation, which is
-      the defect regardless of which way the answer falls.
+      as a reuse mechanism. Cost appears nowhere in that recommendation, which
+      is the defect regardless of which way the answer falls.
 
       Do not assume the answer is "prefer `lift` for a loop over a collection".
       Lazy materialization defaults on, and `packages/runner/src/runner.ts`
@@ -458,16 +483,16 @@ Independent of every other track, cheap, and worth doing this week.
             defaults, using the Track A counters.
       - [ ] Write the guidance the measurement supports, in terms of declared
             read width, and say what it does not fix.
-- [ ] **E2. Name the trap where authors will hit it.** The scan-over-a-reactive-array
-      cost is currently written down in
-      [`skills/perf-investigation/SKILL.md`](../../skills/perf-investigation/SKILL.md),
+- [ ] **E2. Name the trap where authors will hit it.** The
+      scan-over-a-reactive-array cost is currently written down in
+      [`skills/perf-investigation/SKILL.md`](../../../skills/perf-investigation/SKILL.md),
       which an author reads after something is slow. It belongs in the
       pattern-authoring documentation, which they read before.
 - [ ] **E3. Add a transformer diagnostic for the recognizable shape.** A nested
       scan over a reactive collection inside a `computed` body is detectable
       statically. Emit a diagnostic naming the shape and the cheaper spelling,
       through the `TransformationDiagnostic` collector in
-      [`packages/ts-transformers/src/cf-pipeline.ts`](../../packages/ts-transformers/src/cf-pipeline.ts).
+      [`packages/ts-transformers/src/cf-pipeline.ts`](../../../packages/ts-transformers/src/cf-pipeline.ts).
       Ship it as a warning first; the false-positive rate decides whether it
       ever becomes an error.
 
@@ -487,9 +512,9 @@ that is cheap to discover on paper and expensive to discover in two landed
 operators. Write them down, then build.
 
 After the aggregate comparison prioritized above, rank B2 ahead of further
-aggregate extensions by expected value: the tree holds roughly
-250 linear-scan lookups against a handful of aggregates worth incrementalizing.
-B1 still precedes B2, since keyed lookup and join depend on its index contracts.
+aggregate extensions by expected value: the tree holds roughly 250 linear-scan
+lookups against a handful of aggregates worth incrementalizing. B1 still
+precedes B2, since keyed lookup and join depend on its index contracts.
 
 Suggested split for three parallel efforts: one on Track A plus E, one on Track
 C's reproduction and fixes, one settling the Track B contracts and then building
@@ -498,7 +523,7 @@ B1.
 ## Testing
 
 - Pattern tests for each new operator's semantics, per
-  [`docs/development/unit-test-coding-style.md`](../development/unit-test-coding-style.md).
+  [`docs/development/unit-test-coding-style.md`](../../development/unit-test-coding-style.md).
 - Incrementality is a count property, not a duration property: assert on
   scheduler run counts and the Track A access counts, not on milliseconds.
 - Multi-replica integration tests for Track C, since the failures do not

--- a/docs/history/plans/read-cost-budgets.md
+++ b/docs/history/plans/read-cost-budgets.md
@@ -13,7 +13,7 @@ Status: completed. A3 landed in
 and clean Cubic and antagonistic reviews. The authoring surface and measurement boundaries are documented in the
 [read-accounting contract](../../features/read-accounting.md#pattern-test-budgets).
 This plan tracks acceptance in the
-[computation-cost sequence](../../plans/pattern-computation-cost-implementation.md).
+[computation-cost sequence](pattern-computation-cost-implementation.md).
 
 ## Author contract
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -10,9 +10,6 @@ a record: archive it to `docs/history/plans/` following the procedure in
 
 ## Current plans
 
-- [Pattern computation cost: implementation sequence](pattern-computation-cost-implementation.md)
-  executes the design in PR #7155 with checkable measurement, collection
-  operator, multi-replica correctness, and authoring-guidance stages.
 - [Cast-free patterns](cast-free-patterns.md) sequences shared type and API
   repairs, migration of authored patterns and their tests, and enforcement
   through lint and new-source admission.
@@ -61,19 +58,14 @@ a record: archive it to `docs/history/plans/` following the procedure in
   [`../features/vouched-ingest-channel-mint.md`](../features/vouched-ingest-channel-mint.md).
 - [Integration-test video demos](integration-test-video-demos.md) tracks
   optional CI adoption and further fixture hardening.
+- [Lazy materialization fast-follow](lazy-materialization-fast-follow.md)
+  owns handler integration, rollout evidence, flag retirement, and renewed
+  measurements after #7155, with independently checkable stages F0–F5.
 - [Lazy cell materialization](lazy-cell-materialization.md) sequences a
   schema-observing lazy view over a cell, a transaction mode that hands one back
   from every read, and the runner disposition for a reader that touches data the
   schema no longer describes.
-- [Making pattern computation cost declarable and visible](pattern-computation-cost.md)
-  pairs two repairs to the same gap: the collection algebra has incremental
-  `map`, `filter`, and `flatMap` but no `groupBy`, keyed lookup, join, or
-  incremental `reduce`, so a group-by is written as nested scans over a
-  reactive array; and a scheduler node records how often an action ran but not
-  how much it read, so the cost is invisible until somebody profiles. Carries
-  the access counter, the missing operators, the replication failures that
-  currently push authors off the incremental path, and the authoring guidance
-  that steers them into the expensive construct.
+
 - [Choosing which tests a pull request runs](pull-request-test-selection.md)
   replaces the sixty-seven pull-request jobs with five, each running a subset
   chosen from what the record store knows about which tests have caught real

--- a/docs/plans/lazy-cell-materialization.md
+++ b/docs/plans/lazy-cell-materialization.md
@@ -4,6 +4,10 @@ Status: built end to end and on by default behind `lazyMaterialization`. What
 remains is removing the flag and the eager path for lift arguments, plus the
 handler materialization listed under Stage 5.
 
+The remaining execution sequence and acceptance gates are owned by the separate
+[lazy materialization fast-follow](lazy-materialization-fast-follow.md). This
+document retains the view and snapshot design and its implementation record.
+
 `Cell.get()` materializes everything its schema selects, in one pass, before the
 reader touches any of it. A lift declaring a list of a thousand entries gets a
 thousand entries built, link-resolved, defaulted, back-to-cell annotated and
@@ -462,7 +466,9 @@ diffing and the scheduler's own reads keep eager semantics.
       link resolution now applies the same rule, which is also where an eager
       read of such a link used to answer `undefined`.
       `gideon-tests/proxy-length-repro` pins it.
-- [ ] Soak on default-on before removing the flag.
+- [ ] Soak on default-on before removing the flag. F3/F4 in the
+      [fast-follow plan](lazy-materialization-fast-follow.md) own the evidence,
+      retirement decision and implementation sequence.
 
 ## Testing
 

--- a/docs/plans/lazy-materialization-fast-follow.md
+++ b/docs/plans/lazy-materialization-fast-follow.md
@@ -1,0 +1,125 @@
+# Lazy materialization fast-follow
+
+Status: planned as the separate follow-up to the pattern computation cost work
+in #7155. This plan owns the remaining handler investigation, default-on rollout
+evidence, flag retirement, and measurements that the computation-cost tracker
+called D1/D2. It does not authorize a live lunch-poll update.
+
+The [lazy materialization design](lazy-cell-materialization.md) defines the
+schema-observing view and snapshot contracts. Lift arguments use that view under
+the default-on `lazyMaterialization` flag. The handler path in
+[`runner.ts`](../../packages/runner/src/runner.ts) still reads its argument
+without marking the transaction for lazy materialization. Its closed-world event
+validation, cold-input handling, receipts, and effects make it a separate
+integration problem.
+
+## Scope and decision
+
+Complete the outstanding work in this plan after #7155, with independent PRs and
+acceptance evidence. Keep handler semantics separate from removing the lift-path
+rollout switch: either can expose a correctness issue the other does not
+address. The flag's owner and removal condition remain recorded in
+[Experimental options](../development/EXPERIMENTAL_OPTIONS.md#lazymaterialization).
+
+The alternative is to expand #7155 into handler behavior and rollout changes.
+Keeping a separate plan lets its measured collection improvements close with
+their own evidence and gives the broader behavioral changes an explicit review
+boundary. Deferring the work without an execution sequence would leave the
+default-on flag and handler exception without a completion path.
+
+## Execution tracker
+
+Mark a step complete only with its linked evidence. Capture decisions and
+completed investigations in `docs/history/`; update the live contract documents
+in the same PR as behavior changes.
+
+| Step | Depends on       | Deliverable                                                           | State   |
+| ---- | ---------------- | --------------------------------------------------------------------- | ------- |
+| F0   | #7155 acceptance | Fixed baseline and remaining-call-site inventory                      | Pending |
+| F1   | F0               | Handler materialization contract and measured prototype               | Pending |
+| F2   | F1               | Reviewed handler integration, or an explicit evidence-backed deferral | Pending |
+| F3   | F0               | Default-on rollout evidence and flag-retirement decision              | Pending |
+| F4   | F3               | Remove the lift rollout switch and redundant fallback dispatch        | Pending |
+| F5   | F2, F4           | Repeat measurement matrix, update guidance, and archive plans         | Pending |
+
+F1/F2 and F3 can proceed independently. F4 does not depend on making handlers
+lazy unless F1 identifies a concrete shared contract that requires that order.
+Do not delete eager materialization that unmarked transactions still require.
+
+### F0 — Establish the baseline
+
+- [ ] Inventory flag consumers, lift and handler argument entry points, and
+      eager reads required for result writing, diffing, or unmarked callers.
+- [ ] Pin a runtime revision and record flag posture for each process. Preserve
+      the #7155 controlled 74-, 296-, and 1,184-vote fixtures and the
+      representative copy's current-day filter and linked-profile limitations.
+- [ ] Record completed-attempt reads, reactive-body reads, handler and commit
+      work, graph size, allocation/retention, and disabled-accounting durations
+      in separate windows. Preserve their different accounting boundaries.
+
+### F1/F2 — Decide and integrate handler materialization
+
+- [ ] Specify which bound context paths can be lazy and which event-payload
+      checks must complete before the body runs. Start from the existing
+      `$event` / `$ctx` split and closed-world event gate; do not weaken payload
+      validation as a side effect of narrower context reads.
+- [ ] Define touched required-field refusal, optional mismatch, missing linked
+      data, and caught refusal. Distinguish cold input withdrawal from permanent
+      invalidity; do not consume an event that never ran or commit partial
+      handler writes as a successful handling.
+- [ ] Pin receipt identity, duplicate delivery, retry, and effect behavior in
+      both client and server execution. Test that a refusal after a write does
+      not publish that write or an external effect.
+- [ ] Test read/write snapshots, defaults and absent-path dependencies,
+      cross-space context, labels read before and after policy preparation,
+      escaped views, and asynchronous handler continuations where supported.
+- [ ] Compare a scalar read from a large bound context with a full walk and with
+      mutation-heavy handlers. Measure argument setup separately from the body
+      and commit preparation so work is not merely moved out of a counter.
+- [ ] Review the proposed contract and measured prototype. Implement the lazy
+      context path if it preserves the event contract with a useful measured
+      consequence; otherwise record the specific blocker, alternatives, and
+      condition for revisiting it. A deferral must be explicit, not an unchecked
+      handler exception hidden in a completed lift rollout.
+
+Use the existing transaction mark, schema-refusal state, snapshot view and
+event-finalization paths. Keep the mark's lifetime bounded to the argument/body
+contract; result serialization, policy preparation and scheduler bookkeeping
+must not accidentally inherit it.
+
+### F3/F4 — Retire the lift rollout switch
+
+- [ ] Assemble default-on evidence with exact revisions, environments, covered
+      workloads, observed failures, and any use of the rollback override. State
+      the observation period; elapsed time alone is not acceptance.
+- [ ] Run the relevant equivalence, refusal, snapshot and dependency tests in
+      both current flag postures. Resolve unexplained differences and check
+      production-like client/server behavior on isolated data.
+- [ ] Obtain the flag owner's retirement decision with a concrete rollback
+      route. No live data mutation is implied by this plan; coordinate any live
+      deployment separately.
+- [ ] Make the accepted lift behavior unconditional and remove the flag's
+      registry entry, environment/runtime option, obsolete conditional dispatch,
+      and flag-specific documentation and tests. Retain substantive semantic
+      tests and eager machinery used by other callers.
+- [ ] Run affected package suites, authoritative pattern checks when patterns
+      change, repository type/format/lint checks, and applicable independent
+      gates. Require clean antagonistic and Cubic reviews before merging.
+
+### F5 — Measure and close
+
+- [ ] Repeat F0 after each behavioral or flag change, using matched inputs and
+      demanded surfaces. Report changes in access count separately from changes
+      in per-access cost, handler cost, initialization and maintenance.
+- [ ] Repeat mounted headless/browser and same-/cross-space comparisons; keep
+      instrumentation disabled for timing and retain correctness assertions.
+- [ ] Publish the evidence and any remaining limitation, update author/runtime
+      guidance, and archive this plan and the completed design tracker under the
+      [documentation lifecycle](../README.md).
+
+## Out of scope
+
+Sync-selector narrowing and network transfer reduction remain with
+[shaped reads and verb results](shaped-reads-and-verb-results.md). This plan
+does not infer production latency from local-copy timings, change unrelated
+event semantics, or authorize writes to the live lunch poll.

--- a/tools/implementation-progress/README.md
+++ b/tools/implementation-progress/README.md
@@ -2,7 +2,7 @@
 
 Local execution dashboard for the design in PR #7155. The acceptance checklist
 is
-[the implementation tracker](../../docs/plans/pattern-computation-cost-implementation.md).
+[the implementation tracker](../../docs/history/plans/pattern-computation-cost-implementation.md).
 `status.json` records delivery state, review gates, questions, and demo
 milestones. Update it at each milestone and when a question or review finding
 changes. “Landed” means merged; implemented work awaiting review stays “In


### PR DESCRIPTION
## Why

The #7155 implementation needs an explicit acceptance record for the representative poll copy and an execution path for the remaining lazy-materialization work. Mike approved Q9: document that work as a separate fast-follow rather than expand this implementation into handler semantics and flag retirement.

## What Changed

- Add the F0–F5 fast-follow sequence, dependencies, semantic acceptance, rollout decision, and remeasurement gates; link the existing lazy design.
- Record two isolated poll migrations, authored-data preservation, strict reset, matched browser/headless counts, graph and timing tradeoffs, and bounded clock churn. The live poll remains unchanged and production timing is outside this evidence.
- Archive the completed #7155 design and tracker with explicit B3a deferral and D1/D2 handoff; repair incoming links. Prior implementation PRs include #7336, #7385, and the rehearsal adapter correction #7391.

## Test plan

- Rebased onto merged snapshot-replay fix #7395 after the old base repeated the covered 1,184-vote timeout. New head passes that fixture locally: two assertions in 101663 ms, both coverage mechanisms and default idempotency, unchanged read budgets, heap, and 180000 ms action limit. Earlier failures are retained in #7396. No concurrency change was made.

- Repository `deno fmt --check` (6,252 files) and `deno lint` (5,935 files) pass. Repository formatting excludes docs; new records were formatted separately.
- `deno task check-docs`: all 600 code blocks pass.
- History index and conflict-marker gates pass; local link-target scan and `git diff --check` pass.
- Report evidence: 93 authored assertions, two compatible source updates, 102 authored entities preserved in each pass, exact pristine reset, migration store verification, matching rendered content, and clean observer settlement.
- Antagonistic cf-review: reviewed the new report/plan, archive scope and link changes; verified handler/lift marking against runtime code and flag registry. No blocking findings. Historical timing estimates remain unconfirmed; handlers and flag retirement remain pending.
