### PR TITLE
fix(memory): reuse cached revisions during patch replay

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -93,6 +93,7 @@ jobs:
             packages/utils/test/deep-equal.bench.ts \
             packages/fuse/entity-projection.bench.ts \
             packages/memory/test/v2-entity-id-list.bench.ts \
+            packages/memory/test/v2-cached-patch-replay.bench.ts \
             packages/data-model/bench/hashing.bench.ts \
             packages/data-model/bench/codec-json.bench.ts \
             packages/dashboard/machine-calibration.bench.ts \

--- a/docs/specs/memory-v2/01-data-model.md
+++ b/docs/specs/memory-v2/01-data-model.md
@@ -650,6 +650,14 @@ For point-in-time reads at a specific seq:
 2. Collect patches in `(snapshot.seq, targetSeq]`.
 3. Replay from snapshot through patches.
 
+The engine can reuse an immutable decoded revision from its bounded document
+cache as a replay prefix. The cached revision must match the resolved branch and
+scope instance and lie within the selected sequence and operation-index range.
+Only the remaining patches are applied, retaining frozen subtrees outside their
+write paths. An evicted prefix is reconstructed from stored facts. Commit-local
+decoded revisions remain staged until the transaction commits and are discarded
+on rollback. Cache hits include direct reads and replay-prefix reuse.
+
 See §02 Storage for the SQL queries that implement this.
 
 ### 7.3 Snapshot Invariants

--- a/packages/memory/test/v2-cached-patch-replay.bench.ts
+++ b/packages/memory/test/v2-cached-patch-replay.bench.ts
@@ -1,0 +1,66 @@
+/** Repeated commits to a wide document with an immutable untouched subtree. */
+
+import { toFileUrl } from "@std/path";
+
+import { applyCommit, close, open, read } from "../v2/engine.ts";
+
+for (const width of [256, 1184]) {
+  Deno.bench({
+    name: `9 updates / ${width} rows`,
+    group: "cached patch replay",
+    n: 5,
+    warmup: 1,
+    async fn(benchmark) {
+      const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+      const engine = await open({ url: toFileUrl(path) });
+      const id = "of:cached-patch-replay-bench";
+      try {
+        applyCommit(engine, {
+          sessionId: "session:cached-patch-replay-bench",
+          commit: {
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "set",
+              id,
+              value: {
+                value: {
+                  rows: Array.from({ length: width }, (_, index) => ({
+                    index,
+                    metadata: { keys: [`row-${index}`, "shared"] },
+                  })),
+                  count: 0,
+                },
+              },
+            }],
+          },
+        });
+        benchmark.start();
+        for (let count = 1; count <= 9; count++) {
+          applyCommit(engine, {
+            sessionId: "session:cached-patch-replay-bench",
+            commit: {
+              localSeq: count + 1,
+              reads: { confirmed: [], pending: [] },
+              operations: [{
+                op: "patch",
+                id,
+                patches: [{
+                  op: "replace",
+                  path: "/value/count",
+                  value: count,
+                }],
+              }],
+            },
+          });
+        }
+        benchmark.end();
+        const result = read(engine, { id })?.value as { count: number };
+        if (result.count !== 9) throw new Error("patch replay lost an update");
+      } finally {
+        close(engine);
+        await Deno.remove(path);
+      }
+    },
+  });
+}

--- a/packages/memory/test/v2-cached-patch-replay.test.ts
+++ b/packages/memory/test/v2-cached-patch-replay.test.ts
@@ -1,0 +1,133 @@
+/** Patch reconstruction from immutable revisions already in the engine cache. */
+
+import { expect } from "@std/expect";
+import { toFileUrl } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
+import type { ClientCommit, EntityDocument } from "../v2.ts";
+import {
+  applyCommit,
+  close,
+  type Engine,
+  evictDocumentCacheEntries,
+  open,
+  type OpenOptions,
+  read,
+} from "../v2/engine.ts";
+
+const withEngine = async (
+  run: (engine: Engine) => void,
+  options: Omit<OpenOptions, "url"> = {},
+) => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engine = await open({ url: toFileUrl(path), ...options });
+  try {
+    run(engine);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+};
+
+const commit = (
+  engine: Engine,
+  localSeq: number,
+  operations: ClientCommit["operations"],
+) =>
+  applyCommit(engine, {
+    sessionId: "session:cached-patches",
+    commit: { localSeq, reads: { confirmed: [], pending: [] }, operations },
+  });
+
+const seed = (engine: Engine) => {
+  commit(engine, 1, [{
+    op: "set",
+    id: "of:cached-patches",
+    value: { value: { untouched: { list: [1, 2, 3] }, count: 0 } },
+  }]);
+};
+
+const patch = (count: number): ClientCommit["operations"][number] => ({
+  op: "patch",
+  id: "of:cached-patches",
+  patches: [{ op: "replace", path: "/value/count", value: count }],
+});
+
+const value = (document: EntityDocument | null) =>
+  document?.value as { untouched: { list: number[] }; count: number };
+
+describe("cached patch replay", () => {
+  it("shares untouched subtrees from a cached set revision", async () => {
+    await withEngine((engine) => {
+      seed(engine);
+      const original = value(read(engine, { id: "of:cached-patches" }));
+      commit(engine, 2, [patch(1)]);
+      const updated = value(read(engine, { id: "of:cached-patches" }));
+      expect(updated.count).toBe(1);
+      expect(updated.untouched).toBe(original.untouched);
+      expect(original.count).toBe(0);
+      expect(Object.isFrozen(updated.untouched.list)).toBe(true);
+    });
+  });
+
+  it("replays only the suffix after a cached patch revision", async () => {
+    await withEngine((engine) => {
+      seed(engine);
+      commit(engine, 2, [patch(1)]);
+      const previous = value(read(engine, { id: "of:cached-patches" }));
+      commit(engine, 3, [patch(2), patch(3)]);
+      const current = value(read(engine, { id: "of:cached-patches" }));
+      expect(current.count).toBe(3);
+      expect(current.untouched).toBe(previous.untouched);
+      expect(previous.count).toBe(1);
+      expect(value(read(engine, { id: "of:cached-patches", seq: 2 })))
+        .toBe(previous);
+    });
+  });
+
+  it("reconstructs the same value when earlier revisions are evicted", async () => {
+    await withEngine((engine) => {
+      seed(engine);
+      commit(engine, 2, [patch(1)]);
+      evictDocumentCacheEntries(engine, Number.MAX_SAFE_INTEGER);
+      commit(engine, 3, [patch(2)]);
+      expect(read(engine, { id: "of:cached-patches" })).toEqual({
+        value: { untouched: { list: [1, 2, 3] }, count: 2 },
+      });
+    });
+  });
+
+  it("excludes a cached future revision from a historical replay", async () => {
+    await withEngine((engine) => {
+      seed(engine);
+      commit(engine, 2, [patch(1)]);
+      commit(engine, 3, [patch(2)]);
+      const future = value(read(engine, { id: "of:cached-patches" }));
+      // The one-entry cache holds only the newer revision. This historical
+      // read must reconstruct its own bounded range.
+      expect(engine.documentCache.size).toBe(1);
+      expect(value(read(engine, { id: "of:cached-patches", seq: 2 })).count)
+        .toBe(1);
+      expect(future.count).toBe(2);
+      expect(value(read(engine, { id: "of:cached-patches" })).count).toBe(2);
+    }, { documentCacheMaxEntries: 1 });
+  });
+
+  it("rejects an inapplicable patch without caching its rolled-back revision", async () => {
+    await withEngine((engine) => {
+      seed(engine);
+      const previous = value(read(engine, { id: "of:cached-patches" }));
+      expect(() =>
+        commit(engine, 2, [{
+          op: "patch",
+          id: "of:cached-patches",
+          patches: [{ op: "add", path: "/value/count/child", value: 1 }],
+        }])
+      ).toThrow("path is not traversable");
+      expect(value(read(engine, { id: "of:cached-patches" }))).toBe(previous);
+      commit(engine, 2, [patch(9)]);
+      expect(value(read(engine, { id: "of:cached-patches" })).count).toBe(9);
+      expect(previous.count).toBe(0);
+    });
+  });
+});

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -2477,14 +2477,8 @@ const readStateForScopeKey = (
     row.data?.length ?? -1,
   );
   let document: EntityDocument | null;
-  const cached = engine.documentCache.get(cacheKey);
+  const cached = cachedDocumentForRevision(engine, cacheKey);
   if (cached !== undefined) {
-    // Insertion order is the eviction order, so a hit re-inserts: the entry
-    // just read becomes the last to go.
-    engine.documentCache.delete(cacheKey);
-    engine.documentCache.set(cacheKey, cached);
-    engine.documentCacheStats.hits++;
-    engine.documentCacheCoordinator?.touched(engine);
     document = cached.document;
   } else {
     engine.documentCacheStats.misses++;
@@ -7133,17 +7127,12 @@ const reconstructPatchedDocument = (
 
   let baseSeq = 0;
   let baseOpIndex = -1;
-  let document = emptyEntityDocument();
   if (snapshotRow && (!baseRow || snapshotRow.seq >= baseRow.seq)) {
     baseSeq = snapshotRow.seq;
     baseOpIndex = Number.MAX_SAFE_INTEGER;
-    document = decodeStoredDocument(snapshotRow.value);
   } else if (baseRow) {
     baseSeq = baseRow.seq;
     baseOpIndex = baseRow.op_index;
-    if (baseRow.op === "set") {
-      document = decodeStoredDocument(baseRow.data);
-    }
   }
 
   const patches = engine.statements.selectPatches.all({
@@ -7156,7 +7145,53 @@ const reconstructPatchedDocument = (
     op_index: opIndex,
   }) as Array<{ data: string; seq: number; op_index: number }>;
 
-  for (const patch of patches) {
+  // A cached revision is an immutable prefix of this exact branch, scope,
+  // and operation range. Replaying its suffix preserves frozen subtrees
+  // instead of decoding and rebuilding the prefix at every commit.
+  let document: EntityDocument | undefined;
+  let replayFrom = 0;
+  for (let index = patches.length - 1; index >= 0; index--) {
+    const patch = patches[index];
+    const cached = cachedDocumentForRevision(
+      engine,
+      documentCacheKey(
+        branch,
+        id,
+        scopeKey,
+        patch.seq,
+        patch.op_index,
+        "patch",
+        patch.data.length,
+      ),
+    );
+    if (cached?.document !== undefined && cached.document !== null) {
+      document = cached.document;
+      replayFrom = index + 1;
+      break;
+    }
+  }
+  if (document === undefined) {
+    if (snapshotRow && snapshotRow.seq === baseSeq) {
+      document = decodeStoredDocument(snapshotRow.value);
+    } else if (baseRow?.op === "set") {
+      document = cachedDocumentForRevision(
+        engine,
+        documentCacheKey(
+          branch,
+          id,
+          scopeKey,
+          baseRow.seq,
+          baseRow.op_index,
+          baseRow.op,
+          baseRow.data?.length ?? -1,
+        ),
+      )?.document ?? decodeStoredDocument(baseRow.data);
+    } else {
+      document = emptyEntityDocument();
+    }
+  }
+
+  for (const patch of patches.slice(replayFrom)) {
     document = applyPatchToDocument(
       document,
       decodeStoredPatchList(patch.data),
@@ -7301,22 +7336,34 @@ const documentCacheKey = (
   `${branch}\u0000${id}\u0000${scopeKey}\u0000${seq}\u0000${opIndex}` +
   `\u0000${op}\u0000${dataLength}`;
 
+/** Looks up a revision and records its use without publishing staged entries. */
+const cachedDocumentForRevision = (
+  engine: Engine,
+  key: string,
+): DocumentCacheEntry | undefined => {
+  const staged = engine.stagedDocumentCache?.get(key);
+  if (staged !== undefined) {
+    engine.documentCacheStats.hits++;
+    return staged;
+  }
+  const cached = engine.documentCache.get(key);
+  if (cached !== undefined) {
+    engine.documentCache.delete(key);
+    engine.documentCache.set(key, cached);
+    engine.documentCacheStats.hits++;
+    engine.documentCacheCoordinator?.touched(engine);
+  }
+  return cached;
+};
+
 /**
  * Remember the document a revision decodes to.
  *
- * A read taken inside an open transaction is not remembered. Commits read
- * their own uncommitted rows — snapshot materialization asks for the state it
- * has just written — and a transaction that goes on to throw leaves SQLite as
- * it was while this map would keep describing a revision that never happened.
- * A retry then writes its own revision at the sequence and operation index the
- * rolled-back one had, and had that entry survived, patch data of the same
- * length would answer to the same key. Declining to record is what closes
- * that, rather than clearing the map afterwards: it holds for every writer
- * rather than for the one that remembered to.
- *
- * Nothing stops a read inside a transaction from being SERVED. An entry was
- * recorded from durable state, and a transaction that has written its own
- * revision resolves to that revision's own sequence — a different key.
+ * `applyCommit()` stages decoded revisions privately for reuse within its
+ * transaction. Success publishes those entries; rollback discards them, so
+ * a retry at the same sequence and operation index cannot reuse discarded
+ * content. A read in an arbitrary external transaction can use durable entries
+ * but declines to record newly decoded revisions.
  *
  * Eviction is least-recently-read, against a byte budget and an entry cap
  * (see DEFAULT_DOCUMENT_CACHE_BUDGET_BYTES): a working set that fits stays


### PR DESCRIPTION
Repeated patch commits reconstruct and decode the same wide document prefix during snapshot checks. In the 1,184-vote lunch-poll fixture, the CPU profile attributes 35.7 seconds to snapshot materialization, including 32.9 seconds in patch reconstruction.

The engine now reuses a cached immutable revision within the exact resolved branch, entity, scope instance, sequence, and operation-index range, then applies the remaining patches. Patch validation still runs, and unchanged frozen subtrees retain their identity. The existing bounded cache and transaction-local staging govern retention and rollback. Cache-hit diagnostics include prefix reuse.

Includes five focused controls, a scheduled replay benchmark, and updated documentation. Two independent Common Fabric reviews found no actionable issues.

Validation:
- Full Memory package on current main `f1fae6c3b0`: 584 tests / 692 steps, zero failures; focused engine/cache/patch suites: 81 tests / 22 steps.
- Final focused controls against unchanged baseline: two sharing regressions fail and three controls pass; all five pass with the change. Controls cover eviction, historical reads with a newer cached revision, and malformed-patch rollback.
- Unchanged 1,184- and 74-vote lunch fixtures on current main pass all four assertions in 158,681 ms combined, with the original 180-second limit, idempotency, coverage, and read budgets. The earlier isolated main31 run passed the large fixture in 123,559 ms.
- Local diagnostic benchmark on Apple M3 Max / Deno 2.9.4, six samples: p75 for nine updates over 256 rows changes from 21.213 to 13.518 ms; over 1,184 rows, from 67.599 to 33.243 ms. These samples are diagnostic, not a release-grade speedup estimate.
- Repository format, lint, typecheck (421 paths / 46 groups), and docs (600 blocks) passed.

The baseline is current main `f1fae6c3b0`; the patch is independent of the SQLite and session-initialization PRs whose CI exposed the lunch fixture failure.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

