### PR TITLE
fix(tasks): reject a manifest that declares no workspace

### DIFF
--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -292,6 +292,27 @@ Deno.test("readWorkspaceMembers reads the workspace list from a JSONC manifest",
   }
 });
 
+Deno.test("readWorkspaceMembers rejects a manifest declaring no workspace", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "ws-members-" });
+  try {
+    // A workspace member's own manifest, which is the file a caller handed a
+    // package directory or the wrong root reads instead of the root's.
+    const configPath = `${dir}/deno.jsonc`;
+    await Deno.writeTextFile(
+      configPath,
+      JSON.stringify({ tasks: { test: "deno test" } }),
+    );
+    const error = await assertRejects(
+      () => readWorkspaceMembers(configPath),
+      Error,
+      "declares no workspace",
+    );
+    assertStringIncludes(error.message, configPath);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("assertTaskTestsIncluded requires tasks in the root workspace", () => {
   assertTaskTestsIncluded(["./packages/api", "./tasks"]);
   assertThrows(

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -169,8 +169,14 @@ export async function readWorkspaceMembers(
   configPath: string | URL = "./deno.jsonc",
 ): Promise<string[]> {
   const manifest = parseJsonc(await Deno.readTextFile(configPath)) as {
-    workspace: string[];
+    workspace?: string[];
   };
+  // A manifest that declares no workspace is a member's own rather than
+  // the root's, and answering with nothing would read downstream as a
+  // repository holding no packages at all.
+  if (!Array.isArray(manifest.workspace)) {
+    throw new Error(`${configPath} declares no workspace`);
+  }
   return manifest.workspace;
 }
 


### PR DESCRIPTION
PROBLEM

`readWorkspaceMembers()` in `tasks/workspace-tests.ts` reads the list of workspace members from a `deno.jsonc` manifest, casting the parsed result to a type that asserts the field is there:

```ts
const manifest = parseJsonc(await Deno.readTextFile(configPath)) as {
  workspace: string[];
};
return manifest.workspace;
```

A workspace member's own manifest declares no workspace. Handed one, which is what a caller given a package directory or the wrong root reads, the function answers `undefined` under a type that says `string[]`, and the failure lands in the caller instead:

```ts
(await readWorkspaceMembers(path.join(root, "deno.jsonc")))
  .map((member) => member.replace(/^\.\//, ""))
```

That stack names the `.map`, not the manifest.

SOLUTION

Make the field optional in the cast, and throw when the parsed manifest carries no array there, naming the file that was read. Every caller builds the manifest path from a root it was given: `runTests()` and `main()` in the same file, the coverage gate in
`tasks/coverage-gate.ts`, and `gatedMembers()` in
`tasks/test-selection.ts`. Being pointed at the wrong tree is therefore the thing that can go wrong here, and it is now reported where it happens.

`tasks/workspace-tests.test.ts` gains a case beside the one that reads a root manifest: a member's own manifest rejects, and the error message holds the path of the file it read.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

