### PR TITLE
docs: reactive collection guide and computation-cost adoption

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -40,6 +40,7 @@ on the Common Fabric runtime.
 
 - [concepts/pattern.md](concepts/pattern.md) — what a pattern is; inputs, outputs, `[UI]`, `[NAME]`
 - [concepts/reactivity.md](concepts/reactivity.md) — the cell system, read/write access, reactive mental model
+- [concepts/reactive-collections.md](concepts/reactive-collections.md) — `map`, `filter`, `reduce`, shared indexes, named aggregates, and reactive collection recipes
 - [concepts/computed/computed.md](concepts/computed/computed.md) — `computed()`, `lift()`, derived values, and measured collection-loop cost
 - [../features/collection-aggregates.md](../features/collection-aggregates.md) — named aggregates, numeric contracts, and collection computation costs
 - [concepts/action.md](concepts/action.md) — handling events with `action()`

--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -302,6 +302,10 @@ For the hierarchical summary string convention used by container patterns, see
 
 ## Collection-loop cost
 
+For operation selection and examples, see
+[reactive collections](../reactive-collections.md): `map`, `filter`, `reduce`,
+shared indexes, and named aggregates.
+
 Choose `computed` for an inline derivation and a module-level `lift` for a
 reusable derivation. Changing that spelling alone does not make a collection
 scan incremental. With lazy argument materialization enabled by default, the

--- a/docs/common/concepts/reactive-collections.md
+++ b/docs/common/concepts/reactive-collections.md
@@ -1,0 +1,178 @@
+# Reactive collections
+
+Use collection operations to describe derived lists, per-member computations,
+lookups, and summaries. In a pattern body, the compiler turns eligible
+operations on reactive collections into runtime computations. An ordinary
+JavaScript array inside a `computed()` or `lift()` callback still uses ordinary
+array operations; when that computation is invalidated, its loop runs again.
+
+## Choose an operation
+
+| Need                                       | Operation                                                     | Work and semantics                                                                                                                                       |
+| ------------------------------------------ | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Transform or render each member            | `map(callback)`                                               | Reactive callbacks have per-occurrence computations. Preserve linked member identity when passing records to consumers.                                  |
+| Keep matching members                      | `filter(predicate)`                                           | Reactive filtering evaluates a predicate per member and returns original member links in source order. The result is dense, including for sparse inputs. |
+| Produce zero or more results per member    | `flatMap(callback)`                                           | Reactive per-member results are flattened into a list.                                                                                                   |
+| An arbitrary, order-dependent summary      | `reduce(callback, initialValue)` inside a derived computation | The whole reduction runs when its dependencies change. It is not a maintained incremental fold.                                                          |
+| Repeatedly select members by one key       | `groupBy(selector).lookup(key)`                               | One shared index maintains all occurrences for each key. Groups use occurrence-identity order, not source order.                                         |
+| Repeatedly select one member by key        | `keyBy(selector).lookup(key)`                                 | Duplicate keys choose the smallest occurrence identity in UTF-8 order; this is not a uniqueness check or latest-write rule.                              |
+| Count, numeric summary, or extremal member | `count`, `sum`, `min`, `max`, `minBy`, `maxBy`                | Named aggregates maintain results with defined numeric and identity contracts. Membership changes can still require broad reconciliation.                |
+
+Reactive `map`, `filter`, and `flatMap` callbacks receive the element, its
+reactive index, and the source array. Captured reactive values remain inputs to
+the callback. Reading a shared collection inside every callback can make a
+change invalidate every member's computation; per-member callbacks alone do not
+remove repeated scans.
+
+Compiler lowering depends on both context and receiver. In particular, calling
+an array method on a value obtained with `.get()` inside a computation does not
+make every inner loop a separate reactive builtin. Use the patterns below rather
+than inferring incrementality from the method name. The precise compiler rules
+are in the
+[array-method lowering contract](../../specs/ts-transformer/ts_transformers_current_behavior_spec.md#94-array-method-strategy).
+
+## Derive a view, then give each row its own computation
+
+This pattern explicitly derives a filtered view and maps its members to row
+results. The filtering computation scans when its dependencies change; the
+mapped rows have their own reactive computations.
+
+```ts
+import { computed, pattern, Writable } from "commonfabric";
+
+export default pattern<{
+  donuts: Writable<{ name: string; price: number; available: boolean }[]>;
+}>(({ donuts }) => {
+  const available = computed(() =>
+    donuts.get().filter((donut) => donut.available)
+  );
+  const cards = available.map((donut) => ({
+    donut,
+    label: computed(() => `${donut.name}: $${donut.price}`),
+  }));
+  const receipt = computed(() =>
+    donuts.get().reduce((text, donut) => `${text}${donut.name}\n`, "")
+  );
+  return { cards, receipt };
+});
+```
+
+When a callback derives a value from an external collection, put that read in an
+explicit reactive computation or use a shared index lookup. Do not capture a
+one-time plain snapshot and expect a cached row instance to refresh it. Keep
+original linked records when identity matters for editing, selection, or child
+pattern state. Use [canonical identity comparisons](identity.md) rather than
+JavaScript object equality, and bind mutation handlers to stored inputs.
+
+A module-level `lift()` is useful for reusing a derivation. Moving an unchanged
+whole-array loop from `computed()` to `lift()` does not make that loop
+incremental. See
+[collection-loop cost](computed/computed.md#collection-loop-cost).
+
+## Share an index across consumers
+
+Use explicit array `Cell` or `Writable` inputs for the index and aggregate APIs.
+Ordinary array types do not expose these methods, including array-typed pattern
+inputs and the public result type of `map`. A chain such as
+`donuts.map(score).sum()` is not supported by the public types.
+
+```ts
+import { pattern, Writable } from "commonfabric";
+
+export default pattern<{
+  donuts: Writable<{ code: string; glaze: string; price: number }[]>;
+  orders: Writable<{ donutCode: string }[]>;
+  prices: Writable<number[]>;
+}>(({ donuts, orders, prices }) => {
+  const byGlaze = donuts.groupBy((donut) => donut.glaze);
+  const byCode = donuts.keyBy((donut) => donut.code);
+  return {
+    chocolate: byGlaze.lookup("chocolate"),
+    ordersWithDonuts: orders.map((order) => ({
+      order,
+      donut: byCode.lookup(order.donutCode),
+    })),
+    affordableCount: donuts.count((donut) => donut.price < 5),
+    cheapest: donuts.minBy((donut) => donut.price),
+    totalPrice: prices.sum(),
+  };
+});
+```
+
+The indexes are built outside the order callback so all orders share their
+maintenance. Each order remains present even when lookup returns `undefined`:
+this composes a left join without a separate join method. Use `groupBy` instead
+of `keyBy` if every matching right-hand occurrence is needed.
+
+Selectors receive one member, without its array position. Keys may be supported
+primitives or Cell references; nullish keys omit membership. Missing group
+lookups return empty arrays. Cell keys use resolved identity, including space,
+path, and scope, without requiring their payload contents as keys.
+
+Request `keys()` only when a consumer needs all occupied keys: enumeration adds
+its own demand and sorting work. For mixed primitive/Cell keys, use tagged
+`keyEntries()` and perform lookup within the appropriate tag branch. See the
+[full index contract](../../features/collection-indexes.md) for supported keys,
+ordering, descriptor schemas, and cold/resume behavior.
+
+## Choose aggregate semantics deliberately
+
+`count()` counts present members; `count(predicate)` counts truthy predicate
+results. `minBy(score)` and `maxBy(score)` return the selected original member,
+or `undefined` for an empty collection. Tied members use occurrence identity,
+not source position.
+
+Numeric `sum()` accumulates finite binary64 values exactly and rounds once. It
+can differ from a JavaScript reduction: summing `1e16`, `1`, and `-1e16`
+returns 1. Empty sums return positive zero; empty `min()` and `max()` return
+positive and negative infinity respectively. Check the
+[aggregate contract](../../features/collection-aggregates.md) for NaN, infinity,
+signed-zero, and tie behavior before replacing an existing reduction.
+
+For a computed numeric list, introduce a subpattern with an explicit numeric
+Cell input if it needs a named aggregate; do not cast an ordinary array into a
+Cell to bypass the public typing. Keep ordinary reductions for order-dependent
+operations or small workloads where maintaining additional state is unnecessary.
+
+## Implementation patterns and cost boundaries
+
+The runtime retains per-occurrence child computations for reactive list
+operators. Index buckets retain original links, so payload reads can update
+without requiring a membership rebuild. Aggregate predicate and score callbacks
+reuse per-element mapping, and numeric results use an identity-ordered tree with
+leaf blocks of at most 32 members. Updating an independently linked scalar can
+recompute one block and its ancestors.
+
+Membership changes still reconcile collection identities. Appending, removing,
+or reordering can cause broad work; editing an inline primitive array also takes
+the membership path. Large groups cost more to construct and order, and removing
+an indexed winner can require searching its bucket. These operations trade
+maintained graph/state for less repeated consumer work, not a universal
+constant-time update guarantee.
+
+When extending the runtime, reuse its identity, list reconciliation, child
+ownership, and rollback machinery. Test cold initialization, key retargeting,
+cross-space references, resumption, and teardown as well as warm edits. Members
+outside a currently observed group must still be maintained so a later key edit
+can make them enter that group. Detailed implementation entry points are linked
+from the [index](../../features/collection-indexes.md) and
+[aggregate](../../features/collection-aggregates.md) contracts.
+
+## Verify the demanded workload
+
+Start with `cf test --verbose --stats-threshold 0` and the
+[read-accounting guide](../../features/read-accounting.md). Demand the relevant
+outputs or rendered UI: read budgets alone do not mount consumers. Compare
+initialization, member payload edits, membership changes, and lookup retargeting
+at several collection sizes. Check behavior alongside counters.
+
+Use both total and per-run budgets. Total budgets count completed transaction
+attempts through settlement; per-run budgets bound the largest completed action
+body. They catch different regressions. The nonfatal `collection:nested-scan`
+warning can suggest a repeated captured-collection scan, but is not an
+exhaustive complexity analysis.
+
+Measure elapsed time and graph/storage costs separately before claiming a
+speedup. Read counters do not measure network traffic. Preserve narrow
+caller-demand schemas and compact projections when a linked result could expand
+more data than a consumer needs.

--- a/docs/common/concepts/types-and-schemas/writable.md
+++ b/docs/common/concepts/types-and-schemas/writable.md
@@ -92,31 +92,18 @@ list: removing it with `removeByValue` drops it from the list but does not clear
 the element's stored value, so a handler that decides anything by reading the
 element back must clear it when removing.
 
-Because keyed elements are stored as links to separate documents, **read the
-collection through a top-level `computed()` / derived value, not by
-`.filter()`/`.map()`-ing the array inline inside a nested reactive `map`**. A
-function or `computed()` that takes the collection resolves the links; an inline
-filter inside another `map`'s body can see only the links a replica has already
-materialized locally — so an element written on another replica (another user's
-keyed entry) is dropped and renders nothing, even though a top-level count over
-the same collection is correct. Compute the per-element data once at the top
-level, and render it from a single `computed()` rather than a reactive
-`map(...)` of sub-elements: a reactive map caches per-item instances whose
-inputs update flakily when a remote write changes one item, whereas one
-`computed` re-runs as a whole when the resolved data changes — the same
-reliability as the count.
+Keyed elements are stored as links to separate documents. Derive values from
+those links in an explicit reactive computation or through a maintained index
+lookup. A reactive `map` can keep a computation per member; it does not refresh a
+plain snapshot captured when that member's callback was constructed. Preserve
+original linked members when binding editing handlers, and make reads of other
+collections reactive rather than relying on what is already materialized on one
+replica.
 
-```typescript
-// Shown for illustration only.
-// In the pattern body — resolves the vote links:
-const tallies = tally(options, votes);
-// In JSX — one computed over the resolved tally, plain JS maps inside:
-computed(() =>
-  tallies.map((t) => (
-    <div>{t.voters.map((v) => <span>{v.name}</span>)}</div>
-  ))
-);
-```
+See [reactive collections](../reactive-collections.md) for filtered views,
+reactive row computations, shared lookups, and their cost boundaries. Verify
+remote edits and cold loading as well as local updates when testing a derived
+view of keyed members.
 
 For the full model and trade-offs (including the add-wins-after-delete
 ordering), see

--- a/docs/features/collection-aggregates.md
+++ b/docs/features/collection-aggregates.md
@@ -1,5 +1,8 @@
 # Incremental collection aggregates
 
+For authoring recipes alongside `map`, `filter`, and `reduce`, see
+[reactive collections](../common/concepts/reactive-collections.md).
+
 Array-valued `Cell` and `Writable` inputs expose named aggregates. These methods
 build reactive computations in a pattern body. Predicate and score callbacks
 receive an element, its reactive index, and the source array; captured values

--- a/docs/features/collection-indexes.md
+++ b/docs/features/collection-indexes.md
@@ -1,5 +1,8 @@
 # Collection indexes
 
+For authoring recipes alongside `map`, `filter`, and `reduce`, see
+[reactive collections](../common/concepts/reactive-collections.md).
+
 Array-valued Cells expose `groupBy(selector)` and `keyBy(selector)`. Each
 selector receives one source element. The compiler lowers it to reactive key
 extraction; the runtime owns membership maintenance for each source occurrence.

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -4,6 +4,8 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Audits and reports
 
+- [Computation-cost adoption brief](development/performance/2026-09-12-computation-cost-adoption.md) — mechanisms, implementation lessons, announcement prerequisites, and proposed lunch-poll and Topics migrations after the #7155 arc.
+
 - [Representative lunch-poll copy rehearsal](development/performance/2026-09-12-representative-lunch-poll-rehearsal.md) — two isolated migration passes, authored-data preservation, matched browser/headless read counts, graph and timing tradeoffs, bounded clock churn, and the Q9 fast-follow decision.
 
 - [Index maintenance phase counts](development/performance/2026-09-11-index-maintenance-phases.md) — completed action-body counts for both index types across membership edits, key edits and lookup retargeting at three sizes.

--- a/docs/history/development/performance/2026-09-12-computation-cost-adoption.md
+++ b/docs/history/development/performance/2026-09-12-computation-cost-adoption.md
@@ -1,0 +1,331 @@
+---
+status: historical
+created: 2026-09-12
+archived: 2026-09-12
+reason: "Adoption assessment and implementation lessons at the close of the #7155 computation-cost arc."
+---
+
+# Computation cost: mechanisms, adoption, and announcement readiness
+
+This brief assesses the completed #7155 arc at Labs commit
+`eea8b459b3cce482febdb8550d5f06e26f850073`. It is for pattern authors choosing
+collection operations and runtime developers extending their implementation.
+Recommendations below are proposed work, not completed migrations. The linked
+feature documents are the maintained API contracts.
+
+The useful result is a way to express maintained collection computations,
+measure the work a real consumer demands, and prevent regressions with read
+budgets. The operators can reduce repeated scans, but add maintained state and
+reactive graph structure. Choose them for a measured access pattern; fewer reads
+alone do not establish lower latency, memory use, or network traffic.
+
+## What to use, and when
+
+| Mechanism                                      | Use it when                                                                                          | Why it helps; important boundary                                                                                                                                           |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Source-attributed read accounting              | A pattern becomes slower as its collections grow, or an optimization needs evidence.                 | Attributes accesses, link traversals, and document/dependency counts to action bodies. It is opt-in; it does not measure all CPU, storage, or network work.                |
+| Total and per-run read budgets                 | A representative action has a known acceptable scaling envelope.                                     | Total budgets catch work spread across many actions; per-run budgets catch one oversized computation. Tests must demand the relevant UI or output.                         |
+| `groupBy(selector)` and `lookup(key)`          | Many consumers repeatedly filter the same collection by a stable key.                                | Shares membership maintenance and lets consumers read their matching group. Group order is occurrence-identity order, not source-array order.                              |
+| `keyBy(selector)` and `lookup(key)`            | Consumers need one matching record, including repeated joins against a shared right-hand collection. | Avoids each consumer searching the whole collection. Duplicate keys choose the smallest occurrence identity in UTF-8 order, not the latest write.                          |
+| `keys()` and `keyEntries()`                    | The UI actually needs to enumerate distinct groups.                                                  | Enumeration has its own demand and cost. Mixed primitive/Cell keys need tagged `keyEntries()` to preserve their distinction.                                               |
+| `count`, `sum`, `min`, `max`, `minBy`, `maxBy` | A linked collection needs a maintained scalar or extremal member.                                    | Named operations have defined incremental and deterministic semantics. They do not make arbitrary `reduce` callbacks incremental.                                          |
+| Reactive per-row computations and stable links | One row changes while sibling rows should retain their values and interactions.                      | Gives each row an independently reactive computation and preserves identity through rendering. A helper wrapped around a whole-array loop does not achieve this by itself. |
+| `collection:nested-scan` diagnostic            | A callback scans a captured collection inside another collection operation.                          | Offers an early prompt to investigate a possible repeated scan. It is a nonfatal syntax heuristic, not a complexity proof.                                                 |
+
+The contracts and supported call shapes are in
+[read accounting](../../../features/read-accounting.md),
+[collection indexes](../../../features/collection-indexes.md), and
+[collection aggregates](../../../features/collection-aggregates.md).
+
+### Call shapes and semantic choices matter
+
+Index and aggregate methods belong to explicit array `Cell`/`Writable`
+receivers. They are not methods on ordinary JavaScript arrays. In particular,
+the public `Reactive<T>` typing does not make `rows.map(score).sum()` a
+supported chain. Use the documented explicit receiver boundary, as lunch poll
+does with its `indexVotesByOption` subpattern. Callback lowering is part of the
+pattern compiler; an unlowered callback passed directly through the builder is
+not interchangeable.
+
+Build an index once outside its consumers' callbacks. A left join is a
+composition: map the left collection and look up each key in one shared index of
+the right collection. There is no separate join method. Keep unmatched left rows
+and decide whether duplicate right keys should mean a group or a deterministic
+single winner.
+
+Index keys can be supported primitives or Cell references. Nullish selector
+results omit membership. Cell keys use resolved space, document, path, and scope
+identity; reading a reference's contents is not necessary to identify it. Do not
+substitute JSON serialization, a title, or a document ID alone for the runtime's
+canonical identity. For mixed keys, branch on `keyEntries()`'s tag and perform
+the lookup within that branch.
+
+Aggregates also require an explicit semantic choice. `sum()` accumulates finite
+binary64 values exactly and rounds once, so the sequence `1e16, 1, -1e16` sums
+to 1 rather than the 0 produced by that JavaScript addition order. Empty sums
+are positive zero; empty minima/maxima are positive/negative infinity; empty
+`minBy`/`maxBy` results are undefined. NaNs, infinities, signed zero, and tied
+members have defined behavior. Ties for selected members use occurrence
+identity, not array position. These are valuable replay guarantees, not
+incidental details to hide in a migration.
+
+## Implementation details worth carrying forward
+
+### Measure completion, with a precise ownership boundary
+
+The read-accounting implementation distinguishes an action's body from its
+transaction attempt. Bodies include argument materialization and result
+construction. Attempts cover the wider transaction lifetime, including work such
+as preparation and retries. Their totals must not be added together as though
+independent. A test's total budget counts completed attempts; its per-run budget
+bounds the largest completed body.
+
+Completion events capture work from actions that disappear before settlement.
+Subtracting two final scheduler-stat snapshots would miss removed nodes and
+would make a smaller final graph look artificially cheap. Instrumentation stays
+owned by the transaction across asynchronous work and does not create new demand
+or writes. These principles apply to future CPU and allocation probes too.
+
+Budget the operation through actual settlement and demand the same outputs in
+both comparison arms. Merely declaring a budget does not mount the UI. An
+explicit render step or continuous UI demand can expose work a headless state
+assertion never triggers. Use both total and per-run limits, plus functional
+assertions; a cheap computation producing stale output is not a success.
+
+### Incrementality depends on identity and lifecycle
+
+Index buckets retain links to original members. Payload changes can reach a
+consumer without rebuilding membership, and consumers preserve the identity
+needed for editing. Materializer write envelopes keep members outside the
+current bucket demanded so a later key change can move them into it. A
+subscription only to today's matches would miss tomorrow's arrivals.
+
+Cold reads, resumption, lookup retargeting, cross-space links, pending values,
+principal/session ownership, and teardown are part of the operator contract.
+Pending data cannot silently become confirmed absence. A stopped materializer
+must not rearm itself, and a failed confirmation must retain an actionable
+cause. Test these transitions, not just warm insert/remove examples.
+
+The cost boundaries remain real. Source membership changes reconcile identities
+across the collection. Group result construction depends on bucket size;
+removing a `keyBy` winner can scan its bucket. Enumerating all keys adds sorting
+work. Aggregates use an identity-ordered tree with leaf blocks of at most 32
+members: a linked scalar edit can update a block and its ancestors, while
+membership changes can require broad reconciliation and sorting. Inline
+primitive edits can take that membership path. Neither mechanism promises
+constant-time insertion into every collection.
+
+### Lazy reads and shared work improve the substrate
+
+Lazy lift argument materialization is enabled by default in the evaluated
+runtime. It narrows what a computation actually reads; it does not turn a loop
+into a maintained operation. The matched
+[computed/lift experiment](2026-09-11-computed-lift-collection-loops.md) found
+the same read counts for equivalent `computed`, broad-parameter `lift`, and
+narrow-parameter `lift` loops. At 512 linked rows, the relevant edit still cost
+1,025 accesses and 515 link traversals in each arm. An unread-field edit did not
+invalidate those computations.
+
+Consequently, do not rewrite module-scope lifts just to change the spelling.
+Narrow schemas remain useful contracts at helper, hydration, and caller-demand
+boundaries. They also matter for compatibility with stored generations of a
+pattern. Handler argument materialization is a separate remaining task.
+
+[Lazy views](../../../features/lazy-cell-materialization.md) validate
+descendants when touched. An unread malformed subtree no longer prevents an
+otherwise valid read, while a touched mismatch follows the required/optional
+boundary. Missing values and defaults must still register dependencies so later
+arrivals wake the reader. Extending laziness to handlers therefore needs a
+deliberate validation contract, not just enabling the lift flag around another
+callback.
+
+Shared downstream traversal and scoped snapshot reuse remove repeated runtime
+work without requiring authors to add caches. The associated storage
+patch-replay optimization illustrates the same lesson: preserve immutable values
+and reuse canonical machinery, but publish cached state only after a successful
+commit. Cache ownership, rollback, scope, and invalidation are correctness
+properties. A reduction in reactive reads does not excuse expensive work below
+that boundary.
+
+### Validate the observer as well as the computation
+
+The copy rehearsal exposed stale attribute observation in the headless `MockDoc`
+adapter. Its fix needed a negative control and HTML tests, not a change to the
+pattern's intended state. Compare visible behavior as well as counters between
+browser and headless runs. Use counters to locate work, timing to assess user
+impact, and graph/storage measurements to understand what maintenance costs.
+
+## What the lunch-poll evidence establishes
+
+The
+[representative copy rehearsal](2026-09-12-representative-lunch-poll-rehearsal.md)
+compared the deployed source with the maintained-group candidate on a fixed
+runtime. The writable copy had 14 options, 10 participants, and 77 stored votes,
+with only three votes in the current-day workload. Nine original profile spaces
+were unavailable; a local cross-space test profile was present. Two migration
+passes preserved the authored-data hashes. The real poll was not modified.
+
+| Browser measurement for the tested update | Deployed source | Candidate |
+| ----------------------------------------- | --------------: | --------: |
+| Completed action bodies                   |              39 |        29 |
+| Body accesses                             |             629 |       220 |
+| Largest body's accesses                   |              84 |       139 |
+| Graph nodes                               |           2,300 |     2,477 |
+| Graph edges                               |           5,026 |     6,067 |
+| Observed elapsed milliseconds             |          139.07 |    160.49 |
+
+Headless access counts matched the browser within each source arm, but its
+observed timing moved in the other direction, from 235.81 to 148.86 ms. These
+are individual observations, not a latency distribution. The evidence supports
+less repeated read work and preserved tested behavior, with more graph structure
+and a larger maximum body. It does not support a universal speedup or a
+production latency claim. The missing profiles and small current-day cohort
+limit how representative this timing is.
+
+## Suggested changes to existing patterns
+
+### Lunch poll: finish the narrow consumers before adding more machinery
+
+The merged [main pattern](../../../../packages/patterns/lunch-poll/main.tsx)
+already filters votes to the current day, builds a shared `groupBy(optionId)`,
+and computes each option's tally from its lookup. Keep that architecture and the
+reactive row rendering. Preserve the local-calendar day boundary and the empty
+state while the shared clock is unresolved.
+
+The next concrete experiment is the
+[option card](../../../../packages/patterns/lunch-poll/poll-option-card.tsx).
+Each card still receives all of today's votes, and `myVoteFor` searches that
+array for its option and viewer. Try passing the already-maintained option group
+to this read-only display consumer. Keep vote mutation handlers bound to their
+stored inputs. Check duplicate matching votes before doing this: `.find` over
+source order and `.find` over occurrence-identity order can choose differently.
+Either demonstrate uniqueness as an invariant or specify the intended winner.
+
+Measure this change with continuous card demand, vote insertion/removal/color
+changes, viewer changes, option removal, midnight rollover, cold loading, and
+cross-space profiles. Assert button state, swatches, ranking, and handler
+behavior as well as budgets. Do not infer success just from a lower tally cost.
+
+Keep whole-option ranking and history summaries unless profiling identifies them
+as significant. The shipped operators do not provide incremental sorting, and a
+small history reduction may cost less than another maintained graph. Likewise, a
+maintained count is not automatically better than an already-shared length.
+
+Deployment is separate from the merged implementation. Rehearse further changes
+on a fresh copy using the
+[space-clone procedure](../../../development/space-clone-rehearsal.md), then
+coordinate any live poll update with its owner. The completed arc does not
+authorize changing the real poll.
+
+### Topics and Topicboard: maintain the mention relation, preserve demand shape
+
+The [board](../../../../packages/patterns/topics/main.tsx) already centralizes
+backlink derivation. It materializes narrow mention lists once, then scans those
+lists for each destination topic. This avoids repeatedly resolving reactive
+proxies, but still repeats comparisons across the graph. Each
+[topic](../../../../packages/patterns/topics/topic.tsx) also scans the resulting
+table to find its own row.
+
+The highest-value hypothesis is a shared maintained relation of source and
+destination references, grouped by destination, followed by direct lookup for
+backlinks. This requires a prototype; merely adding `groupBy` after
+reconstructing all edges on every edit can retain the expensive producer.
+Measure edge maintenance independently from lookup. A shared keyed lookup over
+the existing cross-reference rows is a smaller first experiment that leaves the
+pivot intact.
+
+Preserve these semantics explicitly:
+
+- Self-mentions are excluded by canonical identity, including aliases and scoped
+  references.
+- Several mentions from one source occurrence currently yield one inbound
+  result, while duplicate source occurrences need separate consideration.
+  Deduplicating every source globally would change the current filter semantics.
+- Inbound results currently follow board source order. Group identity order is
+  different; preserve the visible order or make its change an explicit decision.
+- Cold or unresolved sources do not create rows with invalid identity. Stable
+  cross-reference row addresses and linked topic results must survive
+  resumption.
+- Topics with no match still receive an empty backlink list.
+
+For individual topics, start with simpler sharing: derive `hasComments` from
+`commentCount`, and evaluate reusing the active-link view for `hasLinks` and
+link resolution. For large threads, prototype `count(predicate)` over an
+explicit comment Cell, preserving the optional `removedAt` projection for stored
+topics. Do not mechanically replace the narrow compatibility lift with an opaque
+read.
+
+An activity aggregate is a later experiment. `lastActivityOf` includes comment
+edits and retractions and link removals, even for records absent from the
+visible thread. Dropping those records would let activity move backward.
+Preserve every timestamp surface, its optional defaults, and the original linked
+comment identity; the ordinary mapped-array chaining gap also applies here.
+
+Keep the board's original topic links when sorting cards. There is no shipped
+incremental sort/top-K operation. Keep its compact copied `mentionableIndex` and
+narrow headless `index`: returning linked bucket members does not itself limit
+network expansion. A keyed lookup may accelerate short-name resolution, but it
+must not replace the persistent name allocator or its never-reuse contract.
+
+Before landing a Topics migration, vary topic count and mention-edge count
+independently. Include same-count mention retargeting, duplicate mentions,
+rename-only edits, comment edits/retractions, unrelated sibling edits, aliases,
+cold resume, and multiplayer observation. Measure producer work, lookup work,
+read budgets, graph size, and elapsed time separately. Use bytes/subscriptions
+for any network claim. Run the existing naming, rendering-identity, rejection,
+and multi-user tests, plus a stored-space copy rehearsal.
+
+## What should land before announcing this?
+
+A focused announcement of maintained indexes, named aggregates, and read budgets
+can proceed after publishing the adoption guidance and confirming the target
+runtime includes the merged work. This assessment found no additional core
+correctness fix that must block that scoped announcement. It did not audit the
+currently deployed runtime version.
+
+| Work or claim                                             | Recommendation                                                                                                                                                                                                 |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Public guidance and examples                              | Publish the supported explicit-Cell examples from the maintained feature docs with ordering, duplicate, numeric, and cost caveats. Link a reproducible demanded-UI workload. This is announcement preparation. |
+| “Available on our deployment”                             | Confirm the deployed runtime/compiler version includes the arc before making this claim. Merged source alone is insufficient.                                                                                  |
+| “Lunch poll is faster”                                    | Obtain repeated matched timings with the intended profile data and deployment. Until then announce the demonstrated reduction in reads and disclose maintenance costs.                                         |
+| Topics adoption                                           | Land a measured prototype and compatibility tests before describing Topics as migrated. It is an adopter follow-up, not a prerequisite for announcing the runtime APIs.                                        |
+| Aggregate chaining ergonomics                             | A useful fast-follow before encouraging broad mechanical replacement of `.map(...).reduce(...)`. Explicit-Cell APIs can be announced now with their actual typing.                                             |
+| Handler laziness and lazy flag retirement                 | Execute the separate [lazy-materialization fast-follow](../../../plans/lazy-materialization-fast-follow.md). Q9 deliberately separates it from the completed arc; it does not block the narrower announcement. |
+| Restricted append folds or arbitrary incremental `reduce` | Remain outside the shipped claim. The restricted fold work was explicitly deferred; named aggregates are not a substitute contract for arbitrary reducers.                                                     |
+| Reduced client replication/network demand                 | Qualify separately through [shaped reads](../../../plans/shaped-reads-and-verb-results.md) and replication work. Local read accounting cannot establish this benefit.                                          |
+
+At this assessment,
+[Topics stored-state migration #7345](https://github.com/commontoolsinc/labs/pull/7345)
+and
+[active-view replication #7349](https://github.com/commontoolsinc/labs/pull/7349)
+were open. Coordinate a Topics source update with the former's compatibility
+work. Do not present the latter's behavior as part of this completed arc.
+Neither is automatically a blocker for announcing the scoped collection APIs.
+
+A useful demonstration sequence is: show a repeated-filter workload; demand its
+rendered result; replace the repeated searches with one maintained group; edit a
+member; compare source-attributed reads and visible output; then show startup
+and graph costs too. Follow with a read budget that rejects the scan regression.
+Use synthetic data or the isolated poll copy, not writes to the live poll.
+
+Suggested announcement scope: **Maintained grouping, keyed lookup, and named
+aggregates are available in the runtime, alongside source-attributed read
+accounting and test budgets. They help authors control repeated collection work;
+choose them using measured workloads and their documented identity, ordering,
+and maintenance contracts.**
+
+## Implementation entry points
+
+For extending these mechanisms, start with the maintained feature documents,
+then these sources and their neighboring tests:
+
+- [Index builtins](../../../../packages/runner/src/builtins/collection-index.ts):
+  membership, lookup, enumeration, and lifecycle ownership.
+- [Aggregate builtin](../../../../packages/runner/src/builtins/aggregate.ts):
+  tree maintenance and result ownership.
+- [Lazy schema views](../../../../packages/runner/src/schema-view.ts): per-path
+  materialization and read dependencies.
+- [Memory engine](../../../../packages/memory/v2/engine.ts): revision-cache
+  identity, staged publication, and patch replay.
+- [Completed implementation tracker](../../plans/pattern-computation-cost-implementation.md):
+  landing and validation provenance for the arc, including explicit deferrals.


### PR DESCRIPTION
## Why

Pattern authors need a maintained entry point for collection operations that explains when to use map/filter/reduce, shared indexes, and named aggregates together. The #7155 feature contracts and implementation tracker do not provide that authoring guide or collect the evidence and follow-ups needed for an announcement.

## What Changed

- Add a live Reactive collections guide under the pattern-author concepts, with checked examples for filtered views, reactive rows, shared lookup/left joins, and named aggregates. Cover receiver typing, semantics, runtime implementation patterns, and cost verification.
- Link it from the common index, computed guide, and detailed index/aggregate contracts. Replace the Writable guide's blanket warning against reactive mapped rows with explicit reactive-read and identity guidance.
- Add the dated adoption brief covering implementation lessons, representative lunch-poll evidence, announcement prerequisites, and proposed lunch-poll and Topics/Topicboard changes. Index it as an assessment after #7394.

## Test plan

- Repository `deno fmt --check` and `deno lint` passed; the new documents were explicitly formatted because repository formatting excludes docs.
- `deno task check-docs`: all 602 checked blocks passed, including both new live examples.
- Compile both extracted examples through `cf check --no-run`; inspect transformed output for reactive callback lowering.
- Local source/document links resolve; `git diff --check` passed. History-index and conflict-marker checks passed for the historical addition.
- Applied cf-review to the documentation, cross-checking API contracts, pattern recommendations, and rehearsal measurements against their sources.

Draft for editorial review. This change does not modify runtime behavior or deployed patterns.
