### PR TITLE
docs(background-piece-service): every source file gets its header and every declaration its doc comment

### DIFF
--- a/packages/background-piece-service/src/env.ts
+++ b/packages/background-piece-service/src/env.ts
@@ -1,6 +1,7 @@
 /**
  * The environment this service reads: each variable it recognizes, with the
- * default that stands in for an unset one, parsed once at load into `env`.
+ * default, where one exists, that stands in for an unset one, parsed once at
+ * load into `env`.
  */
 
 import { z } from "zod";
@@ -38,7 +39,7 @@ const envSchema = z.object({
   ),
   OTEL_SERVICE_NAME: z.string().default("bg-piece-service"),
   OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default("http://localhost:4318"),
-  // The EXPERIMENTAL_* feature flags are not declared here: the runtime
+  // The `EXPERIMENTAL_*` feature flags are not declared here: the runtime
   // construction site reads them through the canonical mapping
   // (`experimentalOptionsFromEnv` / EXPERIMENTAL_ENV_VARS in
   // @commonfabric/runner runtime-presets), shared with toolshed and the CLI

--- a/packages/background-piece-service/src/env.ts
+++ b/packages/background-piece-service/src/env.ts
@@ -1,5 +1,11 @@
+/**
+ * The environment this service reads: each variable it recognizes, with the
+ * default that stands in for an unset one, parsed once at load into `env`.
+ */
+
 import { z } from "zod";
 
+/** Schema of the recognized variables, defaults included. */
 const envSchema = z.object({
   // Job queue settings
   //MAX_CONCURRENT_JOBS: z.coerce.number().positive().default(5),
@@ -32,11 +38,11 @@ const envSchema = z.object({
   ),
   OTEL_SERVICE_NAME: z.string().default("bg-piece-service"),
   OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default("http://localhost:4318"),
-  // EXPERIMENTAL_* feature flags are no longer declared here: the runtime
+  // The EXPERIMENTAL_* feature flags are not declared here: the runtime
   // construction site reads them through the canonical mapping
   // (`experimentalOptionsFromEnv` / EXPERIMENTAL_ENV_VARS in
   // @commonfabric/runner runtime-presets), shared with toolshed and the CLI
-  // so the wirings cannot drift (CT-1814).
+  // so the wirings cannot drift.
 
   // Background Piece Service: default is public space "toolshed-system"
   //SERVICE_DID: z.string().default(
@@ -44,8 +50,15 @@ const envSchema = z.object({
   //),
 });
 
+/** The parsed environment, as `loadEnv()` returns it. */
 export type EnvVars = z.infer<typeof envSchema>;
 
+/**
+ * Reads every recognized variable through `source` and returns the parsed
+ * result, defaults filled in.
+ *
+ * @throws If a variable's value fails its schema.
+ */
 export function loadEnv(
   source: (key: string) => string | undefined = (key) => Deno.env.get(key),
 ): EnvVars {
@@ -58,4 +71,5 @@ export function loadEnv(
   return envSchema.parse(rawEnv);
 }
 
+/** The process environment, parsed at module load. */
 export const env = loadEnv();

--- a/packages/background-piece-service/src/main.ts
+++ b/packages/background-piece-service/src/main.ts
@@ -61,9 +61,9 @@ export interface MainDependencies {
 }
 
 /**
- * Returns the worker timeout `args` names with `--timeout`, in milliseconds,
- * or the default when the argument is absent or does not start with an
- * integer.
+ * Returns the worker timeout, in milliseconds, that the `--timeout` argument
+ * in `args` names, or the default when the argument is absent or does not
+ * start with an integer.
  */
 export function parseWorkerTimeout(args: string[]): number {
   const { timeout } = parseArgs(args, {

--- a/packages/background-piece-service/src/main.ts
+++ b/packages/background-piece-service/src/main.ts
@@ -1,3 +1,10 @@
+/**
+ * Entry point of the service binary: reads the environment, builds the runtime
+ * and the service, wires shutdown to `SIGINT` and `SIGTERM`, and starts it.
+ * Everything the entry point reaches outside itself is injectable, so a test
+ * can drive it without a process, a network, or a signal.
+ */
+
 import { parseArgs } from "@std/cli/parse-args";
 
 import type { Identity } from "@commonfabric/identity";
@@ -15,23 +22,48 @@ import { getTracer, initOpenTelemetry, shutdownOpenTelemetry } from "./otel.ts";
 import { BackgroundPieceService } from "./service.ts";
 import { getIdentity } from "./utils.ts";
 
-// 10 minute timeout
+/**
+ * How long a worker request may run before it fails, absent a `--timeout`
+ * argument: ten minutes.
+ */
 export const DEFAULT_WORKER_TIMEOUT_MS = 10 * 60000;
 
+/**
+ * The part of a `BackgroundPieceService` the entry point drives, so a test can
+ * stand one in.
+ */
 type ServiceLike = Pick<BackgroundPieceService, "initialize" | "stop">;
 
+/** Everything the entry point reaches outside itself, each one replaceable. */
 export interface MainDependencies {
+  /** The parsed environment. */
   env: EnvVars;
+
+  /** Derives the identity the service runs as. */
   getIdentity: typeof getIdentity;
+
+  /** Constructs the runtime the service reads the registry through. */
   createRuntime: (env: EnvVars, identity: Identity) => Runtime;
+
+  /** Constructs the service. */
   createService: (
     options: ConstructorParameters<typeof BackgroundPieceService>[0],
   ) => ServiceLike;
+
+  /** Registers a handler for a process signal. */
   addSignalListener: typeof Deno.addSignalListener;
+
+  /** Exits the process. */
   exit: typeof Deno.exit;
+
+  /** Writes a line of startup output. */
   log: typeof console.log;
 }
 
+/**
+ * Returns the worker timeout `args` names with `--timeout`, in milliseconds,
+ * or the default when the argument is absent or not a number.
+ */
 export function parseWorkerTimeout(args: string[]): number {
   const { timeout } = parseArgs(args, {
     string: [
@@ -48,16 +80,25 @@ export function parseWorkerTimeout(args: string[]): number {
   return DEFAULT_WORKER_TIMEOUT_MS;
 }
 
+/**
+ * Constructs the service's runtime: a production-server runtime talking to
+ * the toolshed `env` names, running as `identity`. The experimental flags are
+ * read from the environment through the runner's own mapping, so that this
+ * service, toolshed, and the CLI resolve them alike; the service forwards
+ * this runtime's resolved flags to every worker it starts.
+ */
 export function createRuntime(
   env: EnvVars,
   identity: Identity,
-  // Injectable for tests, mirroring loadEnv's `source`. The EXPERIMENTAL_*
-  // flags are read through the canonical runner mapping rather than declared
-  // in EnvVars (CT-1814), so they are read here, not in loadEnv.
+  /**
+   * Reads one environment variable; injectable for tests, like `loadEnv()`'s
+   * `source`. The EXPERIMENTAL_* flags are read here rather than in
+   * `loadEnv()`, since `EnvVars` does not declare them.
+   */
   readEnv: EnvReader = (key) => Deno.env.get(key),
 ): Runtime {
-  // Shared first-party posture (CT-1814). This runtime's experimental flags
-  // are the single source the service forwards to its workers (service.ts).
+  // Shared first-party posture. This runtime's experimental flags are the
+  // single source the service forwards to its workers (service.ts).
   return new Runtime(runtimePresets.productionServer({
     apiUrl: new URL(env.API_URL),
     storageManager: StorageManager.open({
@@ -68,6 +109,11 @@ export function createRuntime(
   }));
 }
 
+/**
+ * Returns the signal handler that stops `service`, flushes telemetry, and
+ * exits the process through `exit`, exiting even when the stop or the flush
+ * fails.
+ */
 export function shutdown(
   service: Pick<BackgroundPieceService, "stop">,
   exit: typeof Deno.exit = Deno.exit,
@@ -88,6 +134,15 @@ export function shutdown(
       });
 }
 
+/**
+ * Starts the service: initializes telemetry, derives the identity, builds the
+ * runtime and the service, registers the shutdown handler for `SIGINT` and
+ * `SIGTERM`, and initializes the service under a startup span. Returns the
+ * running service.
+ *
+ * @throws Whatever the service's `initialize()` throws, after recording it
+ *   on the span.
+ */
 export async function startBackgroundPieceService(
   args: string[] = Deno.args,
   dependencies: MainDependencies = {
@@ -113,7 +168,7 @@ export async function startBackgroundPieceService(
   const runtime = dependencies.createRuntime(dependencies.env, identity);
   // The server-execution v2 posture this service RESOLVED (the
   // productionServer preset: an explicit EXPERIMENTAL_SERVER_EXECUTION,
-  // else the first-party default — ON since the Phase 7 flip). Logged at
+  // else the first-party default). Logged at
   // startup so the deployed-topology posture gate, and an operator reading
   // service logs, can verify the arm the binary actually runs — the role
   // /api/meta's `experimental` plays for toolshed; this binary has no HTTP
@@ -163,6 +218,10 @@ export async function startBackgroundPieceService(
   return service;
 }
 
+/**
+ * Runs `start()` when this module is the program's main module, which is how
+ * the binary starts; a test passes `isMain` explicitly.
+ */
 export async function runIfMain(
   isMain = import.meta.main,
   start: () => Promise<unknown> = startBackgroundPieceService,

--- a/packages/background-piece-service/src/main.ts
+++ b/packages/background-piece-service/src/main.ts
@@ -62,7 +62,8 @@ export interface MainDependencies {
 
 /**
  * Returns the worker timeout `args` names with `--timeout`, in milliseconds,
- * or the default when the argument is absent or not a number.
+ * or the default when the argument is absent or does not start with an
+ * integer.
  */
 export function parseWorkerTimeout(args: string[]): number {
   const { timeout } = parseArgs(args, {
@@ -83,16 +84,15 @@ export function parseWorkerTimeout(args: string[]): number {
 /**
  * Constructs the service's runtime: a production-server runtime talking to
  * the toolshed `env` names, running as `identity`. The experimental flags are
- * read from the environment through the runner's own mapping, so that this
- * service, toolshed, and the CLI resolve them alike; the service forwards
- * this runtime's resolved flags to every worker it starts.
+ * read from the environment through the runner's own mapping; the service
+ * forwards this runtime's resolved flags to every worker it starts.
  */
 export function createRuntime(
   env: EnvVars,
   identity: Identity,
   /**
    * Reads one environment variable; injectable for tests, like `loadEnv()`'s
-   * `source`. The EXPERIMENTAL_* flags are read here rather than in
+   * `source`. The `EXPERIMENTAL_*` flags are read here rather than in
    * `loadEnv()`, since `EnvVars` does not declare them.
    */
   readEnv: EnvReader = (key) => Deno.env.get(key),
@@ -140,8 +140,8 @@ export function shutdown(
  * `SIGTERM`, and initializes the service under a startup span. Returns the
  * running service.
  *
- * @throws Whatever the service's `initialize()` throws, after recording it
- *   on the span.
+ * @throws Whatever `getIdentity()` throws, and whatever the service's
+ *   `initialize()` throws, the latter after recording it on the startup span.
  */
 export async function startBackgroundPieceService(
   args: string[] = Deno.args,

--- a/packages/background-piece-service/src/otel.ts
+++ b/packages/background-piece-service/src/otel.ts
@@ -2,6 +2,12 @@
 // SDK probes the environment as it loads, which needs --allow-sys; it loads
 // only when telemetry is switched on.
 
+/**
+ * OpenTelemetry for the service: the tracer and meter providers, registered
+ * when `OTEL_ENABLED` is set and left as the API's no-op instruments
+ * otherwise, and the accessors the rest of the service reaches them through.
+ */
+
 import {
   context,
   type Meter,
@@ -11,6 +17,7 @@ import {
 } from "@opentelemetry/api";
 import type { MeterProvider } from "@opentelemetry/sdk-metrics";
 import type { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+
 import { env, type EnvVars } from "./env.ts";
 
 /** The subset of env the tracer setup needs (injectable for tests). */
@@ -28,10 +35,18 @@ let _provider: BasicTracerProvider | undefined;
 // when telemetry is off or has been shut down, so init/shutdown stay idempotent.
 let _meterProvider: MeterProvider | undefined;
 
+/**
+ * Returns the registered tracer provider, or `undefined` when telemetry is
+ * off or has been shut down.
+ */
 export function getTracerProvider() {
   return _provider;
 }
 
+/**
+ * Returns the registered meter provider, or `undefined` when telemetry is
+ * off or has been shut down.
+ */
 export function getMeterProvider() {
   return _meterProvider;
 }
@@ -101,6 +116,12 @@ export async function shutdownOpenTelemetry(): Promise<void> {
   }
 }
 
+/**
+ * Registers the tracer and meter providers, exporting to the OTLP collector
+ * `cfg` names, when telemetry is enabled; does nothing when it is disabled or
+ * already initialized. A setup failure is logged and leaves telemetry off, so
+ * the service boots regardless.
+ */
 export async function initOpenTelemetry(cfg: OtelConfig = env): Promise<void> {
   if (_provider || !cfg.OTEL_ENABLED) {
     if (!cfg.OTEL_ENABLED) {

--- a/packages/background-piece-service/src/otel.ts
+++ b/packages/background-piece-service/src/otel.ts
@@ -4,8 +4,9 @@
 
 /**
  * OpenTelemetry for the service: the tracer and meter providers, registered
- * when `OTEL_ENABLED` is set and left as the API's no-op instruments
- * otherwise, and the accessors the rest of the service reaches them through.
+ * when `OTEL_ENABLED` is true and absent otherwise, and the accessors the rest
+ * of the service reaches them through, which return the API's no-op
+ * instruments while no provider is registered.
  */
 
 import {
@@ -119,8 +120,9 @@ export async function shutdownOpenTelemetry(): Promise<void> {
 /**
  * Registers the tracer and meter providers, exporting to the OTLP collector
  * `cfg` names, when telemetry is enabled; does nothing when it is disabled or
- * already initialized. A setup failure is logged and leaves telemetry off, so
- * the service boots regardless.
+ * already initialized. A setup failure is logged rather than thrown, so the
+ * service boots regardless: one in the tracer setup leaves telemetry off, and
+ * one in the metrics setup leaves tracing registered and metrics off.
  */
 export async function initOpenTelemetry(cfg: OtelConfig = env): Promise<void> {
   if (_provider || !cfg.OTEL_ENABLED) {

--- a/packages/background-piece-service/src/schema.ts
+++ b/packages/background-piece-service/src/schema.ts
@@ -1,10 +1,28 @@
+/**
+ * The registry of background pieces: where it lives, and the shape of each
+ * entry in it.
+ */
+
 import { type JSONSchema, type Schema } from "@commonfabric/runner";
 
-// This is the derived space id for toolshed-system
+/**
+ * The system space holding the registry: the space id derived for
+ * `toolshed-system`.
+ */
 export const BG_SYSTEM_SPACE_ID =
   "did:key:z6Mkfuw7h6jDwqVb6wimYGys14JFcyTem4Kqvdj9DjpFhY88";
-// This maps to of:baedreiew6ioyvfnvp2bdvmgkkz64ffk6gssvgmibh7yaw43yqhtv2nq75a
+
+/**
+ * Cause of the registry cell in the system space, the cell listing every
+ * registered background piece. It resolves to the entity
+ * `of:baedreiew6ioyvfnvp2bdvmgkkz64ffk6gssvgmibh7yaw43yqhtv2nq75a`.
+ */
 export const BG_CELL_CAUSE = "bgUpdater-2025-03-18";
+
+/**
+ * Schema of one registry entry: the piece, the space it lives in, the
+ * integration that registered it, and its scheduling state.
+ */
 export const BGPieceEntrySchema = {
   type: "object",
   properties: {
@@ -27,12 +45,16 @@ export const BGPieceEntrySchema = {
     "status",
   ],
 } as const satisfies JSONSchema;
+
+/** One registry entry, as `BGPieceEntrySchema` types it. */
 export type BGPieceEntry = Schema<typeof BGPieceEntrySchema>;
 
+/** Schema of the registry as a whole: a list of entries, empty by default. */
 export const BGPieceEntriesSchema = {
   type: "array",
   items: BGPieceEntrySchema,
   default: [],
 } as const satisfies JSONSchema;
 
+/** The registry as a whole, as `BGPieceEntriesSchema` types it. */
 export type BGPieceEntries = Schema<typeof BGPieceEntriesSchema>;

--- a/packages/background-piece-service/src/service.ts
+++ b/packages/background-piece-service/src/service.ts
@@ -27,7 +27,7 @@ type SpaceManagerLike = Pick<SpaceManager, "start" | "stop" | "watch">;
 
 /** Options for constructing a `BackgroundPieceService`. */
 export interface BackgroundPieceServiceOptions {
-  /** Identity the service runs as, and hands each space's worker. */
+  /** Identity each space's worker runs as. */
   identity: Identity;
 
   /** URL of the toolshed the workers talk to. */
@@ -139,7 +139,9 @@ export class BackgroundPieceService {
    * the registry's entries: starts a manager for each space with an enabled
    * entry, hands every manager the entries for its space, and stops the
    * manager of a space with no enabled entry left. Returns the `Cancel` that
-   * undoes the watches it registered.
+   * undoes the watches it registered, which the registry sink runs before the
+   * next invocation so that each round's watches replace the last; returns
+   * nothing when the service is not running.
    */
   #ensurePieces(pieces: readonly Cell<BGPieceEntry>[]) {
     // FIXME(ja): space managers should watch their own pieces!

--- a/packages/background-piece-service/src/service.ts
+++ b/packages/background-piece-service/src/service.ts
@@ -1,3 +1,8 @@
+/**
+ * The service's top level: watches the registry of background pieces and
+ * keeps one `SpaceManager` running per space that has an enabled piece in it.
+ */
+
 import { Identity } from "@commonfabric/identity";
 import {
   type Cell,
@@ -14,20 +19,50 @@ import {
 import { SpaceManager } from "./space-manager.ts";
 import { getBGPieces } from "./utils.ts";
 
+/**
+ * The part of a `SpaceManager` the service drives, so that a test can stand
+ * one in.
+ */
 type SpaceManagerLike = Pick<SpaceManager, "start" | "stop" | "watch">;
 
+/** Options for constructing a `BackgroundPieceService`. */
 export interface BackgroundPieceServiceOptions {
+  /** Identity the service runs as, and hands each space's worker. */
   identity: Identity;
+
+  /** URL of the toolshed the workers talk to. */
   toolshedUrl: string;
+
+  /** Runtime the service reads the registry through. */
   runtime: Runtime;
+
+  /** Space holding the registry; the system space by default. */
   bgSpace?: MemorySpace;
+
+  /** Cause of the registry cell; `BG_CELL_CAUSE` by default. */
   bgCause?: string;
+
+  /**
+   * How long a worker request may run before it fails, in milliseconds; each
+   * space's manager passes it on to its worker controller.
+   */
   workerTimeoutMs?: number;
+
+  /**
+   * Factory for a space's manager, which constructs a `SpaceManager` by
+   * default; a test hands in one that builds a stand-in.
+   */
   createSpaceManager?: (
     options: ConstructorParameters<typeof SpaceManager>[0],
   ) => SpaceManagerLike;
 }
 
+/**
+ * Orchestrator of background piece execution. Once initialized it watches the
+ * registry cell, starts a `SpaceManager` for each space with an enabled entry,
+ * hands each manager the entries for its space, and stops the manager of a
+ * space that no longer has one.
+ */
 export class BackgroundPieceService {
   #piecesCell: Cell<Cell<BGPieceEntry>[]> | null = null;
   #isRunning = false;
@@ -42,6 +77,10 @@ export class BackgroundPieceService {
     options: ConstructorParameters<typeof SpaceManager>[0],
   ) => SpaceManagerLike;
 
+  /**
+   * Constructs an instance from `options`, which runs nothing until
+   * `initialize()`.
+   */
   constructor(options: BackgroundPieceServiceOptions) {
     this.#identity = options.identity;
     this.#toolshedUrl = options.toolshedUrl;
@@ -53,6 +92,11 @@ export class BackgroundPieceService {
       ((managerOptions) => new SpaceManager(managerOptions));
   }
 
+  /**
+   * Syncs the registry cell and starts watching it; from then on every change
+   * to the registry reconciles the set of space managers. A second call while
+   * running does nothing.
+   */
   async initialize() {
     if (this.#isRunning) {
       console.log("Service is already running");
@@ -72,6 +116,10 @@ export class BackgroundPieceService {
     this.#piecesCell.sink((cs) => this.#ensurePieces(cs));
   }
 
+  /**
+   * Stops every space manager, and returns how each stop settled. Stops
+   * nothing when the service is not running.
+   */
   stop(): Promise<PromiseSettledResult<void>[]> {
     // FIXME(ja): stop listening to the pieces cell ?
     if (!this.#isRunning) {
@@ -86,10 +134,17 @@ export class BackgroundPieceService {
     return Promise.allSettled(promises);
   }
 
-  // FIXME(ja): space managers should watch their own pieces!
-  // Note(ja): this assumes that sync won't return an empty
-  // array / partial results!
+  /**
+   * Helper for `initialize()`, which reconciles the space managers against
+   * the registry's entries: starts a manager for each space with an enabled
+   * entry, hands every manager the entries for its space, and stops the
+   * manager of a space with no enabled entry left. Returns the `Cancel` that
+   * undoes the watches it registered.
+   */
   #ensurePieces(pieces: readonly Cell<BGPieceEntry>[]) {
+    // FIXME(ja): space managers should watch their own pieces!
+    // Note(ja): this assumes that sync won't return an empty
+    // array / partial results!
     if (!this.#isRunning) {
       console.log("ignoring pieces update because service asked to stop");
       return;

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -32,8 +32,8 @@ export interface PieceSchedulerOptions extends WorkerOptions {
   deactivationTimeoutMs?: number;
 
   /**
-   * How long after a run its piece runs again, in milliseconds; a minute by
-   * default.
+   * How long after a successful run its piece runs again, in milliseconds,
+   * and the unit of the backoff after a failed one; a minute by default.
    */
   rerunIntervalMs?: number;
 }
@@ -73,7 +73,7 @@ export class SpaceManager {
 
   /**
    * Constructs an instance for the space `options` names, and starts its
-   * worker controller. Runs nothing until `start()`.
+   * worker controller. Runs no piece until `start()`.
    */
   constructor(options: PieceSchedulerOptions) {
     this.#did = options.did;
@@ -211,7 +211,7 @@ export class SpaceManager {
   }
 
   /**
-   * The scheduling loop: while running, hands the head of the queue to
+   * Runs the scheduling loop: while running, hands the head of the queue to
    * `#processPiece()` once it is due, the worker is ready, and no piece is in
    * flight, polling between checks.
    */
@@ -291,8 +291,9 @@ export class SpaceManager {
   }
 
   /**
-   * Handler for a change to a watched entry, which schedules a piece that has
-   * become enabled and drops one that has become disabled.
+   * Handler for a watched entry's value, run when the watch is established
+   * and again on each change, which schedules a piece that is enabled and not
+   * yet scheduled, and drops one that has become disabled.
    */
   #updatePieceStatus(raw: BGPieceEntry, entry: Cell<BGPieceEntry>) {
     const pieceId = raw.pieceId;
@@ -340,8 +341,9 @@ export class SpaceManager {
   }
 
   /**
-   * Records a failed run on the entry and queues a retry with a linearly
-   * growing delay; the third failure in a row disables the piece instead.
+   * Records a failed run on the entry and, if the piece is still enabled,
+   * queues a retry with a linearly growing delay; the third failure in a row
+   * disables the piece instead.
    */
   #onProcessFail(
     pieceId: string,

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -1,3 +1,9 @@
+/**
+ * Scheduling of one space's background pieces: which are enabled, when each
+ * next runs, how a failure backs off and eventually disables a piece, and the
+ * worker controller the runs go through.
+ */
+
 import { type Cancel, Cell, useCancelGroup } from "@commonfabric/runner";
 import { sleep } from "@commonfabric/utils/sleep";
 
@@ -8,18 +14,50 @@ import {
   type WorkerOptions,
 } from "./worker-controller.ts";
 
+/**
+ * Options for constructing a `SpaceManager`: the worker controller's, plus
+ * the scheduler's own intervals.
+ */
 export interface PieceSchedulerOptions extends WorkerOptions {
+  /**
+   * How often the loop looks for a runnable task, in milliseconds; 100 by
+   * default.
+   */
   pollingIntervalMs?: number;
+
+  /**
+   * How long `stop()` waits for a piece in flight, in milliseconds; ten
+   * seconds by default.
+   */
   deactivationTimeoutMs?: number;
+
+  /**
+   * How long after a run its piece runs again, in milliseconds; a minute by
+   * default.
+   */
   rerunIntervalMs?: number;
 }
 
+/** A scheduled run of one piece. */
 type Task = {
+  /** Entity id of the piece. */
   pieceId: string;
+
+  /** When the run is due, as a `Date.now()` value. */
   timestamp: number;
+
+  /** The piece's registry entry. */
   entry: Cell<BGPieceEntry>;
 };
 
+/**
+ * Scheduler of one space's background pieces. It keeps the enabled entries it
+ * is watching, a queue of runs ordered by due time, and one
+ * `WorkerController` for the space, and it records each run's outcome on the
+ * piece's registry entry. A piece that fails three runs in a row is disabled,
+ * and a terminal worker error disables every piece in the space and replaces
+ * the worker.
+ */
 export class SpaceManager {
   #did: string;
   #pollingIntervalMs: number;
@@ -33,6 +71,10 @@ export class SpaceManager {
   #workerOptions: WorkerOptions;
   #isRunning = false;
 
+  /**
+   * Constructs an instance for the space `options` names, and starts its
+   * worker controller. Runs nothing until `start()`.
+   */
   constructor(options: PieceSchedulerOptions) {
     this.#did = options.did;
     this.#pollingIntervalMs = options.pollingIntervalMs ?? 100;
@@ -131,6 +173,7 @@ export class SpaceManager {
     return cancel;
   }
 
+  /** Starts the scheduling loop; does nothing if it is already running. */
   start(): void {
     if (this.#isRunning) {
       return;
@@ -140,6 +183,11 @@ export class SpaceManager {
     this.#execLoop();
   }
 
+  /**
+   * Stops the scheduling loop, waits for a piece in flight to finish or for
+   * the deactivation timeout to pass, whichever is first, and shuts the
+   * worker controller down.
+   */
   async stop(): Promise<void> {
     console.log(`${this.#did} Stopping piece scheduler...`);
     this.#isRunning = false;
@@ -162,6 +210,11 @@ export class SpaceManager {
     await this.#workerController.shutdown();
   }
 
+  /**
+   * The scheduling loop: while running, hands the head of the queue to
+   * `#processPiece()` once it is due, the worker is ready, and no piece is in
+   * flight, polling between checks.
+   */
   async #execLoop(): Promise<void> {
     while (this.#isRunning) {
       if (!this.#workerController.isReady()) {
@@ -188,6 +241,10 @@ export class SpaceManager {
     }
   }
 
+  /**
+   * Runs one piece through the worker controller and records the outcome,
+   * skipping a piece whose entry has been disabled.
+   */
   async #processPiece(pieceId: string, entry: Cell<BGPieceEntry>) {
     const raw = entry.get();
 
@@ -213,6 +270,10 @@ export class SpaceManager {
     this.#activePiece = null;
   }
 
+  /**
+   * Queues a run of `pieceId` due `whenInMs` from now, the rerun interval by
+   * default, keeping the queue ordered by due time.
+   */
   #pushTask(
     pieceId: string,
     entry: Cell<BGPieceEntry>,
@@ -229,17 +290,21 @@ export class SpaceManager {
     this.#pendingTasks.sort((a, b) => a.timestamp - b.timestamp);
   }
 
-  #updatePieceStatus(b: BGPieceEntry, c: Cell<BGPieceEntry>) {
-    const pieceId = b.pieceId;
-    const enabled = !b.disabledAt;
+  /**
+   * Handler for a change to a watched entry, which schedules a piece that has
+   * become enabled and drops one that has become disabled.
+   */
+  #updatePieceStatus(raw: BGPieceEntry, entry: Cell<BGPieceEntry>) {
+    const pieceId = raw.pieceId;
+    const enabled = !raw.disabledAt;
     const currentlyScheduled = this.#enabledPieces.has(pieceId) ||
       this.#activePiece?.get().pieceId === pieceId;
 
     if (enabled) {
       // if we aren't already scheduling this piece, add it to the list
       if (!currentlyScheduled) {
-        this.#enabledPieces.set(pieceId, c);
-        this.#pushTask(pieceId, c, 0);
+        this.#enabledPieces.set(pieceId, entry);
+        this.#pushTask(pieceId, entry, 0);
       }
     } else {
       // if we are disabling a piece, remove it from the list
@@ -252,6 +317,10 @@ export class SpaceManager {
     }
   }
 
+  /**
+   * Records a successful run on the entry, clears the piece's failure count,
+   * and queues its next run if it is still enabled.
+   */
   #onProcessSuccess(pieceId: string, entry: Cell<BGPieceEntry>) {
     // If previous runs have failed, clear out the counter
     if (this.#failureTracking.has(pieceId)) {
@@ -270,6 +339,10 @@ export class SpaceManager {
     }
   }
 
+  /**
+   * Records a failed run on the entry and queues a retry with a linearly
+   * growing delay; the third failure in a row disables the piece instead.
+   */
   #onProcessFail(
     pieceId: string,
     entry: Cell<BGPieceEntry>,
@@ -302,6 +375,10 @@ export class SpaceManager {
     }
   }
 
+  /**
+   * Disables `pieceId`, recording `error` as the reason on its entry, and
+   * drops its queued runs.
+   */
   #disablePiece(
     pieceId: string,
     entry: Cell<BGPieceEntry>,
@@ -321,6 +398,7 @@ export class SpaceManager {
     );
   }
 
+  /** Disables every enabled piece in the space, recording `reason` on each. */
   #disableSpace(reason: string) {
     console.log(`${this.#did} Disabling space: ${reason}`);
     for (const [pieceId, entry] of this.#enabledPieces.entries()) {
@@ -360,6 +438,11 @@ export class SpaceManager {
     this.#setupWorkerController();
   };
 
+  /**
+   * Replaces the worker controller with a fresh one, listening for its
+   * terminal errors, and shuts the previous one down. A controller that fails
+   * to initialize disables the space and is replaced in turn.
+   */
   async #setupWorkerController() {
     const previousWorker = this.#workerController;
     const newWorker = new WorkerController(this.#workerOptions);
@@ -380,7 +463,7 @@ export class SpaceManager {
     }
 
     try {
-      await newWorker.initializeResolve;
+      await newWorker.ready;
       console.log(`${this.#did} Worker controller ready for work`);
     } catch (e) {
       // Initialization error. This "should not" occur, but is seen on invalid IPC requests

--- a/packages/background-piece-service/src/utils.ts
+++ b/packages/background-piece-service/src/utils.ts
@@ -1,10 +1,17 @@
+/**
+ * Helpers shared by the service, its workers, and the admin tooling: identity
+ * derivation, id validation, and reads and writes of the registry of
+ * background pieces.
+ */
+
+import { Identity } from "@commonfabric/identity";
 import {
   type Cell,
   type JSONSchema,
   type MemorySpace,
   type Runtime,
 } from "@commonfabric/runner";
-import { Identity } from "@commonfabric/identity";
+
 import {
   BG_CELL_CAUSE,
   BG_SYSTEM_SPACE_ID,
@@ -12,10 +19,12 @@ import {
   BGPieceEntrySchema,
 } from "./schema.ts";
 
+/** Returns whether `did` has the shape of a `did:key` DID. */
 export function isValidDID(did: string): boolean {
   return did?.startsWith("did:key:") && did.length > 10;
 }
 
+/** Returns whether `id` has the length of a piece's entity id. */
 export function isValidPieceId(id: string): boolean {
   return !!id && id.length === 59;
 }
@@ -57,6 +66,13 @@ export async function getIdentity(
   throw new Error("No IDENTITY or OPERATOR_PASS environment set.");
 }
 
+/**
+ * Registers the piece `pieceId` in `space` for background updates on behalf
+ * of `integration`, or re-enables its entry when one already exists. Returns
+ * whether an entry was added.
+ *
+ * @throws If the registry write fails.
+ */
 export async function setBGPiece({
   space,
   pieceId,
@@ -133,6 +149,11 @@ export async function setBGPiece({
   return added;
 }
 
+/**
+ * Returns the registry cell, synced, with its entries read as cells. The
+ * registry lives in `bgSpace` under `bgCause`, the system space and
+ * `BG_CELL_CAUSE` by default.
+ */
 export async function getBGPieces(
   { bgSpace, bgCause, runtime }: {
     bgSpace?: MemorySpace;

--- a/packages/background-piece-service/src/utils.ts
+++ b/packages/background-piece-service/src/utils.ts
@@ -1,7 +1,7 @@
 /**
- * Helpers shared by the service, its workers, and the admin tooling: identity
- * derivation, id validation, and reads and writes of the registry of
- * background pieces.
+ * Helpers shared by the service, the admin tooling, and the registration entry
+ * point `lib.ts` exports: identity derivation, id validation, and reads and
+ * writes of the registry of background pieces.
  */
 
 import { Identity } from "@commonfabric/identity";

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -171,7 +171,8 @@ export class WorkerController extends EventTarget {
 
   /**
    * Settles when the worker's initialization finishes: resolved once the
-   * worker is ready, rejected with the error that stopped it. A worker that
+   * worker is ready, rejected with the error that stopped it, or with the
+   * request's timeout when the worker dies mid-initialization. A worker that
    * dies before announcing itself ready never starts initialization, and
    * leaves this pending.
    */

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -64,6 +64,7 @@ export interface WorkerOptions {
 
   /** Experimental runtime options to forward to the worker. */
   experimental?: {
+    /** Whether the runtime uses the modern cell representation. */
     modernCellRep?: boolean;
   };
 }
@@ -181,8 +182,8 @@ export class WorkerController extends EventTarget {
    * space, toolshed, identity, and experimental options. Called once the
    * worker announces itself ready.
    *
-   * @throws If the controller is not uninitialized, or if the request fails,
-   *   which leaves the controller in the `Error` state.
+   * @throws If the controller is not uninitialized. Also if the request
+   *   fails, which leaves the controller in the `Error` state.
    */
   async startInitialize() {
     if (this.#state !== WorkerState.Uninitialized) {
@@ -206,7 +207,8 @@ export class WorkerController extends EventTarget {
   /**
    * Runs the piece `bg` names in the worker, resolving when the run finishes.
    *
-   * @throws If the worker is not ready, or if the run fails or times out.
+   * @throws If the worker is not ready, or if the run fails, times out, or
+   *   is cut off by `shutdown()`.
    */
   async runPiece(
     bg: Cell<BGPieceEntry>,

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -170,8 +170,10 @@ export class WorkerController extends EventTarget {
   }
 
   /**
-   * Settles when the worker is initialized: resolved once it is ready,
-   * rejected with the error that stopped it.
+   * Settles when the worker's initialization finishes: resolved once the
+   * worker is ready, rejected with the error that stopped it. A worker that
+   * dies before announcing itself ready never starts initialization, and
+   * leaves this pending.
    */
   get ready(): Promise<void> {
     return this.#initializeDeferred.promise;

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -1,3 +1,9 @@
+/**
+ * The main-thread side of a space's worker: spawns it, hands it requests over
+ * the protocol in `worker-ipc.ts`, matches its responses to them, and reports
+ * its terminal errors as events.
+ */
+
 import { Identity, realmValueFromKeyPair } from "@commonfabric/identity";
 import { Cell } from "@commonfabric/runner";
 import { defer, type Deferred } from "@commonfabric/utils/defer";
@@ -9,22 +15,54 @@ import {
   WorkerIPCMessageType,
 } from "./worker-ipc.ts";
 
+/**
+ * How long a request may run before it fails, absent a `timeoutMs` option: a
+ * minute.
+ */
 const DEFAULT_TASK_TIMEOUT = 60_000;
 
+/** Lifecycle states of a worker controller. */
 export enum WorkerState {
+  /** Constructed; the worker has not yet announced itself ready. */
   Uninitialized = "uninitialized",
+
+  /** The `Initialize` request is in flight. */
   Initializing = "initializing",
+
+  /** Initialized; `runPiece()` may be called. */
   Ready = "ready",
+
+  /** `shutdown()` is in progress. */
   Terminating = "terminating",
+
+  /** Shut down; the worker is terminated. */
   Terminated = "terminated",
+
+  /**
+   * Initialization failed, or the worker reported an error and was
+   * terminated.
+   */
   Error = "error",
 }
 
+/** Options for constructing a `WorkerController`. */
 export interface WorkerOptions {
+  /** DID of the space the worker serves. */
   did: string;
+
+  /** URL of the toolshed the worker's runtime talks to. */
   toolshedUrl: string;
+
+  /** Identity the worker runs as. */
   identity: Identity;
+
+  /**
+   * How long a request may run before it fails, in milliseconds; a minute by
+   * default.
+   */
   timeoutMs?: number;
+
+  /** Experimental runtime options to forward to the worker. */
   experimental?: {
     modernCellRep?: boolean;
   };
@@ -46,15 +84,29 @@ export class WorkerControllerErrorEvent extends Event {
   }
 }
 
+/** A request in flight. */
 interface Task {
+  /** The request's message id. */
   msgId: number;
+
+  /** When the request was sent, as a `performance.now()` value. */
   startTime: number;
+
+  /** Kind of the request. */
   type: WorkerIPCMessageType;
+
+  /** Settled by the worker's response, or by timeout or shutdown. */
   deferred: Deferred;
 }
 
 /**
- * @event error A terminal error occurred in the worker.
+ * Controller of one space's worker. Constructing one spawns the worker;
+ * initialization starts on its own once the worker announces itself ready,
+ * and `ready` settles when that finishes. Each request carries a message id,
+ * and fails on its own timeout when the worker does not answer in time.
+ *
+ * @event error A terminal error occurred in the worker, which has been
+ *   terminated; the event is a `WorkerControllerErrorEvent`.
  */
 export class WorkerController extends EventTarget {
   #worker: Worker;
@@ -77,6 +129,10 @@ export class WorkerController extends EventTarget {
 
   #state = WorkerState.Uninitialized;
 
+  /**
+   * Constructs an instance and spawns the worker for the space `options`
+   * names.
+   */
   constructor(options: WorkerOptions) {
     super();
     this.#did = options.did;
@@ -112,11 +168,22 @@ export class WorkerController extends EventTarget {
     };
   }
 
-  /** Promise that settles when the worker is initialized or has failed to. */
-  get initializeResolve(): Promise<void> {
+  /**
+   * Settles when the worker is initialized: resolved once it is ready,
+   * rejected with the error that stopped it.
+   */
+  get ready(): Promise<void> {
     return this.#initializeDeferred.promise;
   }
 
+  /**
+   * Sends the worker its `Initialize` request, carrying this controller's
+   * space, toolshed, identity, and experimental options. Called once the
+   * worker announces itself ready.
+   *
+   * @throws If the controller is not uninitialized, or if the request fails,
+   *   which leaves the controller in the `Error` state.
+   */
   async startInitialize() {
     if (this.#state !== WorkerState.Uninitialized) {
       throw new Error("Worker is not uninitialized.");
@@ -136,6 +203,11 @@ export class WorkerController extends EventTarget {
     }
   }
 
+  /**
+   * Runs the piece `bg` names in the worker, resolving when the run finishes.
+   *
+   * @throws If the worker is not ready, or if the run fails or times out.
+   */
   async runPiece(
     bg: Cell<BGPieceEntry>,
   ): Promise<void> {
@@ -147,6 +219,12 @@ export class WorkerController extends EventTarget {
     });
   }
 
+  /**
+   * Shuts the worker down: rejects every request in flight, asks the worker
+   * to clean up, and terminates it, terminating even when the cleanup fails.
+   *
+   * @throws If a shutdown is already under way or done.
+   */
   async shutdown() {
     if (
       this.#state === WorkerState.Terminating ||
@@ -172,6 +250,7 @@ export class WorkerController extends EventTarget {
     this.#state = WorkerState.Terminated;
   }
 
+  /** Returns whether the worker is initialized and accepting runs. */
   isReady(): boolean {
     return this.#state === WorkerState.Ready;
   }
@@ -256,6 +335,10 @@ export class WorkerController extends EventTarget {
     this.#pending.delete(response.msgId);
   };
 
+  /**
+   * Handler for the worker's `error` event, which terminates the worker and
+   * re-dispatches the error as this controller's own `error` event.
+   */
   #onWorkerError = (err: ErrorEvent) => {
     console.error(`${this.#did}: Worker error:`, err);
     // If not prevented, error is rethrown in this context.
@@ -268,6 +351,7 @@ export class WorkerController extends EventTarget {
     this.dispatchEvent(new WorkerControllerErrorEvent(err));
   };
 
+  /** Logs how `task` ended, at warning level when it failed with `error`. */
   #logTaskResults(task: Task, error?: string) {
     const errorMessage = error ? `: ${error}` : "";
     const state = error ? "failed" : "completed";

--- a/packages/background-piece-service/src/worker-ipc.ts
+++ b/packages/background-piece-service/src/worker-ipc.ts
@@ -1,14 +1,30 @@
+/**
+ * The messages that cross between a `WorkerController` and its worker: the
+ * requests the controller sends, the responses the worker posts back, and the
+ * predicates each side checks an incoming message against.
+ */
+
 import type { RealmEncodedValue } from "@commonfabric/data-model/codec-realm";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 
+/** The kinds of request a controller sends its worker. */
 export enum WorkerIPCMessageType {
+  /** Set the worker up for its space; the first request, sent once. */
   Initialize = "initialize",
+
+  /** Run one piece's background updater. */
   Run = "run",
+
+  /** Tear the worker's runtime down ahead of termination. */
   Cleanup = "cleanup",
 }
 
+/** Payload of an `Initialize` request. */
 export type InitializationData = {
+  /** DID of the space the worker serves. */
   did: string;
+
+  /** URL of the toolshed the worker's runtime talks to. */
   toolshedUrl: string;
 
   /**
@@ -22,11 +38,13 @@ export type InitializationData = {
    */
   encodedIdentity: RealmEncodedValue;
 
+  /** Experimental runtime options, forwarded from the service's own runtime. */
   experimental?: {
     modernCellRep?: boolean;
   };
 };
 
+/** Returns whether `value` has the shape of an `InitializationData`. */
 export function isInitializationData(
   value: unknown,
 ): value is InitializationData {
@@ -40,15 +58,22 @@ export function isInitializationData(
     (value.encodedIdentity.length === 2));
 }
 
+/** Payload of a `Run` request. */
 export type RunData = {
+  /** Entity id of the piece to run. */
   pieceId: string;
 };
 
+/** Returns whether `value` has the shape of a `RunData`. */
 export function isRunData(value: unknown): value is RunData {
   return !!(isObjectNotArray(value) &&
     typeof value.pieceId === "string");
 }
 
+/**
+ * A request from a controller to its worker, tagged by kind and numbered so
+ * that the response can be matched to it.
+ */
 export type WorkerIPCRequest = {
   type: WorkerIPCMessageType.Initialize;
   msgId: number;
@@ -62,6 +87,7 @@ export type WorkerIPCRequest = {
   msgId: number;
 };
 
+/** Returns whether `value` is a `WorkerIPCRequest`, its payload included. */
 export function isWorkerIPCRequest(value: unknown): value is WorkerIPCRequest {
   if (!isObjectNotArray(value) || typeof value.msgId !== "number") {
     return false;
@@ -78,12 +104,23 @@ export function isWorkerIPCRequest(value: unknown): value is WorkerIPCRequest {
   return false;
 }
 
+/**
+ * The worker's answer to a request, carrying the request's `msgId` and, when
+ * the request failed, the error's message. The one unsolicited message, which
+ * the worker posts once it is listening, has `type` set to `ready`.
+ */
 export type WorkerIPCResponse = {
+  /** The `msgId` of the request this answers; `-1` on the `ready` message. */
   msgId: number;
+
+  /** Message of the error that failed the request; absent on success. */
   error?: string;
+
+  /** Kind of an unsolicited message; `ready` is the one kind. */
   type?: string;
 };
 
+/** Returns whether `value` has the shape of a `WorkerIPCResponse`. */
 export function isWorkerIPCResponse(
   value: unknown,
 ): value is WorkerIPCResponse {

--- a/packages/background-piece-service/src/worker-ipc.ts
+++ b/packages/background-piece-service/src/worker-ipc.ts
@@ -76,7 +76,7 @@ export function isRunData(value: unknown): value is RunData {
  * that the response can be matched to it.
  */
 export type WorkerIPCRequest =
-  /** Set the worker up, with what it needs to serve its space. */
+  /** Request to set the worker up, with what it needs to serve its space. */
   | {
     /** Kind of the request. */
     type: WorkerIPCMessageType.Initialize;
@@ -87,7 +87,7 @@ export type WorkerIPCRequest =
     /** The request's payload. */
     data: InitializationData;
   }
-  /** Run one piece's background updater. */
+  /** Request to run one piece's background updater. */
   | {
     /** Kind of the request. */
     type: WorkerIPCMessageType.Run;
@@ -98,7 +98,7 @@ export type WorkerIPCRequest =
     /** The request's payload. */
     data: RunData;
   }
-  /** Tear the worker's runtime down ahead of termination. */
+  /** Request to tear the worker's runtime down ahead of termination. */
   | {
     /** Kind of the request. */
     type: WorkerIPCMessageType.Cleanup;

--- a/packages/background-piece-service/src/worker-ipc.ts
+++ b/packages/background-piece-service/src/worker-ipc.ts
@@ -9,13 +9,13 @@ import { isObjectNotArray } from "@commonfabric/utils/types";
 
 /** The kinds of request a controller sends its worker. */
 export enum WorkerIPCMessageType {
-  /** Set the worker up for its space; the first request, sent once. */
+  /** Request to set the worker up for its space; the first one, sent once. */
   Initialize = "initialize",
 
-  /** Run one piece's background updater. */
+  /** Request to run one piece's background updater. */
   Run = "run",
 
-  /** Tear the worker's runtime down ahead of termination. */
+  /** Request to tear the worker's runtime down ahead of termination. */
   Cleanup = "cleanup",
 }
 
@@ -40,6 +40,7 @@ export type InitializationData = {
 
   /** Experimental runtime options, forwarded from the service's own runtime. */
   experimental?: {
+    /** Whether the runtime uses the modern cell representation. */
     modernCellRep?: boolean;
   };
 };
@@ -74,18 +75,37 @@ export function isRunData(value: unknown): value is RunData {
  * A request from a controller to its worker, tagged by kind and numbered so
  * that the response can be matched to it.
  */
-export type WorkerIPCRequest = {
-  type: WorkerIPCMessageType.Initialize;
-  msgId: number;
-  data: InitializationData;
-} | {
-  type: WorkerIPCMessageType.Run;
-  msgId: number;
-  data: RunData;
-} | {
-  type: WorkerIPCMessageType.Cleanup;
-  msgId: number;
-};
+export type WorkerIPCRequest =
+  /** Set the worker up, with what it needs to serve its space. */
+  | {
+    /** Kind of the request. */
+    type: WorkerIPCMessageType.Initialize;
+
+    /** Number the response carries back, unique among the worker's requests. */
+    msgId: number;
+
+    /** The request's payload. */
+    data: InitializationData;
+  }
+  /** Run one piece's background updater. */
+  | {
+    /** Kind of the request. */
+    type: WorkerIPCMessageType.Run;
+
+    /** Number the response carries back, unique among the worker's requests. */
+    msgId: number;
+
+    /** The request's payload. */
+    data: RunData;
+  }
+  /** Tear the worker's runtime down ahead of termination. */
+  | {
+    /** Kind of the request. */
+    type: WorkerIPCMessageType.Cleanup;
+
+    /** Number the response carries back, unique among the worker's requests. */
+    msgId: number;
+  };
 
 /** Returns whether `value` is a `WorkerIPCRequest`, its payload included. */
 export function isWorkerIPCRequest(value: unknown): value is WorkerIPCRequest {

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -1,3 +1,11 @@
+/**
+ * The worker side of a space: a dedicated thread holding a session and a
+ * runtime for one space, which loads the pieces it is asked to run and fires
+ * each one's `bgUpdater` stream. It answers the requests in `worker-ipc.ts`
+ * over `postMessage`, and announces itself ready once its listener is
+ * installed.
+ */
+
 import {
   createSession,
   type DID,
@@ -49,6 +57,10 @@ let detachOtelBridge: (() => void) | null = null;
 const loadedPieces = new Map<string, Cell<{ bgUpdater: Stream<unknown> }>>();
 let streamValidator = isStream;
 
+/**
+ * Error handler of the worker's runtime, which keeps the latest error so that
+ * `runPiece()` can report it once the run settles.
+ */
 export function recordLatestError(e: ErrorWithContext): void {
   latestError = e;
 }
@@ -56,6 +68,8 @@ export function recordLatestError(e: ErrorWithContext): void {
 const errorHandler: ErrorHandler = recordLatestError;
 
 const trueConsole = globalThis.console;
+
+/** Returns the prefix the worker's own log lines carry, naming its space. */
 export function workerConsoleContext(currentSpaceId = spaceId): string {
   return `Worker(${currentSpaceId ?? "NO_SPACE"})`;
 }
@@ -73,6 +87,13 @@ const console = {
   },
 };
 
+/**
+ * Console handler of the worker's runtime, which prefixes a piece's console
+ * output with the piece's id and renders each argument through
+ * `safeFormat()`.
+ *
+ * @throws If the worker has no space, or the message names a different one.
+ */
 export function formatConsoleMessage(
   {
     metadata,
@@ -103,6 +124,7 @@ export function formatConsoleMessage(
 const consoleHandler: ConsoleHandler = (message) =>
   formatConsoleMessage(message);
 
+/** Sets whichever parts of the worker's module state `state` names. */
 export function setWorkerStateForTesting(
   state: {
     initialized?: boolean;
@@ -134,6 +156,7 @@ export function setWorkerStateForTesting(
   }
 }
 
+/** Resets the worker's module state to its initial values. */
 export function resetWorkerStateForTesting(): void {
   initialized = false;
   spaceId = undefined;
@@ -146,6 +169,11 @@ export function resetWorkerStateForTesting(): void {
   streamValidator = isStream;
 }
 
+/**
+ * Sets the worker up for its space: derives its identity from the encoded
+ * key pair, opens a session, builds the runtime with telemetry bridged in,
+ * and readies the pieces controller. A second call does nothing.
+ */
 export async function initialize(
   data: InitializationData,
 ): Promise<void> {
@@ -170,11 +198,10 @@ export async function initialize(
     spaceDid: spaceId,
   });
 
-  // Initialize runtime and the pieces controller. Shared first-party posture
-  // (CT-1814); `experimental` arrives as data from the main process so the
-  // service has one flag decision point (see main.ts createRuntime). The
-  // preset pins patternEnvironment to `apiUrl`, matching the explicit pin
-  // this site previously carried.
+  // Initialize runtime and the pieces controller. Shared first-party posture:
+  // `experimental` arrives as data from the main process so the service has
+  // one flag decision point (see main.ts createRuntime). The preset pins
+  // patternEnvironment to `apiUrl`.
   runtime = new Runtime(runtimePresets.productionServer({
     apiUrl,
     storageManager: StorageManager.open({
@@ -221,8 +248,13 @@ export async function initialize(
   initialized = true;
 }
 
-// FIXME(ja) should we make sure we kill the worker?
+/**
+ * Tears the worker down: forgets its loaded pieces and session, syncs and
+ * disposes the runtime, detaches the telemetry bridge, and flushes
+ * telemetry. Does nothing when the worker was never initialized.
+ */
 export async function cleanup(): Promise<void> {
+  // FIXME(ja) should we make sure we kill the worker?
   if (!initialized) {
     console.log(`Not initialized, skipping cleanup`);
     return;
@@ -259,6 +291,15 @@ export async function cleanup(): Promise<void> {
   initialized = false;
 }
 
+/**
+ * Runs the piece `data` names: loads it on first use, sends `{}` to its
+ * `bgUpdater` stream, and waits for the runtime to go idle.
+ *
+ * @throws If the worker is not initialized; if the piece is not registered,
+ *   not found, or has no updater stream; or if the run raised an error. A
+ *   piece whose run failed is dropped from the loaded set, so its next run
+ *   reloads it.
+ */
 export async function runPiece(data: RunData): Promise<void> {
   if (!pieces) {
     throw new Error("Worker session not initialized");
@@ -355,16 +396,18 @@ export async function runPiece(data: RunData): Promise<void> {
   }
 }
 
-// Logs here are often viewed through observability dashboards
-// that don't render objects well. Attempt to stringify any objects
-// here.
-//
-// TODO(danfuzz): this is an unsafe use of `stringify()` for piece console
-// arguments, which arrive live and in-process (the runtime's console capture
-// dispatches them without serialization): a logged `FabricSpecialObject`
-// renders as `{}`, silently. Wants a `FabricSpecialObject` test rendering
-// via `toCompactDebugString()` from `@commonfabric/data-model`.
+/**
+ * Renders `value` for a log line: an object is stringified, with
+ * `encodedIdentity` redacted, because the observability dashboards these
+ * logs reach render objects poorly. Anything else, and an object that will
+ * not stringify, is returned as is.
+ */
 export function safeFormat(value: unknown): unknown {
+  // TODO(danfuzz): this is an unsafe use of `stringify()` for piece console
+  // arguments, which arrive live and in-process (the runtime's console capture
+  // dispatches them without serialization): a logged `FabricSpecialObject`
+  // renders as `{}`, silently. Wants a `FabricSpecialObject` test rendering
+  // via `toCompactDebugString()` from `@commonfabric/data-model`.
   if (value && typeof value === "object") {
     try {
       // While we use this formatter for runtime code, we also use
@@ -382,6 +425,10 @@ export function safeFormat(value: unknown): unknown {
   return value;
 }
 
+/**
+ * Handler for the worker's `unhandledrejection` event, which rethrows the
+ * reason so that the rejection surfaces as a worker error.
+ */
 export function throwUnhandledRejectionReason(
   e: PromiseRejectionEvent,
 ): never {
@@ -390,14 +437,25 @@ export function throwUnhandledRejectionReason(
 
 self.addEventListener("unhandledrejection", throwUnhandledRejectionReason);
 
+/** What `handleWorkerMessage()` dispatches to, each part replaceable. */
 type WorkerMessageHandlers = {
+  /** Handles an `Initialize` request. */
   initialize: typeof initialize;
+
+  /** Handles a `Run` request. */
   runPiece: typeof runPiece;
+
+  /** Handles a `Cleanup` request. */
   cleanup: typeof cleanup;
+
+  /** Posts a response to the controller. */
   postMessage: (message: unknown) => void;
+
+  /** Logs a failed request. */
   error: typeof console.error;
 };
 
+/** Returns the handlers wired to this module's own functions and to `self`. */
 function defaultWorkerMessageHandlers(): WorkerMessageHandlers {
   return {
     initialize,
@@ -408,6 +466,11 @@ function defaultWorkerMessageHandlers(): WorkerMessageHandlers {
   };
 }
 
+/**
+ * Dispatches `message` to the handler for its kind.
+ *
+ * @throws If the kind is unknown, or whatever the handler throws.
+ */
 export async function executeWorkerRequest(
   message: WorkerIPCRequest,
   handlers: WorkerMessageHandlers = defaultWorkerMessageHandlers(),
@@ -430,6 +493,10 @@ export async function executeWorkerRequest(
   }
 }
 
+/**
+ * Handles one message posted to the worker: validates it, executes it, and
+ * posts the response, which reports the error when anything failed.
+ */
 export async function handleWorkerMessage(
   message: unknown,
   handlers: WorkerMessageHandlers = defaultWorkerMessageHandlers(),

--- a/packages/background-piece-service/src/worker.ts
+++ b/packages/background-piece-service/src/worker.ts
@@ -89,8 +89,8 @@ const console = {
 
 /**
  * Console handler of the worker's runtime, which prefixes a piece's console
- * output with the piece's id and renders each argument through
- * `safeFormat()`.
+ * output with the piece's id, or a placeholder when the message names none,
+ * and renders each argument through `safeFormat()`.
  *
  * @throws If the worker has no space, or the message names a different one.
  */
@@ -172,7 +172,8 @@ export function resetWorkerStateForTesting(): void {
 /**
  * Sets the worker up for its space: derives its identity from the encoded
  * key pair, opens a session, builds the runtime with telemetry bridged in,
- * and readies the pieces controller. A second call does nothing.
+ * and readies the pieces controller. A call while already initialized does
+ * nothing.
  */
 export async function initialize(
   data: InitializationData,
@@ -251,7 +252,7 @@ export async function initialize(
 /**
  * Tears the worker down: forgets its loaded pieces and session, syncs and
  * disposes the runtime, detaches the telemetry bridge, and flushes
- * telemetry. Does nothing when the worker was never initialized.
+ * telemetry. Does nothing when the worker is not initialized.
  */
 export async function cleanup(): Promise<void> {
   // FIXME(ja) should we make sure we kill the worker?

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -970,7 +970,7 @@ describe("WorkerController", () => {
         toolshedUrl: "http://localhost:8000",
         identity: await Identity.generate({ implementation: "noble" }),
       });
-      await controller.initializeResolve;
+      await controller.ready;
       assertEquals(controller.isReady(), true);
 
       const entry = new FakeEntryCell(pieceEntry());
@@ -994,7 +994,7 @@ describe("WorkerController", () => {
         toolshedUrl: "http://localhost:8000",
         identity: await Identity.generate({ implementation: "noble" }),
       });
-      await errorController.initializeResolve;
+      await errorController.ready;
       let errorSeen = false;
       errorController.addEventListener("error", (event) => {
         assert(event instanceof WorkerControllerErrorEvent);
@@ -1013,7 +1013,7 @@ describe("WorkerController", () => {
         identity: await Identity.generate({ implementation: "noble" }),
         timeoutMs: 1,
       });
-      await controller.initializeResolve;
+      await controller.ready;
       await assertRejects(
         () =>
           (controller as never as {
@@ -1095,7 +1095,7 @@ describe("WorkerController", () => {
         identity: await Identity.generate({ implementation: "noble" }),
         timeoutMs: 1,
       });
-      await controller.initializeResolve;
+      await controller.ready;
       const worker = MockWorker.instances.at(-1)!;
       worker.respond = false;
 
@@ -1118,7 +1118,7 @@ describe("WorkerController", () => {
         toolshedUrl: "http://localhost:8000",
         identity: await Identity.generate({ implementation: "noble" }),
       });
-      await controller.initializeResolve;
+      await controller.ready;
       const worker = MockWorker.instances.at(-1)!;
       worker.respond = false;
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Fable 5.1)

Source conformance for `packages/background-piece-service`, the way `docs/development/code-comment-style.md` and `DEVELOPMENT.md` describe it. Ten of the eleven files under `src/` had no file header (`lib.ts` is a barrel and takes none), and 80 declarations had no doc comment against 14 that did.

What changes, all in `src/` except the last item:

* Every file gets a header stating what it is and why it exists.
* Every exported enum, interface, and type, and every member of one, gets a doc comment: `WorkerIPCMessageType`, `InitializationData`, `RunData`, `WorkerIPCRequest`, `WorkerIPCResponse`, `WorkerState`, `WorkerOptions`, `PieceSchedulerOptions`, `BackgroundPieceServiceOptions`, `MainDependencies`, `EnvVars`, the registry schemas and types, and the module-internal `Task`, `SpaceManagerLike`, `ServiceLike`, and `WorkerMessageHandlers`.
* Every public member of `WorkerController` and `SpaceManager`, both constructors, and every exported function of `worker.ts`, `main.ts`, `utils.ts`, and `otel.ts` gets one, as do the private methods of the two classes.
* `WorkerController`'s class doc says what the class is; the `@event` tag follows it instead of standing alone.
* `WorkerController.initializeResolve` is renamed `ready`: it is a promise that settles when the worker is initialized, not a resolver. Its one source caller (`SpaceManager.#setupWorkerController()`) and five callers in `test/service-modules.test.ts` are renamed with it. Nothing under `docs/` or in the package README names the old member.
* `SpaceManager.#updatePieceStatus(b, c)` becomes `(raw, entry)`, the names its neighbors use for the value and the cell.
* Comments carrying a tracker identifier (`CT-1814`, four sites) or rollout history ("ON since the Phase 7 flip", "matching the explicit pin this site previously carried") state the present instead.
* Two `//` notes that sat between a doc comment and its declaration, or above a declaration that now has a doc comment, move into the body: the `FIXME` on `cleanup()` and the `TODO(danfuzz)` on `safeFormat()`.
* `utils.ts` and `otel.ts` group and collate their imports.

Left alone on purpose: the definite-assignment `!` on `SpaceManager.#workerController`, which needs a restructure rather than a comment, and the class member order in `SpaceManager` (the `#onTerminalError` arrow field sits among the methods). Both are worth their own change.

Verification: `deno task check` in the package (all eleven files); `deno task test` in the package passes every case but one in `otel.test.ts`, which fails in my sandbox because it denies the local `Deno.serve` listener the test opens, and passes when run outside it. `deno fmt --check` and `deno lint` on the package pass. A script over the diff found no doc comment missing its blank line above and no `//` line adjacent to a doc comment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

